### PR TITLE
feat: add configurable volume spike

### DIFF
--- a/backtester.py
+++ b/backtester.py
@@ -95,8 +95,15 @@ def run_backtest(
     data_dir: str | Path = "data/raw_data",
     trades_path: str | Path = "trades.csv",
     equity_path: str | Path | None = None,
+    volume_spike: float = 2.0,
 ) -> dict:
-    """Run a simple breakout backtest and return summary statistics."""
+    """Run a simple breakout backtest and return summary statistics.
+
+    Parameters
+    ----------
+    volume_spike:
+        Multiplier applied to volume statistics when generating signals.
+    """
 
     df = load_data(symbol, data_dir)
     if start:
@@ -237,6 +244,7 @@ def run_backtest(
             delta_oi_series,
             volume_stats,
             funding,
+            volume_spike=volume_spike,
         )
         if not signals:
             continue
@@ -282,12 +290,24 @@ def parse_args() -> argparse.Namespace:
         default="data/raw_data",
         help="Directory containing CSV data",
     )
+    parser.add_argument(
+        "--volume-spike",
+        type=float,
+        default=2.0,
+        help="Volume spike multiplier",
+    )
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
-    stats = run_backtest(args.symbol, args.start, args.end, data_dir=args.data_dir)
+    stats = run_backtest(
+        args.symbol,
+        args.start,
+        args.end,
+        data_dir=args.data_dir,
+        volume_spike=args.volume_spike,
+    )
     for key, value in stats.items():
         print(f"{key}: {value}")
 

--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,9 @@ data_paths:
   data_dir: "data/"
   log_dir: "logs/"
 
+strategy:
+  volume_spike: 2.0
+
 feature_toggles:
   enable_notifications: true
   use_sandbox: false

--- a/main.py
+++ b/main.py
@@ -225,8 +225,15 @@ def init_logging(log_dir: str | Path) -> None:
     )
 
 
-def scan_and_enter() -> None:
-    """Run periodic scanning and entry logic."""
+def scan_and_enter(volume_spike: float = 2.0) -> None:
+    """Run periodic scanning and entry logic.
+
+    Parameters
+    ----------
+    volume_spike:
+        Multiplier applied to volume statistics when generating breakout
+        signals.
+    """
     logging.info("Running scan and entry logic")
     symbols = screener.screen()[:10]
     data = data_collector.collect(symbols)
@@ -264,6 +271,7 @@ def scan_and_enter() -> None:
             delta_oi,
             pd.Series(dtype="float64"),
             funding,
+            volume_spike=volume_spike,
         )
         if signals:
             signals_by_symbol[symbol] = signals
@@ -372,7 +380,8 @@ def main() -> None:
     risk_manager = RiskManager(fetch_balance, max_open_trades=10)
     trader = None
 
-    schedule.every(5).minutes.do(scan_and_enter)
+    vol_spike = config.get("strategy", {}).get("volume_spike", 2.0)
+    schedule.every(5).minutes.do(scan_and_enter, volume_spike=vol_spike)
     schedule.every().day.at("00:00").do(daily_equity_and_risk_check)
     logging.info("Scheduler started")
 

--- a/tests/test_breakout_signals.py
+++ b/tests/test_breakout_signals.py
@@ -31,7 +31,9 @@ def test_long_breakout_signal():
     volume_stats = pd.Series({"avg_volume": 120})
     funding = 0.005
 
-    signals = evaluate_breakout(ohlcv, cluster, cvd, delta_oi, volume_stats, funding)
+    signals = evaluate_breakout(
+        ohlcv, cluster, cvd, delta_oi, volume_stats, funding, volume_spike=1.5
+    )
     assert signals, "Expected a breakout signal"
     sig = signals[0]
     assert isinstance(sig, Signal)
@@ -62,7 +64,9 @@ def test_breakout_blocked_by_trend_filter():
     funding = 0.005
 
     # Trend filter should block this potential breakout
-    signals = evaluate_breakout(ohlcv, cluster, cvd, delta_oi, volume_stats, funding)
+    signals = evaluate_breakout(
+        ohlcv, cluster, cvd, delta_oi, volume_stats, funding, volume_spike=1.5
+    )
     assert signals == []
 
 

--- a/tests/test_trading_logic.py
+++ b/tests/test_trading_logic.py
@@ -94,7 +94,9 @@ def test_scan_and_enter_executes_long(monkeypatch):
     monkeypatch.setattr(
         main,
         "evaluate_breakout",
-        lambda ohlcv, level, cvd, delta_oi, volume_stats, funding: [Signal("long", 101, 99, 103, 105)],
+        lambda ohlcv, level, cvd, delta_oi, volume_stats, funding, volume_spike=2.0: [
+            Signal("long", 101, 99, 103, 105)
+        ],
     )
 
     main.open_long = False

--- a/utils/breakout_signals.py
+++ b/utils/breakout_signals.py
@@ -96,9 +96,11 @@ def evaluate_breakout(
     funding:
         Current funding rate.  Positive values indicate longs pay shorts.
     volume_spike:
-        Deprecated.  Average volume is computed from the last 15 periods and
-        a spike is considered when the current volume exceeds 1.5× that
-        average and the change exceeds two standard deviations.
+        Multiplier applied to both the average volume and the standard
+        deviation of volume changes.  A volume spike is detected when the
+        latest volume exceeds ``volume_spike`` × the rolling average and the
+        change in volume exceeds ``volume_spike`` × the rolling standard
+        deviation.
     ema_short, ema_long:
         Spans for the short and long exponential moving averages (typically
         5–15 and 10–30 respectively).
@@ -128,7 +130,9 @@ def evaluate_breakout(
     vol_delta = df["volume"].diff().iloc[-1]
     if pd.isna(avg_volume) or pd.isna(vol_sigma) or pd.isna(vol_delta):
         return []
-    vol_ok = (last["volume"] > 1.5 * avg_volume) and (vol_delta > 2 * vol_sigma)
+    vol_ok = (last["volume"] > volume_spike * avg_volume) and (
+        vol_delta > volume_spike * vol_sigma
+    )
 
     ema_bull = last["ema_short"] > last["ema_long"]
     ema_bear = last["ema_short"] < last["ema_long"]


### PR DESCRIPTION
## Summary
- make volume spike multiplier configurable and apply to avg volume and volume change thresholds
- pass volume_spike through scan_and_enter and run_backtest, reading default from config
- update tests for new volume_spike parameter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688bba2ad7b48320893d582652c2f5f7