### PR TITLE
feat: optimize thresholds and refresh dynamically

### DIFF
--- a/ai/parameter_optimizer.py
+++ b/ai/parameter_optimizer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import random
 from pathlib import Path
-from typing import Dict
+from typing import Callable, Dict, Optional
 
 import pandas as pd
 from joblib import dump, load
@@ -15,21 +15,58 @@ DEFAULT_OUTPUT = Path("data") / "optimized_thresholds.joblib"
 
 
 def analyze_trade_history(log_path: Path = LOG_PATH) -> Dict[str, float]:
-    """Analyze trade history and compute new parameter thresholds.
+    """Analyze trade history and compute optimized parameter thresholds.
 
-    This simplistic optimizer looks at historical funding rates and
-    derives a new threshold based on the 75th percentile of absolute
-    funding values from profitable trades.
+    The optimizer inspects the trade log and derives thresholds based on
+    historical behaviour of successful trades.  Currently the following
+    metrics are supported:
+
+    ``funding_rate``
+        75th percentile of the absolute funding rate.
+    ``basis``
+        75th percentile of the absolute entry basis.
+    ``holding_time``
+        75th percentile of holding time in seconds.
+    ``volume``
+        75th percentile of traded quantity or volume column.
+    ``liquidity``
+        75th percentile of recorded liquidity values.
     """
+
     if not log_path.exists():
         return {}
+
     df = pd.read_excel(log_path)
-    if df.empty or "funding" not in df.columns:
+    if df.empty:
         return {}
+
     if "pnl" in df.columns:
         df = df[df["pnl"] > 0]
-    funding_threshold = df["funding"].abs().quantile(0.75)
-    return {"funding_rate": float(funding_threshold)}
+
+    thresholds: Dict[str, float] = {}
+
+    if "funding" in df.columns:
+        thresholds["funding_rate"] = float(df["funding"].abs().quantile(0.75))
+
+    if "entry_basis" in df.columns:
+        thresholds["basis"] = float(df["entry_basis"].abs().quantile(0.75))
+
+    if {"entry_time", "exit_time"}.issubset(df.columns):
+        entry_times = pd.to_datetime(df["entry_time"], errors="coerce")
+        exit_times = pd.to_datetime(df["exit_time"], errors="coerce")
+        hold_seconds = (exit_times - entry_times).dt.total_seconds().dropna()
+        if not hold_seconds.empty:
+            thresholds["holding_time"] = float(hold_seconds.quantile(0.75))
+
+    if "volume" in df.columns and not df["volume"].dropna().empty:
+        thresholds["volume"] = float(df["volume"].quantile(0.75))
+    elif "quantity" in df.columns and not df["quantity"].dropna().empty:
+        thresholds["volume"] = float(df["quantity"].quantile(0.75))
+
+    if "liquidity" in df.columns and not df["liquidity"].dropna().empty:
+        thresholds["liquidity"] = float(df["liquidity"].quantile(0.75))
+
+    return thresholds
 
 
 def optimize_and_save(
@@ -48,10 +85,26 @@ async def periodic_optimization(
     max_hours: int = 48,
     log_path: Path = LOG_PATH,
     out_path: Path = DEFAULT_OUTPUT,
+    on_update: Optional[Callable[[Dict[str, float]], None]] = None,
 ) -> None:
-    """Periodically optimize parameters every 24–48 hours."""
+    """Periodically optimize parameters every ``min_hours``–``max_hours``.
+
+    Parameters
+    ----------
+    min_hours, max_hours:
+        Range of hours to wait between optimization runs.
+    log_path, out_path:
+        Locations of the trade log and output file.
+    on_update:
+        Optional callback invoked with the newly computed thresholds after
+        each optimization run.  This allows callers to react to refreshed
+        parameters.
+    """
+
     while True:
-        optimize_and_save(log_path, out_path)
+        thresholds = optimize_and_save(log_path, out_path)
+        if on_update and thresholds:
+            on_update(thresholds)
         wait_hours = random.randint(min_hours, max_hours)
         await asyncio.sleep(wait_hours * 3600)
 

--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,7 @@ thresholds:
   basis: 0.5
   liquidity: 0.0
   volume: 0.0
+  holding_time: 172800
   volatility: 1.0
   open_interest: 0.0
   min_trade_size: 0.0

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ import yaml
 
 from risk import risk_control
 from strategies.funding_arbitrage import get_thresholds
+from ai.parameter_optimizer import periodic_optimization
 
 # Global configuration dictionary that other modules can import.
 CONFIG: Dict[str, Any] = {}
@@ -48,18 +49,37 @@ def initialize_bot() -> None:
 def start_processing_loops() -> None:
     """Start asynchronous processing loops."""
 
+    threshold_version = 0
+
+    def _update_thresholds(new: Dict[str, float]) -> None:
+        nonlocal threshold_version
+        if new:
+            CONFIG.setdefault("thresholds", {}).update(new)
+            threshold_version += 1
+
     async def price_loop() -> None:
+        local_version = threshold_version
         while True:
+            if local_version != threshold_version:
+                local_version = threshold_version
+                print(f"Thresholds updated: {CONFIG.get('thresholds')}")
             print(f"Processing with thresholds: {CONFIG.get('thresholds')}")
             await asyncio.sleep(CONFIG.get("bot", {}).get("poll_interval", 1))
 
     async def risk_loop() -> None:
+        local_version = threshold_version
         while True:
+            if local_version != threshold_version:
+                local_version = threshold_version
+                print("Risk loop acknowledged threshold update")
             print(f"Checking risk limits: {CONFIG.get('risk')}")
             await asyncio.sleep(CONFIG.get("bot", {}).get("poll_interval", 1))
 
+    async def optimization_loop() -> None:
+        await periodic_optimization(on_update=_update_thresholds)
+
     async def runner() -> None:
-        await asyncio.gather(price_loop(), risk_loop())
+        await asyncio.gather(price_loop(), risk_loop(), optimization_loop())
 
     asyncio.run(runner())
 

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -218,7 +218,8 @@ async def monitor_neutral_position(
             if exit_slippage > 0.005:
                 reasons.append("slippage")
             hold_time = time.time() - entry.get("entry_timestamp", time.time())
-            if hold_time > 48 * 3600:
+            max_hold = exit_thresholds.get("holding_time", 48 * 3600)
+            if hold_time > max_hold:
                 reasons.append("time")
             pnl = (
                 (metrics.futures_price - entry.get("entry_futures_price", 0.0))


### PR DESCRIPTION
## Summary
- compute funding, basis, holding time, volume, and liquidity thresholds from trade history
- refresh saved thresholds on a 24–48h schedule and push updates into the running config
- respect holding-time thresholds when evaluating open positions

## Testing
- `pytest`
- `python -m py_compile ai/parameter_optimizer.py main.py strategies/funding_arbitrage.py`


------
https://chatgpt.com/codex/tasks/task_e_688bb5535d208320a9f48ba584a22c9b