### PR TITLE
feat: add parameter optimizer and dynamic thresholds

### DIFF
--- a/ai/__init__.py
+++ b/ai/__init__.py
@@ -1,0 +1,1 @@
+"""AI utilities for adaptive trading parameters."""

--- a/ai/parameter_optimizer.py
+++ b/ai/parameter_optimizer.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import asyncio
+import random
+from pathlib import Path
+from typing import Dict
+
+import pandas as pd
+from joblib import dump, load
+
+from utils.logger import LOG_PATH
+
+# Default location where optimized thresholds are stored
+DEFAULT_OUTPUT = Path("data") / "optimized_thresholds.joblib"
+
+
+def analyze_trade_history(log_path: Path = LOG_PATH) -> Dict[str, float]:
+    """Analyze trade history and compute new parameter thresholds.
+
+    This simplistic optimizer looks at historical funding rates and
+    derives a new threshold based on the 75th percentile of absolute
+    funding values from profitable trades.
+    """
+    if not log_path.exists():
+        return {}
+    df = pd.read_excel(log_path)
+    if df.empty or "funding" not in df.columns:
+        return {}
+    if "pnl" in df.columns:
+        df = df[df["pnl"] > 0]
+    funding_threshold = df["funding"].abs().quantile(0.75)
+    return {"funding_rate": float(funding_threshold)}
+
+
+def optimize_and_save(
+    log_path: Path = LOG_PATH, out_path: Path = DEFAULT_OUTPUT
+) -> Dict[str, float]:
+    """Run optimization on trade history and persist the result using joblib."""
+    thresholds = analyze_trade_history(log_path)
+    if thresholds:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        dump(thresholds, out_path)
+    return thresholds
+
+
+async def periodic_optimization(
+    min_hours: int = 24,
+    max_hours: int = 48,
+    log_path: Path = LOG_PATH,
+    out_path: Path = DEFAULT_OUTPUT,
+) -> None:
+    """Periodically optimize parameters every 24–48 hours."""
+    while True:
+        optimize_and_save(log_path, out_path)
+        wait_hours = random.randint(min_hours, max_hours)
+        await asyncio.sleep(wait_hours * 3600)
+
+
+def load_thresholds(defaults: Dict[str, float], path: Path = DEFAULT_OUTPUT) -> Dict[str, float]:
+    """Load optimized thresholds and merge with ``defaults``."""
+    try:
+        data = load(path)
+        if isinstance(data, dict):
+            return {**defaults, **data}
+    except Exception:
+        pass
+    return defaults
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    asyncio.run(periodic_optimization())

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ from typing import Any, Dict
 import yaml
 
 from risk import risk_control
+from strategies.funding_arbitrage import get_thresholds
 
 # Global configuration dictionary that other modules can import.
 CONFIG: Dict[str, Any] = {}
@@ -32,6 +33,7 @@ def load_config(path: str = "config.yaml") -> None:
     config_path = Path(path)
     with config_path.open("r", encoding="utf-8") as f:
         CONFIG = yaml.safe_load(f) or {}
+    CONFIG["thresholds"] = get_thresholds(CONFIG.get("thresholds", {}))
 
 
 def initialize_bot() -> None:

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -13,6 +13,7 @@ from typing import Dict
 
 from exchanges import fetch_funding, get_orderbook, place_order
 from risk import risk_control
+from ai.parameter_optimizer import load_thresholds as _load_thresholds
 
 
 @dataclass
@@ -119,3 +120,20 @@ async def monitor_neutral_position(
             await close_neutral_position(symbol, quantity)
             break
         await asyncio.sleep(poll_interval)
+
+
+# ---------------------------------------------------------------------------
+# Dynamic parameter loading
+# ---------------------------------------------------------------------------
+
+def get_thresholds(config_thresholds: Dict[str, float]) -> Dict[str, float]:
+    """Return strategy thresholds merged with any optimized values.
+
+    Parameters
+    ----------
+    config_thresholds:
+        Thresholds configured in ``config.yaml``.  Values produced by the
+        optimizer take precedence over these defaults.
+    """
+
+    return _load_thresholds(config_thresholds)


### PR DESCRIPTION
## Summary
- add parameter optimizer using pandas and joblib to update thresholds periodically
- allow funding strategy to merge optimized thresholds
- load optimized thresholds into main config at startup

## Testing
- `python -m pip install pandas joblib openpyxl >/tmp/pip.log && tail -n 20 /tmp/pip.log`
- `python -m py_compile ai/parameter_optimizer.py strategies/funding_arbitrage.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_688ba0a232148320a3040bc20e4ad8a6