### PR TITLE
refactor breakout volume thresholds

### DIFF
--- a/backtester.py
+++ b/backtester.py
@@ -95,14 +95,17 @@ def run_backtest(
     data_dir: str | Path = "data/raw_data",
     trades_path: str | Path = "trades.csv",
     equity_path: str | Path | None = None,
-    volume_spike: float = 2.0,
+    avg_volume_mult: float = 1.5,
+    delta_volume_mult: float = 2.0,
 ) -> dict:
     """Run a simple breakout backtest and return summary statistics.
 
     Parameters
     ----------
-    volume_spike:
-        Multiplier applied to volume statistics when generating signals.
+    avg_volume_mult:
+        Multiplier applied to the rolling average of volume.
+    delta_volume_mult:
+        Multiplier applied to the standard deviation of volume changes.
     """
 
     df = load_data(symbol, data_dir)
@@ -244,7 +247,8 @@ def run_backtest(
             delta_oi_series,
             volume_stats,
             funding,
-            volume_spike=volume_spike,
+            avg_volume_mult=avg_volume_mult,
+            delta_volume_mult=delta_volume_mult,
         )
         if not signals:
             continue
@@ -291,10 +295,16 @@ def parse_args() -> argparse.Namespace:
         help="Directory containing CSV data",
     )
     parser.add_argument(
-        "--volume-spike",
+        "--avg-volume-mult",
+        type=float,
+        default=1.5,
+        help="Average volume multiplier",
+    )
+    parser.add_argument(
+        "--delta-volume-mult",
         type=float,
         default=2.0,
-        help="Volume spike multiplier",
+        help="Volume delta standard deviation multiplier",
     )
     return parser.parse_args()
 
@@ -306,7 +316,8 @@ def main() -> None:
         args.start,
         args.end,
         data_dir=args.data_dir,
-        volume_spike=args.volume_spike,
+        avg_volume_mult=args.avg_volume_mult,
+        delta_volume_mult=args.delta_volume_mult,
     )
     for key, value in stats.items():
         print(f"{key}: {value}")

--- a/config.yaml
+++ b/config.yaml
@@ -28,7 +28,8 @@ data_paths:
   log_dir: "logs/"
 
 strategy:
-  volume_spike: 2.0
+  avg_volume_mult: 1.5
+  delta_volume_mult: 2.0
 
 feature_toggles:
   enable_notifications: true

--- a/main.py
+++ b/main.py
@@ -225,14 +225,16 @@ def init_logging(log_dir: str | Path) -> None:
     )
 
 
-def scan_and_enter(volume_spike: float = 2.0) -> None:
+def scan_and_enter(
+    avg_volume_mult: float = 1.5, delta_volume_mult: float = 2.0
+) -> None:
     """Run periodic scanning and entry logic.
 
     Parameters
     ----------
-    volume_spike:
-        Multiplier applied to volume statistics when generating breakout
-        signals.
+    avg_volume_mult, delta_volume_mult:
+        Multipliers applied to average volume and volume change respectively
+        when generating breakout signals.
     """
     logging.info("Running scan and entry logic")
     symbols = screener.screen()[:10]
@@ -271,7 +273,8 @@ def scan_and_enter(volume_spike: float = 2.0) -> None:
             delta_oi,
             pd.Series(dtype="float64"),
             funding,
-            volume_spike=volume_spike,
+            avg_volume_mult=avg_volume_mult,
+            delta_volume_mult=delta_volume_mult,
         )
         if signals:
             signals_by_symbol[symbol] = signals
@@ -391,8 +394,11 @@ def main() -> None:
     risk_manager = RiskManager(fetch_balance, max_open_trades=10)
     trader = None
 
-    vol_spike = config.get("strategy", {}).get("volume_spike", 2.0)
-    schedule.every(5).minutes.do(scan_and_enter, volume_spike=vol_spike)
+    avg_mult = config.get("strategy", {}).get("avg_volume_mult", 1.5)
+    delta_mult = config.get("strategy", {}).get("delta_volume_mult", 2.0)
+    schedule.every(5).minutes.do(
+        scan_and_enter, avg_volume_mult=avg_mult, delta_volume_mult=delta_mult
+    )
     schedule.every().day.at("00:00").do(daily_equity_and_risk_check)
     logging.info("Scheduler started")
 

--- a/tests/test_breakout_signals.py
+++ b/tests/test_breakout_signals.py
@@ -32,7 +32,13 @@ def test_long_breakout_signal():
     funding = 0.005
 
     signals = evaluate_breakout(
-        ohlcv, cluster, cvd, delta_oi, volume_stats, funding, volume_spike=1.5
+        ohlcv,
+        cluster,
+        cvd,
+        delta_oi,
+        volume_stats,
+        funding,
+        avg_volume_mult=1.5,
     )
     assert signals, "Expected a breakout signal"
     sig = signals[0]
@@ -65,7 +71,13 @@ def test_breakout_blocked_by_trend_filter():
 
     # Trend filter should block this potential breakout
     signals = evaluate_breakout(
-        ohlcv, cluster, cvd, delta_oi, volume_stats, funding, volume_spike=1.5
+        ohlcv,
+        cluster,
+        cvd,
+        delta_oi,
+        volume_stats,
+        funding,
+        avg_volume_mult=1.5,
     )
     assert signals == []
 

--- a/tests/test_trading_logic.py
+++ b/tests/test_trading_logic.py
@@ -98,7 +98,7 @@ def test_scan_and_enter_executes_long(monkeypatch):
     monkeypatch.setattr(
         main,
         "evaluate_breakout",
-        lambda ohlcv, level, cvd, delta_oi, volume_stats, funding, volume_spike=2.0: [
+        lambda ohlcv, level, cvd, delta_oi, volume_stats, funding, avg_volume_mult=1.5, delta_volume_mult=2.0: [
             Signal("long", 101, 99, 103, 105)
         ],
     )

--- a/utils/breakout_signals.py
+++ b/utils/breakout_signals.py
@@ -71,7 +71,8 @@ def evaluate_breakout(
     volume_stats: pd.Series,
     funding: float,
     *,
-    volume_spike: float = 2.0,
+    avg_volume_mult: float = 1.5,
+    delta_volume_mult: float = 2.0,
     ema_short: int = 15,
     ema_long: int = 30,
     funding_limit: float = 0.01,
@@ -95,12 +96,13 @@ def evaluate_breakout(
         Deprecated.  Retained for backward compatibility but ignored.
     funding:
         Current funding rate.  Positive values indicate longs pay shorts.
-    volume_spike:
-        Multiplier applied to both the average volume and the standard
-        deviation of volume changes.  A volume spike is detected when the
-        latest volume exceeds ``volume_spike`` × the rolling average and the
-        change in volume exceeds ``volume_spike`` × the rolling standard
-        deviation.
+    avg_volume_mult:
+        Multiplier applied to the rolling average of volume.  The latest
+        volume must exceed ``avg_volume_mult`` × the rolling average.
+    delta_volume_mult:
+        Multiplier applied to the rolling standard deviation of volume
+        changes.  The change in volume must exceed ``delta_volume_mult`` ×
+        the rolling standard deviation.
     ema_short, ema_long:
         Spans for the short and long exponential moving averages (typically
         5–15 and 10–30 respectively).
@@ -130,8 +132,9 @@ def evaluate_breakout(
     vol_delta = df["volume"].diff().iloc[-1]
     if pd.isna(avg_volume) or pd.isna(vol_sigma) or pd.isna(vol_delta):
         return []
-    vol_ok = (last["volume"] > volume_spike * avg_volume) and (
-        vol_delta > volume_spike * vol_sigma
+    vol_ok = (
+        last["volume"] > avg_volume_mult * avg_volume
+        and vol_delta > delta_volume_mult * vol_sigma
     )
 
     ema_bull = last["ema_short"] > last["ema_long"]


### PR DESCRIPTION
## Summary
- split volume spike threshold into separate `avg_volume_mult` and `delta_volume_mult`
- update breakout scanning and backtester to use new volume multipliers
- adjust config and tests for renamed parameters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c535247088320a3485ad53e9abe61