### PR TITLE
Track trade risk by id

### DIFF
--- a/main.py
+++ b/main.py
@@ -306,19 +306,30 @@ def scan_and_enter(volume_spike: float = 2.0) -> None:
             if not risk_manager.can_open_trade():
                 continue
             try:
-                size = risk_manager.open_trade(sig.entry, sig.stop)
+                trade_id, size = risk_manager.open_trade(sig.entry, sig.stop)
             except ValueError:
                 continue
             side = "buy" if sig.direction == "long" else "sell"
             executed = trader.place_limit_maker_order(
-                symbol, side, size, sig.entry, tp=sig.tp1, sl=sig.stop
+                symbol,
+                side,
+                size,
+                sig.entry,
+                tp=sig.tp1,
+                sl=sig.stop,
+                trade_id=trade_id,
             )
             if not executed:
                 executed = trader.place_market_order(
-                    symbol, side, size, tp=sig.tp1, sl=sig.stop
+                    symbol,
+                    side,
+                    size,
+                    tp=sig.tp1,
+                    sl=sig.stop,
+                    trade_id=trade_id,
                 )
             if not executed:
-                risk_manager.close_trade(0.0)
+                risk_manager.close_trade(trade_id, 0.0)
                 continue
             if sig.direction == "long":
                 open_long = True

--- a/tests/test_futures_trader.py
+++ b/tests/test_futures_trader.py
@@ -101,7 +101,7 @@ def test_exit_orders_with_trailing_stop_and_logging():
         def __init__(self):
             self.pnls = []
 
-        def close_trade(self, pnl):
+        def close_trade(self, trade_id, pnl):
             self.pnls.append(pnl)
 
     risk = DummyRisk()
@@ -113,7 +113,7 @@ def test_exit_orders_with_trailing_stop_and_logging():
         risk_manager=risk,
     )
 
-    trader.place_market_order("BTC/USDT", "buy", 1, tp=21000, sl=19000)
+    trader.place_market_order("BTC/USDT", "buy", 1, tp=21000, sl=19000, trade_id="t1")
 
     # entry + tp + initial sl + trailing stop updates
     assert len(exchange.create_order_calls) >= 5

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -44,13 +44,13 @@ def test_consecutive_loss_halt(tmp_path):
         daily_drawdown_pct=1,
         db_path=tmp_path / "state.db",
     )
-    rm.open_trade(100, 90)
+    trade_id, _ = rm.open_trade(100, 90)
     balance = 990.0
-    rm.close_trade(-10)
+    rm.close_trade(trade_id, -10)
     assert rm.can_open_trade()
-    rm.open_trade(100, 90)
+    trade_id, _ = rm.open_trade(100, 90)
     balance = 980.0
-    rm.close_trade(-10)
+    rm.close_trade(trade_id, -10)
     assert not rm.can_open_trade()
 
 
@@ -66,9 +66,9 @@ def test_daily_drawdown_stop(tmp_path):
         max_consecutive_losses=10,
         db_path=tmp_path / "state.db",
     )
-    rm.open_trade(100, 90)
+    trade_id, _ = rm.open_trade(100, 90)
     balance = 949.0  # >5% drawdown
-    rm.close_trade(-51)
+    rm.close_trade(trade_id, -51)
     assert not rm.can_open_trade()
 
 
@@ -80,16 +80,16 @@ def test_state_persistence(tmp_path):
 
     db = tmp_path / "state.db"
     rm = RiskManager(fetch_balance, max_consecutive_losses=2, db_path=db)
-    rm.open_trade(100, 90)
+    trade_id, _ = rm.open_trade(100, 90)
     balance = 990.0
-    rm.close_trade(-10)
+    rm.close_trade(trade_id, -10)
     assert rm.consecutive_losses == 1
 
     rm2 = RiskManager(fetch_balance, max_consecutive_losses=2, db_path=db)
     assert rm2.consecutive_losses == 1
-    rm2.open_trade(100, 90)
+    trade_id, _ = rm2.open_trade(100, 90)
     balance = 980.0
-    rm2.close_trade(-10)
+    rm2.close_trade(trade_id, -10)
     assert rm2.trading_halted
 
     rm3 = RiskManager(fetch_balance, max_consecutive_losses=2, db_path=db)
@@ -103,13 +103,13 @@ def test_max_open_trades_limit(tmp_path):
         return balance
 
     rm = RiskManager(fetch_balance, max_open_trades=2, db_path=tmp_path / "state.db")
-    rm.open_trade(100, 90)
-    rm.open_trade(100, 90)
+    trade_id1, _ = rm.open_trade(100, 90)
+    trade_id2, _ = rm.open_trade(100, 90)
     assert rm.open_trades == 2
     assert not rm.can_open_trade()
     with pytest.raises(ValueError):
         rm.open_trade(100, 90)
-    rm.close_trade(10)
+    rm.close_trade(trade_id1, 10)
     assert rm.open_trades == 1
     assert rm.can_open_trade()
     rm.open_trade(100, 90)

--- a/tests/test_trading_logic.py
+++ b/tests/test_trading_logic.py
@@ -39,9 +39,9 @@ class DummyRisk:
 
     def open_trade(self, entry, stop):
         self.opened = True
-        return 1.0
+        return "id", 1.0
 
-    def close_trade(self, pnl):
+    def close_trade(self, trade_id, pnl):
         self.opened = False
 
 
@@ -49,12 +49,16 @@ class DummyTrader:
     def __init__(self):
         self.calls = []
 
-    def place_limit_maker_order(self, symbol, side, amount, price, tp=None, sl=None):
-        self.calls.append((symbol, side, amount, price, tp, sl))
+    def place_limit_maker_order(
+        self, symbol, side, amount, price, tp=None, sl=None, trade_id=None
+    ):
+        self.calls.append((symbol, side, amount, price, tp, sl, trade_id))
         return True
 
-    def place_market_order(self, symbol, side, amount, tp=None, sl=None):
-        self.calls.append((symbol, side, amount, None, tp, sl))
+    def place_market_order(
+        self, symbol, side, amount, tp=None, sl=None, trade_id=None
+    ):
+        self.calls.append((symbol, side, amount, None, tp, sl, trade_id))
         return True
 
 

--- a/utils/futures_trader.py
+++ b/utils/futures_trader.py
@@ -92,6 +92,7 @@ class FuturesTrader:
         amount: float,
         tp: float | None = None,
         sl: float | None = None,
+        trade_id: str | None = None,
     ) -> bool:
         """Place a MARKET order and optional TP/SL exits.
 
@@ -114,7 +115,9 @@ class FuturesTrader:
             )
             ts = filled_order.get("timestamp")
             entry_time = pd.to_datetime(ts, unit="ms") if ts is not None else pd.Timestamp.utcnow()
-            exit_events = self.manage_exit_orders(symbol, side, amount, tp, sl)
+            exit_events = self.manage_exit_orders(
+                symbol, side, amount, tp, sl, entry_price, trade_id
+            )
             if exit_events:
                 direction = "long" if side.lower() == "buy" else "short"
                 risk = abs(entry_price - sl) if sl is not None else 0.0
@@ -140,8 +143,6 @@ class FuturesTrader:
                                 "rr": rr,
                             }
                         )
-                    if self.risk_manager:
-                        self.risk_manager.close_trade(pnl)
             return True
         return False
 
@@ -154,6 +155,7 @@ class FuturesTrader:
         price: float,
         tp: float | None = None,
         sl: float | None = None,
+        trade_id: str | None = None,
     ) -> bool:
         """Place a LIMIT-MAKER order with optional TP/SL.
 
@@ -182,7 +184,9 @@ class FuturesTrader:
             )
             ts = filled_order.get("timestamp")
             entry_time = pd.to_datetime(ts, unit="ms") if ts is not None else pd.Timestamp.utcnow()
-            exit_events = self.manage_exit_orders(symbol, side, amount, tp, sl)
+            exit_events = self.manage_exit_orders(
+                symbol, side, amount, tp, sl, entry_price, trade_id
+            )
             if exit_events:
                 direction = "long" if side.lower() == "buy" else "short"
                 risk = abs(entry_price - sl) if sl is not None else 0.0
@@ -208,8 +212,6 @@ class FuturesTrader:
                                 "rr": rr,
                             }
                         )
-                    if self.risk_manager:
-                        self.risk_manager.close_trade(pnl)
             return True
         return False
 
@@ -238,6 +240,8 @@ class FuturesTrader:
         amount: float,
         tp: float | None,
         sl: float | None,
+        entry_price: float,
+        trade_id: str | None = None,
     ) -> list[tuple[float, pd.Timestamp]]:
         """Submit TP/SL orders and manage a trailing stop.
 
@@ -311,7 +315,15 @@ class FuturesTrader:
                     return events
 
             if not tp_filled and tp_status == "closed":
-                events.append((tp if tp is not None else 0.0, pd.Timestamp.utcnow()))
+                exit_price = tp if tp is not None else 0.0
+                events.append((exit_price, pd.Timestamp.utcnow()))
+                if self.risk_manager and trade_id is not None:
+                    pnl = (
+                        exit_price - entry_price
+                        if side.lower() == "buy"
+                        else entry_price - exit_price
+                    )
+                    self.risk_manager.close_trade(trade_id, pnl)
                 tp_filled = True
                 # replace stop for remaining half
                 if sl_id:
@@ -347,6 +359,13 @@ class FuturesTrader:
                     except ccxt.BaseError:
                         pass
                 events.append((current_stop, pd.Timestamp.utcnow()))
+                if self.risk_manager and trade_id is not None:
+                    pnl = (
+                        current_stop - entry_price
+                        if side.lower() == "buy"
+                        else entry_price - current_stop
+                    )
+                    self.risk_manager.close_trade(trade_id, pnl)
                 return events
 
             if tp_filled and sl_id:
@@ -411,6 +430,13 @@ class FuturesTrader:
                     return events
                 if sl_status == "closed":
                     events.append((current_stop, pd.Timestamp.utcnow()))
+                    if self.risk_manager and trade_id is not None:
+                        pnl = (
+                            current_stop - entry_price
+                            if side.lower() == "buy"
+                            else entry_price - current_stop
+                        )
+                        self.risk_manager.close_trade(trade_id, pnl)
                     return events
 
             time.sleep(0.1)

--- a/utils/risk.py
+++ b/utils/risk.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Callable, List
+from typing import Callable, Dict
 import datetime as dt
 import json
 import sqlite3
 from pathlib import Path
+import uuid
 
 
 @dataclass
@@ -40,7 +41,7 @@ class RiskManager:
     max_open_trades: int | None = None
     db_path: str | Path = "risk_state.db"
 
-    open_positions: List[float] = field(default_factory=list)
+    open_positions: Dict[str, float] = field(default_factory=dict)
     open_trades: int = 0
     consecutive_losses: int = 0
     daily_start_balance: float | None = None
@@ -77,12 +78,21 @@ class RiskManager:
     def _load_state(self) -> None:
         conn = sqlite3.connect(self.db_path)
         try:
-            cur = conn.execute("SELECT open_positions, consecutive_losses, daily_start_balance, trading_halted, last_reset_day FROM state WHERE id=1")
+            cur = conn.execute(
+                "SELECT open_positions, consecutive_losses, daily_start_balance, trading_halted, last_reset_day FROM state WHERE id=1"
+            )
             row = cur.fetchone()
             if row:
                 positions, losses, start_balance, halted, last_day = row
                 if positions:
-                    self.open_positions = json.loads(positions)
+                    loaded = json.loads(positions)
+                    if isinstance(loaded, dict):
+                        self.open_positions = loaded
+                    else:
+                        # fallback for legacy list format
+                        self.open_positions = {
+                            str(i): r for i, r in enumerate(loaded)
+                        }
                 self.consecutive_losses = losses or 0
                 self.daily_start_balance = start_balance
                 self.trading_halted = bool(halted)
@@ -136,7 +146,7 @@ class RiskManager:
 
     @property
     def open_risk(self) -> float:
-        return sum(self.open_positions)
+        return sum(self.open_positions.values())
 
     def can_open_trade(self) -> bool:
         """Return ``True`` if new trades are allowed."""
@@ -148,8 +158,8 @@ class RiskManager:
         balance = self._get_balance()
         return self.open_risk < balance * self.max_open_risk_pct
 
-    def open_trade(self, entry: float, stop: float) -> float:
-        """Register a new trade and return its position size."""
+    def open_trade(self, entry: float, stop: float) -> tuple[str, float]:
+        """Register a new trade and return ``(trade_id, position_size)``."""
         self._ensure_daily_reset()
         if not self.can_open_trade():
             raise ValueError("Risk limits breached; cannot open trade")
@@ -158,19 +168,18 @@ class RiskManager:
         if self.open_risk + risk > balance * self.max_open_risk_pct:
             raise ValueError("Open risk would exceed limit")
         size = self.position_size(entry, stop, risk=risk)
-        self.open_positions.append(risk)
-        self.open_trades += 1
+        trade_id = uuid.uuid4().hex
+        self.open_positions[trade_id] = risk
+        self.open_trades = len(self.open_positions)
         self._save_state()
-        return size
+        return trade_id, size
 
-    def close_trade(self, pnl: float) -> None:
+    def close_trade(self, trade_id: str, pnl: float) -> None:
         """Close an existing trade and update risk metrics."""
         self._ensure_daily_reset()
-        if self.open_positions:
-            # Remove risk for the oldest open position
-            self.open_positions.pop(0)
-            if self.open_trades > 0:
-                self.open_trades -= 1
+        removed = self.open_positions.pop(trade_id, None)
+        if removed is not None and self.open_trades > 0:
+            self.open_trades -= 1
         balance = self._get_balance()
         # Update consecutive losses
         if pnl < 0:


### PR DESCRIPTION
## Summary
- track per-trade risk by unique ID
- propagate trade IDs through trader and exit management
- adjust tests for new risk interface

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688bbfce9928832081c0ff5676a2e64a