### PR TITLE
Improve asynchronous setup recorder

### DIFF
--- a/config/constants.py
+++ b/config/constants.py
@@ -3,6 +3,7 @@ from zoneinfo import ZoneInfo
 
 from domain.models.mtf_profile import MTFProfile
 from domain.models.timeframe import Timeframe
+from openpyxl.styles import PatternFill
 
 # Timezone
 TIMEZONE: ZoneInfo = ZoneInfo("Europe/Belgrade")
@@ -88,4 +89,8 @@ EMA_ALPHA: float = 0.2
 LINE_WIDTH: int = 1
 
 PLOT_LEGEND_FONT_SIZE: int = 8
+# Заполнение для устаревших записей в XLSX
+FILL_OUTDATED_ENTRY: PatternFill = PatternFill(
+    start_color="CCCCCC", end_color="CCCCCC", fill_type="solid"
+)
 # endregion

--- a/runner/scanner.py
+++ b/runner/scanner.py
@@ -23,6 +23,7 @@ from domain.models.active_setup import ActiveSetup
 from config.constants import ACTIVE_SETUP_TIMEOUT_MINUTES
 from utils.logger import log, logw
 from utils.plot import Plot
+from services.setup_recorder import record_setup
 
 
 class Scanner:
@@ -135,6 +136,7 @@ class Scanner:
             current_price: float | None
     ) -> None:
         """Отправляет сигнал и при необходимости выполняет сделку."""
+        record_setup(signal)
         message = format_message(signal)
         # Генерация графика
         filename = f"{signal.confidence.value.capitalize()}_{signal.symbol}.png"

--- a/services/setup_recorder.py
+++ b/services/setup_recorder.py
@@ -1,0 +1,77 @@
+import os
+import threading
+from typing import List
+from concurrent.futures import ThreadPoolExecutor
+from openpyxl import Workbook, load_workbook
+from config.constants import FILL_OUTDATED_ENTRY
+
+FILE_PATH = os.path.join('.generated', 'xls', 'setup_log.xlsx')
+LOCK = threading.Lock()
+_EXECUTOR = ThreadPoolExecutor(max_workers=1)
+
+HEADERS = [
+    'Timestamp',
+    'Symbol',
+    'Side',
+    'Confidence',
+    'Entry',
+    'SL',
+    'TP',
+    'RR',
+]
+
+_CONF_ORDER = {
+    'weak': 0,
+    'moderate': 1,
+    'strong': 2,
+}
+
+def _ensure_workbook():
+    os.makedirs(os.path.dirname(FILE_PATH), exist_ok=True)
+    if os.path.exists(FILE_PATH):
+        wb = load_workbook(FILE_PATH)
+        ws = wb.active
+    else:
+        wb = Workbook()
+        ws = wb.active
+        ws.append(HEADERS)
+    return wb, ws
+
+def _row_from_signal(signal) -> List:
+    return [
+        signal.timestamp.isoformat(),
+        signal.symbol,
+        getattr(signal.side, 'value', str(signal.side)),
+        getattr(signal.confidence, 'value', str(signal.confidence)),
+        signal.entry,
+        signal.sl,
+        signal.tp,
+        signal.rr,
+    ]
+
+def _write_setup(signal) -> None:
+    with LOCK:
+        wb, ws = _ensure_workbook()
+        new_row = _row_from_signal(signal)
+        last_idx = None
+        for idx, row in enumerate(ws.iter_rows(min_row=2, values_only=False), start=2):
+            if row[1].value == signal.symbol:
+                last_idx = idx
+        inserted = False
+        if last_idx:
+            prev_conf = ws.cell(row=last_idx, column=4).value
+            if prev_conf in _CONF_ORDER and _CONF_ORDER.get(new_row[3], 0) > _CONF_ORDER.get(prev_conf, 0):
+                for cell in ws[last_idx]:
+                    cell.fill = FILL_OUTDATED_ENTRY
+                ws.insert_rows(last_idx + 1)
+                for col, val in enumerate(new_row, start=1):
+                    ws.cell(row=last_idx + 1, column=col, value=val)
+                inserted = True
+        if not inserted:
+            ws.append(new_row)
+        wb.save(FILE_PATH)
+
+
+def record_setup(signal) -> None:
+    """Записать данные сигнала в файл XLSX в отдельном потоке."""
+    _EXECUTOR.submit(_write_setup, signal)


### PR DESCRIPTION
## Summary
- move outdated entry fill constant to `config.constants`
- record setups asynchronously via a thread executor

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889ba6442ec832096af07ebfad67f81