### PR TITLE
Handle deposit cap percentage when limit is absent

### DIFF
--- a/risk/risk_control.py
+++ b/risk/risk_control.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, Optional, Set
 import time
+import math
 
 
 @dataclass
@@ -54,7 +55,7 @@ def configure(config: Dict[str, float], deposit_size: Optional[float] = None) ->
 
     global _limits
     deposit_cap = config.get("deposit_cap", float("inf"))
-    if deposit_cap is float("inf") and deposit_size is not None:
+    if math.isinf(deposit_cap) and deposit_size is not None:
         pct = config.get("deposit_cap_pct")
         if pct is not None:
             # Переводим процент от депозита в абсолютное значение

--- a/tests/test_risk_control.py
+++ b/tests/test_risk_control.py
@@ -1,0 +1,11 @@
+from risk import risk_control as rc
+
+
+def teardown_module(module):
+    # Reset configuration after tests
+    rc.configure({})
+
+
+def test_deposit_cap_pct_applied():
+    rc.configure({"deposit_cap_pct": 0.1}, deposit_size=1000)
+    assert rc._limits.deposit_cap == 100.0


### PR DESCRIPTION
## Summary
- replace identity check with `math.isinf` for determining unlimited `deposit_cap`
- apply percentage-based deposit cap when `deposit_cap` isn't specified
- test deposit cap calculation from percentage of deposit size

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e26ed2d48832088abe222c0b27d64