### PR TITLE
Add EMA20 trend filter for entries

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,7 +26,8 @@ class DataCollector:
         logging.info("Collecting market data")
         end = pd.Timestamp.utcnow()
         start = end - pd.Timedelta(days=1)
-        fetch_all_from_config(self.config, start, end)
+        # Fetch 5 minute candles for all configured symbols
+        fetch_all_from_config(self.config, start, end, timeframe="5m")
         return {}
 
 

--- a/tests/test_breakout_signals.py
+++ b/tests/test_breakout_signals.py
@@ -1,6 +1,15 @@
+import sys
+from pathlib import Path
+
 import pandas as pd
 
-from utils.breakout_signals import evaluate_breakout, Signal
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils.breakout_signals import (
+    Signal,
+    allow_short,
+    evaluate_breakout,
+)
 
 
 def test_long_breakout_signal():
@@ -30,3 +39,43 @@ def test_long_breakout_signal():
     assert sig.stop == 98
     assert sig.tp1 == 106
     assert sig.tp2 == 110
+
+
+def test_breakout_blocked_by_trend_filter():
+    idx = pd.date_range("2024-01-01", periods=5, freq="1min")
+    ohlcv = pd.DataFrame(
+        {
+            "open": [90, 95, 97, 100, 99],
+            "high": [91, 96, 98, 101, 105],
+            "low": [89, 94, 96, 99, 98],
+            "close": [95, 97, 99, 99, 104],  # candle 4 is bearish
+            "volume": [100, 120, 110, 130, 300],
+        },
+        index=idx,
+    )
+    cluster = pd.DataFrame({"high": [102], "low": [98]})
+    cvd = pd.Series([1, 2, 3, 4, 6], index=idx)
+    oi = pd.Series([100, 102, 103, 105, 110], index=idx)
+    volume_stats = pd.Series({"avg_volume": 120})
+    funding = 0.005
+
+    # Trend filter should block this potential breakout
+    signals = evaluate_breakout(ohlcv, cluster, cvd, oi, volume_stats, funding)
+    assert signals == []
+
+
+def test_allow_short():
+    idx = pd.date_range("2024-01-01", periods=3, freq="5min")
+    df = pd.DataFrame(
+        {
+            "open": [100, 98, 97],
+            "high": [101, 99, 98],
+            "low": [99, 97, 95],
+            "close": [98, 97, 95],
+            "volume": [50, 60, 70],
+        },
+        index=idx,
+    )
+
+    assert allow_short(df)
+

--- a/utils/breakout_signals.py
+++ b/utils/breakout_signals.py
@@ -25,6 +25,44 @@ class Signal:
     tp2: float
 
 
+def allow_long(ohlcv: pd.DataFrame) -> bool:
+    """Return ``True`` if a long trade is allowed.
+
+    A long is permitted when the close is above the 20-period EMA and the
+    two most recent candles are bullish.
+    """
+
+    if ohlcv.shape[0] < 2:
+        return False
+
+    ema20 = ohlcv["close"].ewm(span=20, adjust=False).mean().iloc[-1]
+    last = ohlcv.iloc[-1]
+    prev = ohlcv.iloc[-2]
+    consecutive_up = (last["close"] > last["open"]) and (
+        prev["close"] > prev["open"]
+    )
+    return bool(last["close"] > ema20 and consecutive_up)
+
+
+def allow_short(ohlcv: pd.DataFrame) -> bool:
+    """Return ``True`` if a short trade is allowed.
+
+    A short is permitted when the close is below the 20-period EMA and the
+    two most recent candles are bearish.
+    """
+
+    if ohlcv.shape[0] < 2:
+        return False
+
+    ema20 = ohlcv["close"].ewm(span=20, adjust=False).mean().iloc[-1]
+    last = ohlcv.iloc[-1]
+    prev = ohlcv.iloc[-2]
+    consecutive_down = (last["close"] < last["open"]) and (
+        prev["close"] < prev["open"]
+    )
+    return bool(last["close"] < ema20 and consecutive_down)
+
+
 def evaluate_breakout(
     ohlcv: pd.DataFrame,
     cluster_levels: pd.DataFrame,
@@ -110,6 +148,7 @@ def evaluate_breakout(
         and funding_ok_long
         and oi_ok_long
         and cvd_ok_long
+        and allow_long(df)
     ):
         entry = float(level["high"])
         stop = float(level["low"])
@@ -123,6 +162,7 @@ def evaluate_breakout(
         and funding_ok_short
         and oi_ok_short
         and cvd_ok_short
+        and allow_short(df)
     ):
         entry = float(level["low"])
         stop = float(level["high"])
@@ -132,4 +172,4 @@ def evaluate_breakout(
     return signals
 
 
-__all__ = ["Signal", "evaluate_breakout"]
+__all__ = ["Signal", "evaluate_breakout", "allow_long", "allow_short"]

--- a/utils/ohlcv_fetcher.py
+++ b/utils/ohlcv_fetcher.py
@@ -110,16 +110,33 @@ def update_data(
 
 
 def fetch_all_from_config(
-    config: dict, start: str | pd.Timestamp, end: str | pd.Timestamp
+    config: dict,
+    start: str | pd.Timestamp,
+    end: str | pd.Timestamp,
+    *,
+    timeframe: str = "1m",
 ) -> List[Path]:
-    """Fetch data for all symbols defined in the configuration dict."""
+    """Fetch data for all symbols defined in the configuration dict.
+
+    Parameters
+    ----------
+    config:
+        Configuration dictionary containing at least a ``symbols`` list and
+        optional ``data_paths`` entry with ``data_dir``.
+    start, end:
+        Time range for which to fetch data.
+    timeframe:
+        Candle timeframe passed through to :func:`update_data`.
+    """
 
     data_dir = Path(config.get("data_paths", {}).get("data_dir", "data")) / "raw_data"
     symbols: Iterable[str] = config.get("symbols", [])
     results: List[Path] = []
 
     for symbol in symbols:
-        results.append(update_data(symbol, start, end, data_dir=data_dir))
+        results.append(
+            update_data(symbol, start, end, timeframe=timeframe, data_dir=data_dir)
+        )
 
     return results
 


### PR DESCRIPTION
## Summary
- collect 5m OHLCV data for configured symbols
- add EMA20-based allow_long/allow_short helpers
- block breakout signals when short-term trend disagrees

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b502b20b48320b0801cbd0257d595