### PR TITLE
refactor: pass exchange explicitly

### DIFF
--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -184,17 +184,14 @@ async def _handle_timeout() -> None:
                 client = CLIENTS.get(exchange_name)
                 if client is None:
                     continue
-                exchanges_current = current
                 try:
-                    # Переключаем контекст на биржу клиента для этой позиции.
-                    globals()["_current"] = client
                     entry = strategy.positions.get(symbol, {})
                     quantity = entry.get("quantity") or entry.get(
                         "initial_quantity", 0.0
                     )
                     try:
                         orders = await strategy.close_neutral_position(
-                            symbol, quantity, final=True
+                            client, symbol, quantity, final=True
                         )
                     except Exception as exc_close:
                         logger.error(
@@ -285,7 +282,7 @@ async def _handle_timeout() -> None:
                             )
                         )
                 finally:
-                    globals()["_current"] = exchanges_current
+                    pass
                     task.cancel()
                     with contextlib.suppress(asyncio.CancelledError):
                         await task

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List
 import yaml
 from dotenv import load_dotenv
 
-import exchanges
+from exchanges import BaseExchange
 from exchanges.binance import BinanceExchange
 from exchanges.bybit import BybitExchange
 from risk import risk_control
@@ -30,7 +30,7 @@ load_dotenv()
 CONFIG: Dict[str, Any] = {}
 
 # Соответствие имени биржи созданному клиенту.
-CLIENTS: Dict[str, exchanges.BaseExchange] = {}
+CLIENTS: Dict[str, BaseExchange] = {}
 
 # Белые списки символов для каждой биржи.
 WHITELISTS: Dict[str, List[str]] = {}
@@ -114,10 +114,11 @@ def start_processing_loops() -> None:
 
     async def monitor_position(exchange_name: str, symbol: str, quantity: float) -> None:
         """Следит за открытой позицией до срабатывания условий выхода."""
-        exchanges.current = CLIENTS[exchange_name]
+        exchange = CLIENTS[exchange_name]
         position_id = f"{exchange_name}:{symbol}"
         try:
             await strategy.monitor_neutral_position(
+                exchange,
                 symbol,
                 quantity,
                 CONFIG.get("thresholds", {}),
@@ -191,20 +192,19 @@ def start_processing_loops() -> None:
                 trade_value = 1.0
 
             for name, client in CLIENTS.items():
-                exchanges.current = client
                 # Перебираем символы из белого списка
                 for symbol in WHITELISTS.get(name, []):
                     if risk_control.is_paused() or risk_control.is_symbol_open(symbol):
                         continue
                     try:
-                        base_metrics = await strategy.get_market_metrics(symbol, 1.0)
+                        base_metrics = await strategy.get_market_metrics(client, symbol, 1.0)
                     except Exception as exc:
                         print(f"Ошибка метрик {name} {symbol}: {exc}")
                         continue
                     price = base_metrics.futures_price
                     quantity = trade_value / price if price else 0.0
                     try:
-                        metrics = await strategy.get_market_metrics(symbol, quantity)
+                        metrics = await strategy.get_market_metrics(client, symbol, quantity)
                     except Exception as exc:
                         print(f"Ошибка метрик {name} {symbol}: {exc}")
                         continue
@@ -214,7 +214,7 @@ def start_processing_loops() -> None:
                     ):
                         # Условия входа выполнены – открываем позицию
                         try:
-                            await strategy.open_neutral_position(symbol, quantity)
+                            await strategy.open_neutral_position(client, symbol, quantity)
                             volume_usd = quantity * metrics.futures_price
                             asyncio.create_task(
                                 notify_open(

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -16,16 +16,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
 
-from exchanges import (
-    fetch_funding_history,
-    get_orderbook,
-    get_spot_orderbook,
-    get_stats,
-    get_ohlc,
-    hedge,
-    place_order,
-)
-import exchanges
+from exchanges import BaseExchange
 from risk import risk_control
 from ai.parameter_optimizer import load_thresholds as _load_thresholds
 from main import CONFIG
@@ -55,7 +46,7 @@ class MarketMetrics:
 
 
 async def get_market_metrics(
-    symbol: str, trade_size: float, depth: int = 5
+    exchange: BaseExchange, symbol: str, trade_size: float, depth: int = 5
 ) -> MarketMetrics:
     """Получает расширенные рыночные метрики для ``symbol``.
 
@@ -73,7 +64,7 @@ async def get_market_metrics(
     MarketMetrics
         Метрики рынка, включая оценку проскальзывания по каждой ноге.
     """
-    history = await fetch_funding_history(symbol, hours=8, limit=3)
+    history = await exchange.fetch_funding_history(symbol, hours=8, limit=3)
     if history:
         k = 2 / (len(history) + 1)
         funding = history[0]
@@ -84,8 +75,8 @@ async def get_market_metrics(
         funding = 0.0
 
     # Загружаем стаканы фьючерса и спота
-    perp_book = await get_orderbook(symbol, depth=depth)
-    spot_book = await get_spot_orderbook(symbol, depth=depth)
+    perp_book = await exchange.get_orderbook(symbol, depth=depth)
+    spot_book = await exchange.get_spot_orderbook(symbol, depth=depth)
 
     bids = [(float(p), float(q)) for p, q in perp_book.get("bids", [])]
     asks = [(float(p), float(q)) for p, q in perp_book.get("asks", [])]
@@ -130,7 +121,7 @@ async def get_market_metrics(
     else:
         spread = float("inf")
 
-    stats = await get_stats(symbol)
+    stats = await exchange.get_stats(symbol)
     volume = float(stats.get("volume_24h", 0.0))
     open_interest = float(stats.get("open_interest", 0.0))
     if futures_price and not math.isnan(futures_price):
@@ -143,7 +134,7 @@ async def get_market_metrics(
     )
 
     # Изменение цены за последние 15 минут для оценки волатильности
-    ohlc = await get_ohlc(symbol, interval="15m", limit=1)
+    ohlc = await exchange.get_ohlc(symbol, interval="15m", limit=1)
     if ohlc:
         candle = ohlc[0]
         o = candle.get("open") or 0.0
@@ -256,13 +247,15 @@ def save_positions(path: Path | str = POSITIONS_FILE) -> None:
         json.dump(positions, fh)
 
 
-async def open_neutral_position(symbol: str, quantity: float) -> Dict[str, Dict]:
+async def open_neutral_position(
+    exchange: BaseExchange, symbol: str, quantity: float
+) -> Dict[str, Dict]:
     """Открывает компенсирующие длинную и короткую позиции и сохраняет данные."""
     bot_cfg = CONFIG.get("bot", {})
     if symbol not in bot_cfg.get("whitelist", []):
         raise RuntimeError("Символ отсутствует в белом списке")
     # Получаем метрики рынка для оценки сделки
-    entry_metrics = await get_market_metrics(symbol, quantity)
+    entry_metrics = await get_market_metrics(exchange, symbol, quantity)
     notional = quantity * entry_metrics.futures_price
     deposit = bot_cfg.get("deposit_size", float("inf"))
     deposit_pct = CONFIG.get("thresholds", {}).get("deposit_pct", 1.0)
@@ -272,16 +265,24 @@ async def open_neutral_position(symbol: str, quantity: float) -> Dict[str, Dict]
     if not risk_control.can_open_position(notional) or risk_control.is_symbol_open(symbol):
         raise RuntimeError("Превышены лимиты риска, торговля приостановлена или позиция уже открыта")
     # Хеджируем позицию на споте и фьючерсе
-    orders = await hedge(symbol, quantity)
+    spot_order = await exchange.place_spot_order(symbol, "BUY", quantity)
+    try:
+        perp_order = await exchange.place_order(symbol, "SELL", quantity)
+    except Exception as exc:
+        order_id = str(spot_order.get("orderId") or spot_order.get("id") or "")
+        try:
+            await exchange.cancel_order(order_id)
+        except Exception:
+            pass
+        raise RuntimeError(
+            "Не удалось разместить хедж; спотовая часть откатена"
+        ) from exc
+    orders = {"spot": spot_order, "perp": perp_order}
     risk_control.update_position(notional)
     risk_control.mark_symbol_open(symbol)
     now = time.time()
     commission = sum(float(o.get("fee", 0.0)) for o in orders.values())
-    exchange_name = (
-        type(exchanges.current).__name__.replace("Exchange", "").lower()
-        if getattr(exchanges, "_current", None)
-        else "unknown"
-    )
+    exchange_name = type(exchange).__name__.replace("Exchange", "").lower()
     positions[symbol] = {
         "entry_timestamp": now,
         "entry_futures_price": entry_metrics.futures_price,
@@ -327,7 +328,11 @@ async def open_neutral_position(symbol: str, quantity: float) -> Dict[str, Dict]
 
 
 async def close_neutral_position(
-    symbol: str, quantity: float, pnl: float = 0.0, final: bool = True
+    exchange: BaseExchange,
+    symbol: str,
+    quantity: float,
+    pnl: float = 0.0,
+    final: bool = True,
 ) -> Dict[str, Dict]:
     """Закрывает нейтральную позицию и фиксирует результат.
 
@@ -342,12 +347,12 @@ async def close_neutral_position(
     final:
         Если ``True``, позиция закрывается полностью и риски сбрасываются.
     """
-    close_long = await place_order(symbol, "SELL", quantity)
+    close_long = await exchange.place_order(symbol, "SELL", quantity)
     try:
-        close_short = await place_order(symbol, "BUY", quantity)
+        close_short = await exchange.place_order(symbol, "BUY", quantity)
     except Exception as exc:
         # В случае ошибки возвращаем длинную позицию
-        await place_order(symbol, "BUY", quantity)
+        await exchange.place_order(symbol, "BUY", quantity)
         raise RuntimeError("Не удалось закрыть хедж; длинная нога откатена") from exc
     entry = positions.get(symbol)
     commission = float(close_long.get("fee", 0.0)) + float(
@@ -366,6 +371,7 @@ async def close_neutral_position(
 
 
 async def monitor_neutral_position(
+    exchange: BaseExchange,
     symbol: str,
     quantity: float,
     exit_thresholds: Dict[str, float],
@@ -382,7 +388,7 @@ async def monitor_neutral_position(
     entry = positions.get(symbol, {})
     while True:
         try:
-            metrics = await get_market_metrics(symbol, quantity)
+            metrics = await get_market_metrics(exchange, symbol, quantity)
         except Exception as exc:
             print(f"Ошибка мониторинга {symbol}: {exc}")
             await asyncio.sleep(poll_interval)
@@ -442,7 +448,7 @@ async def monitor_neutral_position(
                     - (metrics.spot_price - entry.get("entry_spot_price", 0.0))
                 ) * partial_qty
                 orders = await close_neutral_position(
-                    symbol, partial_qty, pnl_part, final=False
+                    exchange, symbol, partial_qty, pnl_part, final=False
                 )
                 # Обновляем запись о позиции после частичного выхода
                 quantity -= partial_qty
@@ -462,11 +468,7 @@ async def monitor_neutral_position(
                 volume_usd = partial_qty * entry.get("entry_futures_price", 0.0)
                 pnl_pct = (pnl_part / volume_usd * 100) if volume_usd else 0.0
                 hold_time = exit_ts - entry.get("entry_timestamp", exit_ts)
-                exchange_name = (
-                    type(exchanges.current).__name__.replace("Exchange", "").lower()
-                    if getattr(exchanges, "_current", None)
-                    else "unknown"
-                )
+                exchange_name = type(exchange).__name__.replace("Exchange", "").lower()
                 log_trade(
                     {
                         "symbol": symbol,
@@ -519,7 +521,7 @@ async def monitor_neutral_position(
                         )
                     )
                 continue
-            await close_neutral_position(symbol, quantity, pnl, final=True)
+            await close_neutral_position(exchange, symbol, quantity, pnl, final=True)
             if entry:
                 exit_basis = (
                     ((metrics.futures_price - metrics.spot_price) / metrics.spot_price) * 100
@@ -539,11 +541,7 @@ async def monitor_neutral_position(
                         "pnl": total_pnl,
                     }
                 )
-                exchange_name = (
-                    type(exchanges.current).__name__.replace("Exchange", "").lower()
-                    if getattr(exchanges, "_current", None)
-                    else "unknown"
-                )
+                exchange_name = type(exchange).__name__.replace("Exchange", "").lower()
                 volume_usd = entry.get("entry_futures_price", 0.0) * entry.get(
                     "initial_quantity", entry.get("quantity", 0.0)
                 )


### PR DESCRIPTION
## Summary
- remove reliance on global `exchanges.current`
- pass exchange clients explicitly through strategy and main loops
- adjust timeout handler to close positions using provided client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e2750d6088320a89404373c8e6e36