### PR TITLE
Implement scheduled trading scaffold with config and .env support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+logs/
+.env

--- a/main.py
+++ b/main.py
@@ -1,17 +1,112 @@
 from __future__ import annotations
 
-import yaml
+import logging
+import os
+import time
 from pathlib import Path
+from typing import Any, Optional
+
+import schedule
+import yaml
+from dotenv import load_dotenv
+
+
+class DataCollector:
+    """Placeholder data collector."""
+
+    def __init__(self, api_key: str, api_secret: str, config: dict) -> None:
+        self.api_key = api_key
+        self.api_secret = api_secret
+        self.config = config
+
+    def collect(self) -> Any:
+        logging.info("Collecting market data")
+        return {}
+
+
+class Screener:
+    """Placeholder screener."""
+
+    def screen(self, data: Any) -> Any:
+        logging.info("Screening data")
+        return data
+
+
+class TrendFilter:
+    """Placeholder trend filter."""
+
+    def filter(self, data: Any) -> Any:
+        logging.info("Applying trend filters")
+        return data
+
+
+class RiskManager:
+    """Placeholder risk manager."""
+
+    def evaluate(self, data: Any) -> None:
+        logging.info("Evaluating risk")
+
 
 def load_config(path: str | Path = "config.yaml") -> dict:
     """Load configuration from a YAML file."""
     with open(path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
 
+
+def init_logging(log_dir: str | Path) -> None:
+    """Configure basic logging."""
+    Path(log_dir).mkdir(parents=True, exist_ok=True)
+    log_file = Path(log_dir) / "app.log"
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[logging.FileHandler(log_file), logging.StreamHandler()],
+    )
+
+
+def scan_and_enter() -> None:
+    """Run periodic scanning and entry logic."""
+    logging.info("Running scan and entry logic")
+    data = data_collector.collect()
+    screened = screener.screen(data)
+    trends = trend_filter.filter(screened)
+    risk_manager.evaluate(trends)
+
+
+def daily_equity_and_risk_check() -> None:
+    """Perform daily equity and risk checks."""
+    logging.info("Running daily equity and risk checks")
+
+
+# Instances are created in main() and used by scheduled jobs
+data_collector: Optional[DataCollector] = None
+screener: Optional[Screener] = None
+trend_filter: Optional[TrendFilter] = None
+risk_manager: Optional[RiskManager] = None
+
 def main() -> None:
     config = load_config()
-    print("Configuration loaded:")
-    print(config)
+    init_logging(config["data_paths"]["log_dir"])
+
+    load_dotenv()
+    api_key = os.getenv("API_KEY", config["api"]["api_key"])
+    api_secret = os.getenv("API_SECRET", config["api"]["api_secret"])
+    logging.info("API credentials loaded")
+
+    global data_collector, screener, trend_filter, risk_manager
+    data_collector = DataCollector(api_key, api_secret, config)
+    screener = Screener()
+    trend_filter = TrendFilter()
+    risk_manager = RiskManager()
+
+    schedule.every(5).minutes.do(scan_and_enter)
+    schedule.every().day.at("00:00").do(daily_equity_and_risk_check)
+    logging.info("Scheduler started")
+
+    while True:
+        schedule.run_pending()
+        time.sleep(1)
+
 
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+PyYAML
+python-dotenv
+schedule


### PR DESCRIPTION
## Summary
- read YAML config and load API credentials from `.env`
- set up logging and placeholder trading components
- schedule 5-minute scans and daily equity/risk checks

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile main.py`
- `timeout 2 python main.py`


------
https://chatgpt.com/codex/tasks/task_e_688b43b8cd188320a3953c6bbf202364