### PR TITLE
Add funding arbitrage strategy helpers

### DIFF
--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,0 +1,1 @@
+"""Strategy modules for the trading bot."""

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -1,0 +1,113 @@
+"""Utilities for a funding-rate arbitrage strategy.
+
+This module contains helpers for evaluating entry and exit conditions based on
+funding rates and simple market microstructure metrics.  It also provides
+helpers to open and monitor neutral long/short positions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Dict
+
+from exchanges import fetch_funding, get_orderbook, place_order
+
+
+@dataclass
+class MarketMetrics:
+    """Container for market metrics relevant to the strategy."""
+
+    funding_rate: float
+    spread: float
+    liquidity: float
+    volatility: float
+
+
+async def get_market_metrics(symbol: str, depth: int = 5) -> MarketMetrics:
+    """Fetch funding, spread, liquidity and a naive volatility estimate.
+
+    Parameters
+    ----------
+    symbol:
+        Trading pair symbol understood by the configured exchange.
+    depth:
+        Order book depth to request for liquidity calculations.  Defaults to 5.
+    """
+    funding = await fetch_funding(symbol)
+    orderbook = await get_orderbook(symbol, depth=depth)
+    bids = [(float(p), float(q)) for p, q in orderbook.get("bids", [])]
+    asks = [(float(p), float(q)) for p, q in orderbook.get("asks", [])]
+
+    if bids and asks:
+        spread = asks[0][0] - bids[0][0]
+        mid = (asks[0][0] + bids[0][0]) / 2
+        volatility = spread / mid if mid else float("inf")
+    else:
+        spread = float("inf")
+        volatility = float("inf")
+
+    liquidity = sum(q for _, q in bids) + sum(q for _, q in asks)
+    return MarketMetrics(funding, spread, liquidity, volatility)
+
+
+# ---------------------------------------------------------------------------
+# Condition checks
+# ---------------------------------------------------------------------------
+
+def check_entry_conditions(metrics: MarketMetrics, thresholds: Dict[str, float]) -> bool:
+    """Return ``True`` if all entry thresholds are satisfied."""
+    return (
+        abs(metrics.funding_rate) >= thresholds.get("funding_rate", 0.0)
+        and metrics.spread <= thresholds.get("spread", float("inf"))
+        and metrics.liquidity >= thresholds.get("liquidity", 0.0)
+        and metrics.volatility <= thresholds.get("volatility", float("inf"))
+    )
+
+
+def check_exit_conditions(metrics: MarketMetrics, thresholds: Dict[str, float]) -> bool:
+    """Return ``True`` if any exit condition is met."""
+    return (
+        abs(metrics.funding_rate) <= thresholds.get("funding_rate", float("inf"))
+        or metrics.spread >= thresholds.get("spread", float("-inf"))
+        or metrics.liquidity <= thresholds.get("liquidity", float("inf"))
+        or metrics.volatility >= thresholds.get("volatility", float("-inf"))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Position management
+# ---------------------------------------------------------------------------
+
+async def open_neutral_position(symbol: str, quantity: float) -> Dict[str, Dict]:
+    """Open offsetting long and short positions.
+
+    This naive implementation simply places a buy and a sell market order for
+    ``quantity`` units of ``symbol``.  Real-world usage should handle errors and
+    slippage appropriately.
+    """
+    long_order = await place_order(symbol, "BUY", quantity)
+    short_order = await place_order(symbol, "SELL", quantity)
+    return {"long": long_order, "short": short_order}
+
+
+async def close_neutral_position(symbol: str, quantity: float) -> Dict[str, Dict]:
+    """Close an existing neutral position by reversing both legs."""
+    close_long = await place_order(symbol, "SELL", quantity)
+    close_short = await place_order(symbol, "BUY", quantity)
+    return {"long": close_long, "short": close_short}
+
+
+async def monitor_neutral_position(
+    symbol: str,
+    quantity: float,
+    exit_thresholds: Dict[str, float],
+    poll_interval: float = 5.0,
+) -> None:
+    """Monitor a neutral position and close it when exit criteria are met."""
+    while True:
+        metrics = await get_market_metrics(symbol)
+        if check_exit_conditions(metrics, exit_thresholds):
+            await close_neutral_position(symbol, quantity)
+            break
+        await asyncio.sleep(poll_interval)


### PR DESCRIPTION
## Summary
- add `strategies` package with funding arbitrage utilities
- implement entry/exit checks for funding rate, spread, liquidity and volatility
- provide helpers to open/monitor neutral positions

## Testing
- `python -m py_compile strategies/__init__.py strategies/funding_arbitrage.py`


------
https://chatgpt.com/codex/tasks/task_e_688b9ba53aa08320bfb434706bc05d58