### PR TITLE
Use USD notional for risk and trade sizing

### DIFF
--- a/main.py
+++ b/main.py
@@ -132,13 +132,20 @@ def start_processing_loops() -> None:
         """Continuously scan markets for entry opportunities."""
         while True:
             thresholds = CONFIG.get("thresholds", {})
-            quantity = thresholds.get("min_trade_size", 0.0) or 1.0
+            trade_value = thresholds.get("min_trade_size", 0.0) or 1.0
 
             for name, client in CLIENTS.items():
                 exchanges._current = client
                 for symbol in WHITELISTS.get(name, []):
                     if risk_control.is_paused() or risk_control.is_symbol_open(symbol):
                         continue
+                    try:
+                        base_metrics = await strategy.get_market_metrics(symbol, 1.0)
+                    except Exception as exc:
+                        print(f"Metrics error {name} {symbol}: {exc}")
+                        continue
+                    price = base_metrics.futures_price
+                    quantity = trade_value / price if price else 0.0
                     try:
                         metrics = await strategy.get_market_metrics(symbol, quantity)
                     except Exception as exc:

--- a/risk/risk_control.py
+++ b/risk/risk_control.py
@@ -69,26 +69,26 @@ def configure(config: Dict[str, float], deposit_size: Optional[float] = None) ->
     )
 
 
-def can_open_position(quantity: float) -> bool:
-    """Return ``True`` if a new position of ``quantity`` is allowed."""
+def can_open_position(notional: float) -> bool:
+    """Return ``True`` if a position of ``notional`` USD is allowed."""
 
     if _state.paused:
         return False
     if _state.open_positions >= _limits.max_open_positions:
         return False
-    if _state.total_notional + quantity > _limits.deposit_cap:
+    if _state.total_notional + notional > _limits.deposit_cap:
         return False
-    if _state.total_notional + quantity > _limits.max_position_size:
+    if _state.total_notional + notional > _limits.max_position_size:
         return False
     if _state.daily_loss >= _limits.max_daily_loss:
         return False
     return True
 
 
-def update_position(delta: float) -> None:
-    """Update the tracked notional exposure by ``delta`` units."""
+def update_position(delta_notional: float) -> None:
+    """Update the tracked notional exposure by ``delta_notional`` USD."""
 
-    _state.total_notional = max(_state.total_notional + delta, 0.0)
+    _state.total_notional = max(_state.total_notional + delta_notional, 0.0)
 
 
 def is_symbol_open(symbol: str) -> bool:

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -139,6 +139,7 @@ def check_entry_conditions(
         if metrics.futures_price
         else float("inf")
     )
+    notional = quantity * metrics.futures_price
 
     return (
         abs(metrics.funding_rate) >= thresholds.get("funding_rate", 0.0)
@@ -150,9 +151,9 @@ def check_entry_conditions(
         and metrics.open_interest <= metrics.volume * 2
         and metrics.slippage <= thresholds.get("slippage", float("inf"))
         and thresholds.get("min_trade_size", 0.0)
-        <= quantity
+        <= notional
         <= thresholds.get("max_trade_size", float("inf"))
-        and quantity <= max_deposit_trade
+        and notional <= max_deposit_trade
         and symbol in whitelist
         and not risk_control.is_symbol_open(symbol)
     )
@@ -180,16 +181,17 @@ async def open_neutral_position(symbol: str, quantity: float) -> Dict[str, Dict]
     bot_cfg = CONFIG.get("bot", {})
     if symbol not in bot_cfg.get("whitelist", []):
         raise RuntimeError("Symbol not whitelisted")
+    entry_metrics = await get_market_metrics(symbol, quantity)
+    notional = quantity * entry_metrics.futures_price
     deposit = bot_cfg.get("deposit_size", float("inf"))
     deposit_pct = CONFIG.get("thresholds", {}).get("deposit_pct", 1.0)
     max_trade = deposit * deposit_pct
-    if quantity > deposit or quantity > max_trade:
+    if notional > deposit or notional > max_trade:
         raise RuntimeError("Trade size exceeds deposit limits")
-    if not risk_control.can_open_position(quantity) or risk_control.is_symbol_open(symbol):
+    if not risk_control.can_open_position(notional) or risk_control.is_symbol_open(symbol):
         raise RuntimeError("Risk limits exceeded, trading paused, or position exists")
-    entry_metrics = await get_market_metrics(symbol, quantity)
     orders = await hedge(symbol, quantity)
-    risk_control.update_position(quantity)
+    risk_control.update_position(notional)
     risk_control.mark_symbol_open(symbol)
     now = time.time()
     commission = sum(float(o.get("fee", 0.0)) for o in orders.values())
@@ -211,7 +213,7 @@ async def open_neutral_position(symbol: str, quantity: float) -> Dict[str, Dict]
         if getattr(exchanges, "_current", None)
         else "unknown"
     )
-    volume_usd = quantity * entry_metrics.futures_price
+    volume_usd = notional
     log_trade(
         {
             "symbol": symbol,
@@ -270,7 +272,8 @@ async def close_neutral_position(
     )
     if entry is not None:
         entry["commissions"] = entry.get("commissions", 0.0) + commission
-    risk_control.update_position(-quantity)
+    ref_price = entry.get("entry_futures_price", 0.0) if entry else 0.0
+    risk_control.update_position(-(quantity * ref_price))
     risk_control.record_pnl(pnl)
     if final:
         risk_control.mark_symbol_closed(symbol)
@@ -339,8 +342,13 @@ async def monitor_neutral_position(
         else:
             pnl = 0.0
         if reasons:
-            min_trade = exit_thresholds.get("min_trade_size", 0.0)
-            if entry and quantity > max(min_trade * 2, 0.0):
+            min_trade_usd = exit_thresholds.get("min_trade_size", 0.0)
+            min_trade_qty = (
+                min_trade_usd / metrics.futures_price
+                if metrics.futures_price
+                else 0.0
+            )
+            if entry and quantity > max(min_trade_qty * 2, 0.0):
                 partial_qty = quantity / 2
                 pnl_part = (
                     (metrics.futures_price - entry.get("entry_futures_price", 0.0))


### PR DESCRIPTION
## Summary
- Track risk exposure in USD by passing notional value to risk controls.
- Evaluate entry eligibility using USD-based deposit caps and trade size limits.
- Derive trade quantities from USD thresholds when scanning markets.

## Testing
- `python -m py_compile risk/risk_control.py strategies/funding_arbitrage.py main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c69792f44832096aaf834d066d39d