### PR TITLE
refactor: move exit thresholds to config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,7 @@ thresholds:
   max_trade_size: 100.0
   spread: 0.005         # Maximum allowed spread percentage
   slippage: 0.003       # Maximum expected slippage per trade
+  exit_slippage: 0.005  # Maximum allowed slippage when closing positions
   deposit_pct: 0.05     # Max fraction of total deposit per trade
 risk:
   max_position_size: 100

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -481,11 +481,14 @@ async def monitor_neutral_position(
             exit_slippage = abs(
                 metrics.futures_price - entry.get("entry_futures_price", 0.0)
             ) / max(entry.get("entry_futures_price", 1.0), 1e-9)
-            if exit_slippage > 0.005:
+            max_exit_slippage = exit_thresholds.get(
+                "exit_slippage", exit_thresholds.get("slippage")
+            )
+            if max_exit_slippage is not None and exit_slippage > max_exit_slippage:
                 reasons.append("slippage")
             hold_time = now - entry.get("entry_timestamp", now)
-            max_hold = exit_thresholds.get("holding_time", 48 * 3600)
-            if hold_time > max_hold:
+            max_hold = exit_thresholds.get("holding_time")
+            if max_hold is not None and hold_time > max_hold:
                 reasons.append("time")
             pnl = (
                 (metrics.futures_price - entry.get("entry_futures_price", 0.0))


### PR DESCRIPTION
## Summary
- add `exit_slippage` to configuration thresholds to control acceptable closing slippage
- reference `exit_slippage` and `holding_time` via `exit_thresholds` to remove magic numbers in `monitor_neutral_position`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e5e8bd96c832086d865d1a715f0b6