### PR TITLE
Add tradingview util and column enum

### DIFF
--- a/domain/models/setup_log_column.py
+++ b/domain/models/setup_log_column.py
@@ -1,0 +1,21 @@
+from enum import Enum
+
+class SetupLogColumn(str, Enum):
+    """Названия столбцов в журнале сетапов."""
+
+    TIMESTAMP = 'Timestamp'
+    SYMBOL = 'Symbol'
+    SIDE = 'Side'
+    CONFIDENCE = 'Confidence'
+    ENTRY = 'Entry'
+    SL = 'SL'
+    TP = 'TP'
+    RR = 'RR'
+    TF = 'TF'
+    PRICE_GROWTH_PCT = 'price_growth_pct'
+    VOLUME_GROWTH_X = 'volume_growth_x'
+    ATR_GROWTH_PCT = 'atr_growth_pct'
+    TRADINGVIEW = 'tradingview'
+    MAIN_HIGH_CROSSED = 'main_high_crossed'
+    CORRECTION_LOW_CROSSED = 'correction_low_crossed'
+

--- a/notifier/formatter.py
+++ b/notifier/formatter.py
@@ -1,6 +1,7 @@
 from domain.models.confidence import Confidence
 from domain.models.setup_signal import SetupSignal
 from utils.float_utils import is_defined
+from utils.tradingview import tradingview_link
 
 def format_message(
     signal: SetupSignal,
@@ -13,7 +14,7 @@ def format_message(
         Confidence.STRONG: "🌕",
     }
     emoji = emoji_map.get(signal.confidence, "🌑")
-    url = f"https://www.tradingview.com/symbols/{signal.symbol.replace('USDT', '')}USDT.P/"
+    url = tradingview_link(signal.symbol)
     linked_symbol = f"[{signal.symbol}]({url})"
     msg = f"{emoji} {linked_symbol} +{round(signal.price_growth_pct)}%\n\n"
     details = []

--- a/services/setup_recorder.py
+++ b/services/setup_recorder.py
@@ -3,7 +3,6 @@ import threading
 import time
 from typing import List
 from concurrent.futures import ThreadPoolExecutor
-from enum import Enum
 from datetime import datetime, timedelta
 
 from openpyxl import Workbook, load_workbook
@@ -12,26 +11,12 @@ from data.loader import Loader
 
 from config.constants import FILL_OUTDATED_ENTRY, CROSS_MONITOR_HISTORY_BARS
 from utils.logger import logw
+from utils.setup_log_utils import HEADERS, row_from_signal
+from domain.models.setup_log_column import SetupLogColumn
 
 FILE_PATH = os.path.join('.generated', 'xls', 'setup_log.xlsx')
 
 
-
-class SetupLogColumn(str, Enum):
-    TIMESTAMP = 'Timestamp'
-    SYMBOL = 'Symbol'
-    SIDE = 'Side'
-    CONFIDENCE = 'Confidence'
-    ENTRY = 'Entry'
-    SL = 'SL'
-    TP = 'TP'
-    RR = 'RR'
-    TF = 'TF'
-    MAIN_HIGH_CROSSED = 'main_high_crossed'
-    CORRECTION_LOW_CROSSED = 'correction_low_crossed'
-
-
-HEADERS = [c.value for c in SetupLogColumn]
 
 _CONF_ORDER = {
     'weak': 0,
@@ -60,26 +45,10 @@ class SetupLog:
             ws.append(HEADERS)
         return wb, ws
 
-    @staticmethod
-    def _row_from_signal(signal, setup_tf: Timeframe) -> List:
-        return [
-            signal.timestamp.isoformat(),
-            signal.symbol,
-            getattr(signal.side, 'value', str(signal.side)),
-            getattr(signal.confidence, 'value', str(signal.confidence)),
-            signal.entry,
-            signal.sl,
-            signal.tp,
-            signal.rr,
-            setup_tf.value,
-            None,
-            None,
-        ]
-
     def _write_setup(self, signal, setup_tf: Timeframe) -> None:
         with self.lock:
             wb, ws = self._ensure_workbook()
-            new_row = self._row_from_signal(signal, setup_tf)
+            new_row = row_from_signal(signal, setup_tf)
             last_idx = None
             for idx, row in enumerate(ws.iter_rows(min_row=2, values_only=False), start=2):
                 if row[1].value == signal.symbol:

--- a/utils/setup_log_utils.py
+++ b/utils/setup_log_utils.py
@@ -1,0 +1,28 @@
+from domain.models.setup_signal import SetupSignal
+from domain.models.timeframe import Timeframe
+from domain.models.setup_log_column import SetupLogColumn
+from utils.tradingview import tradingview_link
+
+
+HEADERS = [c.value for c in SetupLogColumn]
+
+
+def row_from_signal(signal: SetupSignal, setup_tf: Timeframe) -> list:
+    """Возвращает список значений для строки журнала в порядке ``HEADERS``."""
+    return [
+        signal.timestamp.isoformat(),
+        signal.symbol,
+        getattr(signal.side, 'value', str(signal.side)),
+        getattr(signal.confidence, 'value', str(signal.confidence)),
+        signal.entry,
+        signal.sl,
+        signal.tp,
+        signal.rr,
+        setup_tf.value,
+        signal.price_growth_pct,
+        signal.volume_growth_x,
+        signal.atr_growth_pct,
+        tradingview_link(signal.symbol),
+        None,
+        None,
+    ]

--- a/utils/tradingview.py
+++ b/utils/tradingview.py
@@ -1,0 +1,5 @@
+def tradingview_link(symbol: str) -> str:
+    """Возвращает ссылку на Superchart TradingView для указанной монеты."""
+    base = symbol.replace('USDT', '')
+    return f"https://www.tradingview.com/chart/?symbol=BINANCE%3A{base}USDT"
+


### PR DESCRIPTION
## Summary
- move log column enum to `domain.models`
- add reusable `tradingview_link` helper for superchart URLs
- update setup log utilities and notifier to use the new helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889b87952048320bfa08d2d7b5341ef