### PR TITLE
Align basis units

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ should be adjusted only after careful consideration:
 | Threshold        | Default     | Purpose |
 | ---------------- | ----------- | ------- |
 | `funding_rate`   | `0.0003`    | Minimum absolute funding rate required to enter a trade |
-| `basis`          | `0.005`     | Minimum spot–futures basis (0.5%) |
+| `basis`          | `0.5`       | Maximum spot–futures basis percentage |
 | `volume`         | `20000000`  | Minimum 24h trading volume to ensure liquidity |
 | `min_trade_size` | `10`        | Minimum notional value per trade |
 | `spread`         | `0.005`     | Maximum allowable spread percentage |

--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@ thresholds:
   buy_signal: 0.8
   sell_signal: 0.2
   funding_rate: 0.0003
-  basis: 0.005          # Minimum spot–futures basis (0.5%)
+  basis: 0.5            # Maximum spot–futures basis percentage
   volume: 20000000      # Minimum 24h trading volume to ensure liquidity
   liquidity: 0.0
   holding_time: 172800

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -43,7 +43,7 @@ class MarketMetrics:
     volume: float
     open_interest: float
     slippage: float
-    basis: float
+    basis: float  # spot–futures basis percentage
 
 
 async def get_market_metrics(
@@ -146,8 +146,11 @@ def check_entry_conditions(
     quantity: float,
     metrics: MarketMetrics,
     thresholds: Dict[str, float],
-) -> bool:
-    """Return ``True`` if all entry thresholds are satisfied."""
+    ) -> bool:
+    """Return ``True`` if all entry thresholds are satisfied.
+
+    The ``basis`` threshold is specified in percentage points.
+    """
 
     whitelist = CONFIG.get("bot", {}).get("whitelist", [])
     deposit = CONFIG.get("bot", {}).get("deposit_size", float("inf"))
@@ -158,11 +161,12 @@ def check_entry_conditions(
         else float("inf")
     )
     notional = quantity * metrics.futures_price
+    max_basis_pct = thresholds.get("basis", float("inf"))
 
     return (
         abs(metrics.funding_rate) >= thresholds.get("funding_rate", 0.0)
         and spread_pct <= thresholds.get("spread", float("inf"))
-        and metrics.basis <= thresholds.get("basis", float("inf"))
+        and metrics.basis <= max_basis_pct
         and metrics.liquidity >= thresholds.get("liquidity", 0.0)
         and metrics.volume >= thresholds.get("volume", 0.0)
         and abs(metrics.volatility)


### PR DESCRIPTION
## Summary
- document basis metric as percentage and compare it to percent threshold
- clarify basis percentage threshold in configuration and docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c874508748320a3e68e7e3bc1da18