### PR TITLE
Handle per-symbol WebSocket connections

### DIFF
--- a/exchanges/binance.py
+++ b/exchanges/binance.py
@@ -36,11 +36,12 @@ class BinanceExchange(BaseExchange):
         self.api_key = api_key
         self.api_secret = api_secret
         self._session: Optional[aiohttp.ClientSession] = None
-        self._ws: Optional[Any] = None
+        # WebSocket соединения для фьючерсных стаканов по каждому символу
+        self._ws: Dict[str, Any] = {}
         self._orderbooks: Dict[str, Dict[str, Any]] = {}
         self._ws_tasks: Dict[str, asyncio.Task] = {}
-        # Обработка WebSocket для спота
-        self._spot_ws: Optional[Any] = None
+        # Обработка WebSocket для спота по каждому символу
+        self._spot_ws: Dict[str, Any] = {}
         self._spot_orderbooks: Dict[str, Dict[str, Any]] = {}
         self._spot_ws_tasks: Dict[str, asyncio.Task] = {}
 
@@ -249,9 +250,9 @@ class BinanceExchange(BaseExchange):
         """Слушает поток спотового order book и кэширует данные."""
         while True:
             try:
-                if self._spot_ws is None:
-                    self._spot_ws = await self._connect_spot(symbol, depth)
-                msg = await self._spot_ws.recv()
+                if symbol not in self._spot_ws:
+                    self._spot_ws[symbol] = await self._connect_spot(symbol, depth)
+                msg = await self._spot_ws[symbol].recv()
                 data = json.loads(msg)
                 if "bids" in data and "asks" in data:
                     self._spot_orderbooks[symbol] = {
@@ -259,14 +260,14 @@ class BinanceExchange(BaseExchange):
                         "asks": data["asks"],
                     }
             except (WebSocketException, json.JSONDecodeError, OSError):
-                # При ошибке пересоздаём соединение
+                # При ошибке пересоздаём соединение для конкретного символа
                 await asyncio.sleep(1)
-                if self._spot_ws is not None:
+                ws = self._spot_ws.pop(symbol, None)
+                if ws is not None:
                     try:
-                        await self._spot_ws.close()
+                        await ws.close()
                     except WebSocketException:
                         pass
-                self._spot_ws = None
 
     async def get_spot_orderbook(self, symbol: str, depth: int = 5) -> dict:
         """Возвращает кэшированный спотовый стакан для ``symbol``."""
@@ -294,9 +295,9 @@ class BinanceExchange(BaseExchange):
         """Слушает поток фьючерсного стакана и сохраняет его в кэше."""
         while True:
             try:
-                if self._ws is None:
-                    self._ws = await self._connect(symbol)
-                msg = await self._ws.recv()
+                if symbol not in self._ws:
+                    self._ws[symbol] = await self._connect(symbol)
+                msg = await self._ws[symbol].recv()
                 data = json.loads(msg)
                 if "bids" in data and "asks" in data:
                     self._orderbooks[symbol] = {
@@ -304,14 +305,14 @@ class BinanceExchange(BaseExchange):
                         "asks": data["asks"],
                     }
             except (WebSocketException, json.JSONDecodeError, OSError):
-                # При ошибке пробуем подключиться заново
+                # При ошибке пробуем подключиться заново для данного символа
                 await asyncio.sleep(1)
-                if self._ws is not None:
+                ws = self._ws.pop(symbol, None)
+                if ws is not None:
                     try:
-                        await self._ws.close()
+                        await ws.close()
                     except WebSocketException:
                         pass
-                self._ws = None
 
     async def get_orderbook(self, symbol: str, depth: int = 5) -> dict:
         """Возвращает кэшированный фьючерсный стакан."""
@@ -323,10 +324,10 @@ class BinanceExchange(BaseExchange):
         """Закрывает все сетевые соединения при выходе из контекста."""
         if self._session is not None:
             await self._session.close()
-        if self._ws is not None:
-            await self._ws.close()
-        if self._spot_ws is not None:
-            await self._spot_ws.close()
+        for ws in self._ws.values():
+            await ws.close()
+        for ws in self._spot_ws.values():
+            await ws.close()
 
 
 # Регистрация биржи

--- a/exchanges/bybit.py
+++ b/exchanges/bybit.py
@@ -34,11 +34,12 @@ class BybitExchange(BaseExchange):
         self.api_key = api_key
         self.api_secret = api_secret
         self._session: Optional[aiohttp.ClientSession] = None
-        self._ws: Optional[Any] = None
+        # WebSocket соединения для фьючерсных стаканов по каждому символу
+        self._ws: Dict[str, Any] = {}
         self._orderbooks: Dict[str, Dict[str, Any]] = {}
         self._ws_tasks: Dict[str, asyncio.Task] = {}
-        # Управление WebSocket спота
-        self._spot_ws: Optional[Any] = None
+        # Управление WebSocket спота по каждому символу
+        self._spot_ws: Dict[str, Any] = {}
         self._spot_orderbooks: Dict[str, Dict[str, Any]] = {}
         self._spot_ws_tasks: Dict[str, asyncio.Task] = {}
 
@@ -263,9 +264,9 @@ class BybitExchange(BaseExchange):
         """Слушает обновления спотового стакана и кэширует их."""
         while True:
             try:
-                if self._spot_ws is None:
-                    self._spot_ws = await self._connect_spot(symbol)
-                msg = await self._spot_ws.recv()
+                if symbol not in self._spot_ws:
+                    self._spot_ws[symbol] = await self._connect_spot(symbol)
+                msg = await self._spot_ws[symbol].recv()
                 data = json.loads(msg)
                 if data.get("topic", "").startswith("orderbook"):
                     book = data.get("data") or {}
@@ -274,14 +275,14 @@ class BybitExchange(BaseExchange):
                         "asks": book.get("a", []),
                     }
             except Exception:
-                # При ошибке пересоздаём соединение
+                # При ошибке пересоздаём соединение для конкретного символа
                 await asyncio.sleep(1)
-                if self._spot_ws is not None:
+                ws = self._spot_ws.pop(symbol, None)
+                if ws is not None:
                     try:
-                        await self._spot_ws.close()
+                        await ws.close()
                     except Exception:
                         pass
-                self._spot_ws = None
 
     async def get_spot_orderbook(self, symbol: str, depth: int = 5) -> dict:
         """Возвращает кэшированный спотовый стакан."""
@@ -313,9 +314,9 @@ class BybitExchange(BaseExchange):
         """Слушает поток фьючерсного стакана и сохраняет его."""
         while True:
             try:
-                if self._ws is None:
-                    self._ws = await self._connect(symbol)
-                msg = await self._ws.recv()
+                if symbol not in self._ws:
+                    self._ws[symbol] = await self._connect(symbol)
+                msg = await self._ws[symbol].recv()
                 data = json.loads(msg)
                 if data.get("topic", "").startswith("orderbook"):
                     book = data.get("data") or {}
@@ -324,14 +325,14 @@ class BybitExchange(BaseExchange):
                         "asks": book.get("a", []),
                     }
             except Exception:
-                # Ошибка — перезапускаем соединение
+                # Ошибка — перезапускаем соединение для конкретного символа
                 await asyncio.sleep(1)
-                if self._ws is not None:
+                ws = self._ws.pop(symbol, None)
+                if ws is not None:
                     try:
-                        await self._ws.close()
+                        await ws.close()
                     except Exception:
                         pass
-                self._ws = None
 
     async def get_orderbook(self, symbol: str, depth: int = 5) -> dict:
         """Возвращает кэшированный фьючерсный стакан."""
@@ -343,10 +344,10 @@ class BybitExchange(BaseExchange):
         """Закрывает все активные соединения при выходе."""
         if self._session is not None:
             await self._session.close()
-        if self._ws is not None:
-            await self._ws.close()
-        if self._spot_ws is not None:
-            await self._spot_ws.close()
+        for ws in self._ws.values():
+            await ws.close()
+        for ws in self._spot_ws.values():
+            await ws.close()
 
 
 # Регистрация биржи

--- a/tests/test_ws_orderbooks.py
+++ b/tests/test_ws_orderbooks.py
@@ -1,0 +1,68 @@
+import asyncio
+import json
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from exchanges.binance import BinanceExchange  # noqa: E402
+
+
+class DummyWebSocket:
+    def __init__(self, symbol: str, payload: dict[str, list[list[str]]]) -> None:
+        self.symbol = symbol
+        self.payload = payload
+        self._sent = False
+
+    async def recv(self) -> str:
+        if not self._sent:
+            self._sent = True
+            return json.dumps(self.payload)
+        # wait forever until cancelled
+        await asyncio.Future()
+
+    async def close(self) -> None:  # pragma: no cover - no cleanup needed
+        pass
+
+
+@pytest.mark.asyncio
+async def test_orderbooks_are_isolated(monkeypatch: pytest.MonkeyPatch) -> None:
+    ex = BinanceExchange("key", "secret")
+
+    messages = {
+        "BTCUSDT": {"bids": [["1", "2"]], "asks": [["3", "4"]]},
+        "ETHUSDT": {"bids": [["5", "6"]], "asks": [["7", "8"]]},
+    }
+
+    async def dummy_connect(symbol: str) -> DummyWebSocket:
+        return DummyWebSocket(symbol, messages[symbol])
+
+    monkeypatch.setattr(ex, "_connect", dummy_connect)
+
+    # Запрашиваем стаканы одновременно, запускаются отдельные слушатели
+    await asyncio.gather(
+        ex.get_orderbook("BTCUSDT"),
+        ex.get_orderbook("ETHUSDT"),
+    )
+
+    # Ждём обновления обоих стаканов
+    async def wait_for_data() -> None:
+        while True:
+            if (
+                ex._orderbooks.get("BTCUSDT") and
+                ex._orderbooks.get("ETHUSDT")
+            ):
+                return
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(wait_for_data(), timeout=1)
+
+    assert ex._orderbooks["BTCUSDT"] == messages["BTCUSDT"]
+    assert ex._orderbooks["ETHUSDT"] == messages["ETHUSDT"]
+    assert ex._orderbooks["BTCUSDT"] != ex._orderbooks["ETHUSDT"]
+
+    for task in ex._ws_tasks.values():
+        task.cancel()
+    await asyncio.gather(*ex._ws_tasks.values(), return_exceptions=True)


### PR DESCRIPTION
## Summary
- Refactor Binance and Bybit exchanges to maintain separate WebSocket connections for each symbol.
- Adjust listeners to use symbol-specific connections and reconnect independently.
- Add test ensuring concurrent orderbook requests keep data isolated.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e740b7e4c8320bdd64452d6309b1b