### PR TITLE
Add HTTP status checks and retry logic

### DIFF
--- a/exchanges/binance.py
+++ b/exchanges/binance.py
@@ -53,6 +53,46 @@ class BinanceExchange(BaseExchange):
             self._session = aiohttp.ClientSession()
         return self._session
 
+    async def _request(
+        self, method: str, url: str, retries: int = 3, **kwargs: Any
+    ) -> Any:
+        """Выполняет HTTP-запрос с повторными попытками.
+
+        При статусе ответа вне диапазона ``200-299`` возбуждает исключение
+        ``aiohttp.ClientResponseError``. В случае ошибок соединения или
+        ответов сервера ``5xx`` выполняет ограниченное число повторов с
+        экспоненциальной задержкой.
+        """
+
+        session = await self._session_get()
+        delay = 1.0
+        for attempt in range(retries):
+            try:
+                request = getattr(session, method.lower())
+                async with request(url, **kwargs) as resp:
+                    if 200 <= resp.status < 300:
+                        return await resp.json()
+
+                    text = await resp.text()
+                    # Повторяем при ошибках сервера
+                    if resp.status >= 500 and attempt < retries - 1:
+                        await asyncio.sleep(delay)
+                        delay *= 2
+                        continue
+
+                    raise aiohttp.ClientResponseError(
+                        resp.request_info,
+                        resp.history,
+                        status=resp.status,
+                        message=text,
+                        headers=resp.headers,
+                    )
+            except aiohttp.ClientError:
+                if attempt >= retries - 1:
+                    raise
+                await asyncio.sleep(delay)
+                delay *= 2
+
     def _sign(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """Подписывает параметры запроса с помощью HMAC SHA256."""
         params = params.copy()
@@ -71,18 +111,15 @@ class BinanceExchange(BaseExchange):
 
     async def fetch_funding(self, symbol: str) -> float:
         """Получает текущую ставку фондирования для ``symbol``."""
-        session = await self._session_get()
         url = f"{self.REST_URL}/fapi/v1/fundingRate"
         params: dict[str, str | int] = {"symbol": symbol, "limit": 1}
-        async with session.get(url, params=params) as resp:
-            data = await resp.json()
+        data = await self._request("GET", url, params=params)
         return float(data[0]["fundingRate"])
 
     async def fetch_funding_history(
         self, symbol: str, hours: int = 8, limit: int = 3
     ) -> list[float]:
         """Возвращает историю ставок фондирования за заданный период."""
-        session = await self._session_get()
         url = f"{self.REST_URL}/fapi/v1/fundingRate"
         end_time = int(time.time() * 1000)
         start_time = end_time - hours * 3600 * 1000
@@ -92,15 +129,13 @@ class BinanceExchange(BaseExchange):
             "endTime": end_time,
             "limit": limit,
         }
-        async with session.get(url, params=params) as resp:
-            data = await resp.json()
+        data = await self._request("GET", url, params=params)
         return [float(entry["fundingRate"]) for entry in data]
 
     async def place_order(
         self, symbol: str, side: str, quantity: float, price: float | None = None
     ) -> dict:
         """Размещает фьючерсный ордер на бирже."""
-        session = await self._session_get()
         url = f"{self.REST_URL}/fapi/v1/order"
         params: Dict[str, Any] = {
             "symbol": symbol,
@@ -112,29 +147,23 @@ class BinanceExchange(BaseExchange):
             params.update({"price": price, "timeInForce": "GTC"})
         headers = {"X-MBX-APIKEY": self.api_key}
         params = self._sign(params)
-        async with session.post(url, params=params, headers=headers) as resp:
-            return await resp.json()
+        return await self._request("POST", url, params=params, headers=headers)
 
     async def get_balance(self) -> dict:
         """Возвращает баланс фьючерсного аккаунта."""
-        session = await self._session_get()
         url = f"{self.REST_URL}/fapi/v2/balance"
         params = self._sign({})
         headers = {"X-MBX-APIKEY": self.api_key}
-        async with session.get(url, params=params, headers=headers) as resp:
-            return await resp.json()
+        return await self._request("GET", url, params=params, headers=headers)
 
     async def get_stats(self, symbol: str) -> dict:
         """Получает 24‑часовой объём и открытый интерес для ``symbol``."""
-        session = await self._session_get()
         ticker_url = f"{self.REST_URL}/fapi/v1/ticker/24hr?symbol={symbol}"
-        async with session.get(ticker_url) as resp:
-            ticker = await resp.json()
+        ticker = await self._request("GET", ticker_url)
         # ``volume`` в базовой валюте; используем ``quoteVolume`` для USD
         volume = float(ticker.get("quoteVolume", ticker.get("volume", 0.0)))
         oi_url = f"{self.REST_URL}/fapi/v1/openInterest?symbol={symbol}"
-        async with session.get(oi_url) as resp:
-            oi = await resp.json()
+        oi = await self._request("GET", oi_url)
         open_interest = float(oi.get("openInterest", 0.0))
         return {"volume_24h": volume, "open_interest": open_interest}
 
@@ -142,11 +171,13 @@ class BinanceExchange(BaseExchange):
         self, symbol: str, interval: str, limit: int = 1
     ) -> list[Dict[str, float]]:
         """Возвращает свечи OHLC для ``symbol``."""
-        session = await self._session_get()
         url = f"{self.REST_URL}/fapi/v1/klines"
-        params: dict[str, str | int] = {"symbol": symbol, "interval": interval, "limit": limit}
-        async with session.get(url, params=params) as resp:
-            data = await resp.json()
+        params: dict[str, str | int] = {
+            "symbol": symbol,
+            "interval": interval,
+            "limit": limit,
+        }
+        data = await self._request("GET", url, params=params)
         return [
             {
                 "open": float(k[1]),
@@ -165,7 +196,6 @@ class BinanceExchange(BaseExchange):
         self, symbol: str, side: str, quantity: float, price: float | None = None
     ) -> dict:
         """Размещает спотовый ордер."""
-        session = await self._session_get()
         url = f"{self.SPOT_REST_URL}/api/v3/order"
         params: Dict[str, Any] = {
             "symbol": symbol,
@@ -177,17 +207,14 @@ class BinanceExchange(BaseExchange):
             params.update({"price": price, "timeInForce": "GTC"})
         headers = {"X-MBX-APIKEY": self.api_key}
         params = self._sign(params)
-        async with session.post(url, params=params, headers=headers) as resp:
-            return await resp.json()
+        return await self._request("POST", url, params=params, headers=headers)
 
     async def get_spot_balance(self) -> dict:
         """Возвращает баланс спотового аккаунта."""
-        session = await self._session_get()
         url = f"{self.SPOT_REST_URL}/api/v3/account"
         params = self._sign({})
         headers = {"X-MBX-APIKEY": self.api_key}
-        async with session.get(url, params=params, headers=headers) as resp:
-            return await resp.json()
+        return await self._request("GET", url, params=params, headers=headers)
 
     # ------------------------------------------------------------------
     # Обработка спотового WebSocket

--- a/exchanges/bybit.py
+++ b/exchanges/bybit.py
@@ -51,6 +51,44 @@ class BybitExchange(BaseExchange):
             self._session = aiohttp.ClientSession()
         return self._session
 
+    async def _request(
+        self, method: str, url: str, retries: int = 3, **kwargs: Any
+    ) -> Any:
+        """Выполняет HTTP-запрос с ограниченным числом повторов.
+
+        При статусе ответа вне диапазона ``200-299`` возбуждает
+        ``aiohttp.ClientResponseError``. В случае сетевых ошибок или
+        ответов сервера ``5xx`` выполняет повтор с экспоненциальной задержкой.
+        """
+
+        session = await self._session_get()
+        delay = 1.0
+        for attempt in range(retries):
+            try:
+                request = getattr(session, method.lower())
+                async with request(url, **kwargs) as resp:
+                    if 200 <= resp.status < 300:
+                        return await resp.json()
+
+                    text = await resp.text()
+                    if resp.status >= 500 and attempt < retries - 1:
+                        await asyncio.sleep(delay)
+                        delay *= 2
+                        continue
+
+                    raise aiohttp.ClientResponseError(
+                        resp.request_info,
+                        resp.history,
+                        status=resp.status,
+                        message=text,
+                        headers=resp.headers,
+                    )
+            except aiohttp.ClientError:
+                if attempt >= retries - 1:
+                    raise
+                await asyncio.sleep(delay)
+                delay *= 2
+
     def _sign(self, method: str, path: str, params: Dict[str, Any]) -> Dict[str, Any]:
         """Подписывает параметры запроса для Bybit."""
         params = params.copy()
@@ -71,24 +109,25 @@ class BybitExchange(BaseExchange):
 
     async def fetch_funding(self, symbol: str) -> float:
         """Получает последнюю ставку фондирования для ``symbol``."""
-        session = await self._session_get()
         url = f"{self.REST_URL}/v5/market/funding/history"
         params: dict[str, str | int] = {"symbol": symbol, "limit": 1}
-        async with session.get(url, params=params) as resp:
-            data = await resp.json()
+        data = await self._request("GET", url, params=params)
         return float(data["result"]["list"][0]["fundingRate"])
 
     async def fetch_funding_history(
         self, symbol: str, hours: int = 8, limit: int = 3
     ) -> list[float]:
         """Возвращает историю ставок фондирования."""
-        session = await self._session_get()
         url = f"{self.REST_URL}/v5/market/funding/history"
         end_time = int(time.time() * 1000)
         start_time = end_time - hours * 3600 * 1000
-        params: dict[str, str | int] = {"symbol": symbol, "startTime": start_time, "endTime": end_time, "limit": limit}
-        async with session.get(url, params=params) as resp:
-            data = await resp.json()
+        params: dict[str, str | int] = {
+            "symbol": symbol,
+            "startTime": start_time,
+            "endTime": end_time,
+            "limit": limit,
+        }
+        data = await self._request("GET", url, params=params)
         records = data.get("result", {}).get("list", [])
         return [float(item.get("fundingRate", 0.0)) for item in records]
 
@@ -96,7 +135,6 @@ class BybitExchange(BaseExchange):
         self, symbol: str, side: str, quantity: float, price: float | None = None
     ) -> dict:
         """Отправляет фьючерсный ордер на Bybit."""
-        session = await self._session_get()
         url_path = "/v5/order/create"
         url = f"{self.REST_URL}{url_path}"
         body: Dict[str, Any] = {
@@ -109,31 +147,27 @@ class BybitExchange(BaseExchange):
             body["price"] = price
         headers = {"Content-Type": "application/json"}
         body = self._sign("POST", url_path, body)
-        async with session.post(url, json=body, headers=headers) as resp:
-            return await resp.json()
+        return await self._request("POST", url, json=body, headers=headers)
 
     async def get_balance(self) -> dict:
         """Возвращает баланс унифицированного аккаунта."""
-        session = await self._session_get()
         url_path = "/v5/account/wallet-balance"
         url = f"{self.REST_URL}{url_path}"
-        params: Dict[str, Any] = self._sign("GET", url_path, {"accountType": "UNIFIED"})
-        async with session.get(url, params=params) as resp:
-            return await resp.json()
+        params: Dict[str, Any] = self._sign(
+            "GET", url_path, {"accountType": "UNIFIED"}
+        )
+        return await self._request("GET", url, params=params)
 
     async def get_stats(self, symbol: str) -> dict:
         """Получает 24‑часовой объём и открытый интерес."""
-        session = await self._session_get()
         ticker_url = f"{self.REST_URL}/v5/market/tickers"
         t_params: dict[str, str] = {"category": "linear", "symbol": symbol}
-        async with session.get(ticker_url, params=t_params) as resp:
-            ticker = await resp.json()
+        ticker = await self._request("GET", ticker_url, params=t_params)
         tick = (ticker.get("result", {}).get("list") or [{}])[0]
         volume = float(tick.get("turnover24h", 0.0))
         oi_url = f"{self.REST_URL}/v5/market/open-interest"
         oi_params: dict[str, str] = {"category": "linear", "symbol": symbol}
-        async with session.get(oi_url, params=oi_params) as resp:
-            oi = await resp.json()
+        oi = await self._request("GET", oi_url, params=oi_params)
         oi_list = oi.get("result", {}).get("list") or [{}]
         open_interest = float(oi_list[0].get("openInterest", 0.0))
         return {"volume_24h": volume, "open_interest": open_interest}
@@ -142,7 +176,6 @@ class BybitExchange(BaseExchange):
         self, symbol: str, interval: str, limit: int = 1
     ) -> list[Dict[str, float]]:
         """Возвращает свечи OHLC."""
-        session = await self._session_get()
         url = f"{self.REST_URL}/v5/market/kline"
         params: dict[str, str | int] = {
             "category": "linear",
@@ -150,8 +183,7 @@ class BybitExchange(BaseExchange):
             "interval": interval,
             "limit": limit,
         }
-        async with session.get(url, params=params) as resp:
-            data = await resp.json()
+        data = await self._request("GET", url, params=params)
         klist = data.get("result", {}).get("list", [])
         return [
             {
@@ -171,7 +203,6 @@ class BybitExchange(BaseExchange):
         self, symbol: str, side: str, quantity: float, price: float | None = None
     ) -> dict:
         """Отправляет спотовый ордер."""
-        session = await self._session_get()
         url_path = "/v5/order/create"
         url = f"{self.REST_URL}{url_path}"
         body: Dict[str, Any] = {
@@ -185,17 +216,16 @@ class BybitExchange(BaseExchange):
             body["price"] = price
         headers = {"Content-Type": "application/json"}
         body = self._sign("POST", url_path, body)
-        async with session.post(url, json=body, headers=headers) as resp:
-            return await resp.json()
+        return await self._request("POST", url, json=body, headers=headers)
 
     async def get_spot_balance(self) -> dict:
         """Получает баланс спотового аккаунта."""
-        session = await self._session_get()
         url_path = "/v5/account/wallet-balance"
         url = f"{self.REST_URL}{url_path}"
-        params: Dict[str, Any] = self._sign("GET", url_path, {"accountType": "SPOT"})
-        async with session.get(url, params=params) as resp:
-            return await resp.json()
+        params: Dict[str, Any] = self._sign(
+            "GET", url_path, {"accountType": "SPOT"}
+        )
+        return await self._request("GET", url, params=params)
 
     # ------------------------------------------------------------------
     # Обработка спотового WebSocket

--- a/tests/test_binance_stats.py
+++ b/tests/test_binance_stats.py
@@ -10,11 +10,15 @@ from exchanges.binance import BinanceExchange  # noqa: E402
 
 
 class DummyResponse:
-    def __init__(self, data: Dict[str, Any]) -> None:
+    def __init__(self, data: Dict[str, Any], status: int = 200) -> None:
         self.data = data
+        self.status = status
 
     async def json(self) -> Dict[str, Any]:
         return self.data
+
+    async def text(self) -> str:  # pragma: no cover - used for errors
+        return ""
 
     async def __aenter__(self) -> "DummyResponse":
         return self
@@ -27,7 +31,7 @@ class DummyResponse:
 
 class DummySession:
     @staticmethod
-    def get(url: str) -> DummyResponse:
+    def get(url: str, **_: Any) -> DummyResponse:
         if "ticker/24hr" in url:
             return DummyResponse({"quoteVolume": "500", "volume": "5"})
         if "openInterest" in url:


### PR DESCRIPTION
## Summary
- add internal `_request` helper for Binance and Bybit clients that checks HTTP status codes
- implement limited exponential backoff retries for REST requests
- update test stubs to include status and support new request API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e28970ec08320aeaf2d933eece171