### PR TITLE
Align data collection with screener output

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,19 +42,27 @@ class DataCollector:
             }
         )
 
-    def collect(self) -> Any:
-        """Fetch recent OHLCV data and metrics for all configured symbols."""
+    def collect(self, symbols: Optional[list[str]] = None) -> Any:
+        """Fetch recent OHLCV data and metrics for the given symbols.
+
+        Parameters
+        ----------
+        symbols:
+            Optional list of symbols to collect data for. If not provided,
+            ``config['symbols']`` is used.
+        """
         logging.info("Collecting market data")
         end = pd.Timestamp.utcnow()
         start = end - pd.Timedelta(days=1)
-        fetch_all_from_config(self.config, start, end, timeframe="5m")
+        symbols = symbols or self.config.get("symbols", [])
+        fetch_all_from_config({**self.config, "symbols": symbols}, start, end, timeframe="5m")
 
         data_dir = (
             Path(self.config.get("data_paths", {}).get("data_dir", "data"))
             / "raw_data"
         )
         results: dict[str, dict[str, Any]] = {}
-        for symbol in self.config.get("symbols", []):
+        for symbol in symbols:
             ohlcv_file = data_dir / f"{symbol.replace('/', '')}_5m.csv"
             df = pd.DataFrame()
             if ohlcv_file.exists():
@@ -220,15 +228,10 @@ def init_logging(log_dir: str | Path) -> None:
 def scan_and_enter() -> None:
     """Run periodic scanning and entry logic."""
     logging.info("Running scan and entry logic")
-    data = data_collector.collect()
-    screened = screener.screen(data)
-    if isinstance(screened, dict):
-        symbols = list(screened.keys())[:10]
-        filtered_data = {s: screened[s] for s in symbols}
-    else:
-        symbols = list(screened)[:10]
-        filtered_data = {s: data.get(s) for s in symbols if s in data}
-    filtered_data = trend_filter.filter(filtered_data)
+    symbols = screener.screen()[:10]
+    data = data_collector.collect(symbols)
+    data = {s: data.get(s) for s in symbols if s in data}
+    filtered_data = trend_filter.filter(data)
     global selected_symbols
     selected_symbols = list(filtered_data.keys())
     for symbol in filtered_data:

--- a/tests/test_market_analysis.py
+++ b/tests/test_market_analysis.py
@@ -5,11 +5,11 @@ import main
 
 
 class Dummy:
-    def collect(self):
+    def collect(self, symbols=None):
         return {}
 
-    def screen(self, data):
-        return data
+    def screen(self):
+        return []
 
 
 class DummyFilter:

--- a/tests/test_trading_logic.py
+++ b/tests/test_trading_logic.py
@@ -7,7 +7,9 @@ class DummyCollector:
     def __init__(self, data):
         self._data = data
 
-    def collect(self):
+    def collect(self, symbols=None):
+        if symbols:
+            return {s: self._data[s] for s in symbols}
         return self._data
 
 
@@ -15,7 +17,7 @@ class DummyScreener:
     def __init__(self, symbol):
         self.symbol = symbol
 
-    def screen(self, data):
+    def screen(self):
         return [self.symbol]
 
 


### PR DESCRIPTION
## Summary
- fetch market data only for screener-selected symbols
- screen before collecting data and limit processing to screener results
- update tests for new data collection workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688bb793ce60832084fccce24dc077ce