### PR TITLE
Handle invalid mid in slippage calculation

### DIFF
--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -145,6 +145,8 @@ async def get_market_metrics(
         """Оценивает проскальзывание при выполнении ``size`` по стакану."""
         if size <= 0 or math.isnan(size):
             return float("inf")
+        if mid <= 0 or not math.isfinite(mid):
+            return float("inf")
         remaining = size
         cost = 0.0
         for price, qty in orders:

--- a/tests/test_slippage_volume.py
+++ b/tests/test_slippage_volume.py
@@ -83,6 +83,24 @@ async def test_slippage_negative_volume() -> None:
 
 
 @pytest.mark.asyncio
+async def test_slippage_zero_mid(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def zero_price_orderbook(symbol, depth=5):
+        return {"bids": [[0.0, 1.0]], "asks": [[0.0, 1.0]]}
+
+    monkeypatch.setattr(
+        "strategies.funding_arbitrage.get_orderbook", zero_price_orderbook
+    )
+    monkeypatch.setattr(
+        "strategies.funding_arbitrage.get_spot_orderbook", zero_price_orderbook
+    )
+
+    metrics = await get_market_metrics("BTCUSDT", trade_size=1)
+    assert math.isinf(metrics.spot_slippage)
+    assert math.isinf(metrics.futures_slippage)
+    assert math.isinf(metrics.slippage)
+
+
+@pytest.mark.asyncio
 async def test_returns_none_on_empty_orderbook(monkeypatch: pytest.MonkeyPatch) -> None:
     async def empty_orderbook(symbol, depth=5):
         return {"bids": [], "asks": []}


### PR DESCRIPTION
## Summary
- prevent division errors in `_calc_slippage` by validating `mid`
- cover zero mid scenario with new test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e6bc4d9f883209ce1dbf8ca13cb53