### PR TITLE
fix unused vars in check_crossings

### DIFF
--- a/services/setup_recorder.py
+++ b/services/setup_recorder.py
@@ -81,8 +81,6 @@ class SetupLog:
                 symbol_idx = headers.index(SetupLogColumn.SYMBOL.value) + 1
                 mh_idx = headers.index(SetupLogColumn.MAIN_HIGH_CROSSED.value) + 1
                 cl_idx = headers.index(SetupLogColumn.CORRECTION_LOW_CROSSED.value) + 1
-                cd_idx = headers.index(SetupLogColumn.CORRECTION_DEPTH_PCT.value) + 1
-                tm_idx = headers.index(SetupLogColumn.TIME_TO_MAIN_HIGH.value) + 1
                 outcome_idx = headers.index(SetupLogColumn.OUTCOME.value) + 1
             except ValueError:
                 return
@@ -134,8 +132,6 @@ class SetupLog:
             sl_idx = headers.index(SetupLogColumn.SL.value)
             tp_idx = headers.index(SetupLogColumn.TP.value)
             tf_idx = headers.index(SetupLogColumn.TF.value)
-            depth_idx = headers.index(SetupLogColumn.CORRECTION_DEPTH_PCT.value)
-            time_idx = headers.index(SetupLogColumn.TIME_TO_MAIN_HIGH.value)
             outcome_idx = headers.index(SetupLogColumn.OUTCOME.value)
         except ValueError:
             return


### PR DESCRIPTION
## Summary
- refactor SetupLog.check_crossings to stop collecting unused depth and time indices

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b153c936c8320bca482f21f0eb4d7