### PR TITLE
Add partial risk reduction to RiskManager

### DIFF
--- a/tests/test_futures_trader.py
+++ b/tests/test_futures_trader.py
@@ -100,9 +100,13 @@ def test_exit_orders_with_trailing_stop_and_logging():
     class DummyRisk:
         def __init__(self):
             self.pnls = []
+            self.reductions = []
 
         def close_trade(self, trade_id, pnl):
             self.pnls.append(pnl)
+
+        def reduce_trade(self, trade_id, fraction):
+            self.reductions.append(fraction)
 
     risk = DummyRisk()
     trader = FuturesTrader(
@@ -136,7 +140,8 @@ def test_exit_orders_with_trailing_stop_and_logging():
     assert logs[0]["tp1"] == 21000
     assert logs[0]["tp2"] > 19000
     assert logs[0]["result"] == "tp2"
-    assert len(risk.pnls) == 2
+    assert len(risk.pnls) == 1
+    assert risk.reductions == [0.5]
 
 
 def test_retry_on_network_error():

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -32,6 +32,19 @@ def test_open_risk_limit(tmp_path):
     assert not rm.can_open_trade()
 
 
+def test_reduce_trade(tmp_path):
+    balance = 1000.0
+
+    def fetch_balance():
+        return balance
+
+    rm = RiskManager(fetch_balance, db_path=tmp_path / "state.db")
+    trade_id, _ = rm.open_trade(100, 90)  # risk 10
+    rm.reduce_trade(trade_id, 0.5)
+    assert rm.open_positions[trade_id] == pytest.approx(5.0)
+    assert rm.open_trades == 1
+
+
 def test_consecutive_loss_halt(tmp_path):
     balance = 1000.0
 

--- a/utils/futures_trader.py
+++ b/utils/futures_trader.py
@@ -276,12 +276,7 @@ class FuturesTrader:
                 tp1_price = exit_price
                 tp1_time = pd.Timestamp.utcnow()
                 if self.risk_manager and trade_id is not None:
-                    pnl = (
-                        exit_price - entry_price
-                        if side.lower() == "buy"
-                        else entry_price - exit_price
-                    )
-                    self.risk_manager.close_trade(trade_id, pnl)
+                    self.risk_manager.reduce_trade(trade_id, 0.5)
                 tp_filled = True
                 # replace stop for remaining half
                 if sl_id:

--- a/utils/risk.py
+++ b/utils/risk.py
@@ -174,6 +174,26 @@ class RiskManager:
         self._save_state()
         return trade_id, size
 
+    def reduce_trade(self, trade_id: str, fraction: float) -> None:
+        """Reduce open risk for ``trade_id`` without closing the trade.
+
+        Parameters
+        ----------
+        trade_id:
+            Identifier of the trade whose risk should be reduced.
+        fraction:
+            Fraction of the trade's risk to remove. Must be between 0 and 1.
+        """
+
+        self._ensure_daily_reset()
+        if not 0 < fraction < 1:
+            raise ValueError("fraction must be between 0 and 1")
+        risk = self.open_positions.get(trade_id)
+        if risk is None:
+            return
+        self.open_positions[trade_id] = risk * (1 - fraction)
+        self._save_state()
+
     def close_trade(self, trade_id: str, pnl: float) -> None:
         """Close an existing trade and update risk metrics."""
         self._ensure_daily_reset()


### PR DESCRIPTION
## Summary
- allow reducing open trade risk via new `RiskManager.reduce_trade`
- use `reduce_trade` for first take-profit in `FuturesTrader`
- adjust tests for new partial close behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c75fc7e3c832089d756dfc673bd08