### PR TITLE
feat: add cancel order implementations

### DIFF
--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -131,14 +131,15 @@ class BaseExchange(ABC):
 
         return {"status": "FILLED", "order_id": order_id}
 
-    @staticmethod
-    async def cancel_order(order_id: str) -> dict:
-        """Отменяет ``order_id`` на рынке ``market``.
+    async def cancel_order(self, symbol: str, order_id: str) -> dict:
+        """Отменяет ордер ``order_id`` для инструмента ``symbol``.
 
-        Реализация по умолчанию просто возвращает статус отменённого ордера.
+        Реализация по умолчанию возвращает подтверждение отмены без выполнения
+        сетевых запросов. Конкретные биржи должны переопределять метод и
+        выполнять реальные API-вызовы.
         """
 
-        return {"status": "CANCELED", "order_id": order_id}
+        return {"status": "CANCELED", "order_id": order_id, "symbol": symbol}
 
 
 # ---------------------------------------------------------------------------
@@ -173,10 +174,10 @@ async def _handle_timeout() -> None:
         "Вызов API превысил %s секунд; отменяем активные ордера", API_TIMEOUT
     )
     if current is not None:
-        for market, oid in list(_OUTSTANDING):
+        for symbol, oid in list(_OUTSTANDING):
             try:
                 await asyncio.wait_for(
-                    current.cancel_order(oid), API_TIMEOUT
+                    current.cancel_order(symbol, oid), API_TIMEOUT
                 )
             except Exception as exc:  # pragma: no cover - best effort
                 logger.error("Не удалось отменить %s %s: %s", oid, exc)
@@ -313,12 +314,12 @@ async def _await_with_timeout(coro: Coroutine[Any, Any, Any]) -> Any:
         raise
 
 
-def _track_order(market: str, order_id: str) -> None:
-    _OUTSTANDING.add((market, order_id))
+def _track_order(symbol: str, order_id: str) -> None:
+    _OUTSTANDING.add((symbol, order_id))
 
 
-def _untrack_order(market: str, order_id: str) -> None:
-    _OUTSTANDING.discard((market, order_id))
+def _untrack_order(symbol: str, order_id: str) -> None:
+    _OUTSTANDING.discard((symbol, order_id))
 
 
 async def place_order(
@@ -340,7 +341,7 @@ async def place_order(
             delay *= 2
 
 
-async def _poll_fill(order_id: str, market: str) -> None:
+async def _poll_fill(order_id: str, symbol: str) -> None:
     """Ожидает исполнения ордера ``order_id`` до статуса FILLED.
 
     Функция опирается на :meth:`BaseExchange.get_order_status` и делает короткие
@@ -357,7 +358,7 @@ async def _poll_fill(order_id: str, market: str) -> None:
             current.get_order_status(order_id)
         )
         if status.get("status") == "FILLED":
-            _untrack_order(market, order_id)
+            _untrack_order(symbol, order_id)
             return
         if time.monotonic() - start > API_TIMEOUT:
             await _handle_timeout()
@@ -384,8 +385,8 @@ async def place_spot_order(
             await asyncio.sleep(delay)
             delay *= 2
     order_id = str(order.get("orderId") or order.get("id") or "")
-    _track_order("spot", order_id)
-    await _poll_fill(order_id, "spot")
+    _track_order(symbol, order_id)
+    await _poll_fill(order_id, symbol)
     return order
 
 
@@ -396,8 +397,8 @@ async def place_perp_order(
 
     order = await place_order(symbol, side, quantity, price)
     order_id = str(order.get("orderId") or order.get("id") or "")
-    _track_order("perp", order_id)
-    await _poll_fill(order_id, "perp")
+    _track_order(symbol, order_id)
+    await _poll_fill(order_id, symbol)
     return order
 
 
@@ -481,7 +482,7 @@ async def hedge(symbol: str, quantity: float) -> Dict[str, Dict]:
         # Откатить спотовую часть, если фьючерсная часть завершается ошибкой.
         try:
             cancel_resp = await _await_with_timeout(
-                current.cancel_order(spot_id)
+                current.cancel_order(symbol, spot_id)
             )
             logger.warning("Откатили спотовый ордер %s: %s", spot_id, cancel_resp)
         except Exception as cancel_exc:  # pragma: no cover - best effort

--- a/exchanges/binance.py
+++ b/exchanges/binance.py
@@ -150,6 +150,18 @@ class BinanceExchange(BaseExchange):
         params = self._sign(params)
         return await self._request("POST", url, params=params, headers=headers)
 
+    async def cancel_order(self, symbol: str, order_id: str) -> dict:
+        """Отменяет ордер по его идентификатору."""
+        params = {"symbol": symbol, "orderId": order_id}
+        headers = {"X-MBX-APIKEY": self.api_key}
+        params = self._sign(params)
+        url = f"{self.REST_URL}/fapi/v1/order"
+        try:
+            return await self._request("DELETE", url, params=params, headers=headers)
+        except aiohttp.ClientResponseError:
+            url = f"{self.SPOT_REST_URL}/api/v3/order"
+            return await self._request("DELETE", url, params=params, headers=headers)
+
     async def get_balance(self) -> dict:
         """Возвращает баланс фьючерсного аккаунта."""
         url = f"{self.REST_URL}/fapi/v2/balance"

--- a/exchanges/bybit.py
+++ b/exchanges/bybit.py
@@ -150,6 +150,22 @@ class BybitExchange(BaseExchange):
         body = self._sign("POST", url_path, body)
         return await self._request("POST", url, json=body, headers=headers)
 
+    async def cancel_order(self, symbol: str, order_id: str) -> dict:
+        """Отменяет ордер как на фьючерсном, так и на спотовом рынке."""
+        url_path = "/v5/order/cancel"
+        url = f"{self.REST_URL}{url_path}"
+        headers = {"Content-Type": "application/json"}
+        last_error: Exception | None = None
+        for category in ("linear", "spot"):
+            body = {"symbol": symbol, "orderId": order_id, "category": category}
+            body = self._sign("POST", url_path, body)
+            try:
+                return await self._request("POST", url, json=body, headers=headers)
+            except aiohttp.ClientResponseError as exc:
+                last_error = exc
+        if last_error is not None:
+            raise last_error
+
     async def get_balance(self) -> dict:
         """Возвращает баланс унифицированного аккаунта."""
         url_path = "/v5/account/wallet-balance"

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -428,7 +428,7 @@ async def open_neutral_position(
     except Exception as exc:
         order_id = str(spot_order.get("orderId") or spot_order.get("id") or "")
         try:
-            await exchange.cancel_order(order_id)
+            await exchange.cancel_order(symbol, order_id)
         except Exception:
             pass
         raise RuntimeError(

--- a/tests/test_cancel_first_leg.py
+++ b/tests/test_cancel_first_leg.py
@@ -1,0 +1,39 @@
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import exchanges
+
+
+class FailingPerpExchange:
+    def __init__(self) -> None:
+        self.cancelled: list[tuple[str, str]] = []
+
+    async def place_spot_order(self, *args, **kwargs):
+        return {"orderId": "spot"}
+
+    async def place_order(self, *args, **kwargs):
+        raise RuntimeError("fail")
+
+    async def cancel_order(self, symbol: str, order_id: str):
+        self.cancelled.append((symbol, order_id))
+        return {"status": "CANCELED"}
+
+    async def get_order_status(self, order_id: str):
+        return {"status": "FILLED", "order_id": order_id}
+
+
+async def _fast_sleep(_: float) -> None:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_first_leg_canceled_on_second_leg_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    exch = FailingPerpExchange()
+    exchanges.current = exch
+    monkeypatch.setattr(exchanges.asyncio, "sleep", _fast_sleep)
+    with pytest.raises(RuntimeError):
+        await exchanges.hedge("BTCUSDT", 1)
+    assert exch.cancelled == [("BTCUSDT", "spot")]


### PR DESCRIPTION
## Summary
- extend BaseExchange and update order tracking to include symbol when cancelling
- implement cancel_order for Binance and Bybit clients
- ensure failing hedges cancel the initial order

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e73e17e3083209cc0f75f71160114