### PR TITLE
Serialize position file IO with async lock

### DIFF
--- a/main.py
+++ b/main.py
@@ -137,8 +137,7 @@ def start_processing_loops() -> None:
 
     poll_interval = CONFIG.get("bot", {}).get("poll_interval", 5)
 
-    # Восстанавливаем ранее сохранённые позиции
-    strategy.load_positions()
+    # Восстановление позиций выполняется внутри runner
 
     def _update_thresholds(new: Dict[str, float]) -> None:
         """Обновляет пороги стратегии новыми значениями."""
@@ -214,7 +213,7 @@ def start_processing_loops() -> None:
             if position_id in POSITION_TASKS:
                 del POSITION_TASKS[position_id]
             if strategy.positions.pop(symbol, None) is not None:
-                strategy.save_positions()
+                await strategy.save_positions()
 
     async def scan_loop() -> None:
         """Постоянно сканирует рынок в поиске входов."""
@@ -306,6 +305,7 @@ def start_processing_loops() -> None:
 
     async def runner() -> None:
         """Создаёт и управляет основными асинхронными задачами."""
+        await strategy.load_positions()
         tasks = [
             asyncio.create_task(scan_loop()),
             asyncio.create_task(risk_loop()),

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -337,6 +337,7 @@ class Position:
 
 
 positions: Dict[str, Position] = {}
+_positions_lock = asyncio.Lock()
 
 
 def _get_positions_path(path: Path | str | None = None) -> Path:
@@ -352,35 +353,40 @@ def _get_positions_path(path: Path | str | None = None) -> Path:
     return Path(cfg_path or DEFAULT_POSITIONS_FILE)
 
 
-def load_positions(path: Path | str | None = None) -> None:
+async def load_positions(path: Path | str | None = None) -> None:
     """Загружает ранее сохранённые позиции из ``path``."""
 
     path = _get_positions_path(path)
-    try:
-        with Path(path).open("r", encoding="utf-8") as fh:
-            data = json.load(fh)
-    except FileNotFoundError:
-        return
-    positions.clear()
-    for symbol, entry in data.items():
+    async with _positions_lock:
         try:
-            pos = Position.from_dict(entry)
-        except (ValueError, TypeError) as exc:
-            logger.warning("Invalid position for %s: %s", symbol, exc)
-            continue
-        positions[symbol] = pos
-        notional = pos.quantity * pos.entry_futures_price
-        if notional:
-            risk_control.update_position(Decimal(str(notional)))
-        risk_control.mark_symbol_open(symbol)
+            with Path(path).open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except FileNotFoundError:
+            return
+        except json.JSONDecodeError:
+            logger.warning("Invalid JSON in %s, starting with empty positions", path)
+            data = {}
+        positions.clear()
+        for symbol, entry in data.items():
+            try:
+                pos = Position.from_dict(entry)
+            except (ValueError, TypeError) as exc:
+                logger.warning("Invalid position for %s: %s", symbol, exc)
+                continue
+            positions[symbol] = pos
+            notional = pos.quantity * pos.entry_futures_price
+            if notional:
+                risk_control.update_position(Decimal(str(notional)))
+            risk_control.mark_symbol_open(symbol)
 
 
-def save_positions(path: Path | str | None = None) -> None:
+async def save_positions(path: Path | str | None = None) -> None:
     """Сохраняет текущие открытые позиции в ``path``."""
 
     path = _get_positions_path(path)
-    with Path(path).open("w", encoding="utf-8") as fh:
-        json.dump({s: p.to_dict() for s, p in positions.items()}, fh)
+    async with _positions_lock:
+        with Path(path).open("w", encoding="utf-8") as fh:
+            json.dump({s: p.to_dict() for s, p in positions.items()}, fh)
 
 
 async def open_neutral_position(
@@ -433,7 +439,7 @@ async def open_neutral_position(
         last_funding_timestamp=now,
         exchange=exchange_name,
     )
-    save_positions()
+    await save_positions()
     volume_usd = float(notional)
     log_trade(
         {
@@ -507,7 +513,7 @@ async def close_neutral_position(
     if final:
         risk_control.mark_symbol_closed(symbol)
         positions.pop(symbol, None)
-        save_positions()
+        await save_positions()
     return {"long": close_long, "short": close_short, "commission": float(commission)}
 
 
@@ -599,7 +605,7 @@ async def monitor_neutral_position(
                 quantity -= partial_qty
                 entry.quantity = quantity
                 entry.pnl += pnl_part
-                save_positions()
+                await save_positions()
                 exit_ts = time.time()
                 exit_basis = calculate_basis(
                     metrics.futures_price, metrics.spot_price, signed=True

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import sys
 import types
@@ -55,9 +56,9 @@ def test_save_and_load_roundtrip(tmp_path, monkeypatch):
         exchange="binance",
     )
     positions["BTCUSDT"] = pos
-    save_positions(file_path)
+    asyncio.run(save_positions(file_path))
     positions.clear()
-    load_positions(file_path)
+    asyncio.run(load_positions(file_path))
     assert "BTCUSDT" in positions
     loaded = positions["BTCUSDT"]
     assert isinstance(loaded, Position)
@@ -74,6 +75,6 @@ def test_load_positions_validation(tmp_path, monkeypatch):
     file_path = tmp_path / "open_positions.json"
     file_path.write_text(json.dumps(data))
     positions.clear()
-    load_positions(file_path)
+    asyncio.run(load_positions(file_path))
     assert "GOOD" in positions
     assert "BAD" not in positions

--- a/tests/test_positions_file_path.py
+++ b/tests/test_positions_file_path.py
@@ -3,6 +3,7 @@ import json
 import pathlib
 import sys
 import types
+import asyncio
 
 import pytest
 
@@ -35,16 +36,16 @@ def test_config_specifies_positions_file(tmp_path, monkeypatch):
     strategy, main = load_strategy(monkeypatch)
     reset_state(strategy)
     cfg_path = tmp_path / "config_positions.json"
-    data = {"BTCUSDT": {"quantity": 1, "entry_futures_price": 100}}
+    data = {"BTCUSDT": {"entry_timestamp": 1.0, "quantity": 1, "commissions": 0.0, "entry_futures_price": 100}}
     cfg_path.write_text(json.dumps(data))
     main.CONFIG.clear()
     main.CONFIG.update({"bot": {"positions_file": str(cfg_path)}})
     monkeypatch.delenv("POSITIONS_FILE_PATH", raising=False)
 
-    strategy.load_positions()
+    asyncio.run(strategy.load_positions())
     assert "BTCUSDT" in strategy.positions
 
-    strategy.save_positions()
+    asyncio.run(strategy.save_positions())
     saved = json.loads(cfg_path.read_text())
     assert "BTCUSDT" in saved
 
@@ -53,7 +54,7 @@ def test_env_var_overrides_config(tmp_path, monkeypatch):
     strategy, main = load_strategy(monkeypatch)
     reset_state(strategy)
     env_path = tmp_path / "env_positions.json"
-    env_data = {"ETHUSDT": {"quantity": 2, "entry_futures_price": 200}}
+    env_data = {"ETHUSDT": {"entry_timestamp": 1.0, "quantity": 2, "commissions": 0.0, "entry_futures_price": 200}}
     env_path.write_text(json.dumps(env_data))
 
     cfg_path = tmp_path / "other.json"
@@ -63,10 +64,10 @@ def test_env_var_overrides_config(tmp_path, monkeypatch):
 
     monkeypatch.setenv("POSITIONS_FILE_PATH", str(env_path))
 
-    strategy.load_positions()
+    asyncio.run(strategy.load_positions())
     assert "ETHUSDT" in strategy.positions
     assert "BTCUSDT" not in strategy.positions
 
-    strategy.save_positions()
+    asyncio.run(strategy.save_positions())
     saved = json.loads(env_path.read_text())
     assert "ETHUSDT" in saved


### PR DESCRIPTION
## Summary
- serialize load/save of position file with an asyncio.Lock
- handle malformed JSON when loading positions
- await asynchronous position IO in the main loop and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e62053ff0832091b24b4d395b881d