### PR TITLE
Implement risk management module with exposure limits

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ import pandas as pd
 import schedule
 import yaml
 from dotenv import load_dotenv
+import ccxt
 from utils.ohlcv_fetcher import fetch_all_from_config
 
 
@@ -47,11 +48,7 @@ class TrendFilter:
         return data
 
 
-class RiskManager:
-    """Placeholder risk manager."""
-
-    def evaluate(self, data: Any) -> None:
-        logging.info("Evaluating risk")
+from utils.risk import RiskManager
 
 
 def load_config(path: str | Path = "config.yaml") -> dict:
@@ -77,7 +74,6 @@ def scan_and_enter() -> None:
     data = data_collector.collect()
     screened = screener.screen(data)
     trends = trend_filter.filter(screened)
-    risk_manager.evaluate(trends)
 
 
 def daily_equity_and_risk_check() -> None:
@@ -100,11 +96,20 @@ def main() -> None:
     api_secret = os.getenv("API_SECRET", config["api"]["api_secret"])
     logging.info("API credentials loaded")
 
+    def fetch_balance() -> float:
+        exchange = ccxt.binance({"apiKey": api_key, "secret": api_secret})
+        try:
+            balance = exchange.fetch_balance()
+            return balance["total"].get("USDT", 0.0)
+        except Exception:
+            logging.exception("Failed to fetch balance")
+            return 0.0
+
     global data_collector, screener, trend_filter, risk_manager
     data_collector = DataCollector(api_key, api_secret, config)
     screener = Screener()
     trend_filter = TrendFilter()
-    risk_manager = RiskManager()
+    risk_manager = RiskManager(fetch_balance)
 
     schedule.every(5).minutes.do(scan_and_enter)
     schedule.every().day.at("00:00").do(daily_equity_and_risk_check)

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -1,0 +1,60 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils.risk import RiskManager
+
+
+def test_risk_per_trade_and_position_size():
+    balance = 1000.0
+
+    def fetch_balance():
+        return balance
+
+    rm = RiskManager(fetch_balance)
+    assert rm.risk_per_trade() == 10.0
+    assert rm.position_size(100, 95) == 2.0
+
+
+def test_open_risk_limit():
+    balance = 1000.0
+
+    def fetch_balance():
+        return balance
+
+    rm = RiskManager(fetch_balance)
+    # open trades until limit reached
+    for _ in range(10):
+        rm.open_trade(100, 90)
+    assert not rm.can_open_trade()
+
+
+def test_consecutive_loss_halt():
+    balance = 1000.0
+
+    def fetch_balance():
+        return balance
+
+    rm = RiskManager(fetch_balance, max_consecutive_losses=2, daily_drawdown_pct=1)
+    rm.open_trade(100, 90)
+    balance = 990.0
+    rm.close_trade(-10)
+    assert rm.can_open_trade()
+    rm.open_trade(100, 90)
+    balance = 980.0
+    rm.close_trade(-10)
+    assert not rm.can_open_trade()
+
+
+def test_daily_drawdown_stop():
+    balance = 1000.0
+
+    def fetch_balance():
+        return balance
+
+    rm = RiskManager(fetch_balance, daily_drawdown_pct=0.05, max_consecutive_losses=10)
+    rm.open_trade(100, 90)
+    balance = 949.0  # >5% drawdown
+    rm.close_trade(-51)
+    assert not rm.can_open_trade()

--- a/utils/risk.py
+++ b/utils/risk.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, List
+import datetime as dt
+
+
+@dataclass
+class RiskManager:
+    """Basic risk management helper.
+
+    Parameters
+    ----------
+    balance_fetcher:
+        Callable that returns the current account balance.
+    risk_per_trade_pct:
+        Fraction of account balance risked per trade (default 1%).
+    max_open_risk_pct:
+        Maximum fraction of balance allowed to be at risk across open trades
+        (default 10%).
+    daily_drawdown_pct:
+        Maximum daily drawdown as fraction of starting balance before
+        trading is halted (default 5%).
+    max_consecutive_losses:
+        Number of consecutive losing trades before trading is halted
+        (default 3).
+    """
+
+    balance_fetcher: Callable[[], float]
+    risk_per_trade_pct: float = 0.01
+    max_open_risk_pct: float = 0.10
+    daily_drawdown_pct: float = 0.05
+    max_consecutive_losses: int = 3
+
+    open_positions: List[float] = field(default_factory=list)
+    consecutive_losses: int = 0
+    daily_start_balance: float | None = None
+    trading_halted: bool = False
+    last_reset_day: dt.date | None = None
+
+    def _ensure_daily_reset(self) -> None:
+        today = dt.date.today()
+        if self.last_reset_day != today:
+            self.daily_start_balance = self.balance_fetcher()
+            self.consecutive_losses = 0
+            self.trading_halted = False
+            self.last_reset_day = today
+
+    def risk_per_trade(self) -> float:
+        """Return the monetary risk allowed per trade."""
+        balance = self.balance_fetcher()
+        return balance * self.risk_per_trade_pct
+
+    def position_size(self, entry: float, stop: float, risk: float | None = None) -> float:
+        """Calculate position size based on entry and stop price."""
+        if risk is None:
+            risk = self.risk_per_trade()
+        return risk / abs(entry - stop)
+
+    @property
+    def open_risk(self) -> float:
+        return sum(self.open_positions)
+
+    def can_open_trade(self) -> bool:
+        """Return ``True`` if new trades are allowed."""
+        self._ensure_daily_reset()
+        if self.trading_halted:
+            return False
+        balance = self.balance_fetcher()
+        return self.open_risk < balance * self.max_open_risk_pct
+
+    def open_trade(self, entry: float, stop: float) -> float:
+        """Register a new trade and return its position size."""
+        self._ensure_daily_reset()
+        if not self.can_open_trade():
+            raise ValueError("Risk limits breached; cannot open trade")
+        risk = self.risk_per_trade()
+        balance = self.balance_fetcher()
+        if self.open_risk + risk > balance * self.max_open_risk_pct:
+            raise ValueError("Open risk would exceed limit")
+        size = self.position_size(entry, stop, risk=risk)
+        self.open_positions.append(risk)
+        return size
+
+    def close_trade(self, pnl: float) -> None:
+        """Close an existing trade and update risk metrics."""
+        self._ensure_daily_reset()
+        if self.open_positions:
+            # Remove risk for the oldest open position
+            self.open_positions.pop(0)
+        balance = self.balance_fetcher()
+        # Update consecutive losses
+        if pnl < 0:
+            self.consecutive_losses += 1
+        else:
+            self.consecutive_losses = 0
+        # Check drawdown and loss limits
+        if self.daily_start_balance is None:
+            self.daily_start_balance = balance
+        drawdown = (self.daily_start_balance - balance) / self.daily_start_balance
+        if (
+            drawdown >= self.daily_drawdown_pct
+            or self.consecutive_losses >= self.max_consecutive_losses
+        ):
+            self.trading_halted = True
+
+


### PR DESCRIPTION
## Summary
- integrate ccxt account balance fetcher and initialize RiskManager
- add RiskManager utility for per-trade risk, position sizing, open risk tracking, and trading halts on drawdown or losses
- cover risk management behaviors with new unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b5296fcb88320aefdeb2a98bca537