### PR TITLE
Add configurable OHLCV fetcher with CLI

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,14 @@ symbols:
   - "BTC/USDT"
   - "ETH/USDT"
 
+fetcher:
+  symbol: "BTC/USDT"
+  limit: 1000
+  timeframes:
+    - "1m"
+    - "5m"
+    - "1h"
+
 trading_defaults:
   leverage: 1
   margin_mode: "cross"

--- a/tests/test_ohlcv_fetcher.py
+++ b/tests/test_ohlcv_fetcher.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from utils import ohlcv_fetcher as of
+
+
+def test_update_data_saves_with_timeframe(tmp_path, monkeypatch):
+    def fake_fetch(exchange, symbol, timeframe, since, limit, max_retries):
+        return [
+            [since, 1, 1, 1, 1, 1],
+            [since + 60_000, 1, 1, 1, 1, 1],
+        ]
+
+    monkeypatch.setattr(of, "_safe_fetch", fake_fetch)
+
+    start = pd.Timestamp("2023-01-01")
+    end = start + pd.Timedelta(minutes=1)
+    path = of.update_data(
+        "TEST/USDT", start, end, timeframe="1m", limit=2, data_dir=tmp_path
+    )
+
+    assert path == Path(tmp_path) / "TESTUSDT_1m.csv"
+    df = pd.read_csv(path)
+    assert len(df) == 2
+
+
+def test_fetch_timeframes_creates_files(tmp_path, monkeypatch):
+    def fake_update_data(symbol, start, end, timeframe, **kwargs):
+        file_path = Path(kwargs.get("data_dir", tmp_path)) / f"{symbol.replace('/', '')}_{timeframe}.csv"
+        Path(kwargs.get("data_dir", tmp_path)).mkdir(parents=True, exist_ok=True)
+        pd.DataFrame(
+            {"timestamp": [], "open": [], "high": [], "low": [], "close": [], "volume": []}
+        ).to_csv(file_path, index=False)
+        return file_path
+
+    monkeypatch.setattr(of, "update_data", fake_update_data)
+
+    paths = of.fetch_timeframes(
+        "TEST/USDT", ["1m", "5m"], limit=2, data_dir=tmp_path
+    )
+
+    names = sorted(p.name for p in paths)
+    assert names == ["TESTUSDT_1m.csv", "TESTUSDT_5m.csv"]

--- a/utils/ohlcv_fetcher.py
+++ b/utils/ohlcv_fetcher.py
@@ -11,19 +11,21 @@ configuration dictionary and updates data for each of them.
 
 from __future__ import annotations
 
+import argparse
 import time
 from pathlib import Path
 from typing import Iterable, List
 
 import ccxt
 import pandas as pd
+import yaml
 
 
 def _safe_fetch(
     exchange: ccxt.Exchange,
     symbol: str,
     timeframe: str,
-    since: int,
+    since: int | None,
     limit: int,
     max_retries: int,
 ) -> List[list]:
@@ -51,14 +53,15 @@ def update_data(
     start: str | pd.Timestamp,
     end: str | pd.Timestamp,
     timeframe: str = "1m",
+    limit: int = 1000,
     data_dir: str | Path = "data/raw_data",
     exchange_name: str = "binance",
     max_retries: int = 5,
 ) -> Path:
     """Fetch OHLCV candles and store them as a CSV file.
 
-    The resulting CSV will be located at ``data_dir/{symbol}.csv`` where
-    the ``/`` in the symbol is removed.  Existing files are appended to
+    The resulting CSV will be located at ``data_dir/{symbol}_{timeframe}.csv``
+    where the ``/`` in the symbol is removed.  Existing files are appended to
     and duplicates are removed.
     """
 
@@ -69,7 +72,6 @@ def update_data(
     end_ts = int(pd.Timestamp(end).timestamp() * 1000)
 
     all_ohlcv: List[list] = []
-    limit = 1000
 
     while since < end_ts:
         ohlcv = _safe_fetch(exchange, symbol, timeframe, since, limit, max_retries)
@@ -95,7 +97,7 @@ def update_data(
 
     data_path = Path(data_dir)
     data_path.mkdir(parents=True, exist_ok=True)
-    file_path = data_path / f"{symbol.replace('/', '')}.csv"
+    file_path = data_path / f"{symbol.replace('/', '')}_{timeframe}.csv"
 
     if file_path.exists() and not df.empty:
         existing = pd.read_csv(file_path, parse_dates=["timestamp"])
@@ -107,6 +109,58 @@ def update_data(
 
     df.to_csv(file_path, index=False)
     return file_path
+
+
+def _timeframe_to_seconds(timeframe: str) -> int:
+    """Convert a ccxt timeframe string (e.g. ``1m``) to seconds."""
+
+    unit = timeframe[-1]
+    amount = int(timeframe[:-1])
+    if unit == "m":
+        return amount * 60
+    if unit == "h":
+        return amount * 60 * 60
+    if unit == "d":
+        return amount * 60 * 60 * 24
+    if unit == "w":
+        return amount * 60 * 60 * 24 * 7
+    raise ValueError(f"Unsupported timeframe: {timeframe}")
+
+
+def fetch_timeframes(
+    symbol: str,
+    timeframes: Iterable[str],
+    *,
+    limit: int = 1000,
+    data_dir: str | Path = "data/raw_data",
+    exchange_name: str = "binance",
+    max_retries: int = 5,
+) -> List[Path]:
+    """Fetch recent OHLCV data for multiple timeframes.
+
+    Parameters are passed through to :func:`update_data` with ``start`` and
+    ``end`` computed from the ``limit`` and each timeframe.
+    """
+
+    end = pd.Timestamp.utcnow()
+    results: List[Path] = []
+    for tf in timeframes:
+        span = _timeframe_to_seconds(tf) * limit
+        start = end - pd.Timedelta(seconds=span)
+        results.append(
+            update_data(
+                symbol,
+                start,
+                end,
+                timeframe=tf,
+                limit=limit,
+                data_dir=data_dir,
+                exchange_name=exchange_name,
+                max_retries=max_retries,
+            )
+        )
+
+    return results
 
 
 def fetch_all_from_config(
@@ -141,5 +195,42 @@ def fetch_all_from_config(
     return results
 
 
-__all__ = ["update_data", "fetch_all_from_config"]
+def _load_config(path: str | Path) -> dict:
+    if Path(path).exists():
+        with open(path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    return {}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fetch OHLCV data for a symbol")
+    parser.add_argument("--symbol", help="Trading pair symbol, e.g. BTC/USDT")
+    parser.add_argument(
+        "--limit", type=int, help="Number of candles to fetch per timeframe"
+    )
+    parser.add_argument(
+        "--config", default="config.yaml", help="Path to configuration file"
+    )
+    args = parser.parse_args()
+
+    config = _load_config(args.config)
+    fetcher_cfg = config.get("fetcher", {})
+
+    symbol = args.symbol or fetcher_cfg.get("symbol")
+    if symbol is None:
+        raise ValueError("symbol must be provided via --symbol or config.yaml")
+
+    limit = args.limit or fetcher_cfg.get("limit", 1000)
+    timeframes: List[str] = fetcher_cfg.get("timeframes", ["1m"])
+
+    data_dir = Path(config.get("data_paths", {}).get("data_dir", "data")) / "raw_data"
+
+    fetch_timeframes(symbol, timeframes, limit=limit, data_dir=data_dir)
+
+
+__all__ = ["update_data", "fetch_all_from_config", "fetch_timeframes"]
+
+
+if __name__ == "__main__":
+    main()
 


### PR DESCRIPTION
## Summary
- allow `update_data` to set fetch limit and write timeframe-specific CSVs
- support multi-timeframe downloads and command-line interface
- configure default symbol, limit, and timeframes in `config.yaml`

## Testing
- `pytest -q`
- `python utils/ohlcv_fetcher.py --help`


------
https://chatgpt.com/codex/tasks/task_e_688b6cf5af508320b21af67d0f1ab263