### PR TITLE
Add Russian documentation and code comments

### DIFF
--- a/ai/parameter_optimizer.py
+++ b/ai/parameter_optimizer.py
@@ -16,13 +16,12 @@ DEFAULT_OUTPUT = Path("data") / "optimized_thresholds.joblib"
 
 
 def analyze_trade_history(log_path: Path = LOG_PATH) -> Dict[str, float]:
-    """Analyze trade history using linear regression to derive thresholds.
+    """Анализирует историю сделок и вычисляет пороги через регрессию.
 
-    A lightweight :class:`~sklearn.linear_model.LinearRegression` model is
-    trained on historical trades to evaluate which features contribute most to
-    profitability.  Thresholds for ``funding_rate``, ``basis``,
-    ``holding_time``, ``volume`` and ``liquidity`` are then derived from the
-    median values of trades that the model predicts to be profitable.
+    Линейная регрессия оценивает, какие признаки сильнее влияют на прибыль.
+    Пороговые значения для ``funding_rate``, ``basis``, ``holding_time``,
+    ``volume`` и ``liquidity`` берутся как медианы сделок, которые модель
+    прогнозирует прибыльными.
     """
 
     if not log_path.exists():
@@ -57,6 +56,7 @@ def analyze_trade_history(log_path: Path = LOG_PATH) -> Dict[str, float]:
     if not features:
         return {}
 
+    # Собираем датафрейм признаков и целевой переменной PnL
     X = pd.DataFrame(features)
     X["pnl"] = df["pnl"]
     X = X.dropna()
@@ -69,6 +69,7 @@ def analyze_trade_history(log_path: Path = LOG_PATH) -> Dict[str, float]:
     model.fit(X, y)
     preds = model.predict(X)
 
+    # Оставляем только сделки, которые модель считает прибыльными
     profitable = X[preds > 0]
     if profitable.empty:
         profitable = X
@@ -83,7 +84,7 @@ def analyze_trade_history(log_path: Path = LOG_PATH) -> Dict[str, float]:
 def optimize_and_save(
     log_path: Path = LOG_PATH, out_path: Path = DEFAULT_OUTPUT
 ) -> Dict[str, float]:
-    """Run optimization on trade history and persist the result using joblib."""
+    """Выполняет оптимизацию на истории и сохраняет результат."""
     thresholds = analyze_trade_history(log_path)
     if thresholds:
         out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -97,19 +98,18 @@ async def periodic_optimization(
     log_path: Path = LOG_PATH,
     out_path: Path = DEFAULT_OUTPUT,
     on_update: Optional[Callable[[Dict[str, float]], None]] = None,
+
 ) -> None:
-    """Periodically optimize parameters every ``min_hours``–``max_hours``.
+    """Периодически оптимизирует параметры в интервале ``min_hours``–``max_hours``.
 
     Parameters
     ----------
     min_hours, max_hours:
-        Range of hours to wait between optimization runs.
+        Диапазон часов ожидания между запусками оптимизации.
     log_path, out_path:
-        Locations of the trade log and output file.
+        Пути к журналу сделок и файлу с результатами.
     on_update:
-        Optional callback invoked with the newly computed thresholds after
-        each optimization run.  This allows callers to react to refreshed
-        parameters.
+        Необязательный колбэк, вызываемый после каждого пересчёта порогов.
     """
 
     while True:
@@ -117,11 +117,12 @@ async def periodic_optimization(
         if on_update and thresholds:
             on_update(thresholds)
         wait_hours = random.randint(min_hours, max_hours)
+        # Ждём случайный промежуток перед следующей оптимизацией
         await asyncio.sleep(wait_hours * 3600)
 
 
 def load_thresholds(defaults: Dict[str, float], path: Path = DEFAULT_OUTPUT) -> Dict[str, float]:
-    """Load optimized thresholds and merge with ``defaults``."""
+    """Загружает оптимизированные пороги и объединяет их с ``defaults``."""
     try:
         data = load(path)
         if isinstance(data, dict):

--- a/exchanges/binance.py
+++ b/exchanges/binance.py
@@ -1,4 +1,4 @@
-"""Binance exchange implementation."""
+"""Реализация клиента биржи Binance."""
 from __future__ import annotations
 
 import asyncio
@@ -15,7 +15,7 @@ from . import BaseExchange, register
 
 
 class BinanceExchange(BaseExchange):
-    """Minimal Binance futures client supporting REST and WebSocket."""
+    """Минимальный клиент Binance с поддержкой REST и WebSocket."""
 
     REST_URL = "https://fapi.binance.com"
     WS_URL = "wss://fstream.binance.com/ws"
@@ -23,6 +23,13 @@ class BinanceExchange(BaseExchange):
     SPOT_WS_URL = "wss://stream.binance.com:9443/ws"
 
     def __init__(self, api_key: str, api_secret: str) -> None:
+        """Инициализация клиента.
+
+        Parameters
+        ----------
+        api_key, api_secret:
+            Ключ и секрет API для авторизации на бирже.
+        """
         self.api_key = api_key
         self.api_secret = api_secret
         self._session: Optional[aiohttp.ClientSession] = None
@@ -39,14 +46,17 @@ class BinanceExchange(BaseExchange):
     # ------------------------------------------------------------------
 
     async def _session_get(self) -> aiohttp.ClientSession:
+        """Создаёт ``ClientSession`` при первом обращении."""
         if self._session is None:
             self._session = aiohttp.ClientSession()
         return self._session
 
     def _sign(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Подписывает параметры запроса с помощью HMAC SHA256."""
         params = params.copy()
         params["timestamp"] = int(time.time() * 1000)
         query = "&".join(f"{k}={v}" for k, v in sorted(params.items()))
+        # Формируем подпись из строки запроса
         signature = hmac.new(
             self.api_secret.encode(), query.encode(), hashlib.sha256
         ).hexdigest()
@@ -58,6 +68,7 @@ class BinanceExchange(BaseExchange):
     # ------------------------------------------------------------------
 
     async def fetch_funding(self, symbol: str) -> float:
+        """Получает текущую ставку фондирования для ``symbol``."""
         session = await self._session_get()
         url = f"{self.REST_URL}/fapi/v1/fundingRate"
         params = {"symbol": symbol, "limit": 1}
@@ -68,6 +79,7 @@ class BinanceExchange(BaseExchange):
     async def fetch_funding_history(
         self, symbol: str, hours: int = 8, limit: int = 3
     ) -> list[float]:
+        """Возвращает историю ставок фондирования за заданный период."""
         session = await self._session_get()
         url = f"{self.REST_URL}/fapi/v1/fundingRate"
         end_time = int(time.time() * 1000)
@@ -85,6 +97,7 @@ class BinanceExchange(BaseExchange):
     async def place_order(
         self, symbol: str, side: str, quantity: float, price: float | None = None
     ) -> dict:
+        """Размещает фьючерсный ордер на бирже."""
         session = await self._session_get()
         url = f"{self.REST_URL}/fapi/v1/order"
         params: Dict[str, Any] = {
@@ -101,6 +114,7 @@ class BinanceExchange(BaseExchange):
             return await resp.json()
 
     async def get_balance(self) -> dict:
+        """Возвращает баланс фьючерсного аккаунта."""
         session = await self._session_get()
         url = f"{self.REST_URL}/fapi/v2/balance"
         params = self._sign({})
@@ -109,13 +123,13 @@ class BinanceExchange(BaseExchange):
             return await resp.json()
 
     async def get_stats(self, symbol: str) -> dict:
+        """Получает 24‑часовой объём и открытый интерес для ``symbol``."""
         session = await self._session_get()
         ticker_url = f"{self.REST_URL}/fapi/v1/ticker/24hr"
         params = {"symbol": symbol}
         async with session.get(ticker_url, params=params) as resp:
             ticker = await resp.json()
-        # ``volume`` is denominated in base currency; use ``quoteVolume`` so that
-        # ``volume_24h`` represents notional value in USD.
+        # ``volume`` в базовой валюте; используем ``quoteVolume`` для USD
         volume = float(ticker.get("quoteVolume", ticker.get("volume", 0.0)))
         oi_url = f"{self.REST_URL}/fapi/v1/openInterest"
         async with session.get(oi_url, params=params) as resp:
@@ -126,6 +140,7 @@ class BinanceExchange(BaseExchange):
     async def get_ohlc(
         self, symbol: str, interval: str, limit: int = 1
     ) -> list[Dict[str, float]]:
+        """Возвращает свечи OHLC для ``symbol``."""
         session = await self._session_get()
         url = f"{self.REST_URL}/fapi/v1/klines"
         params = {"symbol": symbol, "interval": interval, "limit": limit}
@@ -148,6 +163,7 @@ class BinanceExchange(BaseExchange):
     async def place_spot_order(
         self, symbol: str, side: str, quantity: float, price: float | None = None
     ) -> dict:
+        """Размещает спотовый ордер."""
         session = await self._session_get()
         url = f"{self.SPOT_REST_URL}/api/v3/order"
         params: Dict[str, Any] = {
@@ -164,6 +180,7 @@ class BinanceExchange(BaseExchange):
             return await resp.json()
 
     async def get_spot_balance(self) -> dict:
+        """Возвращает баланс спотового аккаунта."""
         session = await self._session_get()
         url = f"{self.SPOT_REST_URL}/api/v3/account"
         params = self._sign({})
@@ -178,6 +195,7 @@ class BinanceExchange(BaseExchange):
     async def _connect_spot(
         self, symbol: str, depth: int
     ) -> websockets.WebSocketClientProtocol:
+        """Подключается к спотовому WebSocket и возвращает соединение."""
         while True:
             try:
                 return await websockets.connect(
@@ -187,6 +205,7 @@ class BinanceExchange(BaseExchange):
                 await asyncio.sleep(5)
 
     async def _listen_spot(self, symbol: str, depth: int) -> None:
+        """Слушает поток спотового order book и кэширует данные."""
         while True:
             try:
                 if self._spot_ws is None:
@@ -199,6 +218,7 @@ class BinanceExchange(BaseExchange):
                         "asks": data["asks"],
                     }
             except Exception:
+                # При ошибке пересоздаём соединение
                 await asyncio.sleep(1)
                 if self._spot_ws is not None:
                     try:
@@ -208,6 +228,7 @@ class BinanceExchange(BaseExchange):
                 self._spot_ws = None
 
     async def get_spot_orderbook(self, symbol: str, depth: int = 5) -> dict:
+        """Возвращает кэшированный спотовый стакан для ``symbol``."""
         if symbol not in self._spot_ws_tasks:
             self._spot_ws_tasks[symbol] = asyncio.create_task(
                 self._listen_spot(symbol, depth)
@@ -219,6 +240,7 @@ class BinanceExchange(BaseExchange):
     # ------------------------------------------------------------------
 
     async def _connect(self, symbol: str) -> websockets.WebSocketClientProtocol:
+        """Создаёт WebSocket‑соединение для фьючерсного стакана."""
         while True:
             try:
                 return await websockets.connect(
@@ -228,6 +250,7 @@ class BinanceExchange(BaseExchange):
                 await asyncio.sleep(5)
 
     async def _listen(self, symbol: str) -> None:
+        """Слушает поток фьючерсного стакана и сохраняет его в кэше."""
         while True:
             try:
                 if self._ws is None:
@@ -240,6 +263,7 @@ class BinanceExchange(BaseExchange):
                         "asks": data["asks"],
                     }
             except Exception:
+                # При ошибке пробуем подключиться заново
                 await asyncio.sleep(1)
                 if self._ws is not None:
                     try:
@@ -249,11 +273,13 @@ class BinanceExchange(BaseExchange):
                 self._ws = None
 
     async def get_orderbook(self, symbol: str, depth: int = 5) -> dict:
+        """Возвращает кэшированный фьючерсный стакан."""
         if symbol not in self._ws_tasks:
             self._ws_tasks[symbol] = asyncio.create_task(self._listen(symbol))
         return self._orderbooks.get(symbol, {"bids": [], "asks": []})
 
     async def __aexit__(self, *exc_info: Any) -> None:  # pragma: no cover
+        """Закрывает все сетевые соединения при выходе из контекста."""
         if self._session is not None:
             await self._session.close()
         if self._ws is not None:

--- a/exchanges/bybit.py
+++ b/exchanges/bybit.py
@@ -1,4 +1,4 @@
-"""Bybit exchange implementation."""
+"""Реализация клиента биржи Bybit."""
 from __future__ import annotations
 
 import asyncio
@@ -15,13 +15,20 @@ from . import BaseExchange, register
 
 
 class BybitExchange(BaseExchange):
-    """Minimal Bybit client supporting REST and WebSocket operations."""
+    """Минимальный клиент Bybit с поддержкой REST и WebSocket."""
 
     REST_URL = "https://api.bybit.com"
     WS_URL = "wss://stream.bybit.com/v5/public/linear"
     SPOT_WS_URL = "wss://stream.bybit.com/v5/public/spot"
 
     def __init__(self, api_key: str, api_secret: str) -> None:
+        """Инициализация клиента.
+
+        Parameters
+        ----------
+        api_key, api_secret:
+            Пара ключей API для авторизации.
+        """
         self.api_key = api_key
         self.api_secret = api_secret
         self._session: Optional[aiohttp.ClientSession] = None
@@ -38,16 +45,19 @@ class BybitExchange(BaseExchange):
     # ------------------------------------------------------------------
 
     async def _session_get(self) -> aiohttp.ClientSession:
+        """Создаёт ``ClientSession`` при первом использовании."""
         if self._session is None:
             self._session = aiohttp.ClientSession()
         return self._session
 
     def _sign(self, method: str, path: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Подписывает параметры запроса для Bybit."""
         params = params.copy()
         params["api_key"] = self.api_key
         params["timestamp"] = int(time.time() * 1000)
         query = "&".join(f"{k}={v}" for k, v in sorted(params.items()))
         sign_str = method + path + query
+        # Создаём подпись HMAC
         signature = hmac.new(
             self.api_secret.encode(), sign_str.encode(), hashlib.sha256
         ).hexdigest()
@@ -59,6 +69,7 @@ class BybitExchange(BaseExchange):
     # ------------------------------------------------------------------
 
     async def fetch_funding(self, symbol: str) -> float:
+        """Получает последнюю ставку фондирования для ``symbol``."""
         session = await self._session_get()
         url = f"{self.REST_URL}/v5/market/funding/history"
         params = {"symbol": symbol, "limit": 1}
@@ -69,6 +80,7 @@ class BybitExchange(BaseExchange):
     async def fetch_funding_history(
         self, symbol: str, hours: int = 8, limit: int = 3
     ) -> list[float]:
+        """Возвращает историю ставок фондирования."""
         session = await self._session_get()
         url = f"{self.REST_URL}/v5/market/funding/history"
         end_time = int(time.time() * 1000)
@@ -82,6 +94,7 @@ class BybitExchange(BaseExchange):
     async def place_order(
         self, symbol: str, side: str, quantity: float, price: float | None = None
     ) -> dict:
+        """Отправляет фьючерсный ордер на Bybit."""
         session = await self._session_get()
         url_path = "/v5/order/create"
         url = f"{self.REST_URL}{url_path}"
@@ -99,6 +112,7 @@ class BybitExchange(BaseExchange):
             return await resp.json()
 
     async def get_balance(self) -> dict:
+        """Возвращает баланс унифицированного аккаунта."""
         session = await self._session_get()
         url_path = "/v5/account/wallet-balance"
         url = f"{self.REST_URL}{url_path}"
@@ -107,6 +121,7 @@ class BybitExchange(BaseExchange):
             return await resp.json()
 
     async def get_stats(self, symbol: str) -> dict:
+        """Получает 24‑часовой объём и открытый интерес."""
         session = await self._session_get()
         ticker_url = f"{self.REST_URL}/v5/market/tickers"
         t_params = {"category": "linear", "symbol": symbol}
@@ -125,6 +140,7 @@ class BybitExchange(BaseExchange):
     async def get_ohlc(
         self, symbol: str, interval: str, limit: int = 1
     ) -> list[Dict[str, float]]:
+        """Возвращает свечи OHLC."""
         session = await self._session_get()
         url = f"{self.REST_URL}/v5/market/kline"
         params = {
@@ -153,6 +169,7 @@ class BybitExchange(BaseExchange):
     async def place_spot_order(
         self, symbol: str, side: str, quantity: float, price: float | None = None
     ) -> dict:
+        """Отправляет спотовый ордер."""
         session = await self._session_get()
         url_path = "/v5/order/create"
         url = f"{self.REST_URL}{url_path}"
@@ -171,6 +188,7 @@ class BybitExchange(BaseExchange):
             return await resp.json()
 
     async def get_spot_balance(self) -> dict:
+        """Получает баланс спотового аккаунта."""
         session = await self._session_get()
         url_path = "/v5/account/wallet-balance"
         url = f"{self.REST_URL}{url_path}"
@@ -183,6 +201,7 @@ class BybitExchange(BaseExchange):
     # ------------------------------------------------------------------
 
     async def _connect_spot(self, symbol: str) -> websockets.WebSocketClientProtocol:
+        """Подключается к спотовому WebSocket потоку стакана."""
         while True:
             try:
                 ws = await websockets.connect(self.SPOT_WS_URL)
@@ -193,6 +212,7 @@ class BybitExchange(BaseExchange):
                 await asyncio.sleep(5)
 
     async def _listen_spot(self, symbol: str) -> None:
+        """Слушает обновления спотового стакана и кэширует их."""
         while True:
             try:
                 if self._spot_ws is None:
@@ -206,6 +226,7 @@ class BybitExchange(BaseExchange):
                         "asks": book.get("a", []),
                     }
             except Exception:
+                # При ошибке пересоздаём соединение
                 await asyncio.sleep(1)
                 if self._spot_ws is not None:
                     try:
@@ -215,6 +236,7 @@ class BybitExchange(BaseExchange):
                 self._spot_ws = None
 
     async def get_spot_orderbook(self, symbol: str, depth: int = 5) -> dict:
+        """Возвращает кэшированный спотовый стакан."""
         if symbol not in self._spot_ws_tasks:
             self._spot_ws_tasks[symbol] = asyncio.create_task(
                 self._listen_spot(symbol)
@@ -226,6 +248,7 @@ class BybitExchange(BaseExchange):
     # ------------------------------------------------------------------
 
     async def _connect(self, symbol: str) -> websockets.WebSocketClientProtocol:
+        """Создаёт WebSocket‑соединение для фьючерсного стакана."""
         while True:
             try:
                 ws = await websockets.connect(self.WS_URL)
@@ -239,6 +262,7 @@ class BybitExchange(BaseExchange):
                 await asyncio.sleep(5)
 
     async def _listen(self, symbol: str) -> None:
+        """Слушает поток фьючерсного стакана и сохраняет его."""
         while True:
             try:
                 if self._ws is None:
@@ -252,6 +276,7 @@ class BybitExchange(BaseExchange):
                         "asks": book.get("a", []),
                     }
             except Exception:
+                # Ошибка — перезапускаем соединение
                 await asyncio.sleep(1)
                 if self._ws is not None:
                     try:
@@ -261,11 +286,13 @@ class BybitExchange(BaseExchange):
                 self._ws = None
 
     async def get_orderbook(self, symbol: str, depth: int = 5) -> dict:
+        """Возвращает кэшированный фьючерсный стакан."""
         if symbol not in self._ws_tasks:
             self._ws_tasks[symbol] = asyncio.create_task(self._listen(symbol))
         return self._orderbooks.get(symbol, {"bids": [], "asks": []})
 
     async def __aexit__(self, *exc_info: Any) -> None:  # pragma: no cover
+        """Закрывает все активные соединения при выходе."""
         if self._session is not None:
             await self._session.close()
         if self._ws is not None:

--- a/main.py
+++ b/main.py
@@ -1,9 +1,8 @@
-"""Main entry point for the trading bot.
+"""Главная точка входа торгового бота.
 
-This module loads configuration from ``config.yaml`` and wires together the
-different building blocks of the project.  It initialises exchange clients,
-starts the strategy loops and exposes the loaded configuration via the
-``CONFIG`` global so that other modules can access the settings.
+Модуль загружает параметры из ``config.yaml``, создаёт клиентов бирж и
+запускает основные циклы стратегии. Загруженная конфигурация сохраняется в
+глобальной переменной ``CONFIG`` для доступа из других модулей.
 """
 
 from __future__ import annotations
@@ -38,32 +37,31 @@ POSITION_TASKS: Dict[str, asyncio.Task] = {}
 
 
 def load_config(path: str = "config.yaml") -> None:
-    """Load YAML configuration into the global ``CONFIG`` variable.
+    """Загружает конфигурацию YAML в глобальную переменную ``CONFIG``.
 
     Parameters
     ----------
     path:
-        Path to the configuration file. Defaults to ``config.yaml`` in the
-        current working directory.
+        Путь к файлу конфигурации. По умолчанию ``config.yaml`` в текущей
+        директории.
     """
     global CONFIG
     config_path = Path(path)
     with config_path.open("r", encoding="utf-8") as f:
         CONFIG = yaml.safe_load(f) or {}
+    # Подгружаем оптимизированные пороги стратегии
     CONFIG["thresholds"] = strategy.get_thresholds(
         CONFIG.get("thresholds", {})
     )
 
 
 def initialize_bot() -> None:
-    """Configure exchange clients and risk management."""
+    """Настраивает клиентов бирж и управление рисками."""
 
     api_keys = CONFIG.get("api_keys", {})
     print(f"Initializing bot with API keys: {list(api_keys.keys())}")
 
-    # Instantiate exchange clients if credentials are provided.  Missing keys
-    # simply result in the respective client not being created which keeps the
-    # bot operational for the remaining exchanges.
+    # Создаём клиентов бирж, если заданы ключи
     binance_key = api_keys.get("binance")
     binance_secret = api_keys.get("secret") or api_keys.get("binance_secret")
     if binance_key and binance_secret:
@@ -74,9 +72,7 @@ def initialize_bot() -> None:
     if bybit_key and bybit_secret:
         CLIENTS["bybit"] = BybitExchange(bybit_key, bybit_secret)
 
-    # Load whitelists per exchange.  ``bot.whitelist`` can either be a mapping
-    # of exchange names to symbol lists or a simple list applied to all
-    # configured exchanges.
+    # Загружаем белые списки символов для каждой биржи
     bot_cfg = CONFIG.get("bot", {})
     wl_cfg = bot_cfg.get("whitelist", {})
     if isinstance(wl_cfg, dict):
@@ -86,21 +82,22 @@ def initialize_bot() -> None:
         for name in CLIENTS:
             WHITELISTS[name] = symbols
 
-    # Configure risk management based on the loaded configuration.
+    # Конфигурируем контроль рисков
     risk_control.configure(CONFIG.get("risk", {}), bot_cfg.get("deposit_size"))
 
 
 def start_processing_loops() -> None:
-    """Start the strategy, risk and optimisation loops."""
+    """Запускает циклы стратегии, рисков и оптимизации параметров."""
 
     poll_interval = CONFIG.get("bot", {}).get("poll_interval", 5)
 
     def _update_thresholds(new: Dict[str, float]) -> None:
+        """Обновляет пороги стратегии новыми значениями."""
         if new:
             CONFIG.setdefault("thresholds", {}).update(new)
 
     async def monitor_position(exchange_name: str, symbol: str, quantity: float) -> None:
-        """Monitor an open position until exit conditions trigger."""
+        """Следит за открытой позицией до срабатывания условий выхода."""
         exchanges._current = CLIENTS[exchange_name]
         position_id = f"{exchange_name}:{symbol}"
         try:
@@ -112,6 +109,7 @@ def start_processing_loops() -> None:
                 position_id=position_id,
             )
         except Exception as exc:
+            # При ошибке закрываем позицию и уведомляем
             entry = strategy._positions.get(symbol, {})
             hold = time.time() - entry.get("entry_timestamp", time.time())
             funding_pct = entry.get("entry_funding", 0.0) * 100
@@ -133,6 +131,7 @@ def start_processing_loops() -> None:
             )
             raise
         else:
+            # Успешное завершение позиции
             entry = strategy._positions.get(symbol, {})
             pnl = entry.get("pnl", 0.0)
             reasons = entry.get("exit_reasons")
@@ -157,17 +156,19 @@ def start_processing_loops() -> None:
                 )
             )
         finally:
+            # Удаляем задачу из списка активных
             POSITION_TASKS.pop(position_id, None)
             strategy._positions.pop(symbol, None)
 
     async def scan_loop() -> None:
-        """Continuously scan markets for entry opportunities."""
+        """Постоянно сканирует рынок в поиске входов."""
         while True:
             thresholds = CONFIG.get("thresholds", {})
             trade_value = thresholds.get("min_trade_size", 0.0) or 1.0
 
             for name, client in CLIENTS.items():
                 exchanges._current = client
+                # Перебираем символы из белого списка
                 for symbol in WHITELISTS.get(name, []):
                     if risk_control.is_paused() or risk_control.is_symbol_open(symbol):
                         continue
@@ -187,6 +188,7 @@ def start_processing_loops() -> None:
                     if strategy.check_entry_conditions(
                         symbol, quantity, metrics, thresholds
                     ):
+                        # Условия входа выполнены – открываем позицию
                         try:
                             await strategy.open_neutral_position(symbol, quantity)
                             volume_usd = quantity * metrics.futures_price
@@ -212,16 +214,18 @@ def start_processing_loops() -> None:
             await asyncio.sleep(poll_interval)
 
     async def risk_loop() -> None:
-        """Periodically check whether trading should be paused."""
+        """Периодически проверяет, нужно ли приостановить торговлю."""
         while True:
             if risk_control.is_paused():
                 print("Trading paused due to risk limits")
             await asyncio.sleep(poll_interval)
 
     async def optimisation_loop() -> None:
+        """Запускает оптимизацию параметров в отдельной задаче."""
         await periodic_optimization(on_update=_update_thresholds)
 
     async def runner() -> None:
+        """Создаёт и управляет основными асинхронными задачами."""
         tasks = [
             asyncio.create_task(scan_loop()),
             asyncio.create_task(risk_loop()),
@@ -240,6 +244,7 @@ def start_processing_loops() -> None:
 
 
 def main() -> None:
+    """Запускает загрузку конфигурации и основной цикл работы бота."""
     load_config()
     initialize_bot()
     start_processing_loops()

--- a/risk/risk_control.py
+++ b/risk/risk_control.py
@@ -1,8 +1,8 @@
-"""Basic risk management helpers.
+"""Простые помощники для управления риском.
 
-This module tracks position sizes, accumulated losses, outstanding
-positions, and consecutive losing trades. Trading can be paused when risk
-limits are violated and automatically resumed after a cooldown period.
+Модуль отслеживает размеры позиций, накопленные убытки и количество
+открытых сделок. При превышении лимитов торговля может быть приостановлена,
+а затем автоматически возобновлена после паузы.
 """
 
 from __future__ import annotations
@@ -14,7 +14,7 @@ import time
 
 @dataclass
 class RiskLimits:
-    """Configuration for risk checks."""
+    """Конфигурация ограничений риска."""
 
     max_position_size: float = float("inf")
     max_daily_loss: float = float("inf")
@@ -25,7 +25,7 @@ class RiskLimits:
 
 @dataclass
 class RiskState:
-    """Runtime risk state tracked across trades."""
+    """Текущее состояние риска, обновляемое после сделок."""
 
     total_notional: float = 0.0
     daily_loss: float = 0.0
@@ -41,16 +41,15 @@ _state = RiskState()
 
 
 def configure(config: Dict[str, float], deposit_size: Optional[float] = None) -> None:
-    """Configure risk limits from a dictionary.
+    """Настраивает пределы риска из словаря.
 
     Parameters
     ----------
     config:
-        Dictionary containing risk configuration values.
+        Словарь с параметрами контроля риска.
     deposit_size:
-        Size of the trading account's deposit. Used to derive the absolute
-        deposit exposure limit from ``deposit_cap_pct`` if ``deposit_cap`` is
-        not specified directly.
+        Размер депозита. Используется для расчёта абсолютного лимита, если
+        ``deposit_cap`` явно не задан и указан процент ``deposit_cap_pct``.
     """
 
     global _limits
@@ -58,6 +57,7 @@ def configure(config: Dict[str, float], deposit_size: Optional[float] = None) ->
     if deposit_cap is float("inf") and deposit_size is not None:
         pct = config.get("deposit_cap_pct")
         if pct is not None:
+            # Переводим процент от депозита в абсолютное значение
             deposit_cap = pct * deposit_size
 
     _limits = RiskLimits(
@@ -70,7 +70,7 @@ def configure(config: Dict[str, float], deposit_size: Optional[float] = None) ->
 
 
 def can_open_position(notional: float) -> bool:
-    """Return ``True`` if a position of ``notional`` USD is allowed."""
+    """Возвращает ``True``, если позицию на ``notional`` USD можно открыть."""
 
     if _state.paused:
         return False
@@ -86,54 +86,56 @@ def can_open_position(notional: float) -> bool:
 
 
 def update_position(delta_notional: float) -> None:
-    """Update the tracked notional exposure by ``delta_notional`` USD."""
+    """Обновляет учёт текущей нагрузки на депозит на ``delta_notional`` USD."""
 
     _state.total_notional = max(_state.total_notional + delta_notional, 0.0)
 
 
 def is_symbol_open(symbol: str) -> bool:
-    """Return ``True`` if a position for ``symbol`` is currently open."""
+    """Возвращает ``True``, если позиция по ``symbol`` уже открыта."""
 
     return symbol in _state.open_symbols
 
 
 def mark_symbol_open(symbol: str) -> None:
-    """Record ``symbol`` as having an open position."""
+    """Помечает ``symbol`` как открытую позицию."""
 
     _state.open_symbols.add(symbol)
     _state.open_positions = len(_state.open_symbols)
 
 
 def mark_symbol_closed(symbol: str) -> None:
-    """Remove ``symbol`` from the set of open positions."""
+    """Удаляет ``symbol`` из набора открытых позиций."""
 
     _state.open_symbols.discard(symbol)
     _state.open_positions = len(_state.open_symbols)
 
 
 def pause(duration: Optional[float] = None) -> None:
-    """Pause trading for ``duration`` seconds or indefinitely."""
+    """Приостанавливает торговлю на ``duration`` секунд или бессрочно."""
 
     _state.paused = True
     _state.pause_until = time.time() + duration if duration else None
 
 
 def record_pnl(pnl: float) -> None:
-    """Record the profit or loss from a completed trade."""
+    """Фиксирует прибыль или убыток по завершённой сделке."""
 
     if pnl < 0:
         _state.daily_loss += abs(pnl)
         _state.consecutive_losses += 1
         if _state.consecutive_losses >= _limits.max_consecutive_losses:
+            # Слишком много подряд убыточных сделок — делаем суточную паузу
             pause(24 * 3600)
     else:
         _state.consecutive_losses = 0
 
 
 def is_paused() -> bool:
-    """Return ``True`` if trading is currently paused."""
+    """Возвращает ``True``, если торговля сейчас приостановлена."""
 
     if _state.paused and _state.pause_until and time.time() >= _state.pause_until:
+        # Истёк таймер паузы — возобновляем торговлю
         _state.paused = False
         _state.pause_until = None
         _state.consecutive_losses = 0

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -1,8 +1,8 @@
-"""Utilities for a funding-rate arbitrage strategy.
+"""Утилиты для стратегии арбитража по ставке фондирования.
 
-This module contains helpers for evaluating entry and exit conditions based on
-funding rates and simple market microstructure metrics.  It also provides
-helpers to open and monitor neutral long/short positions.
+Модуль содержит функции для оценки условий входа и выхода на основе ставок
+фондирования и простых микроструктурных метрик. Также включает вспомогательные
+функции для открытия и мониторинга нейтральных позиций.
 """
 
 from __future__ import annotations
@@ -33,7 +33,7 @@ from utils.telegram import format_duration, notify_partial_close
 
 @dataclass
 class MarketMetrics:
-    """Container for market metrics relevant to the strategy."""
+    """Набор рыночных метрик, используемых стратегией."""
 
     funding_rate: float
     spread: float
@@ -52,31 +52,33 @@ class MarketMetrics:
 async def get_market_metrics(
     symbol: str, trade_size: float, depth: int = 5
 ) -> MarketMetrics:
-    """Fetch comprehensive market metrics for ``symbol``.
+    """Получает расширенные рыночные метрики для ``symbol``.
 
     Parameters
     ----------
     symbol:
-        Trading pair symbol understood by the configured exchange.
+        Торговая пара, поддерживаемая текущей биржей.
     trade_size:
-        Quantity to trade when estimating slippage.
+        Объём сделки для оценки проскальзывания.
     depth:
-        Order book depth to request for liquidity calculations.  Defaults to 5.
+        Глубина стакана для расчёта ликвидности. По умолчанию ``5``.
 
     Returns
     -------
     MarketMetrics
-        Includes per-leg slippage estimates and their combined value.
+        Метрики рынка, включая оценку проскальзывания по каждой ноге.
     """
     history = await fetch_funding_history(symbol, hours=8, limit=3)
     if history:
         k = 2 / (len(history) + 1)
         funding = history[0]
         for rate in history[1:]:
+            # Экспоненциальное сглаживание ставок фондирования
             funding = rate * k + funding * (1 - k)
     else:
         funding = 0.0
 
+    # Загружаем стаканы фьючерса и спота
     perp_book = await get_orderbook(symbol, depth=depth)
     spot_book = await get_spot_orderbook(symbol, depth=depth)
 
@@ -86,9 +88,11 @@ async def get_market_metrics(
     spot_asks = [(float(p), float(q)) for p, q in spot_book.get("asks", [])]
 
     def _calc_slippage(orders, size, mid):
+        """Оценивает проскальзывание при выполнении ``size`` по стакану."""
         remaining = size
         cost = 0.0
         for price, qty in orders:
+            # Берём доступный объём из каждой заявки
             take = min(remaining, qty)
             cost += take * price
             remaining -= take
@@ -113,6 +117,7 @@ async def get_market_metrics(
         spot_price = float("nan")
         spot_slippage = float("inf")
 
+    # Суммарное проскальзывание обеих ног
     slippage = futures_slippage + spot_slippage
 
     if bids and asks and spot_bids and spot_asks:
@@ -132,6 +137,7 @@ async def get_market_metrics(
         (spread / spot_price * 100) if spot_price else float("inf")
     )
 
+    # Изменение цены за последние 15 минут для оценки волатильности
     ohlc = await get_ohlc(symbol, interval="15m", limit=1)
     if ohlc:
         candle = ohlc[0]
@@ -167,9 +173,9 @@ def check_entry_conditions(
     metrics: MarketMetrics,
     thresholds: Dict[str, float],
     ) -> bool:
-    """Return ``True`` if all entry thresholds are satisfied.
+    """Возвращает ``True``, если выполнены все условия входа.
 
-    The ``basis`` threshold is specified in percentage points.
+    Порог ``basis`` задаётся в процентных пунктах.
     """
 
     whitelist = CONFIG.get("bot", {}).get("whitelist", [])
@@ -206,7 +212,7 @@ def check_entry_conditions(
 
 
 def check_exit_conditions(metrics: MarketMetrics, thresholds: Dict[str, float]) -> bool:
-    """Return ``True`` if any exit condition is met."""
+    """Возвращает ``True``, если выполнено любое условие выхода."""
     return (
         abs(metrics.funding_rate) <= thresholds.get("funding_rate", float("inf"))
         or metrics.spread >= thresholds.get("spread", float("-inf"))
@@ -224,10 +230,11 @@ _positions: Dict[str, Dict[str, Any]] = {}
 
 
 async def open_neutral_position(symbol: str, quantity: float) -> Dict[str, Dict]:
-    """Open offsetting long and short positions and record entry details."""
+    """Открывает компенсирующие длинную и короткую позиции и сохраняет данные."""
     bot_cfg = CONFIG.get("bot", {})
     if symbol not in bot_cfg.get("whitelist", []):
         raise RuntimeError("Symbol not whitelisted")
+    # Получаем метрики рынка для оценки сделки
     entry_metrics = await get_market_metrics(symbol, quantity)
     notional = quantity * entry_metrics.futures_price
     deposit = bot_cfg.get("deposit_size", float("inf"))
@@ -237,6 +244,7 @@ async def open_neutral_position(symbol: str, quantity: float) -> Dict[str, Dict]
         raise RuntimeError("Trade size exceeds deposit limits")
     if not risk_control.can_open_position(notional) or risk_control.is_symbol_open(symbol):
         raise RuntimeError("Risk limits exceeded, trading paused, or position exists")
+    # Хеджируем позицию на споте и фьючерсе
     orders = await hedge(symbol, quantity)
     risk_control.update_position(notional)
     risk_control.mark_symbol_open(symbol)
@@ -292,25 +300,24 @@ async def open_neutral_position(symbol: str, quantity: float) -> Dict[str, Dict]
 async def close_neutral_position(
     symbol: str, quantity: float, pnl: float = 0.0, final: bool = True
 ) -> Dict[str, Dict]:
-    """Close an existing neutral position and record PnL.
+    """Закрывает нейтральную позицию и фиксирует результат.
 
     Parameters
     ----------
     symbol:
-        Trading pair symbol.
+        Торговая пара.
     quantity:
-        Size to close.
+        Объём закрытия.
     pnl:
-        Realised profit or loss for the closed size.
+        Полученная прибыль или убыток.
     final:
-        Whether this closes the position entirely.  If ``False`` the position
-        remains open and risk controls are not reset.
+        Если ``True``, позиция закрывается полностью и риски сбрасываются.
     """
     close_long = await place_order(symbol, "SELL", quantity)
     try:
         close_short = await place_order(symbol, "BUY", quantity)
     except Exception as exc:
-        # Rollback long close to restore neutrality
+        # В случае ошибки возвращаем длинную позицию
         await place_order(symbol, "BUY", quantity)
         raise RuntimeError("Failed to close hedge; rolled back long leg") from exc
     entry = _positions.get(symbol)
@@ -334,13 +341,12 @@ async def monitor_neutral_position(
     poll_interval: float = 5.0,
     position_id: str | None = None,
 ) -> None:
-    """Monitor a neutral position and close it when exit criteria are met.
+    """Следит за позицией и закрывает её при срабатывании условий выхода.
 
-    The function supports scaling out of positions.  When exit conditions are
-    met but the remaining size exceeds twice the minimum trade size the
-    position is halved and monitoring continues on the rest.  Telegram updates
-    are sent via :func:`notify_partial_close` so that the original message is
-    edited instead of spammed.
+    Поддерживается частичное закрытие: если размер позиции больше двух
+    минимальных, закрывается половина и отслеживание продолжается. Обновления
+    отправляются через :func:`notify_partial_close`, чтобы редактировать одно
+    сообщение вместо отправки новых.
     """
     entry = _positions.get(symbol, {})
     while True:
@@ -359,6 +365,7 @@ async def monitor_neutral_position(
                 * (now - last)
                 / (8 * 3600)
             )
+            # Накапливаем полученное фондирование
             entry["funding_accrued"] = entry.get("funding_accrued", 0.0) + funding_fee
             entry["last_funding_timestamp"] = now
         reasons: list[str] = []
@@ -404,6 +411,7 @@ async def monitor_neutral_position(
                 orders = await close_neutral_position(
                     symbol, partial_qty, pnl_part, final=False
                 )
+                # Обновляем запись о позиции после частичного выхода
                 quantity -= partial_qty
                 entry["quantity"] = quantity
                 entry["pnl"] = entry.get("pnl", 0.0) + pnl_part
@@ -542,13 +550,13 @@ async def monitor_neutral_position(
 # ---------------------------------------------------------------------------
 
 def get_thresholds(config_thresholds: Dict[str, float]) -> Dict[str, float]:
-    """Return strategy thresholds merged with any optimized values.
+    """Возвращает пороги стратегии с учётом оптимизированных значений.
 
     Parameters
     ----------
     config_thresholds:
-        Thresholds configured in ``config.yaml``.  Values produced by the
-        optimizer take precedence over these defaults.
+        Пороговые значения из ``config.yaml``. Результаты оптимизатора имеют
+        приоритет над этими значениями.
     """
 
     return _load_thresholds(config_thresholds)

--- a/utils/telegram.py
+++ b/utils/telegram.py
@@ -9,12 +9,12 @@ CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
 
 _BOT: Optional[Bot] = Bot(API_TOKEN, parse_mode="HTML") if API_TOKEN else None
 
-# Cache message IDs for each position so that updates edit the same message.
+# Кешируем идентификаторы сообщений для обновления одного и того же поста
 _MESSAGE_CACHE: Dict[str, int] = {}
 
 
 def format_duration(seconds: float) -> str:
-    """Return a human readable duration given ``seconds``."""
+    """Возвращает человекочитаемую длительность по количеству секунд."""
     seconds = max(int(seconds), 0)
     minutes, sec = divmod(seconds, 60)
     hours, minutes = divmod(minutes, 60)
@@ -29,9 +29,9 @@ def format_duration(seconds: float) -> str:
 
 
 async def _send_message(text: str) -> Optional[int]:
-    """Send a new Telegram message and return the message ID."""
+    """Отправляет новое сообщение в Telegram и возвращает его ID."""
     if _BOT is None or CHAT_ID is None:
-        # Fail silently if configuration is missing.
+        # Если нет конфигурации, просто выходим
         return None
     try:
         message = await _BOT.send_message(CHAT_ID, text)
@@ -41,7 +41,7 @@ async def _send_message(text: str) -> Optional[int]:
 
 
 async def _edit_message(message_id: int, text: str) -> None:
-    """Edit an existing Telegram message."""
+    """Редактирует ранее отправленное сообщение."""
     if _BOT is None or CHAT_ID is None:
         return
     try:
@@ -51,7 +51,7 @@ async def _edit_message(message_id: int, text: str) -> None:
 
 
 async def notify_open(position_id: str, text: str) -> None:
-    """Notify that a position has been opened."""
+    """Уведомляет об открытии позиции."""
     message_id = _MESSAGE_CACHE.get(position_id)
     if message_id is None:
         message_id = await _send_message(text)
@@ -62,7 +62,7 @@ async def notify_open(position_id: str, text: str) -> None:
 
 
 async def notify_partial_close(position_id: str, text: str) -> None:
-    """Notify about a partial position closure."""
+    """Уведомляет о частичном закрытии позиции."""
     message_id = _MESSAGE_CACHE.get(position_id)
     if message_id is None:
         message_id = await _send_message(text)
@@ -73,7 +73,7 @@ async def notify_partial_close(position_id: str, text: str) -> None:
 
 
 async def notify_close(position_id: str, text: str) -> None:
-    """Notify that a position has been fully closed and remove it from cache."""
+    """Сообщает о полном закрытии позиции и удаляет запись из кеша."""
     message_id = _MESSAGE_CACHE.get(position_id)
     if message_id is not None:
         await _edit_message(message_id, text)


### PR DESCRIPTION
## Summary
- localize bot entrypoint and helpers with Russian docstrings
- clarify exchange clients and strategy logic with in-line comments
- add Russian documentation for risk control, Telegram, and optimizer modules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688cc5883fe48320866f59a52a118e0b