### PR TITLE
Enforce positive funding rate in entry conditions

### DIFF
--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -186,7 +186,8 @@ def check_entry_conditions(
     slippage_limit = thresholds.get("slippage", 0.003)
 
     return (
-        abs(metrics.funding_rate) >= thresholds.get("funding_rate", 0.0)
+        metrics.funding_rate > 0
+        and metrics.funding_rate >= thresholds.get("funding_rate", 0.0)
         and spread_pct <= thresholds.get("spread", float("inf"))
         and metrics.basis <= max_basis_pct
         and metrics.liquidity >= thresholds.get("liquidity", 0.0)


### PR DESCRIPTION
## Summary
- Require funding rate to be positive and above configured threshold before entering a trade

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cb275575083208fa369b5bde72324