### PR TITLE
Add hedge rollback and API watchdog

### DIFF
--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -12,6 +12,7 @@ Example
 """
 from __future__ import annotations
 
+import asyncio
 from abc import ABC, abstractmethod
 from typing import Dict, Optional, Type
 
@@ -48,6 +49,7 @@ class BaseExchange(ABC):
 
 _EXCHANGES: Dict[str, Type[BaseExchange]] = {}
 _current: Optional[BaseExchange] = None
+API_TIMEOUT = 30
 
 
 def register(name: str, cls: Type[BaseExchange]) -> None:
@@ -71,28 +73,51 @@ async def place_order(
     """Place an order using the configured exchange."""
     if _current is None:  # pragma: no cover - defensive programming
         raise RuntimeError("Exchange not configured")
-    return await _current.place_order(symbol, side, quantity, price)
+    return await asyncio.wait_for(
+        _current.place_order(symbol, side, quantity, price), API_TIMEOUT
+    )
 
 
 async def fetch_funding(symbol: str) -> float:
     """Fetch the funding rate for ``symbol`` from the configured exchange."""
     if _current is None:  # pragma: no cover - defensive programming
         raise RuntimeError("Exchange not configured")
-    return await _current.fetch_funding(symbol)
+    return await asyncio.wait_for(_current.fetch_funding(symbol), API_TIMEOUT)
 
 
 async def get_orderbook(symbol: str, depth: int = 5) -> dict:
     """Retrieve the latest order book from the configured exchange."""
     if _current is None:  # pragma: no cover - defensive programming
         raise RuntimeError("Exchange not configured")
-    return await _current.get_orderbook(symbol, depth)
+    return await asyncio.wait_for(
+        _current.get_orderbook(symbol, depth), API_TIMEOUT
+    )
 
 
 async def get_balance() -> dict:
     """Return the account balance from the configured exchange."""
     if _current is None:  # pragma: no cover - defensive programming
         raise RuntimeError("Exchange not configured")
-    return await _current.get_balance()
+    return await asyncio.wait_for(_current.get_balance(), API_TIMEOUT)
+
+
+async def hedge(symbol: str, quantity: float) -> Dict[str, Dict]:
+    """Place offsetting buy and sell orders with rollback on failure."""
+
+    if _current is None:  # pragma: no cover - defensive programming
+        raise RuntimeError("Exchange not configured")
+
+    long_order: Dict = await place_order(symbol, "BUY", quantity)
+    try:
+        short_order: Dict = await place_order(symbol, "SELL", quantity)
+    except Exception as exc:
+        # Attempt to rollback the long leg if the short leg fails
+        try:
+            await place_order(symbol, "SELL", quantity)
+        finally:
+            pass
+        raise RuntimeError("Hedge placement failed; long leg rolled back") from exc
+    return {"long": long_order, "short": short_order}
 
 # Import built-in exchanges so they register themselves with the factory.
 from . import binance as _binance  # noqa: F401

--- a/risk/risk_control.py
+++ b/risk/risk_control.py
@@ -6,8 +6,8 @@ losing trades.  Trading can be paused when risk limits are violated.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Dict
+from dataclasses import dataclass, field
+from typing import Dict, Set
 
 
 @dataclass
@@ -27,6 +27,7 @@ class RiskState:
     daily_loss: float = 0.0
     consecutive_losses: int = 0
     paused: bool = False
+    open_symbols: Set[str] = field(default_factory=set)
 
 
 _limits = RiskLimits()
@@ -60,6 +61,24 @@ def update_position(delta: float) -> None:
     """Update the tracked position size by ``delta`` units."""
 
     _state.current_position = max(_state.current_position + delta, 0.0)
+
+
+def is_symbol_open(symbol: str) -> bool:
+    """Return ``True`` if a position for ``symbol`` is currently open."""
+
+    return symbol in _state.open_symbols
+
+
+def mark_symbol_open(symbol: str) -> None:
+    """Record ``symbol`` as having an open position."""
+
+    _state.open_symbols.add(symbol)
+
+
+def mark_symbol_closed(symbol: str) -> None:
+    """Remove ``symbol`` from the set of open positions."""
+
+    _state.open_symbols.discard(symbol)
 
 
 def record_pnl(pnl: float) -> None:

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -11,7 +11,7 @@ import asyncio
 from dataclasses import dataclass
 from typing import Dict
 
-from exchanges import fetch_funding, get_orderbook, place_order
+from exchanges import fetch_funding, get_orderbook, hedge, place_order
 from risk import risk_control
 from ai.parameter_optimizer import load_thresholds as _load_thresholds
 
@@ -88,12 +88,12 @@ async def open_neutral_position(symbol: str, quantity: float) -> Dict[str, Dict]
     ``quantity`` units of ``symbol``.  Real-world usage should handle errors and
     slippage appropriately.
     """
-    if not risk_control.can_open_position(quantity):
-        raise RuntimeError("Risk limits exceeded or trading paused")
-    long_order = await place_order(symbol, "BUY", quantity)
-    short_order = await place_order(symbol, "SELL", quantity)
+    if not risk_control.can_open_position(quantity) or risk_control.is_symbol_open(symbol):
+        raise RuntimeError("Risk limits exceeded, trading paused, or position exists")
+    orders = await hedge(symbol, quantity)
     risk_control.update_position(quantity)
-    return {"long": long_order, "short": short_order}
+    risk_control.mark_symbol_open(symbol)
+    return orders
 
 
 async def close_neutral_position(
@@ -101,9 +101,15 @@ async def close_neutral_position(
 ) -> Dict[str, Dict]:
     """Close an existing neutral position and record PnL."""
     close_long = await place_order(symbol, "SELL", quantity)
-    close_short = await place_order(symbol, "BUY", quantity)
+    try:
+        close_short = await place_order(symbol, "BUY", quantity)
+    except Exception as exc:
+        # Rollback long close to restore neutrality
+        await place_order(symbol, "BUY", quantity)
+        raise RuntimeError("Failed to close hedge; rolled back long leg") from exc
     risk_control.update_position(-quantity)
     risk_control.record_pnl(pnl)
+    risk_control.mark_symbol_closed(symbol)
     return {"long": close_long, "short": close_short}
 
 
@@ -115,7 +121,11 @@ async def monitor_neutral_position(
 ) -> None:
     """Monitor a neutral position and close it when exit criteria are met."""
     while True:
-        metrics = await get_market_metrics(symbol)
+        try:
+            metrics = await get_market_metrics(symbol)
+        except asyncio.TimeoutError:
+            await close_neutral_position(symbol, quantity)
+            break
         if check_exit_conditions(metrics, exit_thresholds):
             await close_neutral_position(symbol, quantity)
             break


### PR DESCRIPTION
## Summary
- add open symbol tracking in risk control to avoid duplicate positions
- enforce 30s API timeouts and provide hedged order helper with rollback
- update funding arbitrage strategy for safe hedging and timeout monitoring

## Testing
- `python -m py_compile risk/risk_control.py exchanges/__init__.py strategies/funding_arbitrage.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ba92451f88320919923c275582f0d