### PR TITLE
Allow configurable positions file path

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -25,3 +25,4 @@ bot:
     - BTCUSDT
     - ETHUSDT
   deposit_size: 100
+  positions_file: open_positions.json

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
 from decimal import Decimal, getcontext
+import os
 
 getcontext().prec = 10
 
@@ -28,7 +29,7 @@ from utils.logger import log_trade
 from utils.telegram import format_duration, notify_partial_close
 
 
-POSITIONS_FILE = Path("open_positions.json")
+DEFAULT_POSITIONS_FILE = "open_positions.json"
 
 
 logger = logging.getLogger(__name__)
@@ -281,9 +282,23 @@ def check_exit_conditions(metrics: MarketMetrics, thresholds: Dict[str, float]) 
 positions: Dict[str, Dict[str, Any]] = {}
 
 
-def load_positions(path: Path | str = POSITIONS_FILE) -> None:
+def _get_positions_path(path: Path | str | None = None) -> Path:
+    """Возвращает путь к файлу с позициями из env, config или ``DEFAULT_POSITIONS_FILE``."""
+
+    if path is not None:
+        return Path(path)
+    env_path = os.getenv("POSITIONS_FILE_PATH")
+    if env_path:
+        return Path(env_path)
+    bot_cfg = CONFIG.get("bot", {})
+    cfg_path = bot_cfg.get("positions_file")
+    return Path(cfg_path or DEFAULT_POSITIONS_FILE)
+
+
+def load_positions(path: Path | str | None = None) -> None:
     """Загружает ранее сохранённые позиции из ``path``."""
 
+    path = _get_positions_path(path)
     try:
         with Path(path).open("r", encoding="utf-8") as fh:
             data = json.load(fh)
@@ -298,9 +313,10 @@ def load_positions(path: Path | str = POSITIONS_FILE) -> None:
         risk_control.mark_symbol_open(symbol)
 
 
-def save_positions(path: Path | str = POSITIONS_FILE) -> None:
+def save_positions(path: Path | str | None = None) -> None:
     """Сохраняет текущие открытые позиции в ``path``."""
 
+    path = _get_positions_path(path)
     with Path(path).open("w", encoding="utf-8") as fh:
         json.dump(positions, fh)
 

--- a/tests/test_positions_file_path.py
+++ b/tests/test_positions_file_path.py
@@ -1,0 +1,72 @@
+import importlib
+import json
+import pathlib
+import sys
+import types
+
+import pytest
+
+# Ensure repository root on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+
+def load_strategy(monkeypatch):
+    ai_stub = types.ModuleType("ai.parameter_optimizer")
+    ai_stub.periodic_optimization = lambda *args, **kwargs: None
+    ai_stub.load_thresholds = lambda *args, **kwargs: {}
+    monkeypatch.setitem(sys.modules, "ai.parameter_optimizer", ai_stub)
+
+    main_stub = types.ModuleType("main")
+    main_stub.CONFIG = {}
+    main_stub.WHITELISTS = {}
+    monkeypatch.setitem(sys.modules, "main", main_stub)
+
+    strategy = importlib.reload(importlib.import_module("strategies.funding_arbitrage"))
+    return strategy, main_stub
+
+
+def reset_state(strategy):
+    strategy.positions.clear()
+    from risk import risk_control
+    risk_control._state = risk_control.RiskState()
+
+
+def test_config_specifies_positions_file(tmp_path, monkeypatch):
+    strategy, main = load_strategy(monkeypatch)
+    reset_state(strategy)
+    cfg_path = tmp_path / "config_positions.json"
+    data = {"BTCUSDT": {"quantity": 1, "entry_futures_price": 100}}
+    cfg_path.write_text(json.dumps(data))
+    main.CONFIG.clear()
+    main.CONFIG.update({"bot": {"positions_file": str(cfg_path)}})
+    monkeypatch.delenv("POSITIONS_FILE_PATH", raising=False)
+
+    strategy.load_positions()
+    assert "BTCUSDT" in strategy.positions
+
+    strategy.save_positions()
+    saved = json.loads(cfg_path.read_text())
+    assert "BTCUSDT" in saved
+
+
+def test_env_var_overrides_config(tmp_path, monkeypatch):
+    strategy, main = load_strategy(monkeypatch)
+    reset_state(strategy)
+    env_path = tmp_path / "env_positions.json"
+    env_data = {"ETHUSDT": {"quantity": 2, "entry_futures_price": 200}}
+    env_path.write_text(json.dumps(env_data))
+
+    cfg_path = tmp_path / "other.json"
+    cfg_path.write_text("{}")
+    main.CONFIG.clear()
+    main.CONFIG.update({"bot": {"positions_file": str(cfg_path)}})
+
+    monkeypatch.setenv("POSITIONS_FILE_PATH", str(env_path))
+
+    strategy.load_positions()
+    assert "ETHUSDT" in strategy.positions
+    assert "BTCUSDT" not in strategy.positions
+
+    strategy.save_positions()
+    saved = json.loads(env_path.read_text())
+    assert "ETHUSDT" in saved


### PR DESCRIPTION
## Summary
- allow configuring the positions file path via `bot.positions_file` or `POSITIONS_FILE_PATH`
- load/save positions using the resolved path
- cover path resolution with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e5ee7f15c83208867afb791838c4b