### PR TITLE
Use 15m OHLC price change for volatility

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,10 +7,10 @@ thresholds:
   funding_rate: 0.0003
   basis: 0.5
   liquidity: 0.0
-  volume: 0.0
-  holding_time: 172800
-  volatility: 1.0
-  open_interest: 0.0
+    volume: 0.0
+    holding_time: 172800
+    volatility: 0.025
+    open_interest: 0.0
   min_trade_size: 0.0
   max_trade_size: 1000.0
   spread: 0.005

--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -83,6 +83,15 @@ class BaseExchange(ABC):
     async def get_stats(self, symbol: str) -> dict:
         """Return market stats such as 24h volume and open interest."""
 
+    async def get_ohlc(
+        self, symbol: str, interval: str, limit: int = 1
+    ) -> list[Dict[str, float]]:
+        """Return OHLC data for ``symbol``.
+
+        Exchanges should override this to provide recent candlestick data.
+        """
+        raise NotImplementedError
+
     # ------------------------------------------------------------------
     # Optional order management helpers
     # ------------------------------------------------------------------
@@ -397,6 +406,15 @@ async def get_stats(symbol: str) -> dict:
     if _current is None:  # pragma: no cover - defensive programming
         raise RuntimeError("Exchange not configured")
     return await _await_with_timeout(_current.get_stats(symbol))
+
+
+async def get_ohlc(
+    symbol: str, interval: str = "15m", limit: int = 1
+) -> list[Dict[str, float]]:
+    """Return OHLC data for ``symbol`` from the exchange."""
+    if _current is None:  # pragma: no cover - defensive programming
+        raise RuntimeError("Exchange not configured")
+    return await _await_with_timeout(_current.get_ohlc(symbol, interval, limit))
 
 
 async def hedge(symbol: str, quantity: float) -> Dict[str, Dict]:

--- a/exchanges/binance.py
+++ b/exchanges/binance.py
@@ -121,6 +121,24 @@ class BinanceExchange(BaseExchange):
         open_interest = float(oi.get("openInterest", 0.0))
         return {"volume_24h": volume, "open_interest": open_interest}
 
+    async def get_ohlc(
+        self, symbol: str, interval: str, limit: int = 1
+    ) -> list[Dict[str, float]]:
+        session = await self._session_get()
+        url = f"{self.REST_URL}/fapi/v1/klines"
+        params = {"symbol": symbol, "interval": interval, "limit": limit}
+        async with session.get(url, params=params) as resp:
+            data = await resp.json()
+        return [
+            {
+                "open": float(k[1]),
+                "high": float(k[2]),
+                "low": float(k[3]),
+                "close": float(k[4]),
+            }
+            for k in data
+        ]
+
     # ------------------------------------------------------------------
     # Spot REST methods
     # ------------------------------------------------------------------

--- a/exchanges/bybit.py
+++ b/exchanges/bybit.py
@@ -122,6 +122,30 @@ class BybitExchange(BaseExchange):
         open_interest = float(oi_list[0].get("openInterest", 0.0))
         return {"volume_24h": volume, "open_interest": open_interest}
 
+    async def get_ohlc(
+        self, symbol: str, interval: str, limit: int = 1
+    ) -> list[Dict[str, float]]:
+        session = await self._session_get()
+        url = f"{self.REST_URL}/v5/market/kline"
+        params = {
+            "category": "linear",
+            "symbol": symbol,
+            "interval": interval,
+            "limit": limit,
+        }
+        async with session.get(url, params=params) as resp:
+            data = await resp.json()
+        klist = data.get("result", {}).get("list", [])
+        return [
+            {
+                "open": float(k[1]),
+                "high": float(k[2]),
+                "low": float(k[3]),
+                "close": float(k[4]),
+            }
+            for k in klist
+        ]
+
     # ------------------------------------------------------------------
     # Spot REST methods
     # ------------------------------------------------------------------

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -18,6 +18,7 @@ from exchanges import (
     get_orderbook,
     get_spot_orderbook,
     get_stats,
+    get_ohlc,
     hedge,
     place_order,
 )
@@ -36,7 +37,7 @@ class MarketMetrics:
     funding_rate: float
     spread: float
     liquidity: float
-    volatility: float
+    volatility: float  # 15-minute price change percentage
     spot_price: float
     futures_price: float
     volume: float
@@ -77,9 +78,7 @@ async def get_market_metrics(
     spot_asks = [(float(p), float(q)) for p, q in spot_book.get("asks", [])]
 
     if bids and asks:
-        book_spread = asks[0][0] - bids[0][0]
         futures_price = (asks[0][0] + bids[0][0]) / 2
-        volatility = book_spread / futures_price if futures_price else float("inf")
         remaining = trade_size
         cost = 0.0
         for price, qty in asks:
@@ -95,7 +94,6 @@ async def get_market_metrics(
             slippage = abs(avg_price - futures_price) / futures_price
     else:
         futures_price = float("nan")
-        volatility = float("inf")
         slippage = float("inf")
 
     if spot_bids and spot_asks:
@@ -115,6 +113,15 @@ async def get_market_metrics(
     basis = (
         (spread / spot_price * 100) if spot_price else float("inf")
     )
+
+    ohlc = await get_ohlc(symbol, interval="15m", limit=1)
+    if ohlc:
+        candle = ohlc[0]
+        o = candle.get("open") or 0.0
+        c = candle.get("close") or 0.0
+        volatility = ((c - o) / o) if o else float("inf")
+    else:
+        volatility = float("nan")
 
     return MarketMetrics(
         funding,
@@ -158,7 +165,8 @@ def check_entry_conditions(
         and metrics.basis <= thresholds.get("basis", float("inf"))
         and metrics.liquidity >= thresholds.get("liquidity", 0.0)
         and metrics.volume >= thresholds.get("volume", 0.0)
-        and metrics.volatility <= thresholds.get("volatility", float("inf"))
+        and abs(metrics.volatility)
+        <= thresholds.get("volatility", float("inf"))
         and metrics.open_interest <= metrics.volume * 2
         and metrics.slippage <= thresholds.get("slippage", float("inf"))
         and thresholds.get("min_trade_size", 0.0)
@@ -176,7 +184,8 @@ def check_exit_conditions(metrics: MarketMetrics, thresholds: Dict[str, float]) 
         abs(metrics.funding_rate) <= thresholds.get("funding_rate", float("inf"))
         or metrics.spread >= thresholds.get("spread", float("-inf"))
         or metrics.liquidity <= thresholds.get("liquidity", float("inf"))
-        or metrics.volatility >= thresholds.get("volatility", float("-inf"))
+        or abs(metrics.volatility)
+        >= thresholds.get("volatility", float("-inf"))
     )
 
 


### PR DESCRIPTION
## Summary
- add get_ohlc helper to the exchange interface and implement it for Binance and Bybit
- compute volatility from 15m candle price change and apply absolute 2.5% entry/exit limits
- update volatility threshold configuration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c77cefd0c8320a71e08c9948c5fbf