### PR TITLE
Add exchange adapters for Binance and Bybit

### DIFF
--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -1,0 +1,99 @@
+"""Unified exchange interface for strategy modules.
+
+This package exposes helper functions :func:`configure`, :func:`place_order`,
+:func:`fetch_funding`, and :func:`get_orderbook` which delegate to the
+configured exchange implementation.
+
+Example
+-------
+>>> import exchanges
+>>> exchanges.configure("binance", api_key="key", api_secret="secret")
+>>> await exchanges.fetch_funding("BTCUSDT")
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict, Optional, Type
+
+# ---------------------------------------------------------------------------
+# Base interface
+# ---------------------------------------------------------------------------
+
+
+class BaseExchange(ABC):
+    """Abstract base class for exchange implementations."""
+
+    @abstractmethod
+    async def fetch_funding(self, symbol: str) -> float:
+        """Return the current funding rate for ``symbol``."""
+
+    @abstractmethod
+    async def place_order(
+        self, symbol: str, side: str, quantity: float, price: float | None = None
+    ) -> dict:
+        """Place an order and return exchange response."""
+
+    @abstractmethod
+    async def get_orderbook(self, symbol: str, depth: int = 5) -> dict:
+        """Return the latest order book for ``symbol``."""
+
+    @abstractmethod
+    async def get_balance(self) -> dict:
+        """Return account balance information."""
+
+
+# ---------------------------------------------------------------------------
+# Exchange factory and unified functions
+# ---------------------------------------------------------------------------
+
+_EXCHANGES: Dict[str, Type[BaseExchange]] = {}
+_current: Optional[BaseExchange] = None
+
+
+def register(name: str, cls: Type[BaseExchange]) -> None:
+    """Register an exchange implementation."""
+    _EXCHANGES[name.lower()] = cls
+
+
+def configure(name: str, **kwargs) -> None:
+    """Configure the active exchange by name."""
+    global _current
+    try:
+        cls = _EXCHANGES[name.lower()]
+    except KeyError as exc:  # pragma: no cover - defensive programming
+        raise ValueError(f"Unknown exchange: {name}") from exc
+    _current = cls(**kwargs)
+
+
+async def place_order(
+    symbol: str, side: str, quantity: float, price: float | None = None
+) -> dict:
+    """Place an order using the configured exchange."""
+    if _current is None:  # pragma: no cover - defensive programming
+        raise RuntimeError("Exchange not configured")
+    return await _current.place_order(symbol, side, quantity, price)
+
+
+async def fetch_funding(symbol: str) -> float:
+    """Fetch the funding rate for ``symbol`` from the configured exchange."""
+    if _current is None:  # pragma: no cover - defensive programming
+        raise RuntimeError("Exchange not configured")
+    return await _current.fetch_funding(symbol)
+
+
+async def get_orderbook(symbol: str, depth: int = 5) -> dict:
+    """Retrieve the latest order book from the configured exchange."""
+    if _current is None:  # pragma: no cover - defensive programming
+        raise RuntimeError("Exchange not configured")
+    return await _current.get_orderbook(symbol, depth)
+
+
+async def get_balance() -> dict:
+    """Return the account balance from the configured exchange."""
+    if _current is None:  # pragma: no cover - defensive programming
+        raise RuntimeError("Exchange not configured")
+    return await _current.get_balance()
+
+# Import built-in exchanges so they register themselves with the factory.
+from . import binance as _binance  # noqa: F401
+from . import bybit as _bybit  # noqa: F401

--- a/exchanges/binance.py
+++ b/exchanges/binance.py
@@ -1,0 +1,135 @@
+"""Binance exchange implementation."""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import time
+from typing import Any, Dict, Optional
+
+import aiohttp
+import websockets
+
+from . import BaseExchange, register
+
+
+class BinanceExchange(BaseExchange):
+    """Minimal Binance futures client supporting REST and WebSocket."""
+
+    REST_URL = "https://fapi.binance.com"
+    WS_URL = "wss://fstream.binance.com/ws"
+
+    def __init__(self, api_key: str, api_secret: str) -> None:
+        self.api_key = api_key
+        self.api_secret = api_secret
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._ws: Optional[websockets.WebSocketClientProtocol] = None
+        self._orderbooks: Dict[str, Dict[str, Any]] = {}
+        self._ws_tasks: Dict[str, asyncio.Task] = {}
+
+    # ------------------------------------------------------------------
+    # REST utilities
+    # ------------------------------------------------------------------
+
+    async def _session_get(self) -> aiohttp.ClientSession:
+        if self._session is None:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    def _sign(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        params = params.copy()
+        params["timestamp"] = int(time.time() * 1000)
+        query = "&".join(f"{k}={v}" for k, v in sorted(params.items()))
+        signature = hmac.new(
+            self.api_secret.encode(), query.encode(), hashlib.sha256
+        ).hexdigest()
+        params["signature"] = signature
+        return params
+
+    # ------------------------------------------------------------------
+    # Public methods
+    # ------------------------------------------------------------------
+
+    async def fetch_funding(self, symbol: str) -> float:
+        session = await self._session_get()
+        url = f"{self.REST_URL}/fapi/v1/fundingRate"
+        params = {"symbol": symbol, "limit": 1}
+        async with session.get(url, params=params) as resp:
+            data = await resp.json()
+        return float(data[0]["fundingRate"])
+
+    async def place_order(
+        self, symbol: str, side: str, quantity: float, price: float | None = None
+    ) -> dict:
+        session = await self._session_get()
+        url = f"{self.REST_URL}/fapi/v1/order"
+        params: Dict[str, Any] = {
+            "symbol": symbol,
+            "side": side,
+            "type": "MARKET" if price is None else "LIMIT",
+            "quantity": quantity,
+        }
+        if price is not None:
+            params.update({"price": price, "timeInForce": "GTC"})
+        headers = {"X-MBX-APIKEY": self.api_key}
+        params = self._sign(params)
+        async with session.post(url, params=params, headers=headers) as resp:
+            return await resp.json()
+
+    async def get_balance(self) -> dict:
+        session = await self._session_get()
+        url = f"{self.REST_URL}/fapi/v2/balance"
+        params = self._sign({})
+        headers = {"X-MBX-APIKEY": self.api_key}
+        async with session.get(url, params=params, headers=headers) as resp:
+            return await resp.json()
+
+    # ------------------------------------------------------------------
+    # WebSocket handling
+    # ------------------------------------------------------------------
+
+    async def _connect(self, symbol: str) -> websockets.WebSocketClientProtocol:
+        while True:
+            try:
+                return await websockets.connect(
+                    f"{self.WS_URL}/{symbol.lower()}@depth5@100ms"
+                )
+            except Exception:
+                await asyncio.sleep(5)
+
+    async def _listen(self, symbol: str) -> None:
+        while True:
+            try:
+                if self._ws is None:
+                    self._ws = await self._connect(symbol)
+                msg = await self._ws.recv()
+                data = json.loads(msg)
+                if "bids" in data and "asks" in data:
+                    self._orderbooks[symbol] = {
+                        "bids": data["bids"],
+                        "asks": data["asks"],
+                    }
+            except Exception:
+                await asyncio.sleep(1)
+                if self._ws is not None:
+                    try:
+                        await self._ws.close()
+                    except Exception:
+                        pass
+                self._ws = None
+
+    async def get_orderbook(self, symbol: str, depth: int = 5) -> dict:
+        if symbol not in self._ws_tasks:
+            self._ws_tasks[symbol] = asyncio.create_task(self._listen(symbol))
+        return self._orderbooks.get(symbol, {"bids": [], "asks": []})
+
+    async def __aexit__(self, *exc_info: Any) -> None:  # pragma: no cover
+        if self._session is not None:
+            await self._session.close()
+        if self._ws is not None:
+            await self._ws.close()
+
+
+# Register exchange
+register("binance", BinanceExchange)

--- a/exchanges/bybit.py
+++ b/exchanges/bybit.py
@@ -1,0 +1,143 @@
+"""Bybit exchange implementation."""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import time
+from typing import Any, Dict, Optional
+
+import aiohttp
+import websockets
+
+from . import BaseExchange, register
+
+
+class BybitExchange(BaseExchange):
+    """Minimal Bybit client supporting REST and WebSocket operations."""
+
+    REST_URL = "https://api.bybit.com"
+    WS_URL = "wss://stream.bybit.com/v5/public/linear"
+
+    def __init__(self, api_key: str, api_secret: str) -> None:
+        self.api_key = api_key
+        self.api_secret = api_secret
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._ws: Optional[websockets.WebSocketClientProtocol] = None
+        self._orderbooks: Dict[str, Dict[str, Any]] = {}
+        self._ws_tasks: Dict[str, asyncio.Task] = {}
+
+    # ------------------------------------------------------------------
+    # REST utilities
+    # ------------------------------------------------------------------
+
+    async def _session_get(self) -> aiohttp.ClientSession:
+        if self._session is None:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    def _sign(self, method: str, path: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        params = params.copy()
+        params["api_key"] = self.api_key
+        params["timestamp"] = int(time.time() * 1000)
+        query = "&".join(f"{k}={v}" for k, v in sorted(params.items()))
+        sign_str = method + path + query
+        signature = hmac.new(
+            self.api_secret.encode(), sign_str.encode(), hashlib.sha256
+        ).hexdigest()
+        params["sign"] = signature
+        return params
+
+    # ------------------------------------------------------------------
+    # Public methods
+    # ------------------------------------------------------------------
+
+    async def fetch_funding(self, symbol: str) -> float:
+        session = await self._session_get()
+        url = f"{self.REST_URL}/v5/market/funding/history"
+        params = {"symbol": symbol, "limit": 1}
+        async with session.get(url, params=params) as resp:
+            data = await resp.json()
+        return float(data["result"]["list"][0]["fundingRate"])
+
+    async def place_order(
+        self, symbol: str, side: str, quantity: float, price: float | None = None
+    ) -> dict:
+        session = await self._session_get()
+        url_path = "/v5/order/create"
+        url = f"{self.REST_URL}{url_path}"
+        body: Dict[str, Any] = {
+            "symbol": symbol,
+            "side": side,
+            "qty": quantity,
+            "orderType": "Market" if price is None else "Limit",
+        }
+        if price is not None:
+            body["price"] = price
+        headers = {"Content-Type": "application/json"}
+        body = self._sign("POST", url_path, body)
+        async with session.post(url, json=body, headers=headers) as resp:
+            return await resp.json()
+
+    async def get_balance(self) -> dict:
+        session = await self._session_get()
+        url_path = "/v5/account/wallet-balance"
+        url = f"{self.REST_URL}{url_path}"
+        params = self._sign("GET", url_path, {"accountType": "UNIFIED"})
+        async with session.get(url, params=params) as resp:
+            return await resp.json()
+
+    # ------------------------------------------------------------------
+    # WebSocket handling
+    # ------------------------------------------------------------------
+
+    async def _connect(self, symbol: str) -> websockets.WebSocketClientProtocol:
+        while True:
+            try:
+                ws = await websockets.connect(self.WS_URL)
+                sub = {
+                    "op": "subscribe",
+                    "args": [f"orderbook.1.{symbol}"],
+                }
+                await ws.send(json.dumps(sub))
+                return ws
+            except Exception:
+                await asyncio.sleep(5)
+
+    async def _listen(self, symbol: str) -> None:
+        while True:
+            try:
+                if self._ws is None:
+                    self._ws = await self._connect(symbol)
+                msg = await self._ws.recv()
+                data = json.loads(msg)
+                if data.get("topic", "").startswith("orderbook"):
+                    book = data.get("data") or {}
+                    self._orderbooks[symbol] = {
+                        "bids": book.get("b", []),
+                        "asks": book.get("a", []),
+                    }
+            except Exception:
+                await asyncio.sleep(1)
+                if self._ws is not None:
+                    try:
+                        await self._ws.close()
+                    except Exception:
+                        pass
+                self._ws = None
+
+    async def get_orderbook(self, symbol: str, depth: int = 5) -> dict:
+        if symbol not in self._ws_tasks:
+            self._ws_tasks[symbol] = asyncio.create_task(self._listen(symbol))
+        return self._orderbooks.get(symbol, {"bids": [], "asks": []})
+
+    async def __aexit__(self, *exc_info: Any) -> None:  # pragma: no cover
+        if self._session is not None:
+            await self._session.close()
+        if self._ws is not None:
+            await self._ws.close()
+
+
+# Register exchange
+register("bybit", BybitExchange)


### PR DESCRIPTION
## Summary
- Introduce `exchanges` package with a `BaseExchange` abstraction and unified helpers to configure an exchange and call `place_order`, `fetch_funding`, `get_orderbook`, and `get_balance`
- Implement Binance REST/WebSocket client featuring funding rate retrieval, order placement, balance queries, and auto-reconnecting order book listener
- Implement equivalent Bybit client with REST and WebSocket support

## Testing
- `python -m py_compile exchanges/__init__.py exchanges/binance.py exchanges/bybit.py`


------
https://chatgpt.com/codex/tasks/task_e_688b9a7dc5dc8320a2d83f559d7a56a8