### PR TITLE
Improve SQLite connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# MTF Trend
+
+This repository contains trading utilities and services built around SQLite.
+
+## SQLite mode
+
+`data/db.py` now uses `WAL` journal mode and a 30‑second timeout on
+connections to reduce `database is locked` errors. A module level `DB_LOCK`
+is provided for serializing write operations when running in multi-threaded
+contexts.

--- a/data/db.py
+++ b/data/db.py
@@ -2,6 +2,7 @@ import sqlite3
 from pathlib import Path
 from datetime import datetime
 from typing import List
+import threading
 
 from config.constants import FLOAT_UNDEFINED
 from domain.models.timeframe import Timeframe
@@ -10,12 +11,20 @@ from utils.decorator import log_duration_ms
 DB_PATH = Path(__file__).parent.parent / ".generated" / "db" / "trades.sqlite"
 DB_PATH.parent.mkdir(parents=True, exist_ok=True)
 
+# Lock used for write operations to avoid "database is locked" errors
+# when multiple threads access the database.
+DB_LOCK = threading.Lock()
+
 @log_duration_ms
 def get_connection() -> sqlite3.Connection:
     """
     Создаёт и возвращает соединение с SQLite-базой данных.
+    Использует WAL journal и 30-секундный таймаут подключения для уменьшения
+    вероятности ошибок "database is locked".
     """
-    conn = sqlite3.connect(DB_PATH)
+    conn = sqlite3.connect(DB_PATH, timeout=30)
+    # Enable WAL mode for better concurrency
+    conn.execute("PRAGMA journal_mode=WAL")
 
     # Таблица трейдов
     conn.execute("""
@@ -56,7 +65,7 @@ def save_oi(symbol: str, tf: Timeframe, timestamp: datetime, oi: float) -> None:
     Сохраняет OI для конкретного тикера и таймфрейма в базу, ограничивая историю 1500 записями.
     """
     ts = timestamp.replace(second=0, microsecond=0).isoformat()
-    with get_connection() as conn:
+    with DB_LOCK, get_connection() as conn:
         conn.execute("""
             INSERT INTO oi_history (symbol, tf, timestamp, oi)
             VALUES (?, ?, ?, ?)

--- a/services/position_tracker_service.py
+++ b/services/position_tracker_service.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from data.db import get_connection
+from data.db import get_connection, DB_LOCK
 from services.position_manager import PositionManager
 from utils.logger import log
 from data.binance_client import get_binance_client
@@ -62,7 +62,7 @@ class PositionTrackerService:
         """
         Добавляет новую сделку в БД, ставит cooldown.
         """
-        with get_connection() as conn:
+        with DB_LOCK, get_connection() as conn:
             cursor = conn.cursor()
             # Проверка: если уже есть активная сделка по symbol — новая не добавляется
             cursor.execute(
@@ -89,7 +89,7 @@ class PositionTrackerService:
         """
         Ставит флаг partial_exit_done и обновляет last_action_ts.
         """
-        with get_connection() as conn:
+        with DB_LOCK, get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute(
                 """
@@ -104,7 +104,7 @@ class PositionTrackerService:
         """
         Ставит статус active=0 и обновляет last_action_ts — сделка полностью закрыта.
         """
-        with get_connection() as conn:
+        with DB_LOCK, get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute(
                 """

--- a/services/trade_log.py
+++ b/services/trade_log.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from data.db import get_connection
+from data.db import get_connection, DB_LOCK
 from domain.models.side import Side
 
 class TradeLog:
@@ -13,7 +13,7 @@ class TradeLog:
         """
         Добавить новую исполненную сделку в БД (без стопов и подробностей).
         """
-        with get_connection() as conn:
+        with DB_LOCK, get_connection() as conn:
             conn.execute(
                 "INSERT INTO trades (symbol, side, amount_usdt) VALUES (?, ?, ?)",
                 (symbol, side.value, amount_usdt)


### PR DESCRIPTION
## Summary
- enable WAL mode and connection timeout in SQLite helper
- add `DB_LOCK` for write operations
- serialize writes in trade services
- document DB behavior in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=. python test/test.py` *(fails: No module named 'config.credentials')*

------
https://chatgpt.com/codex/tasks/task_e_688a1c07d9c48320bac0779b855dadd5