### PR TITLE
Serialize position file access with lock

### DIFF
--- a/main.py
+++ b/main.py
@@ -138,7 +138,7 @@ def start_processing_loops() -> None:
     poll_interval = CONFIG.get("bot", {}).get("poll_interval", 5)
 
     # Восстанавливаем ранее сохранённые позиции
-    strategy.load_positions()
+    asyncio.run(strategy.load_positions())
 
     def _update_thresholds(new: Dict[str, float]) -> None:
         """Обновляет пороги стратегии новыми значениями."""
@@ -214,7 +214,7 @@ def start_processing_loops() -> None:
             if position_id in POSITION_TASKS:
                 del POSITION_TASKS[position_id]
             if strategy.positions.pop(symbol, None) is not None:
-                strategy.save_positions()
+                await strategy.save_positions()
 
     async def scan_loop() -> None:
         """Постоянно сканирует рынок в поиске входов."""

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -336,6 +336,9 @@ class Position:
 
 positions: Dict[str, Position] = {}
 
+# Global lock to serialize access to positions file across async tasks
+_positions_lock = asyncio.Lock()
+
 
 def _get_positions_path(path: Path | str | None = None) -> Path:
     """Возвращает путь к файлу с позициями из env, config или ``DEFAULT_POSITIONS_FILE``."""
@@ -350,15 +353,19 @@ def _get_positions_path(path: Path | str | None = None) -> Path:
     return Path(cfg_path or DEFAULT_POSITIONS_FILE)
 
 
-def load_positions(path: Path | str | None = None) -> None:
+async def load_positions(path: Path | str | None = None) -> None:
     """Загружает ранее сохранённые позиции из ``path``."""
 
     path = _get_positions_path(path)
     try:
-        with Path(path).open("r", encoding="utf-8") as fh:
-            data = json.load(fh)
+        async with _positions_lock:
+            with Path(path).open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
     except FileNotFoundError:
         return
+    except json.JSONDecodeError:
+        logger.warning("Некорректный файл позиций %s, начинаем с пустого", path)
+        data = {}
     positions.clear()
     for symbol, entry in data.items():
         try:
@@ -373,12 +380,13 @@ def load_positions(path: Path | str | None = None) -> None:
         risk_control.mark_symbol_open(symbol)
 
 
-def save_positions(path: Path | str | None = None) -> None:
+async def save_positions(path: Path | str | None = None) -> None:
     """Сохраняет текущие открытые позиции в ``path``."""
 
     path = _get_positions_path(path)
-    with Path(path).open("w", encoding="utf-8") as fh:
-        json.dump({s: p.to_dict() for s, p in positions.items()}, fh)
+    async with _positions_lock:
+        with Path(path).open("w", encoding="utf-8") as fh:
+            json.dump({s: p.to_dict() for s, p in positions.items()}, fh)
 
 
 async def open_neutral_position(
@@ -431,7 +439,7 @@ async def open_neutral_position(
         last_funding_timestamp=now,
         exchange=exchange_name,
     )
-    save_positions()
+    await save_positions()
     volume_usd = float(notional)
     log_trade(
         {
@@ -505,7 +513,7 @@ async def close_neutral_position(
     if final:
         risk_control.mark_symbol_closed(symbol)
         positions.pop(symbol, None)
-        save_positions()
+        await save_positions()
     return {"long": close_long, "short": close_short, "commission": float(commission)}
 
 
@@ -603,7 +611,7 @@ async def monitor_neutral_position(
                 quantity -= partial_qty
                 entry.quantity = quantity
                 entry.pnl += pnl_part
-                save_positions()
+                await save_positions()
                 exit_ts = time.time()
                 exit_basis = calculate_basis(
                     metrics.futures_price, metrics.spot_price, signed=True

--- a/tests/test_initialize_whitelist.py
+++ b/tests/test_initialize_whitelist.py
@@ -19,7 +19,11 @@ def test_initialize_filters_whitelist(monkeypatch, caplog):
 
     strategy_stub = types.ModuleType("strategies.funding_arbitrage")
     strategy_stub.get_thresholds = lambda cfg: cfg
-    strategy_stub.load_positions = lambda: None
+
+    async def _noop(*args, **kwargs):
+        return None
+
+    strategy_stub.load_positions = _noop
     strategy_stub.positions = {}
     strategies_pkg = types.ModuleType("strategies")
     monkeypatch.setitem(sys.modules, "strategies", strategies_pkg)

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -1,4 +1,5 @@
 import json
+import asyncio
 import sys
 import types
 from pathlib import Path
@@ -55,9 +56,9 @@ def test_save_and_load_roundtrip(tmp_path, monkeypatch):
         exchange="binance",
     )
     positions["BTCUSDT"] = pos
-    save_positions(file_path)
+    asyncio.run(save_positions(file_path))
     positions.clear()
-    load_positions(file_path)
+    asyncio.run(load_positions(file_path))
     assert "BTCUSDT" in positions
     loaded = positions["BTCUSDT"]
     assert isinstance(loaded, Position)
@@ -74,6 +75,6 @@ def test_load_positions_validation(tmp_path, monkeypatch):
     file_path = tmp_path / "open_positions.json"
     file_path.write_text(json.dumps(data))
     positions.clear()
-    load_positions(file_path)
+    asyncio.run(load_positions(file_path))
     assert "GOOD" in positions
     assert "BAD" not in positions

--- a/tests/test_positions_file_path.py
+++ b/tests/test_positions_file_path.py
@@ -3,6 +3,7 @@ import json
 import pathlib
 import sys
 import types
+import asyncio
 
 import pytest
 
@@ -48,10 +49,10 @@ def test_config_specifies_positions_file(tmp_path, monkeypatch):
     main.CONFIG.update({"bot": {"positions_file": str(cfg_path)}})
     monkeypatch.delenv("POSITIONS_FILE_PATH", raising=False)
 
-    strategy.load_positions()
+    asyncio.run(strategy.load_positions())
     assert "BTCUSDT" in strategy.positions
 
-    strategy.save_positions()
+    asyncio.run(strategy.save_positions())
     saved = json.loads(cfg_path.read_text())
     assert "BTCUSDT" in saved
 
@@ -77,10 +78,10 @@ def test_env_var_overrides_config(tmp_path, monkeypatch):
 
     monkeypatch.setenv("POSITIONS_FILE_PATH", str(env_path))
 
-    strategy.load_positions()
+    asyncio.run(strategy.load_positions())
     assert "ETHUSDT" in strategy.positions
     assert "BTCUSDT" not in strategy.positions
 
-    strategy.save_positions()
+    asyncio.run(strategy.save_positions())
     saved = json.loads(env_path.read_text())
     assert "ETHUSDT" in saved


### PR DESCRIPTION
## Summary
- guard position file reads/writes with a shared `asyncio.Lock`
- make `load_positions` resilient to malformed JSON and support async use
- update main loop and tests to use async load/save helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e65910be483209650d1fbca8d3234