### PR TITLE
Skip trading when trade value invalid

### DIFF
--- a/main.py
+++ b/main.py
@@ -235,7 +235,11 @@ def start_processing_loops() -> None:
             # Торгуем не меньше минимального порога: выбираем большую величину
             trade_value = max(min_trade_usd, deposit * deposit_pct)
             if trade_value in (0.0, float("inf")):
-                trade_value = 1.0
+                logger.error(
+                    "Некорректное значение trade_value: %s", trade_value
+                )
+                await asyncio.sleep(poll_interval)
+                continue
 
             for name, client in CLIENTS.items():
                 # Перебираем символы из белого списка

--- a/tests/test_invalid_trade_config.py
+++ b/tests/test_invalid_trade_config.py
@@ -1,0 +1,83 @@
+import importlib
+import logging
+import pathlib
+import sys
+import types
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+# Ensure repository root on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+
+def test_no_trade_on_invalid_config(monkeypatch, caplog):
+    # Stub heavy modules before importing main
+    ai_stub = types.ModuleType("ai.parameter_optimizer")
+    async def _noop(*args, **kwargs):
+        return None
+    ai_stub.periodic_optimization = _noop
+    ai_stub.load_thresholds = lambda cfg: cfg
+    monkeypatch.setitem(sys.modules, "ai.parameter_optimizer", ai_stub)
+
+    strategy_stub = types.ModuleType("strategies.funding_arbitrage")
+    strategy_stub.get_thresholds = lambda cfg: cfg
+    strategy_stub.get_market_metrics = AsyncMock()
+    strategy_stub.load_positions = _noop
+    strategy_stub.positions = {}
+    strategies_pkg = types.ModuleType("strategies")
+    monkeypatch.setitem(sys.modules, "strategies", strategies_pkg)
+    monkeypatch.setitem(
+        sys.modules, "strategies.funding_arbitrage", strategy_stub
+    )
+
+    telegram_stub = types.ModuleType("utils.telegram")
+    telegram_stub.format_duration = lambda x: ""
+    telegram_stub.notify_close = _noop
+    telegram_stub.notify_open = _noop
+    monkeypatch.setitem(sys.modules, "utils.telegram", telegram_stub)
+
+    main = importlib.import_module("main")
+
+    # Prepare invalid configuration with infinite deposit
+    main.CONFIG = {
+        "bot": {"deposit_size": float("inf"), "poll_interval": 0},
+        "thresholds": {"deposit_pct": 0.5, "min_trade_size": 10},
+    }
+    main.CLIENTS = {"x": object()}
+    main.WHITELISTS = {"x": ["BTCUSDT"]}
+
+    monkeypatch.setattr(main.risk_control, "is_paused", lambda: False)
+    monkeypatch.setattr(main.risk_control, "is_symbol_open", lambda symbol: False)
+
+    captured = {}
+
+    def fake_create_task(coro, *args, **kwargs):
+        if "scan_loop" in getattr(coro, "__qualname__", ""):
+            captured["scan_loop"] = coro
+        loop = asyncio.get_event_loop()
+        fut = loop.create_future()
+        return fut
+
+    async def fake_gather(*aws, **kwargs):
+        return None
+
+    monkeypatch.setattr(asyncio, "create_task", fake_create_task)
+    monkeypatch.setattr(asyncio, "gather", fake_gather)
+
+    # This call will capture scan_loop but not execute it
+    main.start_processing_loops()
+    scan_coro = captured["scan_loop"]
+
+    async def fake_sleep(_):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    caplog.set_level(logging.ERROR)
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(scan_coro)
+
+    assert "Некорректное значение trade_value" in caplog.text
+    strategy_stub.get_market_metrics.assert_not_called()


### PR DESCRIPTION
## Summary
- log and skip trading loop if calculated trade value is zero or infinity
- add regression test ensuring bot doesn't trade on invalid configuration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e6b374b2c8320949a06e1002858c6