### PR TITLE
Fix missing indices for setup log columns

### DIFF
--- a/services/setup_recorder.py
+++ b/services/setup_recorder.py
@@ -81,6 +81,8 @@ class SetupLog:
                 symbol_idx = headers.index(SetupLogColumn.SYMBOL.value) + 1
                 mh_idx = headers.index(SetupLogColumn.MAIN_HIGH_CROSSED.value) + 1
                 cl_idx = headers.index(SetupLogColumn.CORRECTION_LOW_CROSSED.value) + 1
+                cd_idx = headers.index(SetupLogColumn.CORRECTION_DEPTH_PCT.value) + 1
+                tm_idx = headers.index(SetupLogColumn.TIME_TO_MAIN_HIGH.value) + 1
                 outcome_idx = headers.index(SetupLogColumn.OUTCOME.value) + 1
             except ValueError:
                 return


### PR DESCRIPTION
## Summary
- Add column index lookups for correction depth and time to main high in setup recorder
- Use those indices when filling `correction_depth_pct` and `time_to_main_high` fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b3231b1e88320b93e9be72ba7173c