### PR TITLE
feat: increase allowed consecutive losses

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The project implements a multi-timeframe breakout system. OHLCV data is searched
 - **utils/breakout_signals.py** – evaluates whether price breaks above/below the most recent range with supporting volume, CVD, OI and funding filters, returning `Signal` objects【F:utils/breakout_signals.py†L3-L8】【F:utils/breakout_signals.py†L66-L111】.
 - **utils/ohlcv_fetcher.py** – downloads OHLCV candles via ccxt with retry logic and can update all symbols listed in the configuration【F:utils/ohlcv_fetcher.py†L1-L10】【F:utils/ohlcv_fetcher.py†L51-L66】.
 - **utils/futures_trader.py** – wraps ccxt futures APIs to submit market or limit-maker orders, manage TP/SL exits and log trades【F:utils/futures_trader.py†L3-L8】.
-- **utils/risk.py** – `RiskManager` enforces per-trade risk, total open risk, daily drawdown and consecutive loss limits【F:utils/risk.py†L11-L29】.
+- **utils/risk.py** – `RiskManager` enforces per-trade risk, total open risk, daily drawdown and consecutive loss limits (halts after 5 losses by default)【F:utils/risk.py†L11-L29】.
 - **utils/trade_logger.py** – appends executed trades to `trades.csv` and provides daily win rate, average RR and equity change summaries【F:utils/trade_logger.py†L3-L30】【F:utils/trade_logger.py†L33-L64】.
 - **main.py** – orchestrates live trading: collects data, screens for setups, applies trend filters, checks risk and sends daily summaries via Telegram【F:main.py†L18-L32】【F:main.py†L72-L94】.
 

--- a/utils/risk.py
+++ b/utils/risk.py
@@ -26,14 +26,14 @@ class RiskManager:
         trading is halted (default 5%).
     max_consecutive_losses:
         Number of consecutive losing trades before trading is halted
-        (default 3).
+        (default 5).
     """
 
     balance_fetcher: Callable[[], float]
     risk_per_trade_pct: float = 0.01
     max_open_risk_pct: float = 0.10
     daily_drawdown_pct: float = 0.05
-    max_consecutive_losses: int = 3
+    max_consecutive_losses: int = 5
     db_path: str | Path = "risk_state.db"
 
     open_positions: List[float] = field(default_factory=list)


### PR DESCRIPTION
## Summary
- raise default consecutive loss limit to 5 in `RiskManager`
- document new default in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b7f8379fc83209b7da6d16dd6897e