### PR TITLE
Adjust safety threshold defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# MTF Trend Bot
+
+This repository contains tools for multi-timeframe trend-following and funding arbitrage strategies.
+
+## Default Safety Thresholds
+
+The bot ships with conservative defaults in [`config.yaml`](config.yaml) to guard against
+unfavourable market conditions. These values represent **minimum safety thresholds** and
+should be adjusted only after careful consideration:
+
+| Threshold        | Default     | Purpose |
+| ---------------- | ----------- | ------- |
+| `funding_rate`   | `0.0003`    | Minimum absolute funding rate required to enter a trade |
+| `basis`          | `0.005`     | Minimum spot–futures basis (0.5%) |
+| `volume`         | `20000000`  | Minimum 24h trading volume to ensure liquidity |
+| `min_trade_size` | `10`        | Minimum notional value per trade |
+| `spread`         | `0.005`     | Maximum allowable spread percentage |
+| `slippage`       | `0.003`     | Maximum expected slippage per trade |
+| `deposit_pct`    | `0.05`      | Max fraction of total deposit allocated per trade |
+
+These settings aim to provide a safety buffer for new users. Increase or relax them only if
+you fully understand the associated risks.
+

--- a/config.yaml
+++ b/config.yaml
@@ -5,17 +5,17 @@ thresholds:
   buy_signal: 0.8
   sell_signal: 0.2
   funding_rate: 0.0003
-  basis: 0.5
+  basis: 0.005          # Minimum spot–futures basis (0.5%)
+  volume: 20000000      # Minimum 24h trading volume to ensure liquidity
   liquidity: 0.0
-    volume: 0.0
-    holding_time: 172800
-    volatility: 0.025
-    open_interest: 0.0
-  min_trade_size: 0.0
+  holding_time: 172800
+  volatility: 0.025
+  open_interest: 0.0
+  min_trade_size: 10    # Minimum trade size in USD
   max_trade_size: 1000.0
-  spread: 0.005
-  slippage: 0.003
-  deposit_pct: 0.05
+  spread: 0.005         # Maximum allowed spread percentage
+  slippage: 0.003       # Maximum expected slippage per trade
+  deposit_pct: 0.05     # Max fraction of total deposit per trade
 risk:
   max_position_size: 1000
   max_daily_loss: 500


### PR DESCRIPTION
## Summary
- tune default safety thresholds for funding arbitrage strategy
- document default thresholds in a new README

## Testing
- `python - <<'PY'
import yaml
with open('config.yaml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c7cfafe288320bbaf2d00c4570bf2