### PR TITLE
Add risk exposure limits and exchange timeout handling

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,6 +16,8 @@ risk:
   max_position_size: 1000
   max_daily_loss: 500
   max_consecutive_losses: 3
+  max_open_positions: 5
+  deposit_cap_pct: 0.3
 bot:
   poll_interval: 5
   whitelist:

--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -16,9 +16,13 @@ import asyncio
 from abc import ABC, abstractmethod
 import logging
 import time
-from typing import Dict, Optional, Type
+from typing import Any, Coroutine, Dict, Optional, Set, Tuple, Type
+
+from risk import risk_control
 
 logger = logging.getLogger(__name__)
+
+_OUTSTANDING: Set[Tuple[str, str]] = set()
 
 # ---------------------------------------------------------------------------
 # Base interface
@@ -100,14 +104,46 @@ def configure(name: str, **kwargs) -> None:
     _current = cls(**kwargs)
 
 
+async def _handle_timeout() -> None:
+    """Cancel all outstanding orders and pause trading."""
+
+    logger.error("API call exceeded %s seconds; cancelling outstanding orders", API_TIMEOUT)
+    if _current is not None:
+        for market, oid in list(_OUTSTANDING):
+            try:
+                await asyncio.wait_for(
+                    _current.cancel_order(oid, market), API_TIMEOUT
+                )
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.error("Failed to cancel %s %s: %s", market, oid, exc)
+        _OUTSTANDING.clear()
+    risk_control.pause()
+
+
+async def _await_with_timeout(coro: Coroutine[Any, Any, Any]) -> Any:
+    try:
+        return await asyncio.wait_for(coro, API_TIMEOUT)
+    except asyncio.TimeoutError:
+        await _handle_timeout()
+        raise
+
+
+def _track_order(market: str, order_id: str) -> None:
+    _OUTSTANDING.add((market, order_id))
+
+
+def _untrack_order(market: str, order_id: str) -> None:
+    _OUTSTANDING.discard((market, order_id))
+
+
 async def place_order(
     symbol: str, side: str, quantity: float, price: float | None = None
 ) -> dict:
     """Place an order using the configured exchange."""
     if _current is None:  # pragma: no cover - defensive programming
         raise RuntimeError("Exchange not configured")
-    return await asyncio.wait_for(
-        _current.place_order(symbol, side, quantity, price), API_TIMEOUT
+    return await _await_with_timeout(
+        _current.place_order(symbol, side, quantity, price)
     )
 
 
@@ -125,12 +161,14 @@ async def _poll_fill(order_id: str, market: str) -> None:
 
     start = time.monotonic()
     while True:
-        status = await asyncio.wait_for(
-            _current.get_order_status(order_id, market), API_TIMEOUT
+        status = await _await_with_timeout(
+            _current.get_order_status(order_id, market)
         )
         if status.get("status") == "FILLED":
+            _untrack_order(market, order_id)
             return
         if time.monotonic() - start > API_TIMEOUT:
+            await _handle_timeout()
             raise RuntimeError(f"Order {order_id} not filled in time")
         await asyncio.sleep(0.5)
 
@@ -142,6 +180,7 @@ async def place_spot_order(
 
     order = await place_order(symbol, side, quantity, price)
     order_id = str(order.get("orderId") or order.get("id") or "")
+    _track_order("spot", order_id)
     await _poll_fill(order_id, "spot")
     return order
 
@@ -153,6 +192,7 @@ async def place_perp_order(
 
     order = await place_order(symbol, side, quantity, price)
     order_id = str(order.get("orderId") or order.get("id") or "")
+    _track_order("perp", order_id)
     await _poll_fill(order_id, "perp")
     return order
 
@@ -161,23 +201,21 @@ async def fetch_funding(symbol: str) -> float:
     """Fetch the funding rate for ``symbol`` from the configured exchange."""
     if _current is None:  # pragma: no cover - defensive programming
         raise RuntimeError("Exchange not configured")
-    return await asyncio.wait_for(_current.fetch_funding(symbol), API_TIMEOUT)
+    return await _await_with_timeout(_current.fetch_funding(symbol))
 
 
 async def get_orderbook(symbol: str, depth: int = 5) -> dict:
     """Retrieve the latest order book from the configured exchange."""
     if _current is None:  # pragma: no cover - defensive programming
         raise RuntimeError("Exchange not configured")
-    return await asyncio.wait_for(
-        _current.get_orderbook(symbol, depth), API_TIMEOUT
-    )
+    return await _await_with_timeout(_current.get_orderbook(symbol, depth))
 
 
 async def get_balance() -> dict:
     """Return the account balance from the configured exchange."""
     if _current is None:  # pragma: no cover - defensive programming
         raise RuntimeError("Exchange not configured")
-    return await asyncio.wait_for(_current.get_balance(), API_TIMEOUT)
+    return await _await_with_timeout(_current.get_balance())
 
 
 async def hedge(symbol: str, quantity: float) -> Dict[str, Dict]:
@@ -197,8 +235,8 @@ async def hedge(symbol: str, quantity: float) -> Dict[str, Dict]:
     except Exception as exc:
         # Rollback the spot leg if the futures leg fails in any way.
         try:
-            cancel_resp = await asyncio.wait_for(
-                _current.cancel_order(spot_id, "spot"), API_TIMEOUT
+            cancel_resp = await _await_with_timeout(
+                _current.cancel_order(spot_id, "spot")
             )
             logger.warning("Rolled back spot order %s: %s", spot_id, cancel_resp)
         except Exception as cancel_exc:  # pragma: no cover - best effort

--- a/main.py
+++ b/main.py
@@ -40,7 +40,9 @@ def initialize_bot() -> None:
     """Placeholder for any initialization logic using ``CONFIG``."""
     api_keys = CONFIG.get("api_keys", {})
     print(f"Initializing bot with API keys: {list(api_keys.keys())}")
-    risk_control.configure(CONFIG.get("risk", {}))
+    risk_control.configure(
+        CONFIG.get("risk", {}), CONFIG.get("bot", {}).get("deposit_size")
+    )
 
 
 def start_processing_loops() -> None:

--- a/risk/risk_control.py
+++ b/risk/risk_control.py
@@ -1,13 +1,15 @@
 """Basic risk management helpers.
 
-This module tracks position sizes, accumulated losses, and consecutive
-losing trades.  Trading can be paused when risk limits are violated.
+This module tracks position sizes, accumulated losses, outstanding
+positions, and consecutive losing trades. Trading can be paused when risk
+limits are violated and automatically resumed after a cooldown period.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, Set
+from typing import Dict, Optional, Set
+import time
 
 
 @dataclass
@@ -17,31 +19,53 @@ class RiskLimits:
     max_position_size: float = float("inf")
     max_daily_loss: float = float("inf")
     max_consecutive_losses: int = float("inf")
+    max_open_positions: int = float("inf")
+    deposit_cap: float = float("inf")
 
 
 @dataclass
 class RiskState:
     """Runtime risk state tracked across trades."""
 
-    current_position: float = 0.0
+    total_notional: float = 0.0
     daily_loss: float = 0.0
     consecutive_losses: int = 0
     paused: bool = False
     open_symbols: Set[str] = field(default_factory=set)
+    open_positions: int = 0
+    pause_until: Optional[float] = None
 
 
 _limits = RiskLimits()
 _state = RiskState()
 
 
-def configure(config: Dict[str, float]) -> None:
-    """Configure risk limits from a dictionary."""
+def configure(config: Dict[str, float], deposit_size: Optional[float] = None) -> None:
+    """Configure risk limits from a dictionary.
+
+    Parameters
+    ----------
+    config:
+        Dictionary containing risk configuration values.
+    deposit_size:
+        Size of the trading account's deposit. Used to derive the absolute
+        deposit exposure limit from ``deposit_cap_pct`` if ``deposit_cap`` is
+        not specified directly.
+    """
 
     global _limits
+    deposit_cap = config.get("deposit_cap", float("inf"))
+    if deposit_cap is float("inf") and deposit_size is not None:
+        pct = config.get("deposit_cap_pct")
+        if pct is not None:
+            deposit_cap = pct * deposit_size
+
     _limits = RiskLimits(
         max_position_size=config.get("max_position_size", float("inf")),
         max_daily_loss=config.get("max_daily_loss", float("inf")),
         max_consecutive_losses=config.get("max_consecutive_losses", float("inf")),
+        max_open_positions=config.get("max_open_positions", float("inf")),
+        deposit_cap=deposit_cap,
     )
 
 
@@ -50,7 +74,11 @@ def can_open_position(quantity: float) -> bool:
 
     if _state.paused:
         return False
-    if _state.current_position + quantity > _limits.max_position_size:
+    if _state.open_positions >= _limits.max_open_positions:
+        return False
+    if _state.total_notional + quantity > _limits.deposit_cap:
+        return False
+    if _state.total_notional + quantity > _limits.max_position_size:
         return False
     if _state.daily_loss >= _limits.max_daily_loss:
         return False
@@ -58,9 +86,9 @@ def can_open_position(quantity: float) -> bool:
 
 
 def update_position(delta: float) -> None:
-    """Update the tracked position size by ``delta`` units."""
+    """Update the tracked notional exposure by ``delta`` units."""
 
-    _state.current_position = max(_state.current_position + delta, 0.0)
+    _state.total_notional = max(_state.total_notional + delta, 0.0)
 
 
 def is_symbol_open(symbol: str) -> bool:
@@ -73,12 +101,21 @@ def mark_symbol_open(symbol: str) -> None:
     """Record ``symbol`` as having an open position."""
 
     _state.open_symbols.add(symbol)
+    _state.open_positions = len(_state.open_symbols)
 
 
 def mark_symbol_closed(symbol: str) -> None:
     """Remove ``symbol`` from the set of open positions."""
 
     _state.open_symbols.discard(symbol)
+    _state.open_positions = len(_state.open_symbols)
+
+
+def pause(duration: Optional[float] = None) -> None:
+    """Pause trading for ``duration`` seconds or indefinitely."""
+
+    _state.paused = True
+    _state.pause_until = time.time() + duration if duration else None
 
 
 def record_pnl(pnl: float) -> None:
@@ -88,7 +125,7 @@ def record_pnl(pnl: float) -> None:
         _state.daily_loss += abs(pnl)
         _state.consecutive_losses += 1
         if _state.consecutive_losses >= _limits.max_consecutive_losses:
-            _state.paused = True
+            pause(24 * 3600)
     else:
         _state.consecutive_losses = 0
 
@@ -96,4 +133,8 @@ def record_pnl(pnl: float) -> None:
 def is_paused() -> bool:
     """Return ``True`` if trading is currently paused."""
 
+    if _state.paused and _state.pause_until and time.time() >= _state.pause_until:
+        _state.paused = False
+        _state.pause_until = None
+        _state.consecutive_losses = 0
     return _state.paused


### PR DESCRIPTION
## Summary
- enforce max open positions and deposit exposure via risk counters
- auto-unpause trading after 24h cooldown when loss limit hit
- cancel outstanding orders and pause trading on 30s API timeouts

## Testing
- `python -m py_compile main.py risk/risk_control.py exchanges/__init__.py strategies/funding_arbitrage.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688bb2293ac4832082883485a96b9b78