### PR TITLE
feat: enrich market metrics with exchange data

### DIFF
--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -57,6 +57,16 @@ class BaseExchange(ABC):
     async def get_balance(self) -> dict:
         """Return account balance information."""
 
+    @abstractmethod
+    async def fetch_funding_history(
+        self, symbol: str, hours: int = 8, limit: int = 3
+    ) -> list[float]:
+        """Return recent funding rates for ``symbol`` within ``hours``."""
+
+    @abstractmethod
+    async def get_stats(self, symbol: str) -> dict:
+        """Return market stats such as 24h volume and open interest."""
+
     # ------------------------------------------------------------------
     # Optional order management helpers
     # ------------------------------------------------------------------
@@ -216,6 +226,24 @@ async def get_balance() -> dict:
     if _current is None:  # pragma: no cover - defensive programming
         raise RuntimeError("Exchange not configured")
     return await _await_with_timeout(_current.get_balance())
+
+
+async def fetch_funding_history(
+    symbol: str, hours: int = 8, limit: int = 3
+) -> list[float]:
+    """Return recent funding rates for ``symbol`` from the exchange."""
+    if _current is None:  # pragma: no cover - defensive programming
+        raise RuntimeError("Exchange not configured")
+    return await _await_with_timeout(
+        _current.fetch_funding_history(symbol, hours, limit)
+    )
+
+
+async def get_stats(symbol: str) -> dict:
+    """Return market stats such as 24h volume and open interest."""
+    if _current is None:  # pragma: no cover - defensive programming
+        raise RuntimeError("Exchange not configured")
+    return await _await_with_timeout(_current.get_stats(symbol))
 
 
 async def hedge(symbol: str, quantity: float) -> Dict[str, Dict]:

--- a/exchanges/binance.py
+++ b/exchanges/binance.py
@@ -59,6 +59,23 @@ class BinanceExchange(BaseExchange):
             data = await resp.json()
         return float(data[0]["fundingRate"])
 
+    async def fetch_funding_history(
+        self, symbol: str, hours: int = 8, limit: int = 3
+    ) -> list[float]:
+        session = await self._session_get()
+        url = f"{self.REST_URL}/fapi/v1/fundingRate"
+        end_time = int(time.time() * 1000)
+        start_time = end_time - hours * 3600 * 1000
+        params = {
+            "symbol": symbol,
+            "startTime": start_time,
+            "endTime": end_time,
+            "limit": limit,
+        }
+        async with session.get(url, params=params) as resp:
+            data = await resp.json()
+        return [float(entry["fundingRate"]) for entry in data]
+
     async def place_order(
         self, symbol: str, side: str, quantity: float, price: float | None = None
     ) -> dict:
@@ -84,6 +101,19 @@ class BinanceExchange(BaseExchange):
         headers = {"X-MBX-APIKEY": self.api_key}
         async with session.get(url, params=params, headers=headers) as resp:
             return await resp.json()
+
+    async def get_stats(self, symbol: str) -> dict:
+        session = await self._session_get()
+        ticker_url = f"{self.REST_URL}/fapi/v1/ticker/24hr"
+        params = {"symbol": symbol}
+        async with session.get(ticker_url, params=params) as resp:
+            ticker = await resp.json()
+        volume = float(ticker.get("volume", 0.0))
+        oi_url = f"{self.REST_URL}/fapi/v1/openInterest"
+        async with session.get(oi_url, params=params) as resp:
+            oi = await resp.json()
+        open_interest = float(oi.get("openInterest", 0.0))
+        return {"volume_24h": volume, "open_interest": open_interest}
 
     # ------------------------------------------------------------------
     # WebSocket handling

--- a/exchanges/bybit.py
+++ b/exchanges/bybit.py
@@ -61,6 +61,19 @@ class BybitExchange(BaseExchange):
             data = await resp.json()
         return float(data["result"]["list"][0]["fundingRate"])
 
+    async def fetch_funding_history(
+        self, symbol: str, hours: int = 8, limit: int = 3
+    ) -> list[float]:
+        session = await self._session_get()
+        url = f"{self.REST_URL}/v5/market/funding/history"
+        end_time = int(time.time() * 1000)
+        start_time = end_time - hours * 3600 * 1000
+        params = {"symbol": symbol, "startTime": start_time, "endTime": end_time, "limit": limit}
+        async with session.get(url, params=params) as resp:
+            data = await resp.json()
+        records = data.get("result", {}).get("list", [])
+        return [float(item.get("fundingRate", 0.0)) for item in records]
+
     async def place_order(
         self, symbol: str, side: str, quantity: float, price: float | None = None
     ) -> dict:
@@ -87,6 +100,22 @@ class BybitExchange(BaseExchange):
         params = self._sign("GET", url_path, {"accountType": "UNIFIED"})
         async with session.get(url, params=params) as resp:
             return await resp.json()
+
+    async def get_stats(self, symbol: str) -> dict:
+        session = await self._session_get()
+        ticker_url = f"{self.REST_URL}/v5/market/tickers"
+        t_params = {"category": "linear", "symbol": symbol}
+        async with session.get(ticker_url, params=t_params) as resp:
+            ticker = await resp.json()
+        tick = (ticker.get("result", {}).get("list") or [{}])[0]
+        volume = float(tick.get("turnover24h", 0.0))
+        oi_url = f"{self.REST_URL}/v5/market/open-interest"
+        oi_params = {"category": "linear", "symbol": symbol}
+        async with session.get(oi_url, params=oi_params) as resp:
+            oi = await resp.json()
+        oi_list = oi.get("result", {}).get("list") or [{}]
+        open_interest = float(oi_list[0].get("openInterest", 0.0))
+        return {"volume_24h": volume, "open_interest": open_interest}
 
     # ------------------------------------------------------------------
     # WebSocket handling

--- a/main.py
+++ b/main.py
@@ -135,7 +135,7 @@ def start_processing_loops() -> None:
                     if risk_control.is_paused() or risk_control.is_symbol_open(symbol):
                         continue
                     try:
-                        metrics = await strategy.get_market_metrics(symbol)
+                        metrics = await strategy.get_market_metrics(symbol, quantity)
                     except Exception as exc:
                         print(f"Metrics error {name} {symbol}: {exc}")
                         continue

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -13,7 +13,13 @@ from typing import Any, Dict
 import time
 from datetime import datetime
 
-from exchanges import fetch_funding, get_orderbook, hedge, place_order
+from exchanges import (
+    fetch_funding_history,
+    get_orderbook,
+    get_stats,
+    hedge,
+    place_order,
+)
 from risk import risk_control
 from ai.parameter_optimizer import load_thresholds as _load_thresholds
 from main import CONFIG
@@ -36,17 +42,29 @@ class MarketMetrics:
     basis: float
 
 
-async def get_market_metrics(symbol: str, depth: int = 5) -> MarketMetrics:
+async def get_market_metrics(
+    symbol: str, trade_size: float, depth: int = 5
+) -> MarketMetrics:
     """Fetch comprehensive market metrics for ``symbol``.
 
     Parameters
     ----------
     symbol:
         Trading pair symbol understood by the configured exchange.
+    trade_size:
+        Quantity to trade when estimating slippage.
     depth:
         Order book depth to request for liquidity calculations.  Defaults to 5.
     """
-    funding = await fetch_funding(symbol)
+    history = await fetch_funding_history(symbol, hours=8, limit=3)
+    if history:
+        k = 2 / (len(history) + 1)
+        funding = history[0]
+        for rate in history[1:]:
+            funding = rate * k + funding * (1 - k)
+    else:
+        funding = 0.0
+
     orderbook = await get_orderbook(symbol, depth=depth)
     bids = [(float(p), float(q)) for p, q in orderbook.get("bids", [])]
     asks = [(float(p), float(q)) for p, q in orderbook.get("asks", [])]
@@ -55,16 +73,29 @@ async def get_market_metrics(symbol: str, depth: int = 5) -> MarketMetrics:
         spread = asks[0][0] - bids[0][0]
         futures_price = (asks[0][0] + bids[0][0]) / 2
         volatility = spread / futures_price if futures_price else float("inf")
-        slippage = spread / futures_price if futures_price else float("inf")
+        remaining = trade_size
+        cost = 0.0
+        for price, qty in asks:
+            take = min(remaining, qty)
+            cost += take * price
+            remaining -= take
+            if remaining <= 0:
+                break
+        if remaining > 0:
+            slippage = float("inf")
+        else:
+            avg_price = cost / trade_size
+            slippage = abs(avg_price - futures_price) / futures_price
     else:
         spread = float("inf")
         futures_price = float("nan")
         volatility = float("inf")
         slippage = float("inf")
 
+    stats = await get_stats(symbol)
     spot_price = float(orderbook.get("spot_price", futures_price))
-    volume = float(orderbook.get("volume", 0.0))
-    open_interest = float(orderbook.get("open_interest", 0.0))
+    volume = float(stats.get("volume_24h", 0.0))
+    open_interest = float(stats.get("open_interest", 0.0))
     liquidity = sum(q for _, q in bids) + sum(q for _, q in asks)
     basis = (
         ((futures_price - spot_price) / spot_price) * 100
@@ -107,6 +138,7 @@ def check_entry_conditions(
         and metrics.volume >= thresholds.get("volume", 0.0)
         and metrics.volatility <= thresholds.get("volatility", float("inf"))
         and metrics.open_interest <= thresholds.get("open_interest", float("inf"))
+        and metrics.slippage <= thresholds.get("slippage", float("inf"))
         and thresholds.get("min_trade_size", 0.0)
         <= quantity
         <= thresholds.get("max_trade_size", float("inf"))
@@ -142,7 +174,7 @@ async def open_neutral_position(symbol: str, quantity: float) -> Dict[str, Dict]
         raise RuntimeError("Trade size exceeds deposit")
     if not risk_control.can_open_position(quantity) or risk_control.is_symbol_open(symbol):
         raise RuntimeError("Risk limits exceeded, trading paused, or position exists")
-    entry_metrics = await get_market_metrics(symbol)
+    entry_metrics = await get_market_metrics(symbol, quantity)
     orders = await hedge(symbol, quantity)
     risk_control.update_position(quantity)
     risk_control.mark_symbol_open(symbol)
@@ -202,7 +234,7 @@ async def monitor_neutral_position(
     entry = _positions.get(symbol, {})
     while True:
         try:
-            metrics = await get_market_metrics(symbol)
+            metrics = await get_market_metrics(symbol, quantity)
         except asyncio.TimeoutError:
             await close_neutral_position(symbol, quantity)
             break


### PR DESCRIPTION
## Summary
- compute 3-point EMA of funding rate and estimate slippage for target trade size
- pull 24h volume and open interest from exchange APIs
- surface slippage threshold in entry checks and wire trade size through callers

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688bba0bd9b4832093deba94efea6621