### PR TITLE
Plot equity curve after backtests

### DIFF
--- a/backtester.py
+++ b/backtester.py
@@ -24,6 +24,7 @@ import numpy as np
 
 from utils.range_clusters import find_tight_range_clusters
 from utils.breakout_signals import evaluate_breakout, Signal
+from utils.plotting import plot_equity
 
 
 @dataclass
@@ -92,6 +93,7 @@ def run_backtest(
     *,
     data_dir: str | Path = "data/raw_data",
     trades_path: str | Path = "trades.csv",
+    equity_path: str | Path | None = None,
 ) -> dict:
     """Run a simple breakout backtest and return summary statistics."""
 
@@ -249,6 +251,12 @@ def run_backtest(
 
     trades_df = pd.DataFrame([asdict(t) for t in trades])
     trades_df.to_csv(trades_path, index=False)
+
+    if not trades_df.empty:
+        fig = plot_equity(trades_df, price=df)
+        equity_path = Path(equity_path) if equity_path is not None else Path("data") / "equity.png"
+        equity_path.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(equity_path)
 
     winrate = wins / len(trades) if trades else 0.0
     avg_rr = sum(rr_list) / len(rr_list) if rr_list else 0.0

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -31,7 +31,10 @@ def test_backtester_produces_trade(tmp_path):
     create_sample_data(csv_path)
 
     trades_path = tmp_path / "trades.csv"
-    stats = run_backtest("ETHUSDT", data_dir=data_dir, trades_path=trades_path)
+    equity_path = tmp_path / "equity.png"
+    stats = run_backtest(
+        "ETHUSDT", data_dir=data_dir, trades_path=trades_path, equity_path=equity_path
+    )
     trades = pd.read_csv(trades_path)
 
     # two exit events: partial at tp1 and trailing stop for the rest
@@ -45,3 +48,4 @@ def test_backtester_produces_trade(tmp_path):
     assert trades.loc[1, "trail"] > trades.loc[0, "trail"]
     # reported pnl equals sum of individual trade pnls
     assert abs(trades["pnl"].sum() - stats["pnl"]) < 1e-6
+    assert equity_path.exists()


### PR DESCRIPTION
## Summary
- Plot equity and drawdown curves after backtest execution.
- Allow saving the equity figure to a configurable path with default under `data/`.
- Extend tests to verify equity plot generation.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ba92bc7548320870b40109204540f