### PR TITLE
Handle partial fills with rollback logic

### DIFF
--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -21,7 +21,7 @@ import os
 
 getcontext().prec = 10
 
-from exchanges import BaseExchange
+from exchanges import BaseExchange, API_TIMEOUT
 from risk import risk_control
 from ai.parameter_optimizer import load_thresholds as _load_thresholds
 from main import CONFIG, WHITELISTS
@@ -58,6 +58,26 @@ async def get_stats(symbol: str) -> dict:
 async def get_ohlc(symbol: str, interval: str = "15m", limit: int = 1) -> list[Dict[str, float]]:
     """Заглушка для данных OHLC."""
     raise NotImplementedError
+
+
+async def _wait_filled(exchange: BaseExchange, order_id: str) -> bool:
+    """Ожидает исполнения ордера и возвращает ``True`` при полном исполнении.
+
+    Если ордер получает статус ``PARTIALLY_FILLED``, функция возвращает ``False``.
+    При превышении ``API_TIMEOUT`` возбуждается ``RuntimeError``.
+    """
+
+    start = time.monotonic()
+    while True:
+        status = await exchange.get_order_status(order_id)
+        state = status.get("status")
+        if state == "FILLED":
+            return True
+        if state == "PARTIALLY_FILLED":
+            return False
+        if time.monotonic() - start > API_TIMEOUT:
+            raise RuntimeError(f"Ордер {order_id} не исполнен вовремя")
+        await asyncio.sleep(0.5)
 
 
 @dataclass
@@ -423,17 +443,25 @@ async def open_neutral_position(
         raise RuntimeError("Превышены лимиты риска, торговля приостановлена или позиция уже открыта")
     # Хеджируем позицию на споте и фьючерсе
     spot_order = await exchange.place_spot_order(symbol, "BUY", float(quantity))
+    spot_id = str(spot_order.get("orderId") or spot_order.get("id") or "")
+    if not await _wait_filled(exchange, spot_id):
+        await exchange.cancel_order(spot_id)
+        raise RuntimeError("Спотовый ордер выполнен частично")
+
     try:
         perp_order = await exchange.place_order(symbol, "SELL", float(quantity))
     except Exception as exc:
-        order_id = str(spot_order.get("orderId") or spot_order.get("id") or "")
-        try:
-            await exchange.cancel_order(order_id)
-        except Exception:
-            pass
+        # В случае ошибки на второй ноге откатываем спотовую часть
+        await exchange.place_spot_order(symbol, "SELL", float(quantity))
         raise RuntimeError(
-            "Не удалось разместить хедж; спотовая часть откатена"
+            "Не удалось разместить хедж; спотовая часть откатана"
         ) from exc
+    perp_id = str(perp_order.get("orderId") or perp_order.get("id") or "")
+    if not await _wait_filled(exchange, perp_id):
+        await exchange.cancel_order(perp_id)
+        # Откатываем спотовую позицию
+        await exchange.place_spot_order(symbol, "SELL", float(quantity))
+        raise RuntimeError("Не удалось полностью захеджировать позицию; спот откатан")
     orders = {"spot": spot_order, "perp": perp_order}
     risk_control.update_position(notional)
     risk_control.mark_symbol_open(symbol)
@@ -506,8 +534,18 @@ async def close_neutral_position(
     quantity = Decimal(str(quantity))
     pnl = Decimal(str(pnl))
     close_long = await exchange.place_order(symbol, "SELL", float(quantity))
+    long_id = str(close_long.get("orderId") or close_long.get("id") or "")
+    if not await _wait_filled(exchange, long_id):
+        await exchange.cancel_order(long_id)
+        raise RuntimeError("Не удалось закрыть длинную ногу")
+
     try:
         close_short = await exchange.place_order(symbol, "BUY", float(quantity))
+        short_id = str(close_short.get("orderId") or close_short.get("id") or "")
+        if not await _wait_filled(exchange, short_id):
+            await exchange.cancel_order(short_id)
+            await exchange.place_order(symbol, "BUY", float(quantity))
+            raise RuntimeError("Не удалось закрыть хедж; длинная нога откатена")
     except Exception as exc:
         # В случае ошибки возвращаем длинную позицию
         await exchange.place_order(symbol, "BUY", float(quantity))

--- a/tests/test_partial_fill.py
+++ b/tests/test_partial_fill.py
@@ -1,0 +1,117 @@
+import pathlib
+import sys
+from decimal import Decimal
+import types
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+# Подменяем зависимость sklearn, чтобы избежать тяжёлой установки
+linear_model_stub = types.SimpleNamespace(LinearRegression=object)
+sklearn_stub = types.SimpleNamespace(linear_model=linear_model_stub)
+sys.modules.setdefault("sklearn", sklearn_stub)
+sys.modules.setdefault("sklearn.linear_model", linear_model_stub)
+
+from strategies import funding_arbitrage as fa
+from exchanges import BaseExchange
+
+
+class PartialFillExchange(BaseExchange):
+    name = "stub"
+
+    def __init__(self) -> None:
+        self.orders: list[tuple[str, str, float]] = []
+        self.cancelled: list[str] = []
+
+    async def fetch_funding(self, symbol: str) -> float:  # pragma: no cover - unused
+        return 0.0
+
+    async def place_order(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
+        self.orders.append(("perp", side, quantity))
+        return {"id": "perp1"}
+
+    async def get_orderbook(self, symbol: str, depth: int = 5) -> dict:  # pragma: no cover - unused
+        return {}
+
+    async def get_balance(self) -> dict:  # pragma: no cover - unused
+        return {}
+
+    async def place_spot_order(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
+        self.orders.append(("spot", side, quantity))
+        return {"id": "spot1"}
+
+    async def get_spot_orderbook(self, symbol: str, depth: int = 5) -> dict:  # pragma: no cover - unused
+        return {}
+
+    async def get_spot_balance(self) -> dict:  # pragma: no cover - unused
+        return {}
+
+    async def fetch_funding_history(self, symbol: str, hours: int = 8, limit: int = 3) -> list[float]:  # pragma: no cover - unused
+        return []
+
+    async def get_stats(self, symbol: str) -> dict:  # pragma: no cover - unused
+        return {"volume_24h": 0, "open_interest": 0}
+
+    async def get_futures_symbols(self) -> list[str]:  # pragma: no cover - unused
+        return []
+
+    async def get_spot_symbols(self) -> list[str]:  # pragma: no cover - unused
+        return []
+
+    async def get_ohlc(self, symbol: str, interval: str = "15m", limit: int = 1) -> list[dict]:  # pragma: no cover - unused
+        return [{"open": 0, "close": 0, "high": 0, "low": 0}]
+
+    async def get_order_status(self, order_id: str) -> dict:
+        if order_id == "spot1":
+            return {"status": "FILLED", "order_id": order_id}
+        return {"status": "PARTIALLY_FILLED", "order_id": order_id}
+
+    async def cancel_order(self, order_id: str) -> dict:
+        self.cancelled.append(order_id)
+        return {"status": "CANCELED", "order_id": order_id}
+
+
+@pytest.mark.asyncio
+async def test_open_neutral_position_partial_fill(monkeypatch: pytest.MonkeyPatch) -> None:
+    exchange = PartialFillExchange()
+
+    # Настраиваем окружение
+    monkeypatch.setattr(fa, "CONFIG", {"bot": {}, "thresholds": {}})
+    monkeypatch.setattr(fa, "WHITELISTS", {exchange.name: ["BTCUSDT"]})
+    monkeypatch.setattr(fa.risk_control, "can_open_position", lambda *_: True)
+    monkeypatch.setattr(fa.risk_control, "is_symbol_open", lambda *_: False)
+    monkeypatch.setattr(fa.risk_control, "update_position", lambda *_: None)
+    monkeypatch.setattr(fa.risk_control, "mark_symbol_open", lambda *_: None)
+
+    metrics = fa.MarketMetrics(
+        funding_rate=Decimal("0"),
+        spread=0.0,
+        liquidity=0.0,
+        volatility=0.0,
+        spot_price=100.0,
+        futures_price=100.0,
+        volume=0.0,
+        open_interest=0.0,
+        spot_slippage=0.0,
+        futures_slippage=0.0,
+        slippage=0.0,
+        basis=0.0,
+    )
+
+    async def _fake_metrics(symbol: str, trade_size: float, exchange: BaseExchange) -> fa.MarketMetrics:
+        return metrics
+
+    monkeypatch.setattr(fa, "get_market_metrics", _fake_metrics)
+
+    quantity = Decimal("1")
+    with pytest.raises(RuntimeError):
+        await fa.open_neutral_position(exchange, "BTCUSDT", quantity)
+
+    # Первая попытка покупки спота, затем продажа для отката
+    assert exchange.orders == [
+        ("spot", "BUY", 1.0),
+        ("perp", "SELL", 1.0),
+        ("spot", "SELL", 1.0),
+    ]
+    assert exchange.cancelled == ["perp1"]


### PR DESCRIPTION
## Summary
- Poll order status until filled and cancel partial fills
- Roll back hedged spot/futures legs when one side fails
- Test partial fill to ensure rollback behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e743275988320a41776a90c1aa4f4