### PR TITLE
Add retry logic for order placement

### DIFF
--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -143,6 +143,7 @@ class BaseExchange(ABC):
 _EXCHANGES: Dict[str, Type[BaseExchange]] = {}
 current: Optional[BaseExchange] = None
 API_TIMEOUT = 30
+ORDER_RETRIES = 5
 
 
 def register(name: str, cls: Type[BaseExchange]) -> None:
@@ -321,9 +322,17 @@ async def place_order(
     """Размещает ордер через настроенную биржу."""
     if current is None:  # pragma: no cover - defensive programming
         raise RuntimeError("Биржа не настроена")
-    return await _await_with_timeout(
-        current.place_order(symbol, side, quantity, price)
-    )
+    delay = 1.0
+    for attempt in range(ORDER_RETRIES):
+        try:
+            return await _await_with_timeout(
+                current.place_order(symbol, side, quantity, price)
+            )
+        except Exception:
+            if attempt == ORDER_RETRIES - 1:
+                raise
+            await asyncio.sleep(delay)
+            delay *= 2
 
 
 async def _poll_fill(order_id: str, market: str) -> None:
@@ -357,9 +366,18 @@ async def place_spot_order(
     """Размещает спотовый ордер и ожидает его полного исполнения."""
     if current is None:  # pragma: no cover - defensive programming
         raise RuntimeError("Биржа не настроена")
-    order = await _await_with_timeout(
-        current.place_spot_order(symbol, side, quantity, price)
-    )
+    delay = 1.0
+    for attempt in range(ORDER_RETRIES):
+        try:
+            order = await _await_with_timeout(
+                current.place_spot_order(symbol, side, quantity, price)
+            )
+            break
+        except Exception:
+            if attempt == ORDER_RETRIES - 1:
+                raise
+            await asyncio.sleep(delay)
+            delay *= 2
     order_id = str(order.get("orderId") or order.get("id") or "")
     _track_order("spot", order_id)
     await _poll_fill(order_id, "spot")

--- a/tests/test_order_retries.py
+++ b/tests/test_order_retries.py
@@ -1,0 +1,78 @@
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import exchanges
+
+
+class FlakyExchange:
+    def __init__(self) -> None:
+        self.perp_attempts = 0
+        self.spot_attempts = 0
+
+    async def place_order(self, *args, **kwargs):
+        self.perp_attempts += 1
+        if self.perp_attempts < 3:
+            raise RuntimeError("fail")
+        return {"orderId": "perp"}
+
+    async def place_spot_order(self, *args, **kwargs):
+        self.spot_attempts += 1
+        if self.spot_attempts < 2:
+            raise RuntimeError("fail")
+        return {"orderId": "spot"}
+
+    async def get_order_status(self, order_id):
+        return {"status": "FILLED", "order_id": order_id}
+
+
+class AlwaysFailExchange(FlakyExchange):
+    async def place_order(self, *args, **kwargs):  # type: ignore[override]
+        self.perp_attempts += 1
+        raise RuntimeError("fail")
+
+    async def place_spot_order(self, *args, **kwargs):  # type: ignore[override]
+        self.spot_attempts += 1
+        raise RuntimeError("fail")
+
+
+async def _fast_sleep(_: float) -> None:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_place_order_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    exchanges.current = FlakyExchange()
+    monkeypatch.setattr(exchanges.asyncio, "sleep", _fast_sleep)
+    order = await exchanges.place_order("BTCUSDT", "BUY", 1)
+    assert order["orderId"] == "perp"
+    assert exchanges.current.perp_attempts == 3  # type: ignore[attribute-defined-outside-init]
+
+
+@pytest.mark.asyncio
+async def test_spot_order_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    exchanges.current = FlakyExchange()
+    monkeypatch.setattr(exchanges.asyncio, "sleep", _fast_sleep)
+    order = await exchanges.place_spot_order("BTCUSDT", "BUY", 1)
+    assert order["orderId"] == "spot"
+    assert exchanges.current.spot_attempts == 2  # type: ignore[attribute-defined-outside-init]
+
+
+@pytest.mark.asyncio
+async def test_place_order_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    exchanges.current = AlwaysFailExchange()
+    monkeypatch.setattr(exchanges.asyncio, "sleep", _fast_sleep)
+    with pytest.raises(RuntimeError):
+        await exchanges.place_order("BTCUSDT", "BUY", 1)
+    assert exchanges.current.perp_attempts == exchanges.ORDER_RETRIES  # type: ignore[attribute-defined-outside-init]
+
+
+@pytest.mark.asyncio
+async def test_spot_order_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    exchanges.current = AlwaysFailExchange()
+    monkeypatch.setattr(exchanges.asyncio, "sleep", _fast_sleep)
+    with pytest.raises(RuntimeError):
+        await exchanges.place_spot_order("BTCUSDT", "BUY", 1)
+    assert exchanges.current.spot_attempts == exchanges.ORDER_RETRIES  # type: ignore[attribute-defined-outside-init]


### PR DESCRIPTION
## Summary
- add configurable retry constant for exchange orders
- retry spot and perp order placement with exponential backoff and propagate last error
- add unit tests for order placement retries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e5eb979c48320ab7624b3ff4d71d0