### PR TITLE
Add configuration file and loader

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,19 @@
+api:
+  api_key: "YOUR_API_KEY"
+  api_secret: "YOUR_API_SECRET"
+
+trading_defaults:
+  leverage: 1
+  margin_mode: "cross"
+
+risk_limits:
+  max_position_size: 1000
+  daily_loss_limit: 500
+
+data_paths:
+  data_dir: "data/"
+  log_dir: "logs/"
+
+feature_toggles:
+  enable_notifications: true
+  use_sandbox: false

--- a/main.py
+++ b/main.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import yaml
+from pathlib import Path
+
+def load_config(path: str | Path = "config.yaml") -> dict:
+    """Load configuration from a YAML file."""
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+def main() -> None:
+    config = load_config()
+    print("Configuration loaded:")
+    print(config)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add root-level `config.yaml` defining API credentials, trading defaults, risk limits, data paths, and feature toggles
- implement `main.py` with `load_config` helper using `yaml.safe_load`

## Testing
- `python main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688b42f1b45c83208c72beb8e2a1e1a8