### PR TITLE
Ensure trade value respects minimum trade size

### DIFF
--- a/main.py
+++ b/main.py
@@ -232,8 +232,8 @@ def start_processing_loops() -> None:
                 )
                 await asyncio.sleep(poll_interval)
                 continue
-            # Берём меньшую величину: минимальный порог или долю от депозита
-            trade_value = min(min_trade_usd, deposit * deposit_pct)
+            # Торгуем не меньше минимального порога: выбираем большую величину
+            trade_value = max(min_trade_usd, deposit * deposit_pct)
             if trade_value in (0.0, float("inf")):
                 trade_value = 1.0
 


### PR DESCRIPTION
## Summary
- Ensure trade value in `scan_loop` is never below `min_trade_size`

## Testing
- `pytest`
- Manual check: deposit=100 USD, min_trade_size=10 → trade value 10


------
https://chatgpt.com/codex/tasks/task_e_688e688cacc883208dcb3b8d85d5bc71