### PR TITLE
Extend trade log fields and integrate strategy logging

### DIFF
--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -11,11 +11,13 @@ import asyncio
 from dataclasses import dataclass
 from typing import Any, Dict
 import time
+from datetime import datetime
 
 from exchanges import fetch_funding, get_orderbook, hedge, place_order
 from risk import risk_control
 from ai.parameter_optimizer import load_thresholds as _load_thresholds
 from main import CONFIG
+from utils.logger import log_trade
 
 
 @dataclass
@@ -144,13 +146,32 @@ async def open_neutral_position(symbol: str, quantity: float) -> Dict[str, Dict]
     orders = await hedge(symbol, quantity)
     risk_control.update_position(quantity)
     risk_control.mark_symbol_open(symbol)
+    now = time.time()
     _positions[symbol] = {
-        "entry_timestamp": time.time(),
+        "entry_timestamp": now,
         "entry_futures_price": entry_metrics.futures_price,
         "entry_spot_price": entry_metrics.spot_price,
         "entry_basis": entry_metrics.basis,
+        "entry_funding": entry_metrics.funding_rate,
         "quantity": quantity,
     }
+    log_trade(
+        {
+            "symbol": symbol,
+            "entry_time": datetime.fromtimestamp(now).isoformat(),
+            "exit_time": None,
+            "entry_futures_price": entry_metrics.futures_price,
+            "exit_futures_price": None,
+            "entry_spot_price": entry_metrics.spot_price,
+            "exit_spot_price": None,
+            "entry_basis": entry_metrics.basis,
+            "exit_basis": None,
+            "funding": entry_metrics.funding_rate,
+            "quantity": quantity,
+            "pnl": 0.0,
+            "exit_reasons": None,
+        }
+    )
     return orders
 
 
@@ -210,13 +231,37 @@ async def monitor_neutral_position(
         if reasons:
             await close_neutral_position(symbol, quantity, pnl)
             if entry:
+                exit_basis = (
+                    ((metrics.futures_price - metrics.spot_price) / metrics.spot_price) * 100
+                    if metrics.spot_price
+                    else float("inf")
+                )
+                exit_ts = time.time()
                 entry.update(
                     {
-                        "exit_timestamp": time.time(),
+                        "exit_timestamp": exit_ts,
                         "exit_reasons": reasons,
                         "exit_futures_price": metrics.futures_price,
                         "exit_spot_price": metrics.spot_price,
+                        "exit_basis": exit_basis,
                         "pnl": pnl,
+                    }
+                )
+                log_trade(
+                    {
+                        "symbol": symbol,
+                        "entry_time": datetime.fromtimestamp(entry.get("entry_timestamp", exit_ts)).isoformat(),
+                        "exit_time": datetime.fromtimestamp(exit_ts).isoformat(),
+                        "entry_futures_price": entry.get("entry_futures_price"),
+                        "exit_futures_price": metrics.futures_price,
+                        "entry_spot_price": entry.get("entry_spot_price"),
+                        "exit_spot_price": metrics.spot_price,
+                        "entry_basis": entry.get("entry_basis"),
+                        "exit_basis": exit_basis,
+                        "funding": entry.get("entry_funding"),
+                        "quantity": entry.get("quantity"),
+                        "pnl": pnl,
+                        "exit_reasons": reasons,
                     }
                 )
             break

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -10,12 +10,20 @@ following columns:
     Trading pair symbol.
 ``entry_time`` / ``exit_time``
     ISO formatted timestamps for when the position was opened and closed.
-``entry_price`` / ``exit_price``
-    Prices at which the position was entered and exited.
+``entry_futures_price`` / ``exit_futures_price``
+    Futures prices at which the position was entered and exited.
+``entry_spot_price`` / ``exit_spot_price``
+    Spot prices at entry and exit.
+``entry_basis`` / ``exit_basis``
+    Calculated futures/spot basis in percent at entry and exit.
 ``funding``
     Funding rate captured for the trade.
+``quantity``
+    Trade size.
 ``pnl``
     Profit and loss of the completed trade.
+``exit_reasons``
+    Comma separated reasons for closing the position.
 
 The :func:`log_trade` function appends a new row to ``data/funding_bot_log.xlsx``
 creating the file and its parent directory if necessary.  The function guards
@@ -36,10 +44,16 @@ LOG_COLUMNS = [
     "symbol",
     "entry_time",
     "exit_time",
-    "entry_price",
-    "exit_price",
+    "entry_futures_price",
+    "exit_futures_price",
+    "entry_spot_price",
+    "exit_spot_price",
+    "entry_basis",
+    "exit_basis",
     "funding",
+    "quantity",
     "pnl",
+    "exit_reasons",
 ]
 
 
@@ -82,6 +96,14 @@ def log_trade(trade: Mapping[str, Any], path: Path = LOG_PATH) -> None:
     _ensure_parent(path)
     _validate_entry(trade, LOG_COLUMNS)
 
+    # Normalize complex types before writing to the workbook
+    normalized: Dict[str, Any] = {}
+    for col in LOG_COLUMNS:
+        val = trade.get(col)
+        if isinstance(val, (list, tuple)):
+            val = ",".join(map(str, val))
+        normalized[col] = val
+
     if path.exists():
         wb = load_workbook(path)
         ws = wb.active
@@ -94,6 +116,6 @@ def log_trade(trade: Mapping[str, Any], path: Path = LOG_PATH) -> None:
         ws = wb.active
         ws.append(LOG_COLUMNS)
 
-    ws.append([trade[col] for col in LOG_COLUMNS])
+    ws.append([normalized[col] for col in LOG_COLUMNS])
     wb.save(path)
     wb.close()


### PR DESCRIPTION
## Summary
- expand `utils.logger.LOG_COLUMNS` to record futures/spot prices, basis, size and exit reasons
- add normalization of list fields and support for all new columns in `log_trade`
- strategies now log each position open/close with complete trade details

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688bb3e71fc08320a0a261974a2182aa