### PR TITLE
Handle missing market data gracefully

### DIFF
--- a/main.py
+++ b/main.py
@@ -235,6 +235,11 @@ def start_processing_loops() -> None:
                         continue
                     try:
                         base_metrics = await strategy.get_market_metrics(symbol, 1.0, client)
+                        if base_metrics is None:
+                            logger.warning(
+                                "Пропуск %s:%s из-за неполных метрик", name, symbol
+                            )
+                            continue
                     except Exception as exc:
                         logger.error("Ошибка метрик %s %s: %s", name, symbol, exc)
                         continue
@@ -242,6 +247,11 @@ def start_processing_loops() -> None:
                     quantity = trade_value / price if price else 0.0
                     try:
                         metrics = await strategy.get_market_metrics(symbol, quantity, client)
+                        if metrics is None:
+                            logger.warning(
+                                "Пропуск %s:%s из-за неполных метрик", name, symbol
+                            )
+                            continue
                     except Exception as exc:
                         logger.error("Ошибка метрик %s %s: %s", name, symbol, exc)
                         continue

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -103,7 +103,7 @@ async def get_market_metrics(
     trade_size: float,
     exchange: BaseExchange | None = None,
     depth: int = 5,
-) -> MarketMetrics:
+) -> MarketMetrics | None:
     """Получает расширенные рыночные метрики для ``symbol``.
 
     ``exchange`` может быть ``None`` – в этом случае используются
@@ -136,6 +136,10 @@ async def get_market_metrics(
     spot_bids = [(float(p), float(q)) for p, q in spot_book.get("bids", [])]
     spot_asks = [(float(p), float(q)) for p, q in spot_book.get("asks", [])]
 
+    # If any order book side is empty, market data is incomplete
+    if not (bids and asks and spot_bids and spot_asks):
+        return None
+
     def _calc_slippage(orders, size, mid):
         """Оценивает проскальзывание при выполнении ``size`` по стакану."""
         if size <= 0 or math.isnan(size):
@@ -154,32 +158,24 @@ async def get_market_metrics(
         avg_price = cost / size
         return abs(avg_price - mid) / mid
 
-    if bids and asks:
-        futures_price = (asks[0][0] + bids[0][0]) / 2
-        futures_slippage = _calc_slippage(asks, trade_size, futures_price)
-    else:
-        futures_price = float("nan")
-        futures_slippage = float("inf")
+    futures_price = (asks[0][0] + bids[0][0]) / 2
+    futures_slippage = _calc_slippage(asks, trade_size, futures_price)
 
-    if spot_bids and spot_asks:
-        spot_price = (spot_asks[0][0] + spot_bids[0][0]) / 2
-        spot_slippage = _calc_slippage(spot_asks, trade_size, spot_price)
-    else:
-        spot_price = float("nan")
-        spot_slippage = float("inf")
+    spot_price = (spot_asks[0][0] + spot_bids[0][0]) / 2
+    spot_slippage = _calc_slippage(spot_asks, trade_size, spot_price)
 
     # Суммарное проскальзывание обеих ног
     slippage = futures_slippage + spot_slippage
 
-    if bids and asks and spot_bids and spot_asks:
-        spread = abs(futures_price - spot_price)
-    else:
-        spread = float("inf")
+    spread = abs(futures_price - spot_price)
 
     if exchange is not None:
         stats = await exchange.get_stats(symbol)
     else:
         stats = await get_stats(symbol)
+    if not stats:
+        return None
+
     volume = float(stats.get("volume_24h", 0.0))
     open_interest = float(stats.get("open_interest", 0.0))
     if futures_price and not math.isnan(futures_price):
@@ -225,13 +221,17 @@ async def get_market_metrics(
 def check_entry_conditions(
     symbol: str,
     quantity: Decimal,
-    metrics: MarketMetrics,
+    metrics: MarketMetrics | None,
     thresholds: Dict[str, float],
     ) -> bool:
     """Возвращает ``True``, если выполнены все условия входа.
 
     Порог ``basis`` задаётся в процентных пунктах.
     """
+    if metrics is None:
+        logger.warning("Skipping %s: incomplete market metrics", symbol)
+        return False
+
     quantity = Decimal(str(quantity))
     deposit = Decimal(str(CONFIG.get("bot", {}).get("deposit_size", "Infinity")))
     max_deposit_trade = deposit * Decimal(str(thresholds.get("deposit_pct", 1.0)))
@@ -450,6 +450,10 @@ async def monitor_neutral_position(
     while True:
         try:
             metrics = await get_market_metrics(symbol, quantity, exchange)
+            if metrics is None:
+                logger.warning("Неполные рыночные данные для %s", symbol)
+                await asyncio.sleep(poll_interval)
+                continue
         except Exception as exc:
             logger.error("Ошибка мониторинга %s: %s", symbol, exc)
             await asyncio.sleep(poll_interval)

--- a/tests/test_slippage_volume.py
+++ b/tests/test_slippage_volume.py
@@ -1,8 +1,11 @@
+import logging
 import math
 import pathlib
 import sys
 
 import types
+
+from decimal import Decimal
 
 import pytest
 
@@ -24,7 +27,7 @@ ai_module.parameter_optimizer = parameter_optimizer
 sys.modules["ai"] = ai_module
 sys.modules["ai.parameter_optimizer"] = parameter_optimizer
 
-from strategies.funding_arbitrage import get_market_metrics
+from strategies.funding_arbitrage import get_market_metrics, check_entry_conditions
 
 
 @pytest.fixture(autouse=True)
@@ -77,3 +80,35 @@ async def test_slippage_negative_volume() -> None:
     assert math.isinf(metrics.spot_slippage)
     assert math.isinf(metrics.futures_slippage)
     assert math.isinf(metrics.slippage)
+
+
+@pytest.mark.asyncio
+async def test_returns_none_on_empty_orderbook(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def empty_orderbook(symbol, depth=5):
+        return {"bids": [], "asks": []}
+
+    monkeypatch.setattr(
+        "strategies.funding_arbitrage.get_orderbook", empty_orderbook
+    )
+    monkeypatch.setattr(
+        "strategies.funding_arbitrage.get_spot_orderbook", empty_orderbook
+    )
+    metrics = await get_market_metrics("BTCUSDT", trade_size=1)
+    assert metrics is None
+
+
+@pytest.mark.asyncio
+async def test_returns_none_on_missing_stats(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def empty_stats(symbol):
+        return {}
+
+    monkeypatch.setattr("strategies.funding_arbitrage.get_stats", empty_stats)
+    metrics = await get_market_metrics("BTCUSDT", trade_size=1)
+    assert metrics is None
+
+
+def test_check_entry_conditions_none_metrics(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        result = check_entry_conditions("BTCUSDT", Decimal("1"), None, {})
+    assert not result
+    assert "incomplete" in caplog.text.lower()


### PR DESCRIPTION
## Summary
- Treat empty order books or missing stats as incomplete and return `None` from `get_market_metrics`.
- Skip trade evaluation when metrics are missing, logging warnings in `check_entry_conditions` and `monitor_neutral_position`.
- Adjust scan loop to ignore symbols with incomplete market data and extend tests for these scenarios.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e5ed9fa3c8320903df5e8044289c6