### PR TITLE
Use a shared loader

### DIFF
--- a/runner/scanner.py
+++ b/runner/scanner.py
@@ -39,7 +39,7 @@ class Scanner:
         self.setup_detector: SetupDetector = SetupDetector()
         self.orders_notifier: TelegramNotifier = TelegramNotifier(TELEGRAM_ORDERS_BOT_TOKEN)
         self.events_notifier: TelegramNotifier = TelegramNotifier(TELEGRAM_EVENTS_BOT_TOKEN)
-        self.tracker: PositionTrackerService = PositionTrackerService()
+        self.tracker: PositionTrackerService = PositionTrackerService(self.loader)
         self.trade_executor: TradeExecutor = TradeExecutor(self.loader.binance, self.tracker)
         self._sent_signals: Dict[str, Set] = {}  # {symbol: set(confidences)}
         self._pending_signals: Dict[str, UpdateDetails] = {}

--- a/services/position_tracker_service.py
+++ b/services/position_tracker_service.py
@@ -4,6 +4,7 @@ from services.position_manager import PositionManager
 from utils.logger import log
 from data.binance_client import get_binance_client
 from config.constants import MIN_COOLDOWN_PER_SYMBOL_MINUTES
+from data.loader import Loader
 
 
 class PositionTrackerService:
@@ -11,11 +12,13 @@ class PositionTrackerService:
     Сервис для отслеживания, обновления и фиксации статуса открытых и завершённых сделок (trade management).
     Работает с SQLite и Binance API.
     """
-    def __init__(self) -> None:
+    def __init__(self, loader: Loader | None = None) -> None:
         """
         Инициализация соединения с Binance и БД.
+        Принимает общий Loader, чтобы использовать единый экземпляр.
         """
         self.client = get_binance_client()
+        self.loader = loader or Loader()
 
     def track_all(self) -> None:
         """


### PR DESCRIPTION
## Summary
- allow passing Loader instance to `PositionTrackerService`
- pass existing Loader from Scanner to tracker

## Testing
- `python -m py_compile services/position_tracker_service.py`
- `python -m py_compile runner/scanner.py`
- `python -m py_compile services/position_manager.py services/trade_executor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889fb7f736c832086c21141b5ff1a32