### PR TITLE
Use async Telegram notifications

### DIFF
--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -193,15 +193,17 @@ async def _handle_timeout() -> None:
                         funding_pct = entry.get("entry_funding", 0.0) * 100
                         basis_pct = entry.get("entry_basis", 0.0)
                         volume_usd = quantity * entry.get("entry_futures_price", 0.0)
-                        notify_close(
-                            pid,
-                            (
-                                f"Emergency exit failed {symbol} on {exchange_name}: {exc_close}\n"
-                                f"Funding: {funding_pct:.4f}%\n"
-                                f"Basis: {basis_pct:.4f}%\n"
-                                f"Volume: ${volume_usd:.2f}\n"
-                                f"Time in position: {format_duration(hold_time)}"
-                            ),
+                        asyncio.create_task(
+                            notify_close(
+                                pid,
+                                (
+                                    f"Emergency exit failed {symbol} on {exchange_name}: {exc_close}\n"
+                                    f"Funding: {funding_pct:.4f}%\n"
+                                    f"Basis: {basis_pct:.4f}%\n"
+                                    f"Volume: ${volume_usd:.2f}\n"
+                                    f"Time in position: {format_duration(hold_time)}"
+                                ),
+                            )
                         )
                     else:
                         exit_spot = float(
@@ -255,16 +257,18 @@ async def _handle_timeout() -> None:
                         )
                         hold_time = exit_ts - entry.get("entry_timestamp", exit_ts)
                         funding_pct = entry.get("entry_funding", 0.0) * 100
-                        notify_close(
-                            pid,
-                            (
-                                f"Emergency exit {symbol} on {exchange_name}\n"
-                                f"Funding: {funding_pct:.4f}%\n"
-                                f"Basis: {exit_basis:.4f}%\n"
-                                f"Volume: ${volume_usd:.2f}\n"
-                                f"Time in position: {format_duration(hold_time)}\n"
-                                f"PnL: {pnl:.4f}"
-                            ),
+                        asyncio.create_task(
+                            notify_close(
+                                pid,
+                                (
+                                    f"Emergency exit {symbol} on {exchange_name}\n"
+                                    f"Funding: {funding_pct:.4f}%\n"
+                                    f"Basis: {exit_basis:.4f}%\n"
+                                    f"Volume: ${volume_usd:.2f}\n"
+                                    f"Time in position: {format_duration(hold_time)}\n"
+                                    f"PnL: {pnl:.4f}"
+                                ),
+                            )
                         )
                 finally:
                     globals()["_current"] = exchanges_current

--- a/main.py
+++ b/main.py
@@ -119,15 +119,17 @@ def start_processing_loops() -> None:
             volume_usd = entry.get("entry_futures_price", 0.0) * entry.get(
                 "initial_quantity", entry.get("quantity", 0.0)
             )
-            notify_close(
-                position_id,
-                (
-                    f"Error on {exchange_name} {symbol}: {exc}\n"
-                    f"Funding: {funding_pct:.4f}%\n"
-                    f"Basis: {basis_pct:.4f}%\n"
-                    f"Volume: ${volume_usd:.2f}\n"
-                    f"Time in position: {format_duration(hold)}"
-                ),
+            asyncio.create_task(
+                notify_close(
+                    position_id,
+                    (
+                        f"Error on {exchange_name} {symbol}: {exc}\n"
+                        f"Funding: {funding_pct:.4f}%\n"
+                        f"Basis: {basis_pct:.4f}%\n"
+                        f"Volume: ${volume_usd:.2f}\n"
+                        f"Time in position: {format_duration(hold)}"
+                    ),
+                )
             )
             raise
         else:
@@ -141,16 +143,18 @@ def start_processing_loops() -> None:
                 "initial_quantity", entry.get("quantity", 0.0)
             )
             pnl_pct = (pnl / volume_usd * 100) if volume_usd else 0.0
-            notify_close(
-                position_id,
-                (
-                    f"Closed {symbol} on {exchange_name}\n"
-                    f"Funding: {funding_pct:.4f}%\n"
-                    f"Basis: {basis_pct:.4f}%\n"
-                    f"Volume: ${volume_usd:.2f}\n"
-                    f"Time in position: {format_duration(hold)}\n"
-                    f"PnL: {pnl:.4f} ({pnl_pct:.4f}%) Reasons: {reasons}"
-                ),
+            asyncio.create_task(
+                notify_close(
+                    position_id,
+                    (
+                        f"Closed {symbol} on {exchange_name}\n"
+                        f"Funding: {funding_pct:.4f}%\n"
+                        f"Basis: {basis_pct:.4f}%\n"
+                        f"Volume: ${volume_usd:.2f}\n"
+                        f"Time in position: {format_duration(hold)}\n"
+                        f"PnL: {pnl:.4f} ({pnl_pct:.4f}%) Reasons: {reasons}"
+                    ),
+                )
             )
         finally:
             POSITION_TASKS.pop(position_id, None)
@@ -186,16 +190,18 @@ def start_processing_loops() -> None:
                         try:
                             await strategy.open_neutral_position(symbol, quantity)
                             volume_usd = quantity * metrics.futures_price
-                            notify_open(
-                                f"{name}:{symbol}",
-                                (
-                                    f"Opened {symbol} on {name}\n"
-                                    f"Funding: {metrics.funding_rate * 100:.4f}%\n"
-                                    f"Basis: {metrics.basis:.4f}%\n"
-                                    f"Volume: ${volume_usd:.2f}\n"
-                                    f"Time in position: {format_duration(0)}\n"
-                                    "Strategy: Long Spot / Short Perp"
-                                ),
+                            asyncio.create_task(
+                                notify_open(
+                                    f"{name}:{symbol}",
+                                    (
+                                        f"Opened {symbol} on {name}\n"
+                                        f"Funding: {metrics.funding_rate * 100:.4f}%\n"
+                                        f"Basis: {metrics.basis:.4f}%\n"
+                                        f"Volume: ${volume_usd:.2f}\n"
+                                        f"Time in position: {format_duration(0)}\n"
+                                        "Strategy: Long Spot / Short Perp"
+                                    ),
+                                )
                             )
                             task = asyncio.create_task(
                                 monitor_position(name, symbol, quantity)

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -461,17 +461,19 @@ async def monitor_neutral_position(
                         if total_volume
                         else 0.0
                     )
-                    notify_partial_close(
-                        position_id,
-                        (
-                            f"Scaled out {symbol}: remaining {quantity:.4f}\n"
-                            f"Funding: {metrics.funding_rate * 100:.4f}%\n"
-                            f"Basis: {exit_basis:.4f}%\n"
-                            f"Volume: ${volume_usd:.2f}\n"
-                            f"Time in position: {format_duration(hold_time)}\n"
-                            f"Funding accrued: {entry.get('funding_accrued', 0.0):.4f} / "
-                            f"PnL: {pnl_total:+.4f} ({pnl_pct_total:+.2f} %)"
-                        ),
+                    asyncio.create_task(
+                        notify_partial_close(
+                            position_id,
+                            (
+                                f"Scaled out {symbol}: remaining {quantity:.4f}\n"
+                                f"Funding: {metrics.funding_rate * 100:.4f}%\n"
+                                f"Basis: {exit_basis:.4f}%\n"
+                                f"Volume: ${volume_usd:.2f}\n"
+                                f"Time in position: {format_duration(hold_time)}\n"
+                                f"Funding accrued: {entry.get('funding_accrued', 0.0):.4f} / "
+                                f"PnL: {pnl_total:+.4f} ({pnl_pct_total:+.2f} %)"
+                            ),
+                        )
                     )
                 continue
             await close_neutral_position(symbol, quantity, pnl, final=True)

--- a/utils/telegram.py
+++ b/utils/telegram.py
@@ -1,7 +1,7 @@
 import os
 from typing import Dict, Optional
 
-import requests
+import aiohttp
 
 API_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
@@ -26,65 +26,73 @@ def format_duration(seconds: float) -> str:
     return " ".join(parts)
 
 
-def _send_message(text: str) -> Optional[int]:
+async def _send_message(text: str) -> Optional[int]:
     """Send a new Telegram message and return the message ID."""
     if not API_TOKEN or not CHAT_ID:
         # Fail silently if configuration is missing.
         return None
-    response = requests.post(
-        f"{API_URL}/sendMessage",
-        json={"chat_id": CHAT_ID, "text": text, "parse_mode": "HTML"},
-        timeout=10,
-    )
-    response.raise_for_status()
-    payload = response.json()
-    return payload.get("result", {}).get("message_id")
+    try:
+        timeout = aiohttp.ClientTimeout(total=10)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(
+                f"{API_URL}/sendMessage",
+                json={"chat_id": CHAT_ID, "text": text, "parse_mode": "HTML"},
+            ) as response:
+                response.raise_for_status()
+                payload = await response.json()
+                return payload.get("result", {}).get("message_id")
+    except Exception:
+        return None
 
 
-def _edit_message(message_id: int, text: str) -> None:
+async def _edit_message(message_id: int, text: str) -> None:
     """Edit an existing Telegram message."""
     if not API_TOKEN or not CHAT_ID:
         return
-    response = requests.post(
-        f"{API_URL}/editMessageText",
-        json={
-            "chat_id": CHAT_ID,
-            "message_id": message_id,
-            "text": text,
-            "parse_mode": "HTML",
-        },
-        timeout=10,
-    )
-    response.raise_for_status()
+    try:
+        timeout = aiohttp.ClientTimeout(total=10)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(
+                f"{API_URL}/editMessageText",
+                json={
+                    "chat_id": CHAT_ID,
+                    "message_id": message_id,
+                    "text": text,
+                    "parse_mode": "HTML",
+                },
+            ) as response:
+                response.raise_for_status()
+    except Exception:
+        return
 
 
-def notify_open(position_id: str, text: str) -> None:
+async def notify_open(position_id: str, text: str) -> None:
     """Notify that a position has been opened."""
     message_id = _MESSAGE_CACHE.get(position_id)
     if message_id is None:
-        message_id = _send_message(text)
+        message_id = await _send_message(text)
         if message_id is not None:
             _MESSAGE_CACHE[position_id] = message_id
     else:
-        _edit_message(message_id, text)
+        await _edit_message(message_id, text)
 
 
-def notify_partial_close(position_id: str, text: str) -> None:
+async def notify_partial_close(position_id: str, text: str) -> None:
     """Notify about a partial position closure."""
     message_id = _MESSAGE_CACHE.get(position_id)
     if message_id is None:
-        message_id = _send_message(text)
+        message_id = await _send_message(text)
         if message_id is not None:
             _MESSAGE_CACHE[position_id] = message_id
     else:
-        _edit_message(message_id, text)
+        await _edit_message(message_id, text)
 
 
-def notify_close(position_id: str, text: str) -> None:
+async def notify_close(position_id: str, text: str) -> None:
     """Notify that a position has been fully closed and remove it from cache."""
     message_id = _MESSAGE_CACHE.get(position_id)
     if message_id is not None:
-        _edit_message(message_id, text)
+        await _edit_message(message_id, text)
         del _MESSAGE_CACHE[position_id]
     else:
-        _send_message(text)
+        await _send_message(text)


### PR DESCRIPTION
## Summary
- swap `requests` for `aiohttp` and expose async Telegram helpers
- dispatch Telegram updates with `asyncio.create_task` to avoid blocking main loops
- keep bot resilient by catching network errors during message sends

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c9af7b4f48320be01cf27a7709cd8