### PR TITLE
Add spot market support for Binance and Bybit

### DIFF
--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -57,6 +57,22 @@ class BaseExchange(ABC):
     async def get_balance(self) -> dict:
         """Return account balance information."""
 
+    # Spot specific interfaces -------------------------------------------------
+
+    @abstractmethod
+    async def place_spot_order(
+        self, symbol: str, side: str, quantity: float, price: float | None = None
+    ) -> dict:
+        """Place a spot market order and return exchange response."""
+
+    @abstractmethod
+    async def get_spot_orderbook(self, symbol: str, depth: int = 5) -> dict:
+        """Return the latest spot order book for ``symbol``."""
+
+    @abstractmethod
+    async def get_spot_balance(self) -> dict:
+        """Return spot account balance information."""
+
     @abstractmethod
     async def fetch_funding_history(
         self, symbol: str, hours: int = 8, limit: int = 3
@@ -307,8 +323,11 @@ async def place_spot_order(
     symbol: str, side: str, quantity: float, price: float | None = None
 ) -> dict:
     """Place a spot order and wait for full execution."""
-
-    order = await place_order(symbol, side, quantity, price)
+    if _current is None:  # pragma: no cover - defensive programming
+        raise RuntimeError("Exchange not configured")
+    order = await _await_with_timeout(
+        _current.place_spot_order(symbol, side, quantity, price)
+    )
     order_id = str(order.get("orderId") or order.get("id") or "")
     _track_order("spot", order_id)
     await _poll_fill(order_id, "spot")
@@ -341,11 +360,25 @@ async def get_orderbook(symbol: str, depth: int = 5) -> dict:
     return await _await_with_timeout(_current.get_orderbook(symbol, depth))
 
 
+async def get_spot_orderbook(symbol: str, depth: int = 5) -> dict:
+    """Retrieve the latest spot order book from the configured exchange."""
+    if _current is None:  # pragma: no cover - defensive programming
+        raise RuntimeError("Exchange not configured")
+    return await _await_with_timeout(_current.get_spot_orderbook(symbol, depth))
+
+
 async def get_balance() -> dict:
     """Return the account balance from the configured exchange."""
     if _current is None:  # pragma: no cover - defensive programming
         raise RuntimeError("Exchange not configured")
     return await _await_with_timeout(_current.get_balance())
+
+
+async def get_spot_balance() -> dict:
+    """Return the spot account balance from the configured exchange."""
+    if _current is None:  # pragma: no cover - defensive programming
+        raise RuntimeError("Exchange not configured")
+    return await _await_with_timeout(_current.get_spot_balance())
 
 
 async def fetch_funding_history(

--- a/exchanges/binance.py
+++ b/exchanges/binance.py
@@ -19,6 +19,8 @@ class BinanceExchange(BaseExchange):
 
     REST_URL = "https://fapi.binance.com"
     WS_URL = "wss://fstream.binance.com/ws"
+    SPOT_REST_URL = "https://api.binance.com"
+    SPOT_WS_URL = "wss://stream.binance.com:9443/ws"
 
     def __init__(self, api_key: str, api_secret: str) -> None:
         self.api_key = api_key
@@ -27,6 +29,10 @@ class BinanceExchange(BaseExchange):
         self._ws: Optional[websockets.WebSocketClientProtocol] = None
         self._orderbooks: Dict[str, Dict[str, Any]] = {}
         self._ws_tasks: Dict[str, asyncio.Task] = {}
+        # Spot specific websocket handling
+        self._spot_ws: Optional[websockets.WebSocketClientProtocol] = None
+        self._spot_orderbooks: Dict[str, Dict[str, Any]] = {}
+        self._spot_ws_tasks: Dict[str, asyncio.Task] = {}
 
     # ------------------------------------------------------------------
     # REST utilities
@@ -116,6 +122,79 @@ class BinanceExchange(BaseExchange):
         return {"volume_24h": volume, "open_interest": open_interest}
 
     # ------------------------------------------------------------------
+    # Spot REST methods
+    # ------------------------------------------------------------------
+
+    async def place_spot_order(
+        self, symbol: str, side: str, quantity: float, price: float | None = None
+    ) -> dict:
+        session = await self._session_get()
+        url = f"{self.SPOT_REST_URL}/api/v3/order"
+        params: Dict[str, Any] = {
+            "symbol": symbol,
+            "side": side,
+            "type": "MARKET" if price is None else "LIMIT",
+            "quantity": quantity,
+        }
+        if price is not None:
+            params.update({"price": price, "timeInForce": "GTC"})
+        headers = {"X-MBX-APIKEY": self.api_key}
+        params = self._sign(params)
+        async with session.post(url, params=params, headers=headers) as resp:
+            return await resp.json()
+
+    async def get_spot_balance(self) -> dict:
+        session = await self._session_get()
+        url = f"{self.SPOT_REST_URL}/api/v3/account"
+        params = self._sign({})
+        headers = {"X-MBX-APIKEY": self.api_key}
+        async with session.get(url, params=params, headers=headers) as resp:
+            return await resp.json()
+
+    # ------------------------------------------------------------------
+    # Spot WebSocket handling
+    # ------------------------------------------------------------------
+
+    async def _connect_spot(
+        self, symbol: str, depth: int
+    ) -> websockets.WebSocketClientProtocol:
+        while True:
+            try:
+                return await websockets.connect(
+                    f"{self.SPOT_WS_URL}/{symbol.lower()}@depth{depth}@100ms"
+                )
+            except Exception:
+                await asyncio.sleep(5)
+
+    async def _listen_spot(self, symbol: str, depth: int) -> None:
+        while True:
+            try:
+                if self._spot_ws is None:
+                    self._spot_ws = await self._connect_spot(symbol, depth)
+                msg = await self._spot_ws.recv()
+                data = json.loads(msg)
+                if "bids" in data and "asks" in data:
+                    self._spot_orderbooks[symbol] = {
+                        "bids": data["bids"],
+                        "asks": data["asks"],
+                    }
+            except Exception:
+                await asyncio.sleep(1)
+                if self._spot_ws is not None:
+                    try:
+                        await self._spot_ws.close()
+                    except Exception:
+                        pass
+                self._spot_ws = None
+
+    async def get_spot_orderbook(self, symbol: str, depth: int = 5) -> dict:
+        if symbol not in self._spot_ws_tasks:
+            self._spot_ws_tasks[symbol] = asyncio.create_task(
+                self._listen_spot(symbol, depth)
+            )
+        return self._spot_orderbooks.get(symbol, {"bids": [], "asks": []})
+
+    # ------------------------------------------------------------------
     # WebSocket handling
     # ------------------------------------------------------------------
 
@@ -159,6 +238,8 @@ class BinanceExchange(BaseExchange):
             await self._session.close()
         if self._ws is not None:
             await self._ws.close()
+        if self._spot_ws is not None:
+            await self._spot_ws.close()
 
 
 # Register exchange

--- a/exchanges/bybit.py
+++ b/exchanges/bybit.py
@@ -19,6 +19,7 @@ class BybitExchange(BaseExchange):
 
     REST_URL = "https://api.bybit.com"
     WS_URL = "wss://stream.bybit.com/v5/public/linear"
+    SPOT_WS_URL = "wss://stream.bybit.com/v5/public/spot"
 
     def __init__(self, api_key: str, api_secret: str) -> None:
         self.api_key = api_key
@@ -27,6 +28,10 @@ class BybitExchange(BaseExchange):
         self._ws: Optional[websockets.WebSocketClientProtocol] = None
         self._orderbooks: Dict[str, Dict[str, Any]] = {}
         self._ws_tasks: Dict[str, asyncio.Task] = {}
+        # Spot websocket management
+        self._spot_ws: Optional[websockets.WebSocketClientProtocol] = None
+        self._spot_orderbooks: Dict[str, Dict[str, Any]] = {}
+        self._spot_ws_tasks: Dict[str, asyncio.Task] = {}
 
     # ------------------------------------------------------------------
     # REST utilities
@@ -118,6 +123,81 @@ class BybitExchange(BaseExchange):
         return {"volume_24h": volume, "open_interest": open_interest}
 
     # ------------------------------------------------------------------
+    # Spot REST methods
+    # ------------------------------------------------------------------
+
+    async def place_spot_order(
+        self, symbol: str, side: str, quantity: float, price: float | None = None
+    ) -> dict:
+        session = await self._session_get()
+        url_path = "/v5/order/create"
+        url = f"{self.REST_URL}{url_path}"
+        body: Dict[str, Any] = {
+            "symbol": symbol,
+            "side": side,
+            "qty": quantity,
+            "orderType": "Market" if price is None else "Limit",
+            "category": "spot",
+        }
+        if price is not None:
+            body["price"] = price
+        headers = {"Content-Type": "application/json"}
+        body = self._sign("POST", url_path, body)
+        async with session.post(url, json=body, headers=headers) as resp:
+            return await resp.json()
+
+    async def get_spot_balance(self) -> dict:
+        session = await self._session_get()
+        url_path = "/v5/account/wallet-balance"
+        url = f"{self.REST_URL}{url_path}"
+        params = self._sign("GET", url_path, {"accountType": "SPOT"})
+        async with session.get(url, params=params) as resp:
+            return await resp.json()
+
+    # ------------------------------------------------------------------
+    # Spot WebSocket handling
+    # ------------------------------------------------------------------
+
+    async def _connect_spot(self, symbol: str) -> websockets.WebSocketClientProtocol:
+        while True:
+            try:
+                ws = await websockets.connect(self.SPOT_WS_URL)
+                sub = {"op": "subscribe", "args": [f"orderbook.1.{symbol}"]}
+                await ws.send(json.dumps(sub))
+                return ws
+            except Exception:
+                await asyncio.sleep(5)
+
+    async def _listen_spot(self, symbol: str) -> None:
+        while True:
+            try:
+                if self._spot_ws is None:
+                    self._spot_ws = await self._connect_spot(symbol)
+                msg = await self._spot_ws.recv()
+                data = json.loads(msg)
+                if data.get("topic", "").startswith("orderbook"):
+                    book = data.get("data") or {}
+                    self._spot_orderbooks[symbol] = {
+                        "bids": book.get("b", []),
+                        "asks": book.get("a", []),
+                    }
+            except Exception:
+                await asyncio.sleep(1)
+                if self._spot_ws is not None:
+                    try:
+                        await self._spot_ws.close()
+                    except Exception:
+                        pass
+                self._spot_ws = None
+
+    async def get_spot_orderbook(self, symbol: str, depth: int = 5) -> dict:
+        if symbol not in self._spot_ws_tasks:
+            self._spot_ws_tasks[symbol] = asyncio.create_task(
+                self._listen_spot(symbol)
+            )
+        return self._spot_orderbooks.get(symbol, {"bids": [], "asks": []})
+
+    # ------------------------------------------------------------------
     # WebSocket handling
     # ------------------------------------------------------------------
 
@@ -166,6 +246,8 @@ class BybitExchange(BaseExchange):
             await self._session.close()
         if self._ws is not None:
             await self._ws.close()
+        if self._spot_ws is not None:
+            await self._spot_ws.close()
 
 
 # Register exchange

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from exchanges import (
     fetch_funding_history,
     get_orderbook,
+    get_spot_orderbook,
     get_stats,
     hedge,
     place_order,
@@ -67,14 +68,18 @@ async def get_market_metrics(
     else:
         funding = 0.0
 
-    orderbook = await get_orderbook(symbol, depth=depth)
-    bids = [(float(p), float(q)) for p, q in orderbook.get("bids", [])]
-    asks = [(float(p), float(q)) for p, q in orderbook.get("asks", [])]
+    perp_book = await get_orderbook(symbol, depth=depth)
+    spot_book = await get_spot_orderbook(symbol, depth=depth)
+
+    bids = [(float(p), float(q)) for p, q in perp_book.get("bids", [])]
+    asks = [(float(p), float(q)) for p, q in perp_book.get("asks", [])]
+    spot_bids = [(float(p), float(q)) for p, q in spot_book.get("bids", [])]
+    spot_asks = [(float(p), float(q)) for p, q in spot_book.get("asks", [])]
 
     if bids and asks:
-        spread = asks[0][0] - bids[0][0]
+        book_spread = asks[0][0] - bids[0][0]
         futures_price = (asks[0][0] + bids[0][0]) / 2
-        volatility = spread / futures_price if futures_price else float("inf")
+        volatility = book_spread / futures_price if futures_price else float("inf")
         remaining = trade_size
         cost = 0.0
         for price, qty in asks:
@@ -89,20 +94,26 @@ async def get_market_metrics(
             avg_price = cost / trade_size
             slippage = abs(avg_price - futures_price) / futures_price
     else:
-        spread = float("inf")
         futures_price = float("nan")
         volatility = float("inf")
         slippage = float("inf")
 
+    if spot_bids and spot_asks:
+        spot_price = (spot_asks[0][0] + spot_bids[0][0]) / 2
+    else:
+        spot_price = float("nan")
+
+    if bids and asks and spot_bids and spot_asks:
+        spread = abs(futures_price - spot_price)
+    else:
+        spread = float("inf")
+
     stats = await get_stats(symbol)
-    spot_price = float(orderbook.get("spot_price", futures_price))
     volume = float(stats.get("volume_24h", 0.0))
     open_interest = float(stats.get("open_interest", 0.0))
     liquidity = sum(q for _, q in bids) + sum(q for _, q in asks)
     basis = (
-        ((futures_price - spot_price) / spot_price) * 100
-        if spot_price
-        else float("inf")
+        (spread / spot_price * 100) if spot_price else float("inf")
     )
 
     return MarketMetrics(


### PR DESCRIPTION
## Summary
- support dedicated spot REST/WebSocket endpoints on Binance and Bybit
- expose new spot order, balance and order book helpers in exchange interface
- compute perp-spot metrics using real spot order books

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c7530673c8320af3afeb742d96e4b