### PR TITLE
Add configuration loader and main bot entry point

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,11 @@
+api_keys:
+  binance: YOUR_BINANCE_API_KEY
+  secret: YOUR_BINANCE_SECRET
+thresholds:
+  buy_signal: 0.8
+  sell_signal: 0.2
+risk:
+  max_position_size: 1000
+  max_daily_loss: 500
+bot:
+  poll_interval: 5

--- a/main.py
+++ b/main.py
@@ -1,0 +1,70 @@
+"""Main entry point for the trading bot.
+
+This module loads configuration from ``config.yaml``, initializes
+background processing loops, and exposes the loaded configuration via the
+``CONFIG`` global so that other modules can access the settings.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+# Global configuration dictionary that other modules can import.
+CONFIG: Dict[str, Any] = {}
+
+
+def load_config(path: str = "config.yaml") -> None:
+    """Load YAML configuration into the global ``CONFIG`` variable.
+
+    Parameters
+    ----------
+    path:
+        Path to the configuration file. Defaults to ``config.yaml`` in the
+        current working directory.
+    """
+    global CONFIG
+    config_path = Path(path)
+    with config_path.open("r", encoding="utf-8") as f:
+        CONFIG = yaml.safe_load(f) or {}
+
+
+def initialize_bot() -> None:
+    """Placeholder for any initialization logic using ``CONFIG``."""
+    api_keys = CONFIG.get("api_keys", {})
+    print(f"Initializing bot with API keys: {list(api_keys.keys())}")
+
+
+def start_processing_loops() -> None:
+    """Start asynchronous processing loops."""
+
+    async def price_loop() -> None:
+        while True:
+            print(f"Processing with thresholds: {CONFIG.get('thresholds')}")
+            await asyncio.sleep(CONFIG.get("bot", {}).get("poll_interval", 1))
+
+    async def risk_loop() -> None:
+        while True:
+            print(f"Checking risk limits: {CONFIG.get('risk')}")
+            await asyncio.sleep(CONFIG.get("bot", {}).get("poll_interval", 1))
+
+    async def runner() -> None:
+        await asyncio.gather(price_loop(), risk_loop())
+
+    asyncio.run(runner())
+
+
+def main() -> None:
+    load_config()
+    initialize_bot()
+    start_processing_loops()
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("Bot stopped.")


### PR DESCRIPTION
## Summary
- Add `config.yaml` for API keys, thresholds, risk, and bot settings
- Implement `main.py` to load configuration and run processing loops

## Testing
- `python -m py_compile main.py utils/ohlcv_fetcher.py`
- `python - <<'PY'
import main, pprint
main.load_config()
pprint.pprint(main.CONFIG)
print('poll', main.CONFIG['bot']['poll_interval'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_688b9945b63c832086a9d1e12a62434a