### PR TITLE
Log trades after exit with tp1/tp2

### DIFF
--- a/tests/test_futures_trader.py
+++ b/tests/test_futures_trader.py
@@ -131,10 +131,11 @@ def test_exit_orders_with_trailing_stop_and_logging():
     # initial stop should be cancelled after TP1
     assert exchange.cancel_order_calls[0] == ("3", "BTC/USDT")
 
-    # two trade logs: TP1 and trailing exit
-    assert len(logs) == 2
-    assert logs[0]["exit"] == 21000
-    assert logs[1]["exit"] > 19000
+    # single trade log with tp1 and final exit recorded
+    assert len(logs) == 1
+    assert logs[0]["tp1"] == 21000
+    assert logs[0]["tp2"] > 19000
+    assert logs[0]["result"] == "tp2"
     assert len(risk.pnls) == 2
 
 

--- a/tests/test_trade_logger.py
+++ b/tests/test_trade_logger.py
@@ -14,11 +14,12 @@ def test_append_and_daily_summary(tmp_path):
         "entry_time": pd.Timestamp("2024-01-01T00:00:00Z"),
         "entry": 100.0,
         "stop": 95.0,
-        "tp": 110.0,
+        "tp1": 110.0,
+        "tp2": 115.0,
         "exit_time": pd.Timestamp("2024-01-01T01:00:00Z"),
-        "exit": 110.0,
-        "pnl": 10.0,
-        "rr": 2.0,
+        "pnl": 12.5,
+        "rr": 2.5,
+        "result": "tp2",
     }
     trade2 = {
         "symbol": "BTC/USDT",
@@ -26,16 +27,17 @@ def test_append_and_daily_summary(tmp_path):
         "entry_time": pd.Timestamp("2024-01-01T02:00:00Z"),
         "entry": 120.0,
         "stop": 125.0,
-        "tp": 110.0,
+        "tp1": 0.0,
+        "tp2": 125.0,
         "exit_time": pd.Timestamp("2024-01-01T03:00:00Z"),
-        "exit": 125.0,
         "pnl": -5.0,
         "rr": -1.0,
+        "result": "sl",
     }
     append_trade(trade1, trades_path)
     append_trade(trade2, trades_path)
 
     summary = daily_summary(trades_path, date=dt.date(2024, 1, 1))
     assert summary["winrate"] == 0.5
-    assert summary["avg_rr"] == 0.5
-    assert summary["equity_change"] == 5.0
+    assert summary["avg_rr"] == 0.75
+    assert summary["equity_change"] == 7.5

--- a/utils/futures_trader.py
+++ b/utils/futures_trader.py
@@ -114,36 +114,12 @@ class FuturesTrader:
                 filled_order.get("average") or filled_order.get("price") or 0.0
             )
             ts = filled_order.get("timestamp")
-            entry_time = pd.to_datetime(ts, unit="ms") if ts is not None else pd.Timestamp.utcnow()
-            exit_events = self.manage_exit_orders(
-                symbol, side, amount, tp, sl, entry_price, trade_id
+            entry_time = (
+                pd.to_datetime(ts, unit="ms") if ts is not None else pd.Timestamp.utcnow()
             )
-            if exit_events:
-                direction = "long" if side.lower() == "buy" else "short"
-                risk = abs(entry_price - sl) if sl is not None else 0.0
-                for i, (exit_price, exit_time) in enumerate(exit_events):
-                    pnl = (
-                        exit_price - entry_price
-                        if direction == "long"
-                        else entry_price - exit_price
-                    )
-                    rr = pnl / risk if risk else 0.0
-                    if self.trade_logger:
-                        self.trade_logger(
-                            {
-                                "symbol": symbol,
-                                "direction": direction,
-                                "entry_time": entry_time,
-                                "entry": entry_price,
-                                "stop": sl if sl is not None else 0.0,
-                                "tp": tp if (tp is not None and i == 0) else 0.0,
-                                "exit_time": exit_time,
-                                "exit": exit_price,
-                                "pnl": pnl,
-                                "rr": rr,
-                            }
-                        )
-            return True
+            return self.manage_exit_orders(
+                symbol, side, amount, tp, sl, entry_price, entry_time, trade_id
+            )
         return False
 
     # ------------------------------------------------------------------
@@ -183,36 +159,12 @@ class FuturesTrader:
                 filled_order.get("average") or filled_order.get("price") or price
             )
             ts = filled_order.get("timestamp")
-            entry_time = pd.to_datetime(ts, unit="ms") if ts is not None else pd.Timestamp.utcnow()
-            exit_events = self.manage_exit_orders(
-                symbol, side, amount, tp, sl, entry_price, trade_id
+            entry_time = (
+                pd.to_datetime(ts, unit="ms") if ts is not None else pd.Timestamp.utcnow()
             )
-            if exit_events:
-                direction = "long" if side.lower() == "buy" else "short"
-                risk = abs(entry_price - sl) if sl is not None else 0.0
-                for i, (exit_price, exit_time) in enumerate(exit_events):
-                    pnl = (
-                        exit_price - entry_price
-                        if direction == "long"
-                        else entry_price - exit_price
-                    )
-                    rr = pnl / risk if risk else 0.0
-                    if self.trade_logger:
-                        self.trade_logger(
-                            {
-                                "symbol": symbol,
-                                "direction": direction,
-                                "entry_time": entry_time,
-                                "entry": entry_price,
-                                "stop": sl if sl is not None else 0.0,
-                                "tp": tp if (tp is not None and i == 0) else 0.0,
-                                "exit_time": exit_time,
-                                "exit": exit_price,
-                                "pnl": pnl,
-                                "rr": rr,
-                            }
-                        )
-            return True
+            return self.manage_exit_orders(
+                symbol, side, amount, tp, sl, entry_price, entry_time, trade_id
+            )
         return False
 
     # ------------------------------------------------------------------
@@ -241,24 +193,29 @@ class FuturesTrader:
         tp: float | None,
         sl: float | None,
         entry_price: float,
+        entry_time: pd.Timestamp,
         trade_id: str | None = None,
-    ) -> list[tuple[float, pd.Timestamp]]:
-        """Submit TP/SL orders and manage a trailing stop.
+    ) -> bool:
+        """Submit TP/SL orders, manage trailing stop and log the trade.
 
         Two take-profit targets are supported: ``tp`` for 50% of the position
         size and a trailing stop for the remaining half. A fixed ``sl`` can be
         supplied which acts as the initial stop loss before the trailing stop
-        kicks in.  The function returns a list of ``(exit_price, exit_time)``
-        tuples for each filled exit order.
+        kicks in.  Once the trade is closed, :func:`append_trade` is called with
+        aggregated information including ``tp1`` and final exit ``tp2``.
         """
 
         opposite = "sell" if side.lower() == "buy" else "buy"
         tp_id: str | None = None
         sl_id: str | None = None
-        events: list[tuple[float, pd.Timestamp]] = []
         half_amount = amount / 2
         trailing_step = 0.002
         current_stop = sl if sl is not None else 0.0
+        tp1_price: float = 0.0
+        tp1_time: pd.Timestamp | None = None
+        final_price: float = 0.0
+        final_time: pd.Timestamp | None = None
+        result: str = ""
 
         if tp is not None:
             try:
@@ -273,7 +230,7 @@ class FuturesTrader:
                 )
                 tp_id = tp_order.get("id")
             except ccxt.BaseError:
-                return events
+                return False
 
         if sl is not None:
             try:
@@ -288,10 +245,10 @@ class FuturesTrader:
                 )
                 sl_id = sl_order.get("id")
             except ccxt.BaseError:
-                return events
+                return False
 
         if not tp_id and not sl_id:
-            return events
+            return False
 
         tp_filled = False
         highest: float | None = None
@@ -305,18 +262,19 @@ class FuturesTrader:
                         self.exchange.fetch_order, tp_id, symbol
                     ).get("status")
                 except ccxt.BaseError:
-                    return events
+                    return False
             if sl_id:
                 try:
                     sl_status = self._retry(
                         self.exchange.fetch_order, sl_id, symbol
                     ).get("status")
                 except ccxt.BaseError:
-                    return events
+                    return False
 
             if not tp_filled and tp_status == "closed":
                 exit_price = tp if tp is not None else 0.0
-                events.append((exit_price, pd.Timestamp.utcnow()))
+                tp1_price = exit_price
+                tp1_time = pd.Timestamp.utcnow()
                 if self.risk_manager and trade_id is not None:
                     pnl = (
                         exit_price - entry_price
@@ -345,7 +303,7 @@ class FuturesTrader:
                         sl_id = sl_order.get("id")
                         current_stop = sl
                     except ccxt.BaseError:
-                        return events
+                        return False
                 try:
                     ticker = self._retry(self.exchange.fetch_ticker, symbol)
                     price = float(ticker.get("last") or 0.0)
@@ -358,7 +316,8 @@ class FuturesTrader:
                         self._retry(self.exchange.cancel_order, tp_id, symbol)
                     except ccxt.BaseError:
                         pass
-                events.append((current_stop, pd.Timestamp.utcnow()))
+                final_price = current_stop
+                final_time = pd.Timestamp.utcnow()
                 if self.risk_manager and trade_id is not None:
                     pnl = (
                         current_stop - entry_price
@@ -366,7 +325,8 @@ class FuturesTrader:
                         else entry_price - current_stop
                     )
                     self.risk_manager.close_trade(trade_id, pnl)
-                return events
+                result = "sl" if not tp_filled else "tp2"
+                break
 
             if tp_filled and sl_id:
                 try:
@@ -397,7 +357,7 @@ class FuturesTrader:
                             sl_id = sl_order.get("id")
                             current_stop = new_stop
                         except ccxt.BaseError:
-                            return events
+                            return False
                 else:
                     if highest is None or price < highest:
                         highest = price
@@ -420,16 +380,17 @@ class FuturesTrader:
                             sl_id = sl_order.get("id")
                             current_stop = new_stop
                         except ccxt.BaseError:
-                            return events
+                            return False
 
                 try:
                     sl_status = self._retry(
                         self.exchange.fetch_order, sl_id, symbol
                     ).get("status")
                 except ccxt.BaseError:
-                    return events
+                    return False
                 if sl_status == "closed":
-                    events.append((current_stop, pd.Timestamp.utcnow()))
+                    final_price = current_stop
+                    final_time = pd.Timestamp.utcnow()
                     if self.risk_manager and trade_id is not None:
                         pnl = (
                             current_stop - entry_price
@@ -437,7 +398,46 @@ class FuturesTrader:
                             else entry_price - current_stop
                         )
                         self.risk_manager.close_trade(trade_id, pnl)
-                    return events
+                    result = "tp2"
+                    break
 
             time.sleep(0.1)
+
+        # compute and log trade
+        direction = "long" if side.lower() == "buy" else "short"
+        risk = abs(entry_price - sl) if sl is not None else 0.0
+        if tp_filled:
+            pnl1 = (
+                tp1_price - entry_price if direction == "long" else entry_price - tp1_price
+            )
+            pnl2 = (
+                final_price - entry_price
+                if direction == "long"
+                else entry_price - final_price
+            )
+            pnl = (pnl1 + pnl2) / 2
+        else:
+            pnl = (
+                final_price - entry_price
+                if direction == "long"
+                else entry_price - final_price
+            )
+        rr = pnl / risk if risk else 0.0
+        if self.trade_logger:
+            self.trade_logger(
+                {
+                    "symbol": symbol,
+                    "direction": direction,
+                    "entry_time": entry_time,
+                    "entry": entry_price,
+                    "stop": sl if sl is not None else 0.0,
+                    "tp1": tp1_price if tp_filled else 0.0,
+                    "tp2": final_price,
+                    "exit_time": final_time,
+                    "pnl": pnl,
+                    "rr": rr,
+                    "result": result,
+                }
+            )
+        return True
 

--- a/utils/trade_logger.py
+++ b/utils/trade_logger.py
@@ -18,14 +18,27 @@ def append_trade(trade: Dict[str, Any], trades_path: str | Path = "trades.csv") 
     trade:
         Dictionary containing trade details. Expected keys include
         ``symbol``, ``direction``, ``entry_time``, ``entry``, ``stop``,
-        ``tp``, ``exit_time``, ``exit``, ``pnl`` and ``rr``.
+        ``tp1``, ``tp2``, ``exit_time``, ``pnl``, ``rr`` and ``result``.
     trades_path:
         CSV file to append to. Will be created with headers if it does not
         yet exist.
     """
 
     path = Path(trades_path)
-    df = pd.DataFrame([trade])
+    columns = [
+        "symbol",
+        "direction",
+        "entry_time",
+        "entry",
+        "stop",
+        "tp1",
+        "tp2",
+        "exit_time",
+        "pnl",
+        "rr",
+        "result",
+    ]
+    df = pd.DataFrame([trade], columns=columns)
     header = not path.exists()
     df.to_csv(path, mode="a", header=header, index=False)
 


### PR DESCRIPTION
## Summary
- log futures trades only once after exits, capturing first take-profit and final result
- extend trade logger to record `tp1`, `tp2` and `result`
- adjust tests for new logging format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c6fe7c1d88320ae6f17061e1bb66d