### PR TITLE
Add threading locks for Binance client

### DIFF
--- a/data/loader.py
+++ b/data/loader.py
@@ -30,6 +30,7 @@ class Loader:
         # {(symbol, timeframe, limit): (timestamp, bars)}
         self._ohlcv_cache: Dict[tuple, tuple] = {}
         self._cache_lock = threading.Lock()
+        self._client_lock = threading.Lock()
 
     @log_duration_ms
     def clear_cache(self) -> None:
@@ -40,7 +41,8 @@ class Loader:
     @log_duration_ms
     def get_filtered_symbols(self, min_volume_usdt: float = VOLUME_THRESHOLD_USDT) -> List[str]:
         """Возвращает список тикеров, подходящих по объёму торгов и активности."""
-        markets: Dict[str, Any] = self.binance.load_markets()
+        with self._client_lock:
+            markets: Dict[str, Any] = self.binance.load_markets()
         symbols: List[str] = []
         for symbol, data in markets.items():
             if not data.get('linear'):
@@ -100,12 +102,13 @@ class Loader:
 
     @log_duration_ms
     def _fetch_ohlcv(self, symbol, timeframe, since, limit):
-        return self.binance.fetch_ohlcv(
-            symbol,
-            timeframe=timeframe.value,
-            since=since,
-            limit=limit
-        )
+        with self._client_lock:
+            return self.binance.fetch_ohlcv(
+                symbol,
+                timeframe=timeframe.value,
+                since=since,
+                limit=limit
+            )
 
     @log_duration_ms
     def _is_cache_valid(self, use_cache: bool, cache_key: tuple, now: datetime, ttl_minutes: int) -> bool:
@@ -218,12 +221,14 @@ class Loader:
         if end_time:
             params['endTime'] = end_time
 
-        return self.binance.fapidata_get_openinteresthist(params)
+        with self._client_lock:
+            return self.binance.fapidata_get_openinteresthist(params)
 
     @log_duration_ms
     def fetch_oi(self, symbol: str) -> float:
         params: Dict[str, Any] = {'symbol': symbol}
-        result = self.binance.fapipublic_get_openinterest(params)
+        with self._client_lock:
+            result = self.binance.fapipublic_get_openinterest(params)
         return float(result["openInterest"])
 
     @staticmethod

--- a/runner/scanner.py
+++ b/runner/scanner.py
@@ -40,7 +40,11 @@ class Scanner:
         self.orders_notifier: TelegramNotifier = TelegramNotifier(TELEGRAM_ORDERS_BOT_TOKEN)
         self.events_notifier: TelegramNotifier = TelegramNotifier(TELEGRAM_EVENTS_BOT_TOKEN)
         self.tracker: PositionTrackerService = PositionTrackerService(self.loader)
-        self.trade_executor: TradeExecutor = TradeExecutor(self.loader.binance, self.tracker)
+        self.trade_executor: TradeExecutor = TradeExecutor(
+            self.loader.binance,
+            self.tracker,
+            client_lock=self.loader._client_lock
+        )
         self._sent_signals: Dict[str, Set] = {}  # {symbol: set(confidences)}
         self._pending_signals: Dict[str, UpdateDetails] = {}
         self._active_setups: Dict[str, ActiveSetup] = {}

--- a/services/position_manager.py
+++ b/services/position_manager.py
@@ -14,6 +14,7 @@ class PositionManager:
                  sl: float,
                  tp: float,
                  client,
+                 client_lock,
                  atr: float,
                  amount: float,
                  partial_exit_done: bool,
@@ -25,6 +26,7 @@ class PositionManager:
         self.sl = sl
         self.tp = tp
         self.client = client
+        self.client_lock = client_lock
         self.atr = atr
         self.amount = amount
         self.partial_exit_done = partial_exit_done
@@ -63,12 +65,13 @@ class PositionManager:
         try:
             side = 'sell' if self.side == 'long' else 'buy'
             amount_partial = round(self.amount * 0.5, 6)
-            self.client.create_order(
-                symbol=self.symbol,
-                type='market',
-                side=side,
-                amount=amount_partial
-            )
+            with self.client_lock:
+                self.client.create_order(
+                    symbol=self.symbol,
+                    type='market',
+                    side=side,
+                    amount=amount_partial
+                )
             self.tracker.mark_partial_exit(self.trade_id)
         except Exception as error:
             log(f"Ошибка при частичном выходе: {error}")
@@ -81,12 +84,13 @@ class PositionManager:
         log(f"Полный выход из позиции {self.symbol}")
         try:
             side = 'sell' if self.side == 'long' else 'buy'
-            self.client.create_order(
-                symbol=self.symbol,
-                type='market',
-                side=side,
-                amount=self.amount
-            )
+            with self.client_lock:
+                self.client.create_order(
+                    symbol=self.symbol,
+                    type='market',
+                    side=side,
+                    amount=self.amount
+                )
             self.tracker.mark_closed(self.trade_id)
         except Exception as error:
             log(f"Ошибка при полном выходе: {error}")

--- a/services/position_tracker_service.py
+++ b/services/position_tracker_service.py
@@ -5,6 +5,7 @@ from utils.logger import log
 from data.binance_client import get_binance_client
 from config.constants import MIN_COOLDOWN_PER_SYMBOL_MINUTES
 from data.loader import Loader
+import threading
 
 
 class PositionTrackerService:
@@ -19,6 +20,7 @@ class PositionTrackerService:
         """
         self.client = get_binance_client()
         self.loader = loader or Loader()
+        self._client_lock = threading.Lock()
 
     def track_all(self) -> None:
         """
@@ -44,6 +46,7 @@ class PositionTrackerService:
                 sl=sl,
                 tp=tp,
                 client=self.client,
+                client_lock=self._client_lock,
                 atr=atr,
                 amount=amount,
                 partial_exit_done=bool(partial_exit_done),

--- a/services/trade_executor.py
+++ b/services/trade_executor.py
@@ -1,4 +1,5 @@
 from typing import Literal, cast
+import threading
 from config.constants import TRADE_POSITION_USDT, MIN_RISK_REWARD, FLOAT_UNDEFINED, MIN_STOP_LOSS_PERCENT, MIN_TAKE_PROFIT_PERCENT
 from ccxt import binance
 
@@ -14,10 +15,11 @@ class TradeExecutor:
     Класс для автоматического исполнения торговых сигналов (создания ордеров, стопов и тейк-профитов).
     Управляет рисками и регистрирует входы в систему.
     """
-    def __init__(self, client: binance, tracker: PositionTrackerService):
+    def __init__(self, client: binance, tracker: PositionTrackerService, client_lock: threading.Lock | None = None):
         """Сохраняет клиента биржи и трекер сделок."""
         self.client = client
         self.tracker = tracker
+        self._client_lock = client_lock or threading.Lock()
 
     def execute(self,
                 symbol: str,
@@ -29,7 +31,8 @@ class TradeExecutor:
         try:
             symbol_market = symbol
             entry = self._get_price(symbol_market)
-            market = self.client.market(symbol_market)
+            with self._client_lock:
+                market = self.client.market(symbol_market)
 
             if not self._validate_rr(entry, sl, tp, symbol):
                 return
@@ -44,36 +47,39 @@ class TradeExecutor:
             open_side = OrderSide.BUY if side.is_long else OrderSide.SELL
             close_side = OrderSide.SELL if side.is_long else OrderSide.BUY
 
-            self.client.create_order(
-                symbol=symbol_market,
-                type='market',
-                side=cast(Literal["buy", "sell"], open_side.value),
-                amount=amount
-            )
+            with self._client_lock:
+                self.client.create_order(
+                    symbol=symbol_market,
+                    type='market',
+                    side=cast(Literal["buy", "sell"], open_side.value),
+                    amount=amount
+                )
 
-            self.client.create_order(
-                symbol=symbol_market,
-                type='market',
-                side=cast(Literal["buy", "sell"], close_side.value),
-                amount=amount,
-                params={
-                    'type': 'TAKE_PROFIT_MARKET',
-                    'stopPrice': round(tp, precision_price),
-                    'closePosition': True
+            with self._client_lock:
+                self.client.create_order(
+                    symbol=symbol_market,
+                    type='market',
+                    side=cast(Literal["buy", "sell"], close_side.value),
+                    amount=amount,
+                    params={
+                        'type': 'TAKE_PROFIT_MARKET',
+                        'stopPrice': round(tp, precision_price),
+                        'closePosition': True
                 }
-            )
+                )
 
-            self.client.create_order(
-                symbol=symbol_market,
-                type='market',
-                side=cast(Literal["buy", "sell"], close_side.value),
-                amount=amount,
-                params={
-                    'type': 'STOP_MARKET',
-                    'stopPrice': round(sl, precision_price),
-                    'closePosition': True
+            with self._client_lock:
+                self.client.create_order(
+                    symbol=symbol_market,
+                    type='market',
+                    side=cast(Literal["buy", "sell"], close_side.value),
+                    amount=amount,
+                    params={
+                        'type': 'STOP_MARKET',
+                        'stopPrice': round(sl, precision_price),
+                        'closePosition': True
                 }
-            )
+                )
 
             rr = round(abs(tp - entry) / abs(entry - sl), 2)
             log(f"[ВХОД] {symbol} {open_side} @ {entry}\nSL: {sl}, TP: {tp}, RR: {rr}")
@@ -95,7 +101,8 @@ class TradeExecutor:
 
     def _get_price(self, symbol_market: str) -> float:
         """Возвращает последнюю цену по тикеру."""
-        ticker = self.client.fetch_ticker(symbol_market)
+        with self._client_lock:
+            ticker = self.client.fetch_ticker(symbol_market)
         return ticker['last'] if 'last' in ticker else FLOAT_UNDEFINED
 
     @staticmethod


### PR DESCRIPTION
## Summary
- serialize Binance API usage in Loader
- share Loader's lock with TradeExecutor
- lock access in TradeExecutor and PositionManager
- add lock to PositionTrackerService

## Testing
- `python -m py_compile data/loader.py services/trade_executor.py services/position_tracker_service.py services/position_manager.py runner/scanner.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a199ac7988320b390083c31dea292