### PR TITLE
feat: add exchange name property

### DIFF
--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -40,6 +40,8 @@ class BaseExchange(ABC):
     без реальных сетевых запросов.
     """
 
+    name: str
+
     def __init__(self, **_ignored: Any) -> None:
         """Базовый инициализатор, принимающий произвольные параметры.
 
@@ -49,6 +51,9 @@ class BaseExchange(ABC):
         "неожиданных аргументах" при создании экземпляра абстрактного класса.
         """
         super().__init__()
+        self.name = getattr(
+            self, "name", self.__class__.__name__.replace("Exchange", "").lower()
+        )
 
     @abstractmethod
     async def fetch_funding(self, symbol: str) -> float:

--- a/exchanges/binance.py
+++ b/exchanges/binance.py
@@ -32,6 +32,7 @@ class BinanceExchange(BaseExchange):
             Ключ и секрет API для авторизации на бирже.
         """
         super().__init__(**_ignored)
+        self.name = "binance"
         self.api_key = api_key
         self.api_secret = api_secret
         self._session: Optional[aiohttp.ClientSession] = None

--- a/exchanges/bybit.py
+++ b/exchanges/bybit.py
@@ -30,6 +30,7 @@ class BybitExchange(BaseExchange):
             Пара ключей API для авторизации.
         """
         super().__init__(**_ignored)
+        self.name = "bybit"
         self.api_key = api_key
         self.api_secret = api_secret
         self._session: Optional[aiohttp.ClientSession] = None

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -310,7 +310,7 @@ async def open_neutral_position(
 ) -> Dict[str, Dict]:
     """Открывает компенсирующие длинную и короткую позиции и сохраняет данные."""
     bot_cfg = CONFIG.get("bot", {})
-    exchange_name = type(exchange).__name__.replace("Exchange", "").lower()
+    exchange_name = exchange.name
     if symbol not in WHITELISTS.get(exchange_name, []):
         raise RuntimeError("Символ отсутствует в белом списке")
     # Получаем метрики рынка для оценки сделки


### PR DESCRIPTION
## Summary
- add explicit `name` attribute to `BaseExchange`
- set `name` for Binance and Bybit implementations
- use exchange `name` property in `open_neutral_position`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e5e9a54f0832086b37625e598bdbd