### PR TITLE
Add market trend checks and trade cancellation

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,6 +13,11 @@ from dotenv import load_dotenv
 import ccxt
 from utils.ohlcv_fetcher import fetch_all_from_config
 from utils.trade_logger import daily_summary, send_telegram_message
+from utils.market_analysis import (
+    load_btc_eth_candles,
+    has_consecutive_move,
+    price_above_ema,
+)
 
 
 class DataCollector:
@@ -76,6 +81,23 @@ def scan_and_enter() -> None:
     screened = screener.screen(data)
     trends = trend_filter.filter(screened)
 
+    candles = load_btc_eth_candles()
+    btc = candles.get("BTC/USDT")
+    eth = candles.get("ETH/USDT")
+    btc_up = has_consecutive_move(btc, "up")
+    btc_down = has_consecutive_move(btc, "down")
+    eth_up = has_consecutive_move(eth, "up")
+    eth_down = has_consecutive_move(eth, "down")
+    btc_above = price_above_ema(btc)
+
+    global open_long, open_short
+    if open_long and (btc_down or eth_down or not btc_above):
+        logging.info("Conditions violated for long; cancelling long position")
+        open_long = False
+    if open_short and (btc_up or eth_up or btc_above):
+        logging.info("Conditions violated for short; cancelling short position")
+        open_short = False
+
 
 def daily_equity_and_risk_check() -> None:
     """Perform daily equity and risk checks and send summary."""
@@ -99,6 +121,8 @@ data_collector: Optional[DataCollector] = None
 screener: Optional[Screener] = None
 trend_filter: Optional[TrendFilter] = None
 risk_manager: Optional[RiskManager] = None
+open_long: bool = False
+open_short: bool = False
 
 def main() -> None:
     config = load_config()

--- a/tests/test_market_analysis.py
+++ b/tests/test_market_analysis.py
@@ -1,0 +1,57 @@
+import pandas as pd
+
+from utils.market_analysis import has_consecutive_move, price_above_ema
+import main
+
+
+class Dummy:
+    def collect(self):
+        return {}
+
+    def screen(self, data):
+        return data
+
+    def filter(self, data):
+        return data
+
+
+def test_has_consecutive_move():
+    df_up = pd.DataFrame({"close": [1, 2, 3, 4, 5, 6]})
+    assert has_consecutive_move(df_up, "up")
+    assert not has_consecutive_move(df_up, "down")
+    df_down = pd.DataFrame({"close": [6, 5, 4, 3, 2, 1]})
+    assert has_consecutive_move(df_down, "down")
+    assert not has_consecutive_move(df_down, "up")
+
+
+def test_price_above_ema():
+    df = pd.DataFrame({"close": list(range(1, 41))})
+    assert price_above_ema(df)
+    df2 = pd.DataFrame({"close": list(range(40, 0, -1))})
+    assert not price_above_ema(df2)
+
+
+def test_scan_and_enter_cancels_long(monkeypatch):
+    btc = pd.DataFrame({"close": [6, 5, 4, 3, 2, 1]})
+    eth = pd.DataFrame({"close": [6, 5, 4, 3, 2, 1]})
+    monkeypatch.setattr(main, "load_btc_eth_candles", lambda: {"BTC/USDT": btc, "ETH/USDT": eth})
+    main.data_collector = Dummy()
+    main.screener = Dummy()
+    main.trend_filter = Dummy()
+    main.open_long = True
+    main.open_short = False
+    main.scan_and_enter()
+    assert not main.open_long
+
+
+def test_scan_and_enter_cancels_short(monkeypatch):
+    btc = pd.DataFrame({"close": [1, 2, 3, 4, 5, 6]})
+    eth = pd.DataFrame({"close": [1, 2, 3, 4, 5, 6]})
+    monkeypatch.setattr(main, "load_btc_eth_candles", lambda: {"BTC/USDT": btc, "ETH/USDT": eth})
+    main.data_collector = Dummy()
+    main.screener = Dummy()
+    main.trend_filter = Dummy()
+    main.open_short = True
+    main.open_long = False
+    main.scan_and_enter()
+    assert not main.open_short

--- a/utils/market_analysis.py
+++ b/utils/market_analysis.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+"""Helpers for analysing market conditions using 5 minute candles.
+
+The module provides small utility functions to download recent candles for
+BTC and ETH and to evaluate simple trend conditions such as consecutive
+moves and the relation of price to a moving average.
+"""
+
+from typing import Dict, Iterable
+
+import ccxt
+import pandas as pd
+
+SYMBOLS: Iterable[str] = ("BTC/USDT", "ETH/USDT")
+
+
+def load_5m_candles(symbol: str, limit: int = 100, exchange: ccxt.Exchange | None = None) -> pd.DataFrame:
+    """Return recent 5 minute candles for ``symbol`` as a ``DataFrame``.
+
+    Parameters
+    ----------
+    symbol:
+        Market pair such as ``"BTC/USDT"``.
+    limit:
+        Number of candles to fetch.  Defaults to 100.
+    exchange:
+        Optional pre-configured ccxt exchange instance.  When ``None`` a
+        regular binance spot instance is created.
+    """
+
+    exchange = exchange or ccxt.binance()
+    ohlcv = exchange.fetch_ohlcv(symbol, timeframe="5m", limit=limit)
+    df = pd.DataFrame(ohlcv, columns=["timestamp", "open", "high", "low", "close", "volume"])
+    df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
+    return df
+
+
+def load_btc_eth_candles(limit: int = 100, exchange: ccxt.Exchange | None = None) -> Dict[str, pd.DataFrame]:
+    """Convenience wrapper returning candles for both BTC and ETH."""
+
+    return {symbol: load_5m_candles(symbol, limit, exchange) for symbol in SYMBOLS}
+
+
+def has_consecutive_move(df: pd.DataFrame, direction: str, minutes: int = 5) -> bool:
+    """Return ``True`` if the close moved ``direction`` for ``minutes`` candles.
+
+    ``direction`` may be ``"up"`` or ``"down"``.  The function looks at the
+    last ``minutes`` *completed* candles and ensures each close is greater or
+    smaller than the previous one accordingly.
+    """
+
+    if df is None or df.empty or len(df) < minutes + 1:
+        return False
+    closes = df["close"].tail(minutes + 1)
+    diffs = closes.diff().dropna()
+    if direction.lower() == "up":
+        return (diffs > 0).all()
+    if direction.lower() == "down":
+        return (diffs < 0).all()
+    raise ValueError("direction must be 'up' or 'down'")
+
+
+def price_above_ema(df: pd.DataFrame, period: int = 20) -> bool:
+    """Return ``True`` if the latest close is above its EMA."""
+
+    if df is None or df.empty:
+        return False
+    ema = df["close"].ewm(span=period, adjust=False).mean()
+    return df["close"].iloc[-1] > ema.iloc[-1]


### PR DESCRIPTION
## Summary
- add utilities to fetch 5m BTC/ETH candles, check consecutive moves and EMA comparison
- integrate trend checks in scan_and_enter and cancel long/short positions when conditions break
- cover new helpers and cancellation logic with tests

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688b7c38ae2883209d7e2b05ca33ed98