### PR TITLE
Integrate risk manager with futures trader

### DIFF
--- a/main.py
+++ b/main.py
@@ -234,15 +234,24 @@ def scan_and_enter() -> None:
     for symbol in filtered_data:
         logging.debug("Prepared data for %s", symbol)
 
-    global open_long, open_short
+    global open_long, open_short, trader
     if open_long and not getattr(trend_filter, "allow_long", True):
         logging.info("Conditions violated for long; cancelling long position")
         open_long = False
     if open_short and not getattr(trend_filter, "allow_short", True):
         logging.info("Conditions violated for short; cancelling short position")
         open_short = False
-    if not risk_manager or not trader:
+    if not risk_manager:
         return
+    if trader is None:
+        trader = FuturesTrader(
+            data_collector.api_key,
+            data_collector.api_secret,
+            exchange_name=data_collector.config.get("api", {}).get(
+                "futures_exchange", "binanceusdm"
+            ),
+            risk_manager=risk_manager,
+        )
 
     for symbol, info in filtered_data.items():
         ohlcv = info.get("ohlcv")
@@ -349,12 +358,8 @@ def main() -> None:
         exchange_name=config.get("api", {}).get("futures_exchange", "binanceusdm")
     )
     trend_filter = TrendFilter()
-    risk_manager = RiskManager(fetch_balance)
-    trader = FuturesTrader(
-        api_key,
-        api_secret,
-        exchange_name=config.get("api", {}).get("futures_exchange", "binanceusdm"),
-    )
+    risk_manager = RiskManager(fetch_balance, max_open_trades=10)
+    trader = None
 
     schedule.every(5).minutes.do(scan_and_enter)
     schedule.every().day.at("00:00").do(daily_equity_and_risk_check)

--- a/tests/test_futures_trader.py
+++ b/tests/test_futures_trader.py
@@ -97,7 +97,21 @@ def test_exit_orders_with_trailing_stop_and_logging():
     exchange = DummyExchange()
     exchange.ticker_prices = [20000, 20050, 20050]
     logs = []
-    trader = FuturesTrader("key", "secret", exchange=exchange, trade_logger=logs.append)
+    class DummyRisk:
+        def __init__(self):
+            self.pnls = []
+
+        def close_trade(self, pnl):
+            self.pnls.append(pnl)
+
+    risk = DummyRisk()
+    trader = FuturesTrader(
+        "key",
+        "secret",
+        exchange=exchange,
+        trade_logger=logs.append,
+        risk_manager=risk,
+    )
 
     trader.place_market_order("BTC/USDT", "buy", 1, tp=21000, sl=19000)
 
@@ -121,6 +135,7 @@ def test_exit_orders_with_trailing_stop_and_logging():
     assert len(logs) == 2
     assert logs[0]["exit"] == 21000
     assert logs[1]["exit"] > 19000
+    assert len(risk.pnls) == 2
 
 
 def test_retry_on_network_error():

--- a/utils/futures_trader.py
+++ b/utils/futures_trader.py
@@ -15,6 +15,7 @@ import ccxt
 import pandas as pd
 
 from .trade_logger import append_trade
+from .risk import RiskManager
 
 
 class FuturesTrader:
@@ -38,6 +39,7 @@ class FuturesTrader:
         exchange_name: str = "binanceusdm",
         exchange: Optional[ccxt.Exchange] = None,
         trade_logger: Callable[[Dict[str, Any]], None] | None = append_trade,
+        risk_manager: RiskManager | None = None,
     ) -> None:
         if exchange is None:
             exchange_class = getattr(ccxt, exchange_name)
@@ -51,6 +53,7 @@ class FuturesTrader:
             )
         self.exchange = exchange
         self.trade_logger = trade_logger
+        self.risk_manager = risk_manager
 
     # ------------------------------------------------------------------
     # internal helpers
@@ -112,7 +115,7 @@ class FuturesTrader:
             ts = filled_order.get("timestamp")
             entry_time = pd.to_datetime(ts, unit="ms") if ts is not None else pd.Timestamp.utcnow()
             exit_events = self.manage_exit_orders(symbol, side, amount, tp, sl)
-            if exit_events and self.trade_logger:
+            if exit_events:
                 direction = "long" if side.lower() == "buy" else "short"
                 risk = abs(entry_price - sl) if sl is not None else 0.0
                 for i, (exit_price, exit_time) in enumerate(exit_events):
@@ -122,20 +125,23 @@ class FuturesTrader:
                         else entry_price - exit_price
                     )
                     rr = pnl / risk if risk else 0.0
-                    self.trade_logger(
-                        {
-                            "symbol": symbol,
-                            "direction": direction,
-                            "entry_time": entry_time,
-                            "entry": entry_price,
-                            "stop": sl if sl is not None else 0.0,
-                            "tp": tp if (tp is not None and i == 0) else 0.0,
-                            "exit_time": exit_time,
-                            "exit": exit_price,
-                            "pnl": pnl,
-                            "rr": rr,
-                        }
-                    )
+                    if self.trade_logger:
+                        self.trade_logger(
+                            {
+                                "symbol": symbol,
+                                "direction": direction,
+                                "entry_time": entry_time,
+                                "entry": entry_price,
+                                "stop": sl if sl is not None else 0.0,
+                                "tp": tp if (tp is not None and i == 0) else 0.0,
+                                "exit_time": exit_time,
+                                "exit": exit_price,
+                                "pnl": pnl,
+                                "rr": rr,
+                            }
+                        )
+                    if self.risk_manager:
+                        self.risk_manager.close_trade(pnl)
             return True
         return False
 
@@ -177,7 +183,7 @@ class FuturesTrader:
             ts = filled_order.get("timestamp")
             entry_time = pd.to_datetime(ts, unit="ms") if ts is not None else pd.Timestamp.utcnow()
             exit_events = self.manage_exit_orders(symbol, side, amount, tp, sl)
-            if exit_events and self.trade_logger:
+            if exit_events:
                 direction = "long" if side.lower() == "buy" else "short"
                 risk = abs(entry_price - sl) if sl is not None else 0.0
                 for i, (exit_price, exit_time) in enumerate(exit_events):
@@ -187,20 +193,23 @@ class FuturesTrader:
                         else entry_price - exit_price
                     )
                     rr = pnl / risk if risk else 0.0
-                    self.trade_logger(
-                        {
-                            "symbol": symbol,
-                            "direction": direction,
-                            "entry_time": entry_time,
-                            "entry": entry_price,
-                            "stop": sl if sl is not None else 0.0,
-                            "tp": tp if (tp is not None and i == 0) else 0.0,
-                            "exit_time": exit_time,
-                            "exit": exit_price,
-                            "pnl": pnl,
-                            "rr": rr,
-                        }
-                    )
+                    if self.trade_logger:
+                        self.trade_logger(
+                            {
+                                "symbol": symbol,
+                                "direction": direction,
+                                "entry_time": entry_time,
+                                "entry": entry_price,
+                                "stop": sl if sl is not None else 0.0,
+                                "tp": tp if (tp is not None and i == 0) else 0.0,
+                                "exit_time": exit_time,
+                                "exit": exit_price,
+                                "pnl": pnl,
+                                "rr": rr,
+                            }
+                        )
+                    if self.risk_manager:
+                        self.risk_manager.close_trade(pnl)
             return True
         return False
 


### PR DESCRIPTION
## Summary
- Instantiate `RiskManager` with a 10 trade limit
- Allow `FuturesTrader` to use a `RiskManager` and close trades after exits
- Create the `FuturesTrader` inside `scan_and_enter` and wire it to risk management

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bb3bcdbfc832096d273a636283763