### PR TITLE
Refine order signal validation

### DIFF
--- a/domain/models/setup_signal.py
+++ b/domain/models/setup_signal.py
@@ -7,6 +7,7 @@ from domain.models.confidence import Confidence
 from domain.models.side import Side
 from domain.models.swing_point import SwingPoint
 from domain.models.trendline import Trendline
+from utils.float_utils import is_defined
 
 
 @dataclass
@@ -34,7 +35,10 @@ class SetupSignal:
         """
         True, если сигнал достаточно надёжен и подходит для генерации торговой заявки (стоп/тейк не пустые, уровень strong).
         """
-        return self.confidence.is_strong and self.tp is not None and self.sl is not None
+        return (
+            self.confidence.is_strong
+            and is_defined(self.tp, self.sl)
+        )
 
     @property
     def is_event_signal(self) -> bool:


### PR DESCRIPTION
## Summary
- ensure order signal validity checks use `is_defined` on `tp` and `sl`
- add missing import for `is_defined`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b3536f7788320a0c8504834c95385