### PR TITLE
Add trade logging and daily summaries with Telegram alerts

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ import yaml
 from dotenv import load_dotenv
 import ccxt
 from utils.ohlcv_fetcher import fetch_all_from_config
+from utils.trade_logger import daily_summary, send_telegram_message
 
 
 class DataCollector:
@@ -77,8 +78,20 @@ def scan_and_enter() -> None:
 
 
 def daily_equity_and_risk_check() -> None:
-    """Perform daily equity and risk checks."""
+    """Perform daily equity and risk checks and send summary."""
     logging.info("Running daily equity and risk checks")
+    summary = daily_summary()
+    msg = (
+        f"Daily summary\n"
+        f"Winrate: {summary['winrate']:.2%}\n"
+        f"Avg RR: {summary['avg_rr']:.2f}\n"
+        f"Equity change: {summary['equity_change']:.2f}"
+    )
+    logging.info(msg)
+    token = os.getenv("TELEGRAM_TOKEN")
+    chat_id = os.getenv("TELEGRAM_CHAT_ID")
+    if token and chat_id:
+        send_telegram_message(token, chat_id, msg)
 
 
 # Instances are created in main() and used by scheduled jobs

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ schedule
 ccxt
 pandas
 matplotlib
+requests

--- a/tests/test_trade_logger.py
+++ b/tests/test_trade_logger.py
@@ -1,0 +1,41 @@
+import datetime as dt
+from pathlib import Path
+
+import pandas as pd
+
+from utils.trade_logger import append_trade, daily_summary
+
+
+def test_append_and_daily_summary(tmp_path):
+    trades_path = tmp_path / "trades.csv"
+    trade1 = {
+        "symbol": "BTC/USDT",
+        "direction": "long",
+        "entry_time": pd.Timestamp("2024-01-01T00:00:00Z"),
+        "entry": 100.0,
+        "stop": 95.0,
+        "tp": 110.0,
+        "exit_time": pd.Timestamp("2024-01-01T01:00:00Z"),
+        "exit": 110.0,
+        "pnl": 10.0,
+        "rr": 2.0,
+    }
+    trade2 = {
+        "symbol": "BTC/USDT",
+        "direction": "short",
+        "entry_time": pd.Timestamp("2024-01-01T02:00:00Z"),
+        "entry": 120.0,
+        "stop": 125.0,
+        "tp": 110.0,
+        "exit_time": pd.Timestamp("2024-01-01T03:00:00Z"),
+        "exit": 125.0,
+        "pnl": -5.0,
+        "rr": -1.0,
+    }
+    append_trade(trade1, trades_path)
+    append_trade(trade2, trades_path)
+
+    summary = daily_summary(trades_path, date=dt.date(2024, 1, 1))
+    assert summary["winrate"] == 0.5
+    assert summary["avg_rr"] == 0.5
+    assert summary["equity_change"] == 5.0

--- a/utils/futures_trader.py
+++ b/utils/futures_trader.py
@@ -8,10 +8,13 @@ leverage.  It also monitors order fills, submits take-profit/stop-loss exit
 orders and retries API calls on transient network errors.
 """
 
-from typing import Callable, Optional
+from typing import Callable, Optional, Dict, Any
 import time
 
 import ccxt
+import pandas as pd
+
+from .trade_logger import append_trade
 
 
 class FuturesTrader:
@@ -34,6 +37,7 @@ class FuturesTrader:
         api_secret: str,
         exchange_name: str = "binanceusdm",
         exchange: Optional[ccxt.Exchange] = None,
+        trade_logger: Callable[[Dict[str, Any]], None] | None = append_trade,
     ) -> None:
         if exchange is None:
             exchange_class = getattr(ccxt, exchange_name)
@@ -46,6 +50,7 @@ class FuturesTrader:
                 }
             )
         self.exchange = exchange
+        self.trade_logger = trade_logger
 
     # ------------------------------------------------------------------
     # internal helpers
@@ -90,10 +95,39 @@ class FuturesTrader:
 
         self.set_margin_and_leverage(symbol)
         order = self._retry(self.exchange.create_order, symbol, "market", side, amount)
-        filled = self.monitor_fill(order["id"], symbol)
-        if filled:
-            self.manage_exit_orders(symbol, side, amount, tp, sl)
-        return filled
+        filled_order = self.monitor_fill(order["id"], symbol)
+        if filled_order:
+            entry_price = float(
+                filled_order.get("average") or filled_order.get("price") or 0.0
+            )
+            ts = filled_order.get("timestamp")
+            entry_time = pd.to_datetime(ts, unit="ms") if ts is not None else pd.Timestamp.utcnow()
+            exit_price = self.manage_exit_orders(symbol, side, amount, tp, sl)
+            if exit_price is not None and self.trade_logger:
+                direction = "long" if side.lower() == "buy" else "short"
+                pnl = (
+                    exit_price - entry_price
+                    if direction == "long"
+                    else entry_price - exit_price
+                )
+                risk = abs(entry_price - sl) if sl is not None else 0.0
+                rr = pnl / risk if risk else 0.0
+                self.trade_logger(
+                    {
+                        "symbol": symbol,
+                        "direction": direction,
+                        "entry_time": entry_time,
+                        "entry": entry_price,
+                        "stop": sl if sl is not None else 0.0,
+                        "tp": tp if tp is not None else 0.0,
+                        "exit_time": pd.Timestamp.utcnow(),
+                        "exit": exit_price,
+                        "pnl": pnl,
+                        "rr": rr,
+                    }
+                )
+            return True
+        return False
 
     # ------------------------------------------------------------------
     def place_limit_maker_order(
@@ -112,22 +146,53 @@ class FuturesTrader:
         order = self._retry(
             self.exchange.create_order, symbol, "limit", side, amount, price, params
         )
-        filled = self.monitor_fill(order["id"], symbol)
-        if filled:
-            self.manage_exit_orders(symbol, side, amount, tp, sl)
-        return filled
+        filled_order = self.monitor_fill(order["id"], symbol)
+        if filled_order:
+            entry_price = float(
+                filled_order.get("average") or filled_order.get("price") or price
+            )
+            ts = filled_order.get("timestamp")
+            entry_time = pd.to_datetime(ts, unit="ms") if ts is not None else pd.Timestamp.utcnow()
+            exit_price = self.manage_exit_orders(symbol, side, amount, tp, sl)
+            if exit_price is not None and self.trade_logger:
+                direction = "long" if side.lower() == "buy" else "short"
+                pnl = (
+                    exit_price - entry_price
+                    if direction == "long"
+                    else entry_price - exit_price
+                )
+                risk = abs(entry_price - sl) if sl is not None else 0.0
+                rr = pnl / risk if risk else 0.0
+                self.trade_logger(
+                    {
+                        "symbol": symbol,
+                        "direction": direction,
+                        "entry_time": entry_time,
+                        "entry": entry_price,
+                        "stop": sl if sl is not None else 0.0,
+                        "tp": tp if tp is not None else 0.0,
+                        "exit_time": pd.Timestamp.utcnow(),
+                        "exit": exit_price,
+                        "pnl": pnl,
+                        "rr": rr,
+                    }
+                )
+            return True
+        return False
 
     # ------------------------------------------------------------------
-    def monitor_fill(self, order_id: str, symbol: str, timeout: float = 30.0) -> bool:
+    def monitor_fill(
+        self, order_id: str, symbol: str, timeout: float = 30.0
+    ) -> Optional[Dict[str, Any]]:
         """Poll the exchange until ``order_id`` is filled or timed out."""
 
         start = time.time()
         while time.time() - start < timeout:
             order = self._retry(self.exchange.fetch_order, order_id, symbol)
             if order.get("status") == "closed":
-                return True
+                return order
             time.sleep(1)
-        return False
+        return None
 
     # ------------------------------------------------------------------
     def manage_exit_orders(
@@ -137,8 +202,11 @@ class FuturesTrader:
         amount: float,
         tp: float | None,
         sl: float | None,
-    ) -> None:
-        """Submit TP/SL orders and cancel the remaining when one fills."""
+    ) -> float | None:
+        """Submit TP/SL orders and cancel the remaining when one fills.
+
+        Returns the exit price when either TP or SL is hit, otherwise ``None``.
+        """
 
         opposite = "sell" if side.lower() == "buy" else "buy"
         tp_id: str | None = None
@@ -169,7 +237,7 @@ class FuturesTrader:
             sl_id = sl_order.get("id")
 
         if not tp_id and not sl_id:
-            return
+            return None
 
         while True:
             tp_status = None
@@ -186,10 +254,10 @@ class FuturesTrader:
             if tp_status == "closed":
                 if sl_id:
                     self._retry(self.exchange.cancel_order, sl_id, symbol)
-                break
+                return tp if tp is not None else None
             if sl_status == "closed":
                 if tp_id:
                     self._retry(self.exchange.cancel_order, tp_id, symbol)
-                break
+                return sl if sl is not None else None
             time.sleep(1)
 

--- a/utils/trade_logger.py
+++ b/utils/trade_logger.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+"""Helper utilities for trade logging and daily summaries."""
+
+from pathlib import Path
+from typing import Dict, Any
+import datetime as dt
+
+import pandas as pd
+import requests
+
+
+def append_trade(trade: Dict[str, Any], trades_path: str | Path = "trades.csv") -> None:
+    """Append ``trade`` information to ``trades.csv``.
+
+    Parameters
+    ----------
+    trade:
+        Dictionary containing trade details. Expected keys include
+        ``symbol``, ``direction``, ``entry_time``, ``entry``, ``stop``,
+        ``tp``, ``exit_time``, ``exit``, ``pnl`` and ``rr``.
+    trades_path:
+        CSV file to append to. Will be created with headers if it does not
+        yet exist.
+    """
+
+    path = Path(trades_path)
+    df = pd.DataFrame([trade])
+    header = not path.exists()
+    df.to_csv(path, mode="a", header=header, index=False)
+
+
+def daily_summary(trades_path: str | Path = "trades.csv", date: dt.date | None = None) -> Dict[str, float]:
+    """Return winrate, average RR and equity change for ``date``.
+
+    Parameters
+    ----------
+    trades_path:
+        Path to ``trades.csv``.
+    date:
+        Day to summarise. Defaults to today.
+    """
+
+    path = Path(trades_path)
+    if not path.exists():
+        return {"winrate": 0.0, "avg_rr": 0.0, "equity_change": 0.0}
+
+    df = pd.read_csv(path, parse_dates=["entry_time", "exit_time"])
+    if df.empty:
+        return {"winrate": 0.0, "avg_rr": 0.0, "equity_change": 0.0}
+
+    if date is None:
+        date = dt.date.today()
+    mask = df["exit_time"].dt.date == date
+    day_trades = df.loc[mask]
+    if day_trades.empty:
+        return {"winrate": 0.0, "avg_rr": 0.0, "equity_change": 0.0}
+
+    wins = (day_trades["pnl"] > 0).sum()
+    total = len(day_trades)
+    winrate = wins / total if total else 0.0
+    avg_rr = day_trades["rr"].mean() if total else 0.0
+    equity_change = day_trades["pnl"].sum()
+    return {"winrate": winrate, "avg_rr": avg_rr, "equity_change": equity_change}
+
+
+def send_telegram_message(token: str, chat_id: str, text: str) -> None:
+    """Send ``text`` via Telegram bot API."""
+
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    payload = {"chat_id": chat_id, "text": text}
+    try:
+        requests.post(url, json=payload, timeout=10)
+    except requests.RequestException:
+        # Best effort: log/ignore network issues silently
+        pass


### PR DESCRIPTION
## Summary
- log executed trades to `trades.csv`
- compute daily summaries (winrate, average RR, equity change)
- send optional Telegram notifications with daily results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b629909f08320a98b18ca614cc424