### PR TITLE
Add configurable risk-reward parameters

### DIFF
--- a/backtester.py
+++ b/backtester.py
@@ -97,6 +97,8 @@ def run_backtest(
     equity_path: str | Path | None = None,
     avg_volume_mult: float = 1.5,
     delta_volume_mult: float = 2.0,
+    tp1_rr: float = 1.5,
+    tp2_rr: float = 3.0,
 ) -> dict:
     """Run a simple breakout backtest and return summary statistics.
 
@@ -106,6 +108,8 @@ def run_backtest(
         Multiplier applied to the rolling average of volume.
     delta_volume_mult:
         Multiplier applied to the standard deviation of volume changes.
+    tp1_rr, tp2_rr:
+        Risk-reward multiples for the first and second take profit levels.
     """
 
     df = load_data(symbol, data_dir)
@@ -249,6 +253,8 @@ def run_backtest(
             funding,
             avg_volume_mult=avg_volume_mult,
             delta_volume_mult=delta_volume_mult,
+            tp1_rr=tp1_rr,
+            tp2_rr=tp2_rr,
         )
         if not signals:
             continue
@@ -306,6 +312,18 @@ def parse_args() -> argparse.Namespace:
         default=2.0,
         help="Volume delta standard deviation multiplier",
     )
+    parser.add_argument(
+        "--tp1-rr",
+        type=float,
+        default=1.5,
+        help="Risk-reward multiple for first take-profit",
+    )
+    parser.add_argument(
+        "--tp2-rr",
+        type=float,
+        default=3.0,
+        help="Risk-reward multiple for second take-profit",
+    )
     return parser.parse_args()
 
 
@@ -318,6 +336,8 @@ def main() -> None:
         data_dir=args.data_dir,
         avg_volume_mult=args.avg_volume_mult,
         delta_volume_mult=args.delta_volume_mult,
+        tp1_rr=args.tp1_rr,
+        tp2_rr=args.tp2_rr,
     )
     for key, value in stats.items():
         print(f"{key}: {value}")

--- a/config.yaml
+++ b/config.yaml
@@ -30,6 +30,8 @@ data_paths:
 strategy:
   avg_volume_mult: 1.5
   delta_volume_mult: 2.0
+  tp1_rr: 1.5
+  tp2_rr: 3.0
 
 feature_toggles:
   enable_notifications: true

--- a/main.py
+++ b/main.py
@@ -226,7 +226,10 @@ def init_logging(log_dir: str | Path) -> None:
 
 
 def scan_and_enter(
-    avg_volume_mult: float = 1.5, delta_volume_mult: float = 2.0
+    avg_volume_mult: float = 1.5,
+    delta_volume_mult: float = 2.0,
+    tp1_rr: float = 1.5,
+    tp2_rr: float = 3.0,
 ) -> None:
     """Run periodic scanning and entry logic.
 
@@ -235,6 +238,8 @@ def scan_and_enter(
     avg_volume_mult, delta_volume_mult:
         Multipliers applied to average volume and volume change respectively
         when generating breakout signals.
+    tp1_rr, tp2_rr:
+        Risk-reward multiples for the first and second take profit levels.
     """
     logging.info("Running scan and entry logic")
     symbols = screener.screen()[:10]
@@ -275,6 +280,8 @@ def scan_and_enter(
             funding,
             avg_volume_mult=avg_volume_mult,
             delta_volume_mult=delta_volume_mult,
+            tp1_rr=tp1_rr,
+            tp2_rr=tp2_rr,
         )
         if signals:
             signals_by_symbol[symbol] = signals
@@ -396,8 +403,14 @@ def main() -> None:
 
     avg_mult = config.get("strategy", {}).get("avg_volume_mult", 1.5)
     delta_mult = config.get("strategy", {}).get("delta_volume_mult", 2.0)
+    tp1_rr = config.get("strategy", {}).get("tp1_rr", 1.5)
+    tp2_rr = config.get("strategy", {}).get("tp2_rr", 3.0)
     schedule.every(5).minutes.do(
-        scan_and_enter, avg_volume_mult=avg_mult, delta_volume_mult=delta_mult
+        scan_and_enter,
+        avg_volume_mult=avg_mult,
+        delta_volume_mult=delta_mult,
+        tp1_rr=tp1_rr,
+        tp2_rr=tp2_rr,
     )
     schedule.every().day.at("00:00").do(daily_equity_and_risk_check)
     logging.info("Scheduler started")

--- a/tests/test_trading_logic.py
+++ b/tests/test_trading_logic.py
@@ -98,7 +98,8 @@ def test_scan_and_enter_executes_long(monkeypatch):
     monkeypatch.setattr(
         main,
         "evaluate_breakout",
-        lambda ohlcv, level, cvd, delta_oi, volume_stats, funding, avg_volume_mult=1.5, delta_volume_mult=2.0: [
+        lambda ohlcv, level, cvd, delta_oi, volume_stats, funding,
+        avg_volume_mult=1.5, delta_volume_mult=2.0, tp1_rr=1.5, tp2_rr=3.0: [
             Signal("long", 101, 99, 103, 105)
         ],
     )

--- a/utils/breakout_signals.py
+++ b/utils/breakout_signals.py
@@ -77,6 +77,8 @@ def evaluate_breakout(
     ema_long: int = 30,
     funding_limit: float = 0.01,
     delta_oi_thresh: float = 0.0,
+    tp1_rr: float = 1.5,
+    tp2_rr: float = 3.0,
 ) -> List[Signal]:
     """Evaluate breakout conditions and return trading signals.
 
@@ -110,6 +112,9 @@ def evaluate_breakout(
         Maximum absolute funding rate allowed for signals.
     delta_oi_thresh:
         Minimum absolute change in open interest required.
+    tp1_rr, tp2_rr:
+        Risk-reward multiples used to compute the first and second take profit
+        levels relative to the entry price and calculated risk.
 
     Returns
     -------
@@ -173,8 +178,8 @@ def evaluate_breakout(
                 "long",
                 entry,
                 stop,
-                entry + 1.5 * risk,
-                entry + 3 * risk,
+                entry + tp1_rr * risk,
+                entry + tp2_rr * risk,
             )
         )
 
@@ -196,8 +201,8 @@ def evaluate_breakout(
                 "short",
                 entry,
                 stop,
-                entry - 1.5 * risk,
-                entry - 3 * risk,
+                entry - tp1_rr * risk,
+                entry - tp2_rr * risk,
             )
         )
 


### PR DESCRIPTION
## Summary
- make risk/reward ratios configurable in `evaluate_breakout`
- expose take-profit RR parameters throughout trading and backtesting entry logic
- extend config and tests for new TP RR options

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c5a18242083209f4207ff790b7141