### PR TITLE
Fix get_pct argument order for SL/TP validation

### DIFF
--- a/services/trade_executor.py
+++ b/services/trade_executor.py
@@ -108,11 +108,11 @@ class TradeExecutor:
     @staticmethod
     def _validate_rr(entry: float, sl: float, tp: float, symbol: str) -> bool:
         """Проверяет, что RR и расстояния удовлетворяют минимуму."""
-        if not get_pct(sl, entry) > MIN_STOP_LOSS_PERCENT:
+        if not get_pct(entry, sl) > MIN_STOP_LOSS_PERCENT:
             logw(f"Entry и SL слишком близки (entry={entry}, sl={sl}).")
             return False
 
-        if not get_pct(tp, entry) > MIN_TAKE_PROFIT_PERCENT:
+        if not get_pct(entry, tp) > MIN_TAKE_PROFIT_PERCENT:
             logw(f"Entry и TP слишком близки (entry={entry}, tp={tp}).")
             return False
 


### PR DESCRIPTION
## Summary
- fix percent distance calculation from entry to SL/TP in risk validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b35f604d48320a6ef64e1ac7c62f5