### PR TITLE
Fix thread safety in DB access and cache

### DIFF
--- a/data/loader.py
+++ b/data/loader.py
@@ -1,6 +1,7 @@
 from bisect import bisect_right
 from datetime import datetime, timedelta
 from typing import List, Dict, Optional, Any
+import threading
 
 
 from utils.decorator import log_duration_ms
@@ -28,11 +29,13 @@ class Loader:
         self.binance = get_binance_client()
         # {(symbol, timeframe, limit): (timestamp, bars)}
         self._ohlcv_cache: Dict[tuple, tuple] = {}
+        self._cache_lock = threading.Lock()
 
     @log_duration_ms
     def clear_cache(self) -> None:
         """Очистка кэша OHLCV."""
-        self._ohlcv_cache.clear()
+        with self._cache_lock:
+            self._ohlcv_cache.clear()
 
     @log_duration_ms
     def get_filtered_symbols(self, min_volume_usdt: float = VOLUME_THRESHOLD_USDT) -> List[str]:
@@ -70,8 +73,10 @@ class Loader:
         """Загружает OHLCV и OI для инструмента на заданном таймфрейме."""
         cache_key = (symbol, timeframe, limit, has_oi)
         now = datetime.now()
-        if self._is_cache_valid(use_cache, cache_key, now, ttl_minutes):
-            return self._ohlcv_cache[cache_key][1]
+        if use_cache:
+            with self._cache_lock:
+                if self._is_cache_valid(use_cache, cache_key, now, ttl_minutes):
+                    return self._ohlcv_cache[cache_key][1]
 
         since, end_time = self._calculate_time_bounds(to_time, timeframe, limit)
 
@@ -89,7 +94,8 @@ class Loader:
             bars[i].atr = atrs[i]
 
         if use_cache:
-            self._ohlcv_cache[cache_key] = (now, bars)
+            with self._cache_lock:
+                self._ohlcv_cache[cache_key] = (now, bars)
         return bars
 
     @log_duration_ms

--- a/services/position_tracker_service.py
+++ b/services/position_tracker_service.py
@@ -16,18 +16,20 @@ class PositionTrackerService:
         Инициализация соединения с Binance и БД.
         """
         self.client = get_binance_client()
-        self.conn = get_connection()
 
     def track_all(self) -> None:
         """
         Обходит все открытые сделки и запускает PositionManager для сопровождения позиции.
         """
-        cursor = self.conn.cursor()
-        cursor.execute("""
+        with get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
             SELECT id, symbol, side, entry, sl, tp, atr, amount_usdt, partial_exit_done
             FROM trades WHERE active = 1
-        """)
-        rows = cursor.fetchall()
+        """
+            )
+            rows = cursor.fetchall()
 
         for row in rows:
             trade_id, symbol, side, entry, sl, tp, atr, amount, partial_exit_done = row
@@ -54,40 +56,55 @@ class PositionTrackerService:
         """
         Добавляет новую сделку в БД, ставит cooldown.
         """
-        cursor = self.conn.cursor()
-        # Проверка: если уже есть активная сделка по symbol — новая не добавляется
-        cursor.execute("SELECT COUNT(*) FROM trades WHERE symbol = ? AND active = 1", (symbol,))
-        result = cursor.fetchone()
-        if result and result[0] > 0:
-            log(f"[DB] Есть активная сделка по {symbol}, новая не создаётся")
-            return
-        # Рассчитываем cooldown до
-        cooldown_until = datetime.now() + timedelta(minutes=MIN_COOLDOWN_PER_SYMBOL_MINUTES)
-        cursor.execute("""
+        with get_connection() as conn:
+            cursor = conn.cursor()
+            # Проверка: если уже есть активная сделка по symbol — новая не добавляется
+            cursor.execute(
+                "SELECT COUNT(*) FROM trades WHERE symbol = ? AND active = 1",
+                (symbol,),
+            )
+            result = cursor.fetchone()
+            if result and result[0] > 0:
+                log(f"[DB] Есть активная сделка по {symbol}, новая не создаётся")
+                return
+            # Рассчитываем cooldown до
+            cooldown_until = datetime.now() + timedelta(minutes=MIN_COOLDOWN_PER_SYMBOL_MINUTES)
+            cursor.execute(
+                """
             INSERT INTO trades (symbol, side, entry, sl, tp, atr, amount_usdt, active, cooldown_until)
             VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?)
-        """, (symbol, side, entry, sl, tp, atr, amount, cooldown_until.isoformat()))
-        self.conn.commit()
-        log(f"[DB] Добавлена сделка {symbol} {side} @ {entry}")
+        """,
+                (symbol, side, entry, sl, tp, atr, amount, cooldown_until.isoformat()),
+            )
+            conn.commit()
+            log(f"[DB] Добавлена сделка {symbol} {side} @ {entry}")
 
     def mark_partial_exit(self, trade_id: int) -> None:
         """
         Ставит флаг partial_exit_done и обновляет last_action_ts.
         """
-        cursor = self.conn.cursor()
-        cursor.execute("""
+        with get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
             UPDATE trades SET partial_exit_done = 1, last_action_ts = ? WHERE id = ?
-        """, (datetime.now().isoformat(), trade_id))
-        self.conn.commit()
-        log(f"[DB] Частичный выход зафиксирован для сделки ID={trade_id}")
+        """,
+                (datetime.now().isoformat(), trade_id),
+            )
+            conn.commit()
+            log(f"[DB] Частичный выход зафиксирован для сделки ID={trade_id}")
 
     def mark_closed(self, trade_id: int) -> None:
         """
         Ставит статус active=0 и обновляет last_action_ts — сделка полностью закрыта.
         """
-        cursor = self.conn.cursor()
-        cursor.execute("""
+        with get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
             UPDATE trades SET active = 0, last_action_ts = ? WHERE id = ?
-        """, (datetime.now().isoformat(), trade_id))
-        self.conn.commit()
-        log(f"[DB] Сделка ID={trade_id} закрыта")
+        """,
+                (datetime.now().isoformat(), trade_id),
+            )
+            conn.commit()
+            log(f"[DB] Сделка ID={trade_id} закрыта")

--- a/services/trade_log.py
+++ b/services/trade_log.py
@@ -7,14 +7,14 @@ class TradeLog:
     Упростённый логгер исполненных сделок и их истории для отчётов и проверки (по времени, символу и т.д.).
     """
     def __init__(self) -> None:
-        self.conn = get_connection()
+        pass
 
     def record_trade(self, symbol: str, side: Side, amount_usdt: float) -> None:
         """
         Добавить новую исполненную сделку в БД (без стопов и подробностей).
         """
-        with self.conn:
-            self.conn.execute(
+        with get_connection() as conn:
+            conn.execute(
                 "INSERT INTO trades (symbol, side, amount_usdt) VALUES (?, ?, ?)",
                 (symbol, side.value, amount_usdt)
             )
@@ -24,10 +24,11 @@ class TradeLog:
         Возвращает количество сделок за последнюю 1 час.
         """
         one_hour_ago = datetime.now() - timedelta(hours=1)
-        result = self.conn.execute(
-            "SELECT COUNT(*) FROM trades WHERE timestamp > ?",
-            (one_hour_ago.isoformat(),)
-        ).fetchone()
+        with get_connection() as conn:
+            result = conn.execute(
+                "SELECT COUNT(*) FROM trades WHERE timestamp > ?",
+                (one_hour_ago.isoformat(),)
+            ).fetchone()
         return result[0] if result else 0
 
     def traded_recently(self, symbol: str, minutes: int) -> bool:
@@ -35,8 +36,9 @@ class TradeLog:
         Проверяет, была ли активность по символу за последние N минут.
         """
         limit = datetime.now() - timedelta(minutes=minutes)
-        result = self.conn.execute(
-            "SELECT 1 FROM trades WHERE symbol = ? AND timestamp > ? LIMIT 1",
-            (symbol, limit.isoformat())
-        ).fetchone()
+        with get_connection() as conn:
+            result = conn.execute(
+                "SELECT 1 FROM trades WHERE symbol = ? AND timestamp > ? LIMIT 1",
+                (symbol, limit.isoformat())
+            ).fetchone()
         return result is not None


### PR DESCRIPTION
## Summary
- protect OHLCV cache in `Loader` with a lock
- use per-call SQLite connections in `PositionTrackerService`
- open SQLite connection on demand in `TradeLog`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889ddbfc6e08320875d41a013b45acf