### PR TITLE
Add risk management module and integrate checks

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,5 +7,6 @@ thresholds:
 risk:
   max_position_size: 1000
   max_daily_loss: 500
+  max_consecutive_losses: 3
 bot:
   poll_interval: 5

--- a/main.py
+++ b/main.py
@@ -13,6 +13,8 @@ from typing import Any, Dict
 
 import yaml
 
+from risk import risk_control
+
 # Global configuration dictionary that other modules can import.
 CONFIG: Dict[str, Any] = {}
 
@@ -36,6 +38,7 @@ def initialize_bot() -> None:
     """Placeholder for any initialization logic using ``CONFIG``."""
     api_keys = CONFIG.get("api_keys", {})
     print(f"Initializing bot with API keys: {list(api_keys.keys())}")
+    risk_control.configure(CONFIG.get("risk", {}))
 
 
 def start_processing_loops() -> None:

--- a/risk/__init__.py
+++ b/risk/__init__.py
@@ -1,0 +1,1 @@
+"""Risk management package."""

--- a/risk/risk_control.py
+++ b/risk/risk_control.py
@@ -1,0 +1,80 @@
+"""Basic risk management helpers.
+
+This module tracks position sizes, accumulated losses, and consecutive
+losing trades.  Trading can be paused when risk limits are violated.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class RiskLimits:
+    """Configuration for risk checks."""
+
+    max_position_size: float = float("inf")
+    max_daily_loss: float = float("inf")
+    max_consecutive_losses: int = float("inf")
+
+
+@dataclass
+class RiskState:
+    """Runtime risk state tracked across trades."""
+
+    current_position: float = 0.0
+    daily_loss: float = 0.0
+    consecutive_losses: int = 0
+    paused: bool = False
+
+
+_limits = RiskLimits()
+_state = RiskState()
+
+
+def configure(config: Dict[str, float]) -> None:
+    """Configure risk limits from a dictionary."""
+
+    global _limits
+    _limits = RiskLimits(
+        max_position_size=config.get("max_position_size", float("inf")),
+        max_daily_loss=config.get("max_daily_loss", float("inf")),
+        max_consecutive_losses=config.get("max_consecutive_losses", float("inf")),
+    )
+
+
+def can_open_position(quantity: float) -> bool:
+    """Return ``True`` if a new position of ``quantity`` is allowed."""
+
+    if _state.paused:
+        return False
+    if _state.current_position + quantity > _limits.max_position_size:
+        return False
+    if _state.daily_loss >= _limits.max_daily_loss:
+        return False
+    return True
+
+
+def update_position(delta: float) -> None:
+    """Update the tracked position size by ``delta`` units."""
+
+    _state.current_position = max(_state.current_position + delta, 0.0)
+
+
+def record_pnl(pnl: float) -> None:
+    """Record the profit or loss from a completed trade."""
+
+    if pnl < 0:
+        _state.daily_loss += abs(pnl)
+        _state.consecutive_losses += 1
+        if _state.consecutive_losses >= _limits.max_consecutive_losses:
+            _state.paused = True
+    else:
+        _state.consecutive_losses = 0
+
+
+def is_paused() -> bool:
+    """Return ``True`` if trading is currently paused."""
+
+    return _state.paused

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import Dict
 
 from exchanges import fetch_funding, get_orderbook, place_order
+from risk import risk_control
 
 
 @dataclass
@@ -86,15 +87,22 @@ async def open_neutral_position(symbol: str, quantity: float) -> Dict[str, Dict]
     ``quantity`` units of ``symbol``.  Real-world usage should handle errors and
     slippage appropriately.
     """
+    if not risk_control.can_open_position(quantity):
+        raise RuntimeError("Risk limits exceeded or trading paused")
     long_order = await place_order(symbol, "BUY", quantity)
     short_order = await place_order(symbol, "SELL", quantity)
+    risk_control.update_position(quantity)
     return {"long": long_order, "short": short_order}
 
 
-async def close_neutral_position(symbol: str, quantity: float) -> Dict[str, Dict]:
-    """Close an existing neutral position by reversing both legs."""
+async def close_neutral_position(
+    symbol: str, quantity: float, pnl: float = 0.0
+) -> Dict[str, Dict]:
+    """Close an existing neutral position and record PnL."""
     close_long = await place_order(symbol, "SELL", quantity)
     close_short = await place_order(symbol, "BUY", quantity)
+    risk_control.update_position(-quantity)
+    risk_control.record_pnl(pnl)
     return {"long": close_long, "short": close_short}
 
 


### PR DESCRIPTION
## Summary
- introduce risk control module enforcing position caps and loss limits while tracking consecutive losses for pause logic
- wire risk configuration at startup and add max_consecutive_losses setting
- apply risk checks in funding arbitrage strategy before placing orders

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688b9cb06f348320ae7b9b2201584a1f