### PR TITLE
Add 1m data fallback and save unsuffixed CSVs

### DIFF
--- a/backtester.py
+++ b/backtester.py
@@ -70,10 +70,15 @@ class Position:
 
 def load_data(symbol: str, data_dir: str | Path) -> pd.DataFrame:
     """Load OHLCV data for ``symbol`` from ``data_dir``."""
-
     path = Path(data_dir) / f"{symbol}.csv"
     if not path.exists():
-        raise FileNotFoundError(f"No data for {symbol} at {path}")
+        alt = Path(data_dir) / f"{symbol}_1m.csv"
+        if alt.exists():
+            path = alt
+        else:
+            raise FileNotFoundError(
+                f"No data for {symbol} at {path} or {alt}"
+            )
     return pd.read_csv(path, parse_dates=["timestamp"])
 
 

--- a/main.py
+++ b/main.py
@@ -68,6 +68,7 @@ class DataCollector:
             df = pd.DataFrame()
             if ohlcv_file.exists():
                 df = pd.read_csv(ohlcv_file, parse_dates=["timestamp"])
+                df.to_csv(data_dir / f"{symbol.replace('/', '')}.csv", index=False)
 
             db_path = Path(self.config.get("data_paths", {}).get("data_dir", "data")) / "market_data.db"
             db_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- Load 1m fallback files when unsuffixed OHLCV data is missing
- Save unsuffixed OHLCV CSV alongside 1m data during collection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c796390d48320994a5b8fd4bf2fd9