### PR TITLE
Fix API calls and type hints

### DIFF
--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -448,5 +448,5 @@ async def hedge(symbol: str, quantity: float) -> Dict[str, Dict]:
         raise RuntimeError("Не удалось разместить хедж; спотовая часть откатена") from exc
 
 # Импорт встроенных бирж для регистрации в фабрике.
-from . import binance as _binance  # noqa: F401
-from . import bybit as _bybit  # noqa: F401
+from . import binance as _binance  # noqa: E402,F401
+from . import bybit as _bybit  # noqa: E402,F401

--- a/exchanges/binance.py
+++ b/exchanges/binance.py
@@ -33,11 +33,11 @@ class BinanceExchange(BaseExchange):
         self.api_key = api_key
         self.api_secret = api_secret
         self._session: Optional[aiohttp.ClientSession] = None
-        self._ws: Optional[websockets.WebSocketClientProtocol] = None
+        self._ws: Optional[Any] = None
         self._orderbooks: Dict[str, Dict[str, Any]] = {}
         self._ws_tasks: Dict[str, asyncio.Task] = {}
         # Обработка WebSocket для спота
-        self._spot_ws: Optional[websockets.WebSocketClientProtocol] = None
+        self._spot_ws: Optional[Any] = None
         self._spot_orderbooks: Dict[str, Dict[str, Any]] = {}
         self._spot_ws_tasks: Dict[str, asyncio.Task] = {}
 
@@ -71,7 +71,7 @@ class BinanceExchange(BaseExchange):
         """Получает текущую ставку фондирования для ``symbol``."""
         session = await self._session_get()
         url = f"{self.REST_URL}/fapi/v1/fundingRate"
-        params = {"symbol": symbol, "limit": 1}
+        params: dict[str, str | int] = {"symbol": symbol, "limit": 1}
         async with session.get(url, params=params) as resp:
             data = await resp.json()
         return float(data[0]["fundingRate"])
@@ -84,7 +84,7 @@ class BinanceExchange(BaseExchange):
         url = f"{self.REST_URL}/fapi/v1/fundingRate"
         end_time = int(time.time() * 1000)
         start_time = end_time - hours * 3600 * 1000
-        params = {
+        params: dict[str, int | str] = {
             "symbol": symbol,
             "startTime": start_time,
             "endTime": end_time,
@@ -125,14 +125,13 @@ class BinanceExchange(BaseExchange):
     async def get_stats(self, symbol: str) -> dict:
         """Получает 24‑часовой объём и открытый интерес для ``symbol``."""
         session = await self._session_get()
-        ticker_url = f"{self.REST_URL}/fapi/v1/ticker/24hr"
-        params = {"symbol": symbol}
-        async with session.get(ticker_url, params=params) as resp:
+        ticker_url = f"{self.REST_URL}/fapi/v1/ticker/24hr?symbol={symbol}"
+        async with session.get(ticker_url) as resp:
             ticker = await resp.json()
         # ``volume`` в базовой валюте; используем ``quoteVolume`` для USD
         volume = float(ticker.get("quoteVolume", ticker.get("volume", 0.0)))
-        oi_url = f"{self.REST_URL}/fapi/v1/openInterest"
-        async with session.get(oi_url, params=params) as resp:
+        oi_url = f"{self.REST_URL}/fapi/v1/openInterest?symbol={symbol}"
+        async with session.get(oi_url) as resp:
             oi = await resp.json()
         open_interest = float(oi.get("openInterest", 0.0))
         return {"volume_24h": volume, "open_interest": open_interest}
@@ -143,7 +142,7 @@ class BinanceExchange(BaseExchange):
         """Возвращает свечи OHLC для ``symbol``."""
         session = await self._session_get()
         url = f"{self.REST_URL}/fapi/v1/klines"
-        params = {"symbol": symbol, "interval": interval, "limit": limit}
+        params: dict[str, str | int] = {"symbol": symbol, "interval": interval, "limit": limit}
         async with session.get(url, params=params) as resp:
             data = await resp.json()
         return [
@@ -194,7 +193,7 @@ class BinanceExchange(BaseExchange):
 
     async def _connect_spot(
         self, symbol: str, depth: int
-    ) -> websockets.WebSocketClientProtocol:
+    ) -> Any:
         """Подключается к спотовому WebSocket и возвращает соединение."""
         while True:
             try:
@@ -239,7 +238,7 @@ class BinanceExchange(BaseExchange):
     # Обработка WebSocket
     # ------------------------------------------------------------------
 
-    async def _connect(self, symbol: str) -> websockets.WebSocketClientProtocol:
+    async def _connect(self, symbol: str) -> Any:
         """Создаёт WebSocket‑соединение для фьючерсного стакана."""
         while True:
             try:

--- a/exchanges/bybit.py
+++ b/exchanges/bybit.py
@@ -32,11 +32,11 @@ class BybitExchange(BaseExchange):
         self.api_key = api_key
         self.api_secret = api_secret
         self._session: Optional[aiohttp.ClientSession] = None
-        self._ws: Optional[websockets.WebSocketClientProtocol] = None
+        self._ws: Optional[Any] = None
         self._orderbooks: Dict[str, Dict[str, Any]] = {}
         self._ws_tasks: Dict[str, asyncio.Task] = {}
         # Управление WebSocket спота
-        self._spot_ws: Optional[websockets.WebSocketClientProtocol] = None
+        self._spot_ws: Optional[Any] = None
         self._spot_orderbooks: Dict[str, Dict[str, Any]] = {}
         self._spot_ws_tasks: Dict[str, asyncio.Task] = {}
 
@@ -72,7 +72,7 @@ class BybitExchange(BaseExchange):
         """Получает последнюю ставку фондирования для ``symbol``."""
         session = await self._session_get()
         url = f"{self.REST_URL}/v5/market/funding/history"
-        params = {"symbol": symbol, "limit": 1}
+        params: dict[str, str | int] = {"symbol": symbol, "limit": 1}
         async with session.get(url, params=params) as resp:
             data = await resp.json()
         return float(data["result"]["list"][0]["fundingRate"])
@@ -85,7 +85,7 @@ class BybitExchange(BaseExchange):
         url = f"{self.REST_URL}/v5/market/funding/history"
         end_time = int(time.time() * 1000)
         start_time = end_time - hours * 3600 * 1000
-        params = {"symbol": symbol, "startTime": start_time, "endTime": end_time, "limit": limit}
+        params: dict[str, str | int] = {"symbol": symbol, "startTime": start_time, "endTime": end_time, "limit": limit}
         async with session.get(url, params=params) as resp:
             data = await resp.json()
         records = data.get("result", {}).get("list", [])
@@ -116,7 +116,7 @@ class BybitExchange(BaseExchange):
         session = await self._session_get()
         url_path = "/v5/account/wallet-balance"
         url = f"{self.REST_URL}{url_path}"
-        params = self._sign("GET", url_path, {"accountType": "UNIFIED"})
+        params: Dict[str, Any] = self._sign("GET", url_path, {"accountType": "UNIFIED"})
         async with session.get(url, params=params) as resp:
             return await resp.json()
 
@@ -124,13 +124,13 @@ class BybitExchange(BaseExchange):
         """Получает 24‑часовой объём и открытый интерес."""
         session = await self._session_get()
         ticker_url = f"{self.REST_URL}/v5/market/tickers"
-        t_params = {"category": "linear", "symbol": symbol}
+        t_params: dict[str, str] = {"category": "linear", "symbol": symbol}
         async with session.get(ticker_url, params=t_params) as resp:
             ticker = await resp.json()
         tick = (ticker.get("result", {}).get("list") or [{}])[0]
         volume = float(tick.get("turnover24h", 0.0))
         oi_url = f"{self.REST_URL}/v5/market/open-interest"
-        oi_params = {"category": "linear", "symbol": symbol}
+        oi_params: dict[str, str] = {"category": "linear", "symbol": symbol}
         async with session.get(oi_url, params=oi_params) as resp:
             oi = await resp.json()
         oi_list = oi.get("result", {}).get("list") or [{}]
@@ -143,7 +143,7 @@ class BybitExchange(BaseExchange):
         """Возвращает свечи OHLC."""
         session = await self._session_get()
         url = f"{self.REST_URL}/v5/market/kline"
-        params = {
+        params: dict[str, str | int] = {
             "category": "linear",
             "symbol": symbol,
             "interval": interval,
@@ -192,7 +192,7 @@ class BybitExchange(BaseExchange):
         session = await self._session_get()
         url_path = "/v5/account/wallet-balance"
         url = f"{self.REST_URL}{url_path}"
-        params = self._sign("GET", url_path, {"accountType": "SPOT"})
+        params: Dict[str, Any] = self._sign("GET", url_path, {"accountType": "SPOT"})
         async with session.get(url, params=params) as resp:
             return await resp.json()
 
@@ -200,7 +200,7 @@ class BybitExchange(BaseExchange):
     # Обработка спотового WebSocket
     # ------------------------------------------------------------------
 
-    async def _connect_spot(self, symbol: str) -> websockets.WebSocketClientProtocol:
+    async def _connect_spot(self, symbol: str) -> Any:
         """Подключается к спотовому WebSocket потоку стакана."""
         while True:
             try:
@@ -247,7 +247,7 @@ class BybitExchange(BaseExchange):
     # Обработка WebSocket
     # ------------------------------------------------------------------
 
-    async def _connect(self, symbol: str) -> websockets.WebSocketClientProtocol:
+    async def _connect(self, symbol: str) -> Any:
         """Создаёт WebSocket‑соединение для фьючерсного стакана."""
         while True:
             try:

--- a/main.py
+++ b/main.py
@@ -16,8 +16,6 @@ from typing import Any, Dict, List
 import yaml
 from dotenv import load_dotenv
 
-load_dotenv()
-
 import exchanges
 from exchanges.binance import BinanceExchange
 from exchanges.bybit import BybitExchange
@@ -25,6 +23,8 @@ from risk import risk_control
 from strategies import funding_arbitrage as strategy
 from ai.parameter_optimizer import periodic_optimization
 from utils.telegram import format_duration, notify_close, notify_open
+
+load_dotenv()
 
 # Глобальный словарь конфигурации, доступный другим модулям.
 CONFIG: Dict[str, Any] = {}

--- a/risk/risk_control.py
+++ b/risk/risk_control.py
@@ -18,8 +18,8 @@ class RiskLimits:
 
     max_position_size: float = float("inf")
     max_daily_loss: float = float("inf")
-    max_consecutive_losses: int = float("inf")
-    max_open_positions: int = float("inf")
+    max_consecutive_losses: float = float("inf")
+    max_open_positions: float = float("inf")
     deposit_cap: float = float("inf")
 
 

--- a/tests/test_binance_stats.py
+++ b/tests/test_binance_stats.py
@@ -1,31 +1,33 @@
-import pytest
-import sys
 import pathlib
+import sys
+from typing import Any, Dict
 
 import pytest
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
-from exchanges.binance import BinanceExchange
+from exchanges.binance import BinanceExchange  # noqa: E402
 
 
 class DummyResponse:
-    def __init__(self, data):
+    def __init__(self, data: Dict[str, Any]) -> None:
         self.data = data
 
-    async def json(self):
+    async def json(self) -> Dict[str, Any]:
         return self.data
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> "DummyResponse":
         return self
 
-    async def __aexit__(self, exc_type, exc, tb):
+    async def __aexit__(
+        self, exc_type: Any, exc: Any, tb: Any
+    ) -> None:  # pragma: no cover - no cleanup needed
         pass
 
 
 class DummySession:
     @staticmethod
-    def get(url):
+    def get(url: str) -> DummyResponse:
         if "ticker/24hr" in url:
             return DummyResponse({"quoteVolume": "500", "volume": "5"})
         if "openInterest" in url:
@@ -34,11 +36,13 @@ class DummySession:
 
 
 @pytest.mark.asyncio
-async def test_get_stats_uses_quote_volume(monkeypatch):
+async def test_get_stats_uses_quote_volume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     ex = BinanceExchange("key", "secret")
     dummy = DummySession()
 
-    async def session_get():
+    async def session_get() -> DummySession:
         return dummy
 
     monkeypatch.setattr(ex, "_session_get", session_get)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+# Utility package

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Простые утилиты для логирования сделок в Excel.
 
 Модуль предоставляет небольшую функцию для сохранения информации о сделках
@@ -43,16 +41,18 @@ from __future__ import annotations
 для добавления строк без полного переписывания файла через pandas.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping
 
 from openpyxl import Workbook, load_workbook
 
 # Расположение файла журнала по умолчанию.
-LOG_PATH = Path("data") / "funding_bot_log.xlsx"
+LOG_PATH: Path = Path("data") / "funding_bot_log.xlsx"
 
 # Упорядоченный список колонок, ожидаемых для каждой сделки.
-LOG_COLUMNS = [
+LOG_COLUMNS: list[str] = [
     "symbol",
     "exchange",
     "entry_time",

--- a/utils/telegram.py
+++ b/utils/telegram.py
@@ -7,8 +7,8 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-API_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
-CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
+API_TOKEN: str | None = os.getenv("TELEGRAM_BOT_TOKEN")
+CHAT_ID: str | None = os.getenv("TELEGRAM_CHAT_ID")
 
 _BOT: Optional[Bot] = Bot(API_TOKEN, parse_mode="HTML") if API_TOKEN else None
 


### PR DESCRIPTION
## Summary
- use query strings instead of params in Binance stats request
- add typing-friendly parameter dictionaries and generalize websocket types
- adjust risk limit defaults and mark utils as package
- reorder imports, add type annotations, and ensure lint checks pass

## Testing
- `ruff check .`
- `mypy --ignore-missing-imports .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d29a3d5a483209fb6745949bb540f