### PR TITLE
Validate trade parameters before trading

### DIFF
--- a/main.py
+++ b/main.py
@@ -221,9 +221,18 @@ def start_processing_loops() -> None:
         while True:
             thresholds = CONFIG.get("thresholds", {})
             deposit = CONFIG.get("bot", {}).get("deposit_size", float("inf"))
-            deposit_pct = thresholds.get("deposit_pct", 0.05)
+            deposit_pct_raw = thresholds.get("deposit_pct", 0.05)
+            deposit_pct = max(0.0, min(1.0, deposit_pct_raw))
             min_trade_usd = thresholds.get("min_trade_size", float("inf"))
-            # Берём меньшую величину: минимальный порог или 5 % от депозита
+            if deposit_pct_raw != deposit_pct or min_trade_usd <= 0:
+                logger.warning(
+                    "Некорректные параметры торговли: deposit_pct=%s, min_trade_size=%s",
+                    deposit_pct_raw,
+                    min_trade_usd,
+                )
+                await asyncio.sleep(poll_interval)
+                continue
+            # Берём меньшую величину: минимальный порог или долю от депозита
             trade_value = min(min_trade_usd, deposit * deposit_pct)
             if trade_value in (0.0, float("inf")):
                 trade_value = 1.0


### PR DESCRIPTION
## Summary
- Clamp deposit_pct to [0,1] and ensure min_trade_size is positive before trading
- Warn and skip trading when invalid parameters are detected

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e5e68059c832094a6a85537eef226