### PR TITLE
feat: validate exchange symbols against whitelists

### DIFF
--- a/main.py
+++ b/main.py
@@ -105,13 +105,19 @@ def initialize_bot() -> None:
         return set(futures) & set(spot)
 
     async def _fetch_all() -> dict[str, set[str]]:
-        result: dict[str, set[str]] = {}
-        for name, client in CLIENTS.items():
+        """Получает доступные символы всех бирж параллельно."""
+
+        async def _task(name: str, client: BaseExchange) -> tuple[str, set[str]]:
             try:
-                result[name] = await _collect(client)
+                return name, await _collect(client)
             except Exception as exc:  # pragma: no cover - network errors
                 logger.error("Не удалось получить символы %s: %s", name, exc)
-        return result
+                return name, set()
+
+        pairs = await asyncio.gather(
+            *(_task(n, c) for n, c in CLIENTS.items())
+        )
+        return dict(pairs)
 
     available = asyncio.run(_fetch_all()) if CLIENTS else {}
     for name, allowed in available.items():

--- a/tests/test_initialize_whitelist.py
+++ b/tests/test_initialize_whitelist.py
@@ -1,0 +1,69 @@
+import importlib
+import logging
+import pathlib
+import sys
+import types
+
+import pytest
+
+# Ensure repository root on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+
+def test_initialize_filters_whitelist(monkeypatch, caplog):
+    # Provide lightweight stand-ins for heavy modules
+    ai_stub = types.ModuleType("ai.parameter_optimizer")
+    ai_stub.periodic_optimization = lambda *args, **kwargs: None
+    ai_stub.load_thresholds = lambda *args, **kwargs: {}
+    monkeypatch.setitem(sys.modules, "ai.parameter_optimizer", ai_stub)
+
+    strategy_stub = types.ModuleType("strategies.funding_arbitrage")
+    strategy_stub.get_thresholds = lambda cfg: cfg
+    strategy_stub.load_positions = lambda: None
+    strategy_stub.positions = {}
+    strategies_pkg = types.ModuleType("strategies")
+    monkeypatch.setitem(sys.modules, "strategies", strategies_pkg)
+    monkeypatch.setitem(sys.modules, "strategies.funding_arbitrage", strategy_stub)
+
+    # Import modules after stubbing
+    main = importlib.import_module("main")
+    BinanceExchange = importlib.import_module("exchanges.binance").BinanceExchange
+    BybitExchange = importlib.import_module("exchanges.bybit").BybitExchange
+
+    # Prepare dummy config
+    main.CONFIG = {
+        "api_keys": {"binance": "k", "secret": "s", "bybit": "k2", "bybit_secret": "s2"},
+        "bot": {"whitelist": ["BTCUSDT", "ETHUSDT", "FOOUSD"], "deposit_size": 100},
+        "risk": {},
+    }
+    main.CLIENTS.clear()
+    main.WHITELISTS.clear()
+
+    monkeypatch.setattr(main.risk_control, "configure", lambda *args, **kwargs: None)
+
+    async def futures_ok(self):
+        return ["BTCUSDT", "ETHUSDT"]
+
+    async def spot_ok(self):
+        return ["BTCUSDT", "ETHUSDT", "BNBUSDT"]
+
+    async def futures_bybit(self):
+        return ["BTCUSDT"]
+
+    async def spot_bybit(self):
+        return ["BTCUSDT"]
+
+    monkeypatch.setattr(BinanceExchange, "get_futures_symbols", futures_ok)
+    monkeypatch.setattr(BinanceExchange, "get_spot_symbols", spot_ok)
+    monkeypatch.setattr(BybitExchange, "get_futures_symbols", futures_bybit)
+    monkeypatch.setattr(BybitExchange, "get_spot_symbols", spot_bybit)
+
+    caplog.set_level(logging.WARNING)
+    main.initialize_bot()
+
+    assert main.WHITELISTS["binance"] == ["BTCUSDT", "ETHUSDT"]
+    assert main.WHITELISTS["bybit"] == ["BTCUSDT"]
+
+    warnings = [rec.getMessage() for rec in caplog.records if rec.levelno == logging.WARNING]
+    joined = "\n".join(warnings)
+    assert "FOOUSD" in joined and "ETHUSDT" in joined


### PR DESCRIPTION
## Summary
- parallelize exchange symbol retrieval during bot initialization
- drop unsupported trading pairs from each exchange whitelist and log warnings
- cover initialization whitelist filtering with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e3c5001d08320acd29155da837c22