### PR TITLE
Include funding, basis, volume, and duration in Telegram alerts

### DIFF
--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -135,7 +135,7 @@ async def _handle_timeout() -> None:
             from main import CLIENTS, POSITION_TASKS
             from strategies import funding_arbitrage as strategy
             from utils.logger import log_trade
-            from utils.telegram import notify_close
+            from utils.telegram import notify_close, format_duration
             from datetime import datetime
         except Exception as exc:  # pragma: no cover - defensive
             logger.error("Emergency exit setup failed: %s", exc)
@@ -164,9 +164,19 @@ async def _handle_timeout() -> None:
                             exchange_name,
                             exc_close,
                         )
+                        hold_time = time.time() - entry.get("entry_timestamp", time.time())
+                        funding_pct = entry.get("entry_funding", 0.0) * 100
+                        basis_pct = entry.get("entry_basis", 0.0)
+                        volume_usd = quantity * entry.get("entry_futures_price", 0.0)
                         notify_close(
                             pid,
-                            f"Emergency exit failed {symbol} on {exchange_name}: {exc_close}",
+                            (
+                                f"Emergency exit failed {symbol} on {exchange_name}: {exc_close}\n"
+                                f"Funding: {funding_pct:.4f}%\n"
+                                f"Basis: {basis_pct:.4f}%\n"
+                                f"Volume: ${volume_usd:.2f}\n"
+                                f"Time in position: {format_duration(hold_time)}"
+                            ),
                         )
                     else:
                         exit_spot = float(
@@ -218,9 +228,18 @@ async def _handle_timeout() -> None:
                                 "notes": "emergency_exit",
                             }
                         )
+                        hold_time = exit_ts - entry.get("entry_timestamp", exit_ts)
+                        funding_pct = entry.get("entry_funding", 0.0) * 100
                         notify_close(
                             pid,
-                            f"Emergency exit {symbol} on {exchange_name} PnL:{pnl:.4f}",
+                            (
+                                f"Emergency exit {symbol} on {exchange_name}\n"
+                                f"Funding: {funding_pct:.4f}%\n"
+                                f"Basis: {exit_basis:.4f}%\n"
+                                f"Volume: ${volume_usd:.2f}\n"
+                                f"Time in position: {format_duration(hold_time)}\n"
+                                f"PnL: {pnl:.4f}"
+                            ),
                         )
                 finally:
                     globals()["_current"] = exchanges_current

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ starts the strategy loops and exposes the loaded configuration via the
 from __future__ import annotations
 
 import asyncio
+import time
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -20,7 +21,7 @@ from exchanges.bybit import BybitExchange
 from risk import risk_control
 from strategies import funding_arbitrage as strategy
 from ai.parameter_optimizer import periodic_optimization
-from utils.telegram import notify_close, notify_open
+from utils.telegram import format_duration, notify_close, notify_open
 
 # Global configuration dictionary that other modules can import.
 CONFIG: Dict[str, Any] = {}
@@ -111,18 +112,44 @@ def start_processing_loops() -> None:
                 position_id=position_id,
             )
         except Exception as exc:
+            entry = strategy._positions.get(symbol, {})
+            hold = time.time() - entry.get("entry_timestamp", time.time())
+            funding_pct = entry.get("entry_funding", 0.0) * 100
+            basis_pct = entry.get("entry_basis", 0.0)
+            volume_usd = entry.get("entry_futures_price", 0.0) * entry.get(
+                "initial_quantity", entry.get("quantity", 0.0)
+            )
             notify_close(
                 position_id,
-                f"Error on {exchange_name} {symbol}: {exc}",
+                (
+                    f"Error on {exchange_name} {symbol}: {exc}\n"
+                    f"Funding: {funding_pct:.4f}%\n"
+                    f"Basis: {basis_pct:.4f}%\n"
+                    f"Volume: ${volume_usd:.2f}\n"
+                    f"Time in position: {format_duration(hold)}"
+                ),
             )
             raise
         else:
             entry = strategy._positions.get(symbol, {})
             pnl = entry.get("pnl", 0.0)
             reasons = entry.get("exit_reasons")
+            hold = entry.get("exit_timestamp", 0) - entry.get("entry_timestamp", 0)
+            funding_pct = entry.get("exit_funding", entry.get("entry_funding", 0.0)) * 100
+            basis_pct = entry.get("exit_basis", 0.0)
+            volume_usd = entry.get("entry_futures_price", 0.0) * entry.get(
+                "initial_quantity", entry.get("quantity", 0.0)
+            )
             notify_close(
                 position_id,
-                f"Closed {symbol} on {exchange_name} PnL:{pnl} reasons:{reasons}",
+                (
+                    f"Closed {symbol} on {exchange_name}\n"
+                    f"Funding: {funding_pct:.4f}%\n"
+                    f"Basis: {basis_pct:.4f}%\n"
+                    f"Volume: ${volume_usd:.2f}\n"
+                    f"Time in position: {format_duration(hold)}\n"
+                    f"PnL: {pnl:.4f} Reasons: {reasons}"
+                ),
             )
         finally:
             POSITION_TASKS.pop(position_id, None)
@@ -157,9 +184,16 @@ def start_processing_loops() -> None:
                     ):
                         try:
                             await strategy.open_neutral_position(symbol, quantity)
+                            volume_usd = quantity * metrics.futures_price
                             notify_open(
                                 f"{name}:{symbol}",
-                                f"Opened {symbol} on {name} qty {quantity}",
+                                (
+                                    f"Opened {symbol} on {name}\n"
+                                    f"Funding: {metrics.funding_rate * 100:.4f}%\n"
+                                    f"Basis: {metrics.basis:.4f}%\n"
+                                    f"Volume: ${volume_usd:.2f}\n"
+                                    f"Time in position: {format_duration(0)}"
+                                ),
                             )
                             task = asyncio.create_task(
                                 monitor_position(name, symbol, quantity)

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -25,7 +25,7 @@ from risk import risk_control
 from ai.parameter_optimizer import load_thresholds as _load_thresholds
 from main import CONFIG
 from utils.logger import log_trade
-from utils.telegram import notify_partial_close
+from utils.telegram import format_duration, notify_partial_close
 
 
 @dataclass
@@ -372,6 +372,7 @@ async def monitor_neutral_position(
                 )
                 volume_usd = partial_qty * entry.get("entry_futures_price", 0.0)
                 pnl_pct = (pnl_part / volume_usd * 100) if volume_usd else 0.0
+                hold_time = exit_ts - entry.get("entry_timestamp", exit_ts)
                 exchange_name = (
                     type(exchanges._current).__name__.replace("Exchange", "").lower()
                     if getattr(exchanges, "_current", None)
@@ -407,9 +408,15 @@ async def monitor_neutral_position(
                 if position_id:
                     notify_partial_close(
                         position_id,
-                        f"Scaled out {symbol}: remaining {quantity:.4f}, "
-                        f"funding {entry.get('funding_accrued', 0.0):.4f}, "
-                        f"pnl {entry.get('pnl', 0.0):.4f}",
+                        (
+                            f"Scaled out {symbol}: remaining {quantity:.4f}\n"
+                            f"Funding: {metrics.funding_rate * 100:.4f}%\n"
+                            f"Basis: {exit_basis:.4f}%\n"
+                            f"Volume: ${volume_usd:.2f}\n"
+                            f"Time in position: {format_duration(hold_time)}\n"
+                            f"Funding accrued: {entry.get('funding_accrued', 0.0):.4f}\n"
+                            f"PnL: {entry.get('pnl', 0.0):.4f}"
+                        ),
                     )
                 continue
             await close_neutral_position(symbol, quantity, pnl, final=True)
@@ -428,6 +435,7 @@ async def monitor_neutral_position(
                         "exit_futures_price": metrics.futures_price,
                         "exit_spot_price": metrics.spot_price,
                         "exit_basis": exit_basis,
+                        "exit_funding": metrics.funding_rate,
                         "pnl": total_pnl,
                     }
                 )

--- a/utils/telegram.py
+++ b/utils/telegram.py
@@ -11,6 +11,21 @@ API_URL = f"https://api.telegram.org/bot{API_TOKEN}"
 _MESSAGE_CACHE: Dict[str, int] = {}
 
 
+def format_duration(seconds: float) -> str:
+    """Return a human readable duration given ``seconds``."""
+    seconds = max(int(seconds), 0)
+    minutes, sec = divmod(seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    parts = []
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes:
+        parts.append(f"{minutes}m")
+    if not parts:
+        parts.append(f"{sec}s")
+    return " ".join(parts)
+
+
 def _send_message(text: str) -> Optional[int]:
     """Send a new Telegram message and return the message ID."""
     if not API_TOKEN or not CHAT_ID:


### PR DESCRIPTION
## Summary
- add `format_duration` helper and maintain Telegram message cache
- include funding rate, basis %, trade volume, and position time in open, partial close, and close alerts
- update emergency exit alerts with additional market and position details

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c724f51f88320bef4dfb86cc637d2