### PR TITLE
Refactor Bybit WebSocket handling for per-symbol connections

### DIFF
--- a/exchanges/bybit.py
+++ b/exchanges/bybit.py
@@ -34,11 +34,12 @@ class BybitExchange(BaseExchange):
         self.api_key = api_key
         self.api_secret = api_secret
         self._session: Optional[aiohttp.ClientSession] = None
-        self._ws: Optional[Any] = None
+        # Отдельные соединения и задачи для каждого символа
+        self._ws: Dict[str, Any] = {}
         self._orderbooks: Dict[str, Dict[str, Any]] = {}
         self._ws_tasks: Dict[str, asyncio.Task] = {}
         # Управление WebSocket спота
-        self._spot_ws: Optional[Any] = None
+        self._spot_ws: Dict[str, Any] = {}
         self._spot_orderbooks: Dict[str, Dict[str, Any]] = {}
         self._spot_ws_tasks: Dict[str, asyncio.Task] = {}
 
@@ -263,9 +264,11 @@ class BybitExchange(BaseExchange):
         """Слушает обновления спотового стакана и кэширует их."""
         while True:
             try:
-                if self._spot_ws is None:
-                    self._spot_ws = await self._connect_spot(symbol)
-                msg = await self._spot_ws.recv()
+                ws = self._spot_ws.get(symbol)
+                if ws is None:
+                    ws = await self._connect_spot(symbol)
+                    self._spot_ws[symbol] = ws
+                msg = await ws.recv()
                 data = json.loads(msg)
                 if data.get("topic", "").startswith("orderbook"):
                     book = data.get("data") or {}
@@ -276,12 +279,12 @@ class BybitExchange(BaseExchange):
             except Exception:
                 # При ошибке пересоздаём соединение
                 await asyncio.sleep(1)
-                if self._spot_ws is not None:
+                ws = self._spot_ws.pop(symbol, None)
+                if ws is not None:
                     try:
-                        await self._spot_ws.close()
+                        await ws.close()
                     except Exception:
                         pass
-                self._spot_ws = None
 
     async def get_spot_orderbook(self, symbol: str, depth: int = 5) -> dict:
         """Возвращает кэшированный спотовый стакан."""
@@ -313,9 +316,11 @@ class BybitExchange(BaseExchange):
         """Слушает поток фьючерсного стакана и сохраняет его."""
         while True:
             try:
-                if self._ws is None:
-                    self._ws = await self._connect(symbol)
-                msg = await self._ws.recv()
+                ws = self._ws.get(symbol)
+                if ws is None:
+                    ws = await self._connect(symbol)
+                    self._ws[symbol] = ws
+                msg = await ws.recv()
                 data = json.loads(msg)
                 if data.get("topic", "").startswith("orderbook"):
                     book = data.get("data") or {}
@@ -326,12 +331,12 @@ class BybitExchange(BaseExchange):
             except Exception:
                 # Ошибка — перезапускаем соединение
                 await asyncio.sleep(1)
-                if self._ws is not None:
+                ws = self._ws.pop(symbol, None)
+                if ws is not None:
                     try:
-                        await self._ws.close()
+                        await ws.close()
                     except Exception:
                         pass
-                self._ws = None
 
     async def get_orderbook(self, symbol: str, depth: int = 5) -> dict:
         """Возвращает кэшированный фьючерсный стакан."""
@@ -343,10 +348,16 @@ class BybitExchange(BaseExchange):
         """Закрывает все активные соединения при выходе."""
         if self._session is not None:
             await self._session.close()
-        if self._ws is not None:
-            await self._ws.close()
-        if self._spot_ws is not None:
-            await self._spot_ws.close()
+        for ws in self._ws.values():
+            try:
+                await ws.close()
+            except Exception:
+                pass
+        for ws in self._spot_ws.values():
+            try:
+                await ws.close()
+            except Exception:
+                pass
 
 
 # Регистрация биржи

--- a/tests/test_bybit_multiple_symbols.py
+++ b/tests/test_bybit_multiple_symbols.py
@@ -1,0 +1,77 @@
+import asyncio
+import json
+import pathlib
+import sys
+
+import pytest
+
+# Add repository root to sys.path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from exchanges.bybit import BybitExchange  # noqa: E402
+
+
+class DummyWS:
+    """Simple websocket stub delivering queued messages."""
+
+    def __init__(self, symbol: str) -> None:
+        self.symbol = symbol
+        self.queue: asyncio.Queue[str] = asyncio.Queue()
+
+    async def send(self, _msg: str) -> None:  # pragma: no cover - unused
+        pass
+
+    async def recv(self) -> str:
+        return await self.queue.get()
+
+    async def close(self) -> None:  # pragma: no cover - no cleanup needed
+        pass
+
+
+@pytest.mark.asyncio
+async def test_orderbook_multiple_symbols(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: dict[str, asyncio.Queue[str]] = {}
+
+    async def fake_connect(self: BybitExchange, symbol: str) -> DummyWS:
+        ws = DummyWS(symbol)
+        events[symbol] = ws.queue
+        return ws
+
+    ex = BybitExchange("key", "secret")
+    # Patch _connect to return our dummy websockets
+    monkeypatch.setattr(ex, "_connect", fake_connect.__get__(ex, BybitExchange))
+
+    # Subscribe to two different symbols
+    await ex.get_orderbook("BTCUSDT")
+    await ex.get_orderbook("ETHUSDT")
+
+    # Allow tasks to establish connections
+    await asyncio.sleep(0.01)
+
+    # Ensure queues for both symbols exist (separate connections created)
+    assert set(events.keys()) == {"BTCUSDT", "ETHUSDT"}
+
+    # Send distinct messages for each symbol
+    await events["BTCUSDT"].put(
+        json.dumps({
+            "topic": "orderbook.1.BTCUSDT",
+            "data": {"b": [["1", "2"]], "a": []},
+        })
+    )
+    await events["ETHUSDT"].put(
+        json.dumps({
+            "topic": "orderbook.1.ETHUSDT",
+            "data": {"b": [["3", "4"]], "a": []},
+        })
+    )
+
+    # Allow listener tasks to process messages
+    await asyncio.sleep(0.1)
+
+    assert ex._orderbooks["BTCUSDT"]["bids"][0][0] == "1"
+    assert ex._orderbooks["ETHUSDT"]["bids"][0][0] == "3"
+
+    # Cleanup tasks
+    for task in ex._ws_tasks.values():
+        task.cancel()
+    await asyncio.gather(*ex._ws_tasks.values(), return_exceptions=True)


### PR DESCRIPTION
## Summary
- manage separate WebSocket connections and tasks for each Bybit symbol
- gracefully close all active connections on exit
- test concurrent orderbook subscriptions across multiple symbols

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e7426ccd08320aad18e8d942d0ed5