### PR TITLE
Handle open interest deltas in breakout signals

### DIFF
--- a/backtester.py
+++ b/backtester.py
@@ -80,6 +80,7 @@ def compute_indicators(df: pd.DataFrame) -> pd.DataFrame:
     direction = np.where(change > 0, 1, np.where(change < 0, -1, 0))
     df["cvd"] = (direction * df["volume"].astype(float)).cumsum()
     df["oi"] = df.get("open_interest", pd.Series(0, index=df.index)).astype(float)
+    df["delta_oi"] = df["oi"].diff().fillna(0)
     df["avg_volume"] = df["volume"].rolling(20).mean()
     if "funding" not in df.columns:
         df["funding"] = 0.0
@@ -226,14 +227,14 @@ def run_backtest(
             continue
         level = clusters.iloc[[-1]][["high", "low"]]
         cvd_series = window["cvd"]
-        oi_series = window["oi"]
+        delta_oi_series = window["delta_oi"]
         volume_stats = pd.Series({"avg_volume": window["avg_volume"].iloc[-1]})
         funding = float(window["funding"].iloc[-1])
         signals = evaluate_breakout(
             window[["open", "high", "low", "close", "volume"]],
             level,
             cvd_series,
-            oi_series,
+            delta_oi_series,
             volume_stats,
             funding,
         )

--- a/main.py
+++ b/main.py
@@ -69,16 +69,42 @@ class DataCollector:
                 vol_delta = 0.0
 
             try:
-                oi_info = self.exchange.fetch_open_interest(symbol)
-                open_interest = float(
-                    oi_info.get("openInterestAmount")
-                    or oi_info.get("openInterest")
-                    or oi_info.get("openInterestValue")
-                    or 0.0
+                limit = len(df) if not df.empty else 100
+                oi_hist = self.exchange.fetch_open_interest_history(
+                    symbol, timeframe="5m", limit=limit
                 )
+                oi_df = pd.DataFrame(oi_hist)
+                if not oi_df.empty:
+                    oi_df["timestamp"] = pd.to_datetime(oi_df["timestamp"], unit="ms")
+                    oi_col = next(
+                        (
+                            c
+                            for c in [
+                                "openInterest",
+                                "openInterestAmount",
+                                "openInterestValue",
+                            ]
+                            if c in oi_df.columns
+                        ),
+                        None,
+                    )
+                    if oi_col is not None:
+                        oi_series = oi_df.set_index("timestamp")[oi_col].astype(float)
+                        if not df.empty:
+                            oi_series = oi_series.reindex(df["timestamp"]).fillna(method="ffill")
+                        delta_oi = oi_series.diff().fillna(0)
+                    else:
+                        oi_series = pd.Series(dtype="float64")
+                        delta_oi = pd.Series(dtype="float64")
+                else:
+                    oi_series = pd.Series(dtype="float64")
+                    delta_oi = pd.Series(dtype="float64")
             except Exception:
-                logging.exception("Failed to fetch open interest for %s", symbol)
-                open_interest = 0.0
+                logging.exception(
+                    "Failed to fetch open interest history for %s", symbol
+                )
+                oi_series = pd.Series(dtype="float64")
+                delta_oi = pd.Series(dtype="float64")
 
             try:
                 fr = self.exchange.fetch_funding_rate(symbol)
@@ -94,7 +120,8 @@ class DataCollector:
                 "ohlcv": df,
                 "cvd": cvd,
                 "volume_delta": vol_delta,
-                "open_interest": open_interest,
+                "open_interest": oi_series,
+                "delta_oi": delta_oi,
                 "funding_rate": funding_rate,
             }
 
@@ -236,14 +263,14 @@ def scan_and_enter() -> None:
         levels = clusters.iloc[[-1]][["high", "low"]]
         cvd = info.get("cvd", pd.Series(dtype="float64"))
         cvd = cvd.reindex(ohlcv.index).fillna(method="ffill").fillna(0)
-        oi_val = float(info.get("open_interest", 0.0))
-        oi = pd.Series([oi_val] * len(ohlcv), index=ohlcv.index)
+        delta_oi = info.get("delta_oi", pd.Series(dtype="float64"))
+        delta_oi = delta_oi.reindex(ohlcv.index).fillna(0)
         funding = float(info.get("funding_rate", 0.0))
         signals = evaluate_breakout(
             ohlcv[["open", "high", "low", "close", "volume"]],
             levels,
             cvd,
-            oi,
+            delta_oi,
             pd.Series(dtype="float64"),
             funding,
         )

--- a/tests/test_breakout_signals.py
+++ b/tests/test_breakout_signals.py
@@ -27,10 +27,11 @@ def test_long_breakout_signal():
     cluster = pd.DataFrame({"high": [102], "low": [98]})
     cvd = pd.Series([1, 2, 3, 4, 6], index=idx)
     oi = pd.Series([100, 102, 103, 105, 110], index=idx)
+    delta_oi = oi.diff().fillna(0)
     volume_stats = pd.Series({"avg_volume": 120})
     funding = 0.005
 
-    signals = evaluate_breakout(ohlcv, cluster, cvd, oi, volume_stats, funding)
+    signals = evaluate_breakout(ohlcv, cluster, cvd, delta_oi, volume_stats, funding)
     assert signals, "Expected a breakout signal"
     sig = signals[0]
     assert isinstance(sig, Signal)
@@ -56,11 +57,12 @@ def test_breakout_blocked_by_trend_filter():
     cluster = pd.DataFrame({"high": [102], "low": [98]})
     cvd = pd.Series([1, 2, 3, 4, 6], index=idx)
     oi = pd.Series([100, 102, 103, 105, 110], index=idx)
+    delta_oi = oi.diff().fillna(0)
     volume_stats = pd.Series({"avg_volume": 120})
     funding = 0.005
 
     # Trend filter should block this potential breakout
-    signals = evaluate_breakout(ohlcv, cluster, cvd, oi, volume_stats, funding)
+    signals = evaluate_breakout(ohlcv, cluster, cvd, delta_oi, volume_stats, funding)
     assert signals == []
 
 

--- a/tests/test_trading_logic.py
+++ b/tests/test_trading_logic.py
@@ -72,7 +72,8 @@ def test_scan_and_enter_executes_long(monkeypatch):
         "ohlcv": ohlcv,
         "cvd": cvd,
         "volume_delta": 0.0,
-        "open_interest": 10.0,
+        "open_interest": pd.Series([10, 11], index=timestamps),
+        "delta_oi": pd.Series([0, 1], index=timestamps),
         "funding_rate": 0.0,
     }
     main.data_collector = DummyCollector({symbol: info})
@@ -91,7 +92,7 @@ def test_scan_and_enter_executes_long(monkeypatch):
     monkeypatch.setattr(
         main,
         "evaluate_breakout",
-        lambda ohlcv, level, cvd, oi, volume_stats, funding: [Signal("long", 101, 99, 103, 105)],
+        lambda ohlcv, level, cvd, delta_oi, volume_stats, funding: [Signal("long", 101, 99, 103, 105)],
     )
 
     main.open_long = False

--- a/utils/breakout_signals.py
+++ b/utils/breakout_signals.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 """Breakout evaluation utilities.
 
 This module provides a function to evaluate breakout conditions using
-market data, cluster levels, cumulative volume delta (CVD), open interest
-(OI) and volume statistics.  The resulting signals describe potential
-trades with entry, stop and take profit levels.
+market data, cluster levels, cumulative volume delta (CVD), changes in
+open interest (ΔOI) and volume statistics.  The resulting signals
+describe potential trades with entry, stop and take profit levels.
 """
 
 from dataclasses import dataclass
@@ -67,7 +67,7 @@ def evaluate_breakout(
     ohlcv: pd.DataFrame,
     cluster_levels: pd.DataFrame,
     cvd: pd.Series,
-    oi: pd.Series,
+    delta_oi: pd.Series,
     volume_stats: pd.Series,
     funding: float,
     *,
@@ -88,8 +88,9 @@ def evaluate_breakout(
         columns.
     cvd:
         Cumulative volume delta series aligned with ``ohlcv``.
-    oi:
-        Open interest series aligned with ``ohlcv``.
+    delta_oi:
+        Change in open interest aligned with ``ohlcv``. Positive values
+        indicate increasing participation.
     volume_stats:
         Deprecated.  Retained for backward compatibility but ignored.
     funding:
@@ -135,9 +136,8 @@ def evaluate_breakout(
     funding_ok_long = funding <= funding_limit
     funding_ok_short = funding >= -funding_limit
 
-    delta_oi = oi.diff().iloc[-1]
-    oi_ok_long = delta_oi >= delta_oi_thresh
-    oi_ok_short = delta_oi <= -delta_oi_thresh
+    delta_oi_last = delta_oi.iloc[-1] if not delta_oi.empty else 0.0
+    oi_ok = delta_oi_last > delta_oi_thresh
 
     cvd_smoothed = cvd.ewm(span=3, adjust=False).mean()
     cvd_delta = cvd_smoothed.diff().iloc[-1]
@@ -152,7 +152,7 @@ def evaluate_breakout(
         and vol_ok
         and ema_bull
         and funding_ok_long
-        and oi_ok_long
+        and oi_ok
         and cvd_ok_long
         and allow_long(df)
     ):
@@ -175,7 +175,7 @@ def evaluate_breakout(
         and vol_ok
         and ema_bear
         and funding_ok_short
-        and oi_ok_short
+        and oi_ok
         and cvd_ok_short
         and allow_short(df)
     ):


### PR DESCRIPTION
## Summary
- Build an open-interest history in `DataCollector.collect` and derive a ΔOI series
- Require positive ΔOI for both long and short breakouts
- Feed the ΔOI series through `scan_and_enter` into breakout evaluation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bb22b69bc83208f34830f38d2f9c6