### PR TITLE
Clamp correction depth percent

### DIFF
--- a/services/setup_recorder.py
+++ b/services/setup_recorder.py
@@ -189,7 +189,7 @@ class SetupLog:
                     outcome = 'dump'
                     break
             if outcome:
-                depth_pct = min(80.0, (tp_val - min_low) / pump_range * 100)
+                depth_pct = min(80.0, max(0.0, (tp_val - min_low) / pump_range * 100))
                 self.update_setup_row(
                     timestamp=ts_str,
                     symbol=symbol,


### PR DESCRIPTION
## Summary
- clamp correction depth percent to stay within 0-80 range

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688b13c7f8b08320bea98ce30145afc0