### PR TITLE
Handle None risk limit values

### DIFF
--- a/risk/risk_control.py
+++ b/risk/risk_control.py
@@ -43,7 +43,7 @@ _limits = RiskLimits()
 _state = RiskState()
 
 
-def configure(config: Dict[str, float], deposit_size: Optional[float] = None) -> None:
+def configure(config: Dict[str, Optional[float]], deposit_size: Optional[float] = None) -> None:
     """Настраивает пределы риска из словаря.
 
     Параметры
@@ -56,17 +56,30 @@ def configure(config: Dict[str, float], deposit_size: Optional[float] = None) ->
     """
 
     global _limits
-    deposit_cap = Decimal(str(config.get("deposit_cap", "Infinity")))
+
+    dep_cap_value = config.get("deposit_cap")
+    deposit_cap = (
+        Decimal("Infinity") if dep_cap_value is None else Decimal(str(dep_cap_value))
+    )
     if deposit_cap.is_infinite() and deposit_size is not None:
         pct = config.get("deposit_cap_pct")
         if pct is not None:
             deposit_cap = Decimal(str(pct)) * Decimal(str(deposit_size))
 
+    max_pos_size = config.get("max_position_size")
+    max_daily_loss = config.get("max_daily_loss")
+    max_consecutive_losses = config.get("max_consecutive_losses")
+    max_open_positions = config.get("max_open_positions")
+
     _limits = RiskLimits(
-        max_position_size=Decimal(str(config.get("max_position_size", "Infinity"))),
-        max_daily_loss=Decimal(str(config.get("max_daily_loss", "Infinity"))),
-        max_consecutive_losses=config.get("max_consecutive_losses", float("inf")),
-        max_open_positions=config.get("max_open_positions", float("inf")),
+        max_position_size=
+            Decimal("Infinity") if max_pos_size is None else Decimal(str(max_pos_size)),
+        max_daily_loss=
+            Decimal("Infinity") if max_daily_loss is None else Decimal(str(max_daily_loss)),
+        max_consecutive_losses=
+            float("inf") if max_consecutive_losses is None else max_consecutive_losses,
+        max_open_positions=
+            float("inf") if max_open_positions is None else max_open_positions,
         deposit_cap=deposit_cap,
     )
 

--- a/tests/test_risk_control.py
+++ b/tests/test_risk_control.py
@@ -9,3 +9,22 @@ def teardown_module(module):
 def test_deposit_cap_pct_applied():
     rc.configure({"deposit_cap_pct": 0.1}, deposit_size=1000)
     assert rc._limits.deposit_cap == 100.0
+
+
+def test_configure_handles_none_values():
+    rc.configure(
+        {
+            "max_position_size": None,
+            "max_daily_loss": None,
+            "deposit_cap": None,
+            "max_consecutive_losses": None,
+            "max_open_positions": None,
+            "deposit_cap_pct": None,
+        },
+        deposit_size=1000,
+    )
+    assert rc._limits.max_position_size.is_infinite()
+    assert rc._limits.max_daily_loss.is_infinite()
+    assert rc._limits.deposit_cap.is_infinite()
+    assert rc._limits.max_consecutive_losses == float("inf")
+    assert rc._limits.max_open_positions == float("inf")


### PR DESCRIPTION
## Summary
- handle `None` in risk limits configuration by defaulting to infinite values
- cover `configure` with a test for `None` inputs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e685b67948320a6ac2875fe6e1ed6