### PR TITLE
Switch funding and commissions to Decimal with precision test

### DIFF
--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -20,6 +20,10 @@ import time
 from typing import Any, Coroutine, Dict, Optional, Set, Tuple, Type
 
 from risk import risk_control
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from strategies.funding_arbitrage import Position
 
 logger = logging.getLogger(__name__)
 
@@ -199,7 +203,12 @@ async def _handle_timeout() -> None:
                 if client is None:
                     continue
                 try:
-                    entry = strategy.positions.get(symbol, {})
+                    entry_obj = strategy.positions.get(symbol, {})
+                    entry = (
+                        entry_obj.to_dict()
+                        if hasattr(entry_obj, "to_dict")
+                        else entry_obj
+                    )
                     quantity = entry.get("quantity") or entry.get(
                         "initial_quantity", 0.0
                     )

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -304,8 +304,8 @@ class Position:
     quantity: float
     initial_quantity: float
     pnl: Decimal = Decimal(0)
-    funding_accrued: float = 0.0
-    commissions: float = 0.0
+    funding_accrued: Decimal = Decimal(0)
+    commissions: Decimal = Decimal(0)
     last_funding_timestamp: float = 0.0
     exchange: str = ""
     exit_timestamp: float | None = None
@@ -318,6 +318,8 @@ class Position:
     def to_dict(self) -> Dict[str, Any]:
         data = asdict(self)
         data["pnl"] = float(self.pnl)
+        data["funding_accrued"] = float(self.funding_accrued)
+        data["commissions"] = float(self.commissions)
         return data
 
     @classmethod
@@ -333,8 +335,8 @@ class Position:
             quantity=float(data["quantity"]),
             initial_quantity=float(data.get("initial_quantity", data["quantity"])),
             pnl=Decimal(str(data.get("pnl", 0.0))),
-            funding_accrued=float(data.get("funding_accrued", 0.0)),
-            commissions=float(data.get("commissions", 0.0)),
+            funding_accrued=Decimal(str(data.get("funding_accrued", 0.0))),
+            commissions=Decimal(str(data.get("commissions", 0.0))),
             last_funding_timestamp=float(
                 data.get("last_funding_timestamp", data.get("entry_timestamp", 0.0))
             ),
@@ -448,8 +450,8 @@ async def open_neutral_position(
         quantity=float(quantity),
         initial_quantity=float(quantity),
         pnl=Decimal(0),
-        funding_accrued=0.0,
-        commissions=float(commission),
+        funding_accrued=Decimal(0),
+        commissions=commission,
         last_funding_timestamp=now,
         exchange=exchange_name,
     )
@@ -517,7 +519,7 @@ async def close_neutral_position(
         str(close_short.get("fee", 0.0))
     )
     if entry is not None:
-        entry.commissions += float(commission)
+        entry.commissions += commission
         ref_price = Decimal(str(entry.entry_futures_price))
     else:
         ref_price = Decimal(0)
@@ -572,7 +574,7 @@ async def monitor_neutral_position(
                 / Decimal(8 * 3600)
             )
             # Накапливаем полученное фондирование
-            entry.funding_accrued = float(Decimal(str(entry.funding_accrued)) + funding_fee)
+            entry.funding_accrued += funding_fee
             entry.last_funding_timestamp = now
         reasons: list[str] = []
         exit_slippage = 0.0
@@ -605,10 +607,7 @@ async def monitor_neutral_position(
             )
             pnl = (fut_diff - spot_diff) * Decimal(str(quantity))
             if (
-                pnl
-                + Decimal(str(entry.funding_accrued))
-                - Decimal(str(entry.commissions))
-                < Decimal(0)
+                pnl + entry.funding_accrued - entry.commissions < Decimal(0)
             ):
                 reasons.append("pnl_vs_cost")
         else:
@@ -663,7 +662,7 @@ async def monitor_neutral_position(
                         "pnl": float(pnl_net),
                         "pnl_pct": float(pnl_pct),
                         "commissions": float(commission),
-                        "funding_accrued": entry.funding_accrued,
+                        "funding_accrued": float(entry.funding_accrued),
                         "slippage": exit_slippage,
                         "exit_reasons": ["partial"],
                         "notes": "частичный выход",
@@ -673,11 +672,7 @@ async def monitor_neutral_position(
                     total_volume = Decimal(str(entry.entry_futures_price)) * Decimal(
                         str(entry.initial_quantity)
                     )
-                    pnl_total = (
-                        entry.pnl
-                        + Decimal(str(entry.funding_accrued))
-                        - Decimal(str(entry.commissions))
-                    )
+                    pnl_total = entry.pnl + entry.funding_accrued - entry.commissions
                     pnl_pct_total = (
                         pnl_total / total_volume * 100 if total_volume != 0 else Decimal(0)
                     )
@@ -705,11 +700,7 @@ async def monitor_neutral_position(
                 )
                 exit_ts = time.time()
                 total_pnl = entry.pnl + pnl
-                net_pnl = (
-                    total_pnl
-                    + Decimal(str(entry.funding_accrued))
-                    - Decimal(str(entry.commissions))
-                )
+                net_pnl = total_pnl + entry.funding_accrued - entry.commissions
                 entry.exit_timestamp = exit_ts
                 entry.exit_reasons = reasons
                 entry.exit_futures_price = metrics.futures_price
@@ -742,8 +733,8 @@ async def monitor_neutral_position(
                         "volume_usd": float(volume_usd),
                         "pnl": float(net_pnl),
                         "pnl_pct": float(pnl_pct),
-                        "commissions": entry.commissions,
-                        "funding_accrued": entry.funding_accrued,
+                        "commissions": float(entry.commissions),
+                        "funding_accrued": float(entry.funding_accrued),
                         "slippage": exit_slippage,
                         "exit_reasons": reasons,
                         "notes": None,

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -31,6 +31,7 @@ from strategies.funding_arbitrage import (
     positions,
     save_positions,
     load_positions,
+    close_neutral_position,
 )
 from risk import risk_control
 
@@ -38,6 +39,8 @@ from risk import risk_control
 def _patch_risk(monkeypatch):
     monkeypatch.setattr(risk_control, "update_position", lambda *_: None)
     monkeypatch.setattr(risk_control, "mark_symbol_open", lambda *_: None)
+    monkeypatch.setattr(risk_control, "record_pnl", lambda *_: None)
+    monkeypatch.setattr(risk_control, "mark_symbol_closed", lambda *_: None)
 
 
 def test_save_and_load_roundtrip(tmp_path, monkeypatch):
@@ -52,7 +55,7 @@ def test_save_and_load_roundtrip(tmp_path, monkeypatch):
         entry_funding=0.01,
         quantity=3.0,
         initial_quantity=3.0,
-        commissions=0.1,
+        commissions=Decimal("0.1"),
         last_funding_timestamp=1.0,
         exchange="binance",
     )
@@ -64,7 +67,8 @@ def test_save_and_load_roundtrip(tmp_path, monkeypatch):
     loaded = positions["BTCUSDT"]
     assert isinstance(loaded, Position)
     assert loaded.quantity == 3.0
-    assert loaded.commissions == 0.1
+    assert isinstance(loaded.commissions, Decimal)
+    assert loaded.commissions == Decimal("0.1")
     assert isinstance(loaded.pnl, Decimal)
     assert loaded.pnl == Decimal(0)
 
@@ -81,3 +85,38 @@ def test_load_positions_validation(tmp_path, monkeypatch):
     asyncio.run(load_positions(file_path))
     assert "GOOD" in positions
     assert "BAD" not in positions
+
+
+def test_commission_and_funding_precision(monkeypatch):
+    _patch_risk(monkeypatch)
+    class DummyExchange:
+        name = "dummy"
+
+        async def place_order(self, symbol, side, quantity, price=None):
+            fee = "0.1" if side == "SELL" else "0.2"
+            return {"fee": fee}
+
+    positions.clear()
+    pos = Position(
+        entry_timestamp=0.0,
+        entry_futures_price=100.0,
+        entry_spot_price=100.0,
+        entry_basis=0.0,
+        entry_funding=0.0,
+        quantity=1.0,
+        initial_quantity=1.0,
+        exchange="dummy",
+    )
+    positions["TST"] = pos
+
+    qty = Decimal("1")
+    price = Decimal("100")
+    rate = Decimal("0.0001")
+    elapsed = Decimal("3600")
+    fee = qty * price * rate * elapsed / Decimal(8 * 3600)
+    pos.funding_accrued += fee
+    pos.funding_accrued += fee
+    assert pos.funding_accrued == fee * 2
+
+    asyncio.run(close_neutral_position(DummyExchange(), "TST", qty, final=False))
+    assert positions["TST"].commissions == Decimal("0.3")


### PR DESCRIPTION
## Summary
- Represent Position.commissions and Position.funding_accrued using `Decimal`
- Update serialization, deserialization, and runtime accumulation to operate with `Decimal`
- Ensure exchange emergency close handles dataclass positions
- Add tests verifying precise Decimal accumulation of commissions and funding

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e73e71ec88320a06df23f24a3f5c8