### PR TITLE
Add ccxt-based futures trading wrapper

### DIFF
--- a/tests/test_futures_trader.py
+++ b/tests/test_futures_trader.py
@@ -1,0 +1,110 @@
+import ccxt
+
+from utils.futures_trader import FuturesTrader
+
+
+class DummyExchange:
+    """Minimal ccxt-like exchange for testing FuturesTrader."""
+
+    def __init__(self):
+        self.set_margin_mode_calls = []
+        self.set_leverage_calls = []
+        self.create_order_calls = []
+        self.fetch_order_calls = []
+        self.cancel_order_calls = []
+        self.create_order_should_fail_once = False
+        self._failed_once = False
+        self.fetch_order_responses = {}
+
+    def set_margin_mode(self, mode, symbol):
+        self.set_margin_mode_calls.append((mode, symbol))
+
+    def set_leverage(self, leverage, symbol):
+        self.set_leverage_calls.append((leverage, symbol))
+
+    def create_order(self, symbol, type_, side, amount, price=None, params=None):
+        if self.create_order_should_fail_once and not self._failed_once:
+            self._failed_once = True
+            raise ccxt.NetworkError("timeout")
+        order_id = str(len(self.create_order_calls) + 1)
+        self.create_order_calls.append((symbol, type_, side, amount, price, params))
+        # default order life-cycle: open then close
+        if params and params.get("stopPrice"):
+            # stop-loss remains open until cancelled
+            self.fetch_order_responses[order_id] = [
+                {"id": order_id, "status": "open"},
+                {"id": order_id, "status": "open"},
+            ]
+        elif params and params.get("reduceOnly"):
+            # take-profit fills immediately
+            self.fetch_order_responses[order_id] = [
+                {"id": order_id, "status": "closed"}
+            ]
+        else:
+            self.fetch_order_responses[order_id] = [
+                {"id": order_id, "status": "open"},
+                {"id": order_id, "status": "closed"},
+            ]
+        return {"id": order_id, "status": "open"}
+
+    def fetch_order(self, order_id, symbol):
+        self.fetch_order_calls.append((order_id, symbol))
+        responses = self.fetch_order_responses.get(order_id, [{"id": order_id, "status": "closed"}])
+        result = responses.pop(0)
+        self.fetch_order_responses[order_id] = responses
+        return result
+
+    def cancel_order(self, order_id, symbol):
+        self.cancel_order_calls.append((order_id, symbol))
+
+
+def test_market_order_sets_leverage_and_margin():
+    exchange = DummyExchange()
+    trader = FuturesTrader("key", "secret", exchange=exchange)
+
+    trader.place_market_order("BTC/USDT", "buy", 1)
+
+    assert exchange.set_margin_mode_calls == [("ISOLATED", "BTC/USDT")]
+    assert exchange.set_leverage_calls == [(3, "BTC/USDT")]
+    assert exchange.create_order_calls[0][1] == "market"
+
+
+def test_limit_maker_uses_gtx():
+    exchange = DummyExchange()
+    trader = FuturesTrader("key", "secret", exchange=exchange)
+
+    trader.place_limit_maker_order("BTC/USDT", "sell", 1, 20000)
+
+    params = exchange.create_order_calls[0][5]
+    assert params == {"timeInForce": "GTX"}
+
+
+def test_exit_orders_after_fill():
+    exchange = DummyExchange()
+    trader = FuturesTrader("key", "secret", exchange=exchange)
+
+    trader.place_market_order("BTC/USDT", "buy", 1, tp=21000, sl=19000)
+
+    # three create_order calls: entry, tp, sl
+    assert len(exchange.create_order_calls) == 3
+    # take profit should be reduce-only limit
+    entry, tp_order, sl_order = exchange.create_order_calls
+    assert tp_order[2] == "sell"
+    assert tp_order[5] == {"reduceOnly": True}
+    assert sl_order[5]["stopPrice"] == 19000
+    # stop-loss should be cancelled once TP fills
+    assert exchange.cancel_order_calls == [("3", "BTC/USDT")]
+
+
+def test_retry_on_network_error():
+    exchange = DummyExchange()
+    exchange.create_order_should_fail_once = True
+    trader = FuturesTrader("key", "secret", exchange=exchange)
+
+    trader.place_market_order("BTC/USDT", "buy", 1)
+
+    # first attempt fails then succeeds
+    assert len(exchange.create_order_calls) == 1
+    # ensure fetch_order eventually called
+    assert exchange.fetch_order_calls
+

--- a/utils/futures_trader.py
+++ b/utils/futures_trader.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+"""Utilities for executing futures trades via ccxt.
+
+This module provides a small wrapper around ccxt's futures endpoints to
+place MARKET and LIMIT-MAKER orders using isolated margin with configurable
+leverage.  It also monitors order fills, submits take-profit/stop-loss exit
+orders and retries API calls on transient network errors.
+"""
+
+from typing import Callable, Optional
+import time
+
+import ccxt
+
+
+class FuturesTrader:
+    """Simple ccxt based futures trader.
+
+    Parameters
+    ----------
+    api_key, api_secret:
+        API credentials for the exchange.
+    exchange_name:
+        ccxt exchange id, defaults to ``"binanceusdm"``.
+    exchange:
+        Optional pre-initialised ccxt exchange instance.  Mainly useful for
+        testing where network calls should be avoided.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        api_secret: str,
+        exchange_name: str = "binanceusdm",
+        exchange: Optional[ccxt.Exchange] = None,
+    ) -> None:
+        if exchange is None:
+            exchange_class = getattr(ccxt, exchange_name)
+            exchange = exchange_class(
+                {
+                    "apiKey": api_key,
+                    "secret": api_secret,
+                    "enableRateLimit": True,
+                    "options": {"defaultType": "future"},
+                }
+            )
+        self.exchange = exchange
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    def _retry(
+        self,
+        func: Callable,
+        *args,
+        max_retries: int = 3,
+        delay: float = 1.0,
+        **kwargs,
+    ):
+        """Call ``func`` retrying on temporary network errors."""
+
+        for attempt in range(max_retries):
+            try:
+                return func(*args, **kwargs)
+            except (ccxt.NetworkError, ccxt.ExchangeError):
+                if attempt == max_retries - 1:
+                    raise
+                time.sleep(delay)
+                delay *= 2
+
+    # ------------------------------------------------------------------
+    def set_margin_and_leverage(
+        self, symbol: str, leverage: int = 3, margin_mode: str = "ISOLATED"
+    ) -> None:
+        """Ensure isolated margin and leverage for ``symbol``."""
+
+        self._retry(self.exchange.set_margin_mode, margin_mode, symbol)
+        self._retry(self.exchange.set_leverage, leverage, symbol)
+
+    # ------------------------------------------------------------------
+    def place_market_order(
+        self,
+        symbol: str,
+        side: str,
+        amount: float,
+        tp: float | None = None,
+        sl: float | None = None,
+    ) -> bool:
+        """Place a MARKET order and optional TP/SL exits."""
+
+        self.set_margin_and_leverage(symbol)
+        order = self._retry(self.exchange.create_order, symbol, "market", side, amount)
+        filled = self.monitor_fill(order["id"], symbol)
+        if filled:
+            self.manage_exit_orders(symbol, side, amount, tp, sl)
+        return filled
+
+    # ------------------------------------------------------------------
+    def place_limit_maker_order(
+        self,
+        symbol: str,
+        side: str,
+        amount: float,
+        price: float,
+        tp: float | None = None,
+        sl: float | None = None,
+    ) -> bool:
+        """Place a LIMIT-MAKER order with optional TP/SL."""
+
+        self.set_margin_and_leverage(symbol)
+        params = {"timeInForce": "GTX"}
+        order = self._retry(
+            self.exchange.create_order, symbol, "limit", side, amount, price, params
+        )
+        filled = self.monitor_fill(order["id"], symbol)
+        if filled:
+            self.manage_exit_orders(symbol, side, amount, tp, sl)
+        return filled
+
+    # ------------------------------------------------------------------
+    def monitor_fill(self, order_id: str, symbol: str, timeout: float = 30.0) -> bool:
+        """Poll the exchange until ``order_id`` is filled or timed out."""
+
+        start = time.time()
+        while time.time() - start < timeout:
+            order = self._retry(self.exchange.fetch_order, order_id, symbol)
+            if order.get("status") == "closed":
+                return True
+            time.sleep(1)
+        return False
+
+    # ------------------------------------------------------------------
+    def manage_exit_orders(
+        self,
+        symbol: str,
+        side: str,
+        amount: float,
+        tp: float | None,
+        sl: float | None,
+    ) -> None:
+        """Submit TP/SL orders and cancel the remaining when one fills."""
+
+        opposite = "sell" if side.lower() == "buy" else "buy"
+        tp_id: str | None = None
+        sl_id: str | None = None
+
+        if tp is not None:
+            tp_order = self._retry(
+                self.exchange.create_order,
+                symbol,
+                "limit",
+                opposite,
+                amount,
+                tp,
+                {"reduceOnly": True},
+            )
+            tp_id = tp_order.get("id")
+
+        if sl is not None:
+            sl_order = self._retry(
+                self.exchange.create_order,
+                symbol,
+                "stop",
+                opposite,
+                amount,
+                None,
+                {"stopPrice": sl, "reduceOnly": True},
+            )
+            sl_id = sl_order.get("id")
+
+        if not tp_id and not sl_id:
+            return
+
+        while True:
+            tp_status = None
+            sl_status = None
+            if tp_id:
+                tp_status = self._retry(self.exchange.fetch_order, tp_id, symbol).get(
+                    "status"
+                )
+            if sl_id:
+                sl_status = self._retry(self.exchange.fetch_order, sl_id, symbol).get(
+                    "status"
+                )
+
+            if tp_status == "closed":
+                if sl_id:
+                    self._retry(self.exchange.cancel_order, sl_id, symbol)
+                break
+            if sl_status == "closed":
+                if tp_id:
+                    self._retry(self.exchange.cancel_order, tp_id, symbol)
+                break
+            time.sleep(1)
+


### PR DESCRIPTION
## Summary
- implement `FuturesTrader` wrapper for ccxt futures trading with retry logic, isolated 3x leverage, and TP/SL management
- add unit tests covering leverage, maker orders, exit handling, and retry behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b548e44c48320a8d7a5294b81dc7b