### PR TITLE
Use quote volume for Binance stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ should be adjusted only after careful consideration:
 | ---------------- | ----------- | ------- |
 | `funding_rate`   | `0.0003`    | Minimum absolute funding rate required to enter a trade |
 | `basis`          | `0.5`       | Maximum spot–futures basis percentage |
-| `volume`         | `20000000`  | Minimum 24h trading volume to ensure liquidity |
+| `volume`         | `20000000`  | Minimum 24h trading volume (USD) to ensure liquidity |
 | `min_trade_size` | `10`        | Minimum notional value per trade |
 | `spread`         | `0.005`     | Maximum allowable spread percentage |
 | `slippage`       | `0.003`     | Maximum expected combined slippage across spot and futures |

--- a/config.yaml
+++ b/config.yaml
@@ -6,7 +6,7 @@ thresholds:
   sell_signal: 0.2
   funding_rate: 0.0003
   basis: 0.5            # Maximum spot–futures basis percentage
-  volume: 20000000      # Minimum 24h trading volume to ensure liquidity
+  volume: 20000000      # Minimum 24h trading volume in USD to ensure liquidity
   liquidity: 0.0
   holding_time: 172800
   volatility: 0.025

--- a/exchanges/binance.py
+++ b/exchanges/binance.py
@@ -114,7 +114,9 @@ class BinanceExchange(BaseExchange):
         params = {"symbol": symbol}
         async with session.get(ticker_url, params=params) as resp:
             ticker = await resp.json()
-        volume = float(ticker.get("volume", 0.0))
+        # ``volume`` is denominated in base currency; use ``quoteVolume`` so that
+        # ``volume_24h`` represents notional value in USD.
+        volume = float(ticker.get("quoteVolume", ticker.get("volume", 0.0)))
         oi_url = f"{self.REST_URL}/fapi/v1/openInterest"
         async with session.get(oi_url, params=params) as resp:
             oi = await resp.json()

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import Any, Dict
 import time
 from datetime import datetime
+import math
 
 from exchanges import (
     fetch_funding_history,
@@ -122,6 +123,10 @@ async def get_market_metrics(
     stats = await get_stats(symbol)
     volume = float(stats.get("volume_24h", 0.0))
     open_interest = float(stats.get("open_interest", 0.0))
+    if futures_price and not math.isnan(futures_price):
+        open_interest *= futures_price
+    else:
+        open_interest = 0.0
     liquidity = sum(q for _, q in bids) + sum(q for _, q in asks)
     basis = (
         (spread / spot_price * 100) if spot_price else float("inf")

--- a/tests/test_binance_stats.py
+++ b/tests/test_binance_stats.py
@@ -1,0 +1,47 @@
+import pytest
+import sys
+import pathlib
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from exchanges.binance import BinanceExchange
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self.data = data
+
+    async def json(self):
+        return self.data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+class DummySession:
+    def get(self, url, params=None):
+        if "ticker/24hr" in url:
+            return DummyResponse({"quoteVolume": "500", "volume": "5"})
+        if "openInterest" in url:
+            return DummyResponse({"openInterest": "10"})
+        return DummyResponse({})
+
+
+@pytest.mark.asyncio
+async def test_get_stats_uses_quote_volume(monkeypatch):
+    ex = BinanceExchange("key", "secret")
+    dummy = DummySession()
+
+    async def session_get():
+        return dummy
+
+    monkeypatch.setattr(ex, "_session_get", session_get)
+
+    stats = await ex.get_stats("BTCUSDT")
+    assert stats["volume_24h"] == 500.0
+    assert stats["open_interest"] == 10.0


### PR DESCRIPTION
## Summary
- report Binance 24h volume in USD by reading `quoteVolume`
- convert open interest to USD in market metrics for consistent comparisons
- clarify volume units in config and README; add test for Binance stats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c968b5e888320b6560d83e738b4aa