### PR TITLE
Use Decimal for funding and commission tracking

### DIFF
--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -324,8 +324,8 @@ class Position:
     quantity: float
     initial_quantity: float
     pnl: Decimal = Decimal(0)
-    funding_accrued: float = 0.0
-    commissions: float = 0.0
+    funding_accrued: Decimal = Decimal(0)
+    commissions: Decimal = Decimal(0)
     last_funding_timestamp: float = 0.0
     exchange: str = ""
     exit_timestamp: float | None = None
@@ -338,6 +338,8 @@ class Position:
     def to_dict(self) -> Dict[str, Any]:
         data = asdict(self)
         data["pnl"] = float(self.pnl)
+        data["funding_accrued"] = float(self.funding_accrued)
+        data["commissions"] = float(self.commissions)
         return data
 
     @classmethod
@@ -353,8 +355,8 @@ class Position:
             quantity=float(data["quantity"]),
             initial_quantity=float(data.get("initial_quantity", data["quantity"])),
             pnl=Decimal(str(data.get("pnl", 0.0))),
-            funding_accrued=float(data.get("funding_accrued", 0.0)),
-            commissions=float(data.get("commissions", 0.0)),
+            funding_accrued=Decimal(str(data.get("funding_accrued", 0.0))),
+            commissions=Decimal(str(data.get("commissions", 0.0))),
             last_funding_timestamp=float(
                 data.get("last_funding_timestamp", data.get("entry_timestamp", 0.0))
             ),
@@ -480,8 +482,8 @@ async def open_neutral_position(
             quantity=float(quantity),
             initial_quantity=float(quantity),
             pnl=Decimal(0),
-            funding_accrued=0.0,
-            commissions=float(commission),
+            funding_accrued=Decimal(0),
+            commissions=commission,
             last_funding_timestamp=now,
             exchange=exchange_name,
         )
@@ -560,7 +562,7 @@ async def close_neutral_position(
     async with positions_lock:
         entry = positions.get(symbol)
         if entry is not None:
-            entry.commissions += float(commission)
+            entry.commissions += commission
             ref_price = Decimal(str(entry.entry_futures_price))
         else:
             ref_price = Decimal(0)
@@ -615,7 +617,7 @@ async def monitor_neutral_position(
                 / Decimal(8 * 3600)
             )
             # Накапливаем полученное фондирование
-            entry.funding_accrued = float(Decimal(str(entry.funding_accrued)) + funding_fee)
+            entry.funding_accrued += funding_fee
             entry.last_funding_timestamp = now
         reasons: list[str] = []
         exit_slippage = 0.0
@@ -647,12 +649,7 @@ async def monitor_neutral_position(
                 str(entry.entry_spot_price)
             )
             pnl = (fut_diff - spot_diff) * Decimal(str(quantity))
-            if (
-                pnl
-                + Decimal(str(entry.funding_accrued))
-                - Decimal(str(entry.commissions))
-                < Decimal(0)
-            ):
+            if pnl + entry.funding_accrued - entry.commissions < Decimal(0):
                 reasons.append("pnl_vs_cost")
         else:
             pnl = Decimal(0)
@@ -707,7 +704,7 @@ async def monitor_neutral_position(
                         "pnl": float(pnl_net),
                         "pnl_pct": float(pnl_pct),
                         "commissions": float(commission),
-                        "funding_accrued": entry.funding_accrued,
+                        "funding_accrued": float(entry.funding_accrued),
                         "slippage": exit_slippage,
                         "exit_reasons": ["partial"],
                         "notes": "частичный выход",
@@ -717,11 +714,7 @@ async def monitor_neutral_position(
                     total_volume = Decimal(str(entry.entry_futures_price)) * Decimal(
                         str(entry.initial_quantity)
                     )
-                    pnl_total = (
-                        entry.pnl
-                        + Decimal(str(entry.funding_accrued))
-                        - Decimal(str(entry.commissions))
-                    )
+                    pnl_total = entry.pnl + entry.funding_accrued - entry.commissions
                     pnl_pct_total = (
                         pnl_total / total_volume * 100 if total_volume != 0 else Decimal(0)
                     )
@@ -749,11 +742,7 @@ async def monitor_neutral_position(
                 )
                 exit_ts = time.time()
                 total_pnl = entry.pnl + pnl
-                net_pnl = (
-                    total_pnl
-                    + Decimal(str(entry.funding_accrued))
-                    - Decimal(str(entry.commissions))
-                )
+                net_pnl = total_pnl + entry.funding_accrued - entry.commissions
                 entry.exit_timestamp = exit_ts
                 entry.exit_reasons = reasons
                 entry.exit_futures_price = metrics.futures_price
@@ -786,8 +775,8 @@ async def monitor_neutral_position(
                         "volume_usd": float(volume_usd),
                         "pnl": float(net_pnl),
                         "pnl_pct": float(pnl_pct),
-                        "commissions": entry.commissions,
-                        "funding_accrued": entry.funding_accrued,
+                        "commissions": float(entry.commissions),
+                        "funding_accrued": float(entry.funding_accrued),
                         "slippage": exit_slippage,
                         "exit_reasons": reasons,
                         "notes": None,

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -52,7 +52,7 @@ def test_save_and_load_roundtrip(tmp_path, monkeypatch):
         entry_funding=0.01,
         quantity=3.0,
         initial_quantity=3.0,
-        commissions=0.1,
+        commissions=Decimal("0.1"),
         last_funding_timestamp=1.0,
         exchange="binance",
     )
@@ -64,7 +64,10 @@ def test_save_and_load_roundtrip(tmp_path, monkeypatch):
     loaded = positions["BTCUSDT"]
     assert isinstance(loaded, Position)
     assert loaded.quantity == 3.0
-    assert loaded.commissions == 0.1
+    assert loaded.commissions == Decimal("0.1")
+    assert isinstance(loaded.commissions, Decimal)
+    assert loaded.funding_accrued == Decimal(0)
+    assert isinstance(loaded.funding_accrued, Decimal)
     assert isinstance(loaded.pnl, Decimal)
     assert loaded.pnl == Decimal(0)
 

--- a/tests/test_positions_lock.py
+++ b/tests/test_positions_lock.py
@@ -45,6 +45,10 @@ class DummyExchange:
         await asyncio.sleep(0)
         return {"id": f"{side}_{quantity}", "fee": 0.0}
 
+    async def get_order_status(self, order_id):
+        await asyncio.sleep(0)
+        return {"status": "FILLED"}
+
 
 def test_concurrent_close(monkeypatch):
     _patch_risk(monkeypatch)


### PR DESCRIPTION
## Summary
- switch Position's funding_accrued and commissions fields to Decimal and handle JSON serialization
- use Decimal arithmetic when updating funding and checking PnL
- adapt tests for Decimal fields and extend dummy exchange in concurrency test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e7c3b0a288320b8be14d1e0344357