### PR TITLE
Persist risk state and handle network errors

### DIFF
--- a/tests/test_futures_trader.py
+++ b/tests/test_futures_trader.py
@@ -108,3 +108,14 @@ def test_retry_on_network_error():
     # ensure fetch_order eventually called
     assert exchange.fetch_order_calls
 
+
+def test_market_order_network_failure():
+    class FailingExchange(DummyExchange):
+        def create_order(self, *args, **kwargs):  # type: ignore[override]
+            raise ccxt.NetworkError("timeout")
+
+    exchange = FailingExchange()
+    trader = FuturesTrader("key", "secret", exchange=exchange)
+
+    assert not trader.place_market_order("BTC/USDT", "buy", 1)
+

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -6,37 +6,42 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from utils.risk import RiskManager
 
 
-def test_risk_per_trade_and_position_size():
+def test_risk_per_trade_and_position_size(tmp_path):
     balance = 1000.0
 
     def fetch_balance():
         return balance
 
-    rm = RiskManager(fetch_balance)
+    rm = RiskManager(fetch_balance, db_path=tmp_path / "state.db")
     assert rm.risk_per_trade() == 10.0
     assert rm.position_size(100, 95) == 2.0
 
 
-def test_open_risk_limit():
+def test_open_risk_limit(tmp_path):
     balance = 1000.0
 
     def fetch_balance():
         return balance
 
-    rm = RiskManager(fetch_balance)
+    rm = RiskManager(fetch_balance, db_path=tmp_path / "state.db")
     # open trades until limit reached
     for _ in range(10):
         rm.open_trade(100, 90)
     assert not rm.can_open_trade()
 
 
-def test_consecutive_loss_halt():
+def test_consecutive_loss_halt(tmp_path):
     balance = 1000.0
 
     def fetch_balance():
         return balance
 
-    rm = RiskManager(fetch_balance, max_consecutive_losses=2, daily_drawdown_pct=1)
+    rm = RiskManager(
+        fetch_balance,
+        max_consecutive_losses=2,
+        daily_drawdown_pct=1,
+        db_path=tmp_path / "state.db",
+    )
     rm.open_trade(100, 90)
     balance = 990.0
     rm.close_trade(-10)
@@ -47,14 +52,43 @@ def test_consecutive_loss_halt():
     assert not rm.can_open_trade()
 
 
-def test_daily_drawdown_stop():
+def test_daily_drawdown_stop(tmp_path):
     balance = 1000.0
 
     def fetch_balance():
         return balance
 
-    rm = RiskManager(fetch_balance, daily_drawdown_pct=0.05, max_consecutive_losses=10)
+    rm = RiskManager(
+        fetch_balance,
+        daily_drawdown_pct=0.05,
+        max_consecutive_losses=10,
+        db_path=tmp_path / "state.db",
+    )
     rm.open_trade(100, 90)
     balance = 949.0  # >5% drawdown
     rm.close_trade(-51)
     assert not rm.can_open_trade()
+
+
+def test_state_persistence(tmp_path):
+    balance = 1000.0
+
+    def fetch_balance():
+        return balance
+
+    db = tmp_path / "state.db"
+    rm = RiskManager(fetch_balance, max_consecutive_losses=2, db_path=db)
+    rm.open_trade(100, 90)
+    balance = 990.0
+    rm.close_trade(-10)
+    assert rm.consecutive_losses == 1
+
+    rm2 = RiskManager(fetch_balance, max_consecutive_losses=2, db_path=db)
+    assert rm2.consecutive_losses == 1
+    rm2.open_trade(100, 90)
+    balance = 980.0
+    rm2.close_trade(-10)
+    assert rm2.trading_halted
+
+    rm3 = RiskManager(fetch_balance, max_consecutive_losses=2, db_path=db)
+    assert rm3.trading_halted

--- a/utils/futures_trader.py
+++ b/utils/futures_trader.py
@@ -78,7 +78,6 @@ class FuturesTrader:
         self, symbol: str, leverage: int = 3, margin_mode: str = "ISOLATED"
     ) -> None:
         """Ensure isolated margin and leverage for ``symbol``."""
-
         self._retry(self.exchange.set_margin_mode, margin_mode, symbol)
         self._retry(self.exchange.set_leverage, leverage, symbol)
 
@@ -93,9 +92,14 @@ class FuturesTrader:
     ) -> bool:
         """Place a MARKET order and optional TP/SL exits."""
 
-        self.set_margin_and_leverage(symbol)
-        order = self._retry(self.exchange.create_order, symbol, "market", side, amount)
-        filled_order = self.monitor_fill(order["id"], symbol)
+        try:
+            self.set_margin_and_leverage(symbol)
+            order = self._retry(
+                self.exchange.create_order, symbol, "market", side, amount
+            )
+            filled_order = self.monitor_fill(order["id"], symbol)
+        except ccxt.BaseError:
+            return False
         if filled_order:
             entry_price = float(
                 filled_order.get("average") or filled_order.get("price") or 0.0
@@ -141,12 +145,21 @@ class FuturesTrader:
     ) -> bool:
         """Place a LIMIT-MAKER order with optional TP/SL."""
 
-        self.set_margin_and_leverage(symbol)
-        params = {"timeInForce": "GTX"}
-        order = self._retry(
-            self.exchange.create_order, symbol, "limit", side, amount, price, params
-        )
-        filled_order = self.monitor_fill(order["id"], symbol)
+        try:
+            self.set_margin_and_leverage(symbol)
+            params = {"timeInForce": "GTX"}
+            order = self._retry(
+                self.exchange.create_order,
+                symbol,
+                "limit",
+                side,
+                amount,
+                price,
+                params,
+            )
+            filled_order = self.monitor_fill(order["id"], symbol)
+        except ccxt.BaseError:
+            return False
         if filled_order:
             entry_price = float(
                 filled_order.get("average") or filled_order.get("price") or price
@@ -188,7 +201,10 @@ class FuturesTrader:
 
         start = time.time()
         while time.time() - start < timeout:
-            order = self._retry(self.exchange.fetch_order, order_id, symbol)
+            try:
+                order = self._retry(self.exchange.fetch_order, order_id, symbol)
+            except ccxt.BaseError:
+                return None
             if order.get("status") == "closed":
                 return order
             time.sleep(1)
@@ -213,28 +229,34 @@ class FuturesTrader:
         sl_id: str | None = None
 
         if tp is not None:
-            tp_order = self._retry(
-                self.exchange.create_order,
-                symbol,
-                "limit",
-                opposite,
-                amount,
-                tp,
-                {"reduceOnly": True},
-            )
-            tp_id = tp_order.get("id")
+            try:
+                tp_order = self._retry(
+                    self.exchange.create_order,
+                    symbol,
+                    "limit",
+                    opposite,
+                    amount,
+                    tp,
+                    {"reduceOnly": True},
+                )
+                tp_id = tp_order.get("id")
+            except ccxt.BaseError:
+                return None
 
         if sl is not None:
-            sl_order = self._retry(
-                self.exchange.create_order,
-                symbol,
-                "stop",
-                opposite,
-                amount,
-                None,
-                {"stopPrice": sl, "reduceOnly": True},
-            )
-            sl_id = sl_order.get("id")
+            try:
+                sl_order = self._retry(
+                    self.exchange.create_order,
+                    symbol,
+                    "stop",
+                    opposite,
+                    amount,
+                    None,
+                    {"stopPrice": sl, "reduceOnly": True},
+                )
+                sl_id = sl_order.get("id")
+            except ccxt.BaseError:
+                return None
 
         if not tp_id and not sl_id:
             return None
@@ -243,21 +265,33 @@ class FuturesTrader:
             tp_status = None
             sl_status = None
             if tp_id:
-                tp_status = self._retry(self.exchange.fetch_order, tp_id, symbol).get(
-                    "status"
-                )
+                try:
+                    tp_status = self._retry(
+                        self.exchange.fetch_order, tp_id, symbol
+                    ).get("status")
+                except ccxt.BaseError:
+                    return None
             if sl_id:
-                sl_status = self._retry(self.exchange.fetch_order, sl_id, symbol).get(
-                    "status"
-                )
+                try:
+                    sl_status = self._retry(
+                        self.exchange.fetch_order, sl_id, symbol
+                    ).get("status")
+                except ccxt.BaseError:
+                    return None
 
             if tp_status == "closed":
                 if sl_id:
-                    self._retry(self.exchange.cancel_order, sl_id, symbol)
+                    try:
+                        self._retry(self.exchange.cancel_order, sl_id, symbol)
+                    except ccxt.BaseError:
+                        pass
                 return tp if tp is not None else None
             if sl_status == "closed":
                 if tp_id:
-                    self._retry(self.exchange.cancel_order, tp_id, symbol)
+                    try:
+                        self._retry(self.exchange.cancel_order, tp_id, symbol)
+                    except ccxt.BaseError:
+                        pass
                 return sl if sl is not None else None
             time.sleep(1)
 

--- a/utils/risk.py
+++ b/utils/risk.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Callable, List
 import datetime as dt
+import json
+import sqlite3
+from pathlib import Path
 
 
 @dataclass
 class RiskManager:
-    """Basic risk management helper.
+    """Basic risk management helper with optional state persistence.
 
     Parameters
     ----------
@@ -31,6 +34,7 @@ class RiskManager:
     max_open_risk_pct: float = 0.10
     daily_drawdown_pct: float = 0.05
     max_consecutive_losses: int = 3
+    db_path: str | Path = "risk_state.db"
 
     open_positions: List[float] = field(default_factory=list)
     consecutive_losses: int = 0
@@ -38,17 +42,84 @@ class RiskManager:
     trading_halted: bool = False
     last_reset_day: dt.date | None = None
 
+    def __post_init__(self) -> None:
+        self.db_path = Path(self.db_path)
+        self._init_db()
+        self._load_state()
+
+    # ------------------------------------------------------------------
+    # database helpers
+    def _init_db(self) -> None:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS state (
+                    id INTEGER PRIMARY KEY,
+                    open_positions TEXT,
+                    consecutive_losses INTEGER,
+                    daily_start_balance REAL,
+                    trading_halted INTEGER,
+                    last_reset_day TEXT
+                )
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def _load_state(self) -> None:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            cur = conn.execute("SELECT open_positions, consecutive_losses, daily_start_balance, trading_halted, last_reset_day FROM state WHERE id=1")
+            row = cur.fetchone()
+            if row:
+                positions, losses, start_balance, halted, last_day = row
+                if positions:
+                    self.open_positions = json.loads(positions)
+                self.consecutive_losses = losses or 0
+                self.daily_start_balance = start_balance
+                self.trading_halted = bool(halted)
+                self.last_reset_day = dt.date.fromisoformat(last_day) if last_day else None
+            else:
+                conn.execute(
+                    "INSERT INTO state (id, open_positions, consecutive_losses, daily_start_balance, trading_halted, last_reset_day) VALUES (1, ?, ?, ?, ?, ?)",
+                    (json.dumps(self.open_positions), self.consecutive_losses, self.daily_start_balance, int(self.trading_halted), self.last_reset_day.isoformat() if self.last_reset_day else None),
+                )
+                conn.commit()
+        finally:
+            conn.close()
+
+    def _save_state(self) -> None:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute(
+                "UPDATE state SET open_positions=?, consecutive_losses=?, daily_start_balance=?, trading_halted=?, last_reset_day=? WHERE id=1",
+                (
+                    json.dumps(self.open_positions),
+                    self.consecutive_losses,
+                    self.daily_start_balance,
+                    int(self.trading_halted),
+                    self.last_reset_day.isoformat() if self.last_reset_day else None,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
     def _ensure_daily_reset(self) -> None:
         today = dt.date.today()
         if self.last_reset_day != today:
-            self.daily_start_balance = self.balance_fetcher()
+            self.daily_start_balance = self._get_balance()
             self.consecutive_losses = 0
             self.trading_halted = False
             self.last_reset_day = today
+            self._save_state()
 
     def risk_per_trade(self) -> float:
         """Return the monetary risk allowed per trade."""
-        balance = self.balance_fetcher()
+        balance = self._get_balance()
         return balance * self.risk_per_trade_pct
 
     def position_size(self, entry: float, stop: float, risk: float | None = None) -> float:
@@ -66,7 +137,7 @@ class RiskManager:
         self._ensure_daily_reset()
         if self.trading_halted:
             return False
-        balance = self.balance_fetcher()
+        balance = self._get_balance()
         return self.open_risk < balance * self.max_open_risk_pct
 
     def open_trade(self, entry: float, stop: float) -> float:
@@ -75,11 +146,12 @@ class RiskManager:
         if not self.can_open_trade():
             raise ValueError("Risk limits breached; cannot open trade")
         risk = self.risk_per_trade()
-        balance = self.balance_fetcher()
+        balance = self._get_balance()
         if self.open_risk + risk > balance * self.max_open_risk_pct:
             raise ValueError("Open risk would exceed limit")
         size = self.position_size(entry, stop, risk=risk)
         self.open_positions.append(risk)
+        self._save_state()
         return size
 
     def close_trade(self, pnl: float) -> None:
@@ -88,7 +160,7 @@ class RiskManager:
         if self.open_positions:
             # Remove risk for the oldest open position
             self.open_positions.pop(0)
-        balance = self.balance_fetcher()
+        balance = self._get_balance()
         # Update consecutive losses
         if pnl < 0:
             self.consecutive_losses += 1
@@ -103,5 +175,15 @@ class RiskManager:
             or self.consecutive_losses >= self.max_consecutive_losses
         ):
             self.trading_halted = True
+        self._save_state()
+
+    def _get_balance(self) -> float:
+        try:
+            return self.balance_fetcher()
+        except Exception:
+            # Halt trading on network issues when balance cannot be fetched
+            self.trading_halted = True
+            self._save_state()
+            return 0.0
 
 


### PR DESCRIPTION
## Summary
- Persist RiskManager state in SQLite and reload on startup to enforce drawdown and consecutive loss limits across restarts
- Halt trading on balance fetch failures and add retries/exception handling in FuturesTrader order flow and exit management
- Test state persistence and robust network error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b688398708320bd7c625eeb463756