### PR TITLE
feat(backtester): add market trend filter

### DIFF
--- a/backtester.py
+++ b/backtester.py
@@ -25,6 +25,11 @@ import numpy as np
 from utils.range_clusters import find_tight_range_clusters
 from utils.breakout_signals import evaluate_breakout, Signal
 from utils.plotting import plot_equity
+from utils.market_analysis import (
+    load_btc_eth_candles,
+    has_consecutive_move,
+    price_above_ema,
+)
 
 
 @dataclass
@@ -259,6 +264,25 @@ def run_backtest(
         if not signals:
             continue
         sig = signals[0]
+
+        # Evaluate broader market trend using recent BTC and ETH candles
+        candles = load_btc_eth_candles()
+        btc = candles.get("BTC/USDT")
+        eth = candles.get("ETH/USDT")
+        btc_down = has_consecutive_move(btc, "down")
+        eth_down = has_consecutive_move(eth, "down")
+        btc_up = has_consecutive_move(btc, "up")
+        eth_up = has_consecutive_move(eth, "up")
+        btc_above = price_above_ema(btc)
+        eth_above = price_above_ema(eth)
+
+        allow_long = not (btc_down or eth_down or not btc_above or not eth_above)
+        allow_short = not (btc_up or eth_up)
+
+        if sig.direction == "long" and not allow_long:
+            continue
+        if sig.direction == "short" and not allow_short:
+            continue
         open_trade = Position(
             symbol=symbol,
             direction=sig.direction,

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -37,6 +37,13 @@ def test_backtester_produces_trade(tmp_path, monkeypatch):
 
     monkeypatch.setattr(backtester, "find_tight_range_clusters", fake_clusters)
 
+    def fake_candles(limit=100, exchange=None):
+        ts = pd.date_range("2024-01-01", periods=6, freq="5T")
+        df = pd.DataFrame({"timestamp": ts, "close": [1, 2, 3, 4, 5, 6]})
+        return {"BTC/USDT": df, "ETH/USDT": df}
+
+    monkeypatch.setattr(backtester, "load_btc_eth_candles", fake_candles)
+
     trades_path = tmp_path / "trades.csv"
     equity_path = tmp_path / "equity.png"
     stats = backtester.run_backtest(
@@ -56,3 +63,33 @@ def test_backtester_produces_trade(tmp_path, monkeypatch):
     # reported pnl equals sum of individual trade pnls
     assert abs(trades["pnl"].sum() - stats["pnl"]) < 1e-6
     assert equity_path.exists()
+
+
+def test_backtester_skips_when_trend_disallows(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data" / "raw_data"
+    csv_path = data_dir / "ETHUSDT.csv"
+    create_sample_data(csv_path)
+
+    def fake_clusters(df, atr_multiplier=0.5, min_bars=10, max_bars=30):
+        return pd.DataFrame(
+            [{"start": df["timestamp"].iloc[0], "end": df["timestamp"].iloc[-1], "high": 101, "low": 99, "duration": 10}]
+        )
+
+    monkeypatch.setattr(backtester, "find_tight_range_clusters", fake_clusters)
+
+    def fake_candles(limit=100, exchange=None):
+        ts = pd.date_range("2024-01-01", periods=6, freq="5T")
+        df = pd.DataFrame({"timestamp": ts, "close": [6, 5, 4, 3, 2, 1]})
+        return {"BTC/USDT": df, "ETH/USDT": df}
+
+    monkeypatch.setattr(backtester, "load_btc_eth_candles", fake_candles)
+
+    trades_path = tmp_path / "trades.csv"
+    stats = backtester.run_backtest(
+        "ETHUSDT", data_dir=data_dir, trades_path=trades_path, equity_path=tmp_path / "equity.png"
+    )
+    try:
+        trades = pd.read_csv(trades_path)
+    except pd.errors.EmptyDataError:
+        trades = pd.DataFrame()
+    assert trades.empty


### PR DESCRIPTION
## Summary
- load recent BTC and ETH 5m candles before opening a trade
- skip signals when broader market trend disallows entry
- add test coverage for trend filter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c71a191208320bb15f72ca72b6762