### PR TITLE
Handle missing OHLC data and validate volatility

### DIFF
--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -191,13 +191,21 @@ async def get_market_metrics(
         ohlc = await exchange.get_ohlc(symbol, interval="15m", limit=1)
     else:
         ohlc = await get_ohlc(symbol, interval="15m", limit=1)
-    if ohlc:
-        candle = ohlc[0]
-        o = candle.get("open") or 0.0
-        c = candle.get("close") or 0.0
-        volatility = ((c - o) / o) if o else float("inf")
+    if not ohlc:
+        # Without recent OHLC data we cannot estimate volatility.
+        # Returning ``None`` signals to the caller that metrics are incomplete
+        # so the strategy can skip trading for this symbol.
+        return None
+
+    candle = ohlc[0]
+    o = float(candle.get("open", float("nan")))
+    c = float(candle.get("close", float("nan")))
+    if o == 0.0 or not math.isfinite(o) or not math.isfinite(c):
+        # Treat zero/invalid open or close price as infinite volatility so that
+        # the strategy can trigger protective actions.
+        volatility = float("inf")
     else:
-        volatility = float("nan")
+        volatility = (c - o) / o
 
     return MarketMetrics(
         funding,
@@ -266,6 +274,8 @@ def check_entry_conditions(
 
 def check_exit_conditions(metrics: MarketMetrics, thresholds: Dict[str, float]) -> bool:
     """Возвращает ``True``, если выполнено любое условие выхода."""
+    if not math.isfinite(metrics.volatility):
+        return True
     return (
         abs(metrics.funding_rate) <= thresholds.get("funding_rate", float("inf"))
         or metrics.spread >= thresholds.get("spread", float("-inf"))

--- a/tests/test_slippage_volume.py
+++ b/tests/test_slippage_volume.py
@@ -27,7 +27,12 @@ ai_module.parameter_optimizer = parameter_optimizer
 sys.modules["ai"] = ai_module
 sys.modules["ai.parameter_optimizer"] = parameter_optimizer
 
-from strategies.funding_arbitrage import get_market_metrics, check_entry_conditions
+from strategies.funding_arbitrage import (
+    MarketMetrics,
+    check_entry_conditions,
+    check_exit_conditions,
+    get_market_metrics,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -107,8 +112,38 @@ async def test_returns_none_on_missing_stats(monkeypatch: pytest.MonkeyPatch) ->
     assert metrics is None
 
 
+@pytest.mark.asyncio
+async def test_returns_none_on_missing_ohlc(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def empty_ohlc(symbol, interval="15m", limit=1):
+        return []
+
+    monkeypatch.setattr("strategies.funding_arbitrage.get_ohlc", empty_ohlc)
+    metrics = await get_market_metrics("BTCUSDT", trade_size=1)
+    assert metrics is None
+
+
 def test_check_entry_conditions_none_metrics(caplog: pytest.LogCaptureFixture) -> None:
     with caplog.at_level(logging.WARNING):
         result = check_entry_conditions("BTCUSDT", Decimal("1"), None, {})
     assert not result
     assert "incomplete" in caplog.text.lower()
+
+
+def test_exit_on_non_finite_volatility() -> None:
+    metrics = MarketMetrics(
+        Decimal("0"),
+        0.0,
+        0.0,
+        float("inf"),
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+    )
+    assert check_exit_conditions(metrics, {})
+    metrics.volatility = float("nan")
+    assert check_exit_conditions(metrics, {})


### PR DESCRIPTION
## Summary
- Return `None` from `get_market_metrics` when OHLC data is absent and flag invalid prices with infinite volatility
- Exit positions when volatility is not finite
- Cover new behaviours with tests for missing OHLC data and non-finite volatility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e6bdada4c8320bca17a5bfad48438