### PR TITLE
feat: lazily init telegram bot

### DIFF
--- a/utils/telegram.py
+++ b/utils/telegram.py
@@ -12,12 +12,41 @@ load_dotenv()
 API_TOKEN: str | None = os.getenv("TELEGRAM_BOT_TOKEN")
 CHAT_ID: str | None = os.getenv("TELEGRAM_CHAT_ID")
 
-_BOT: Optional[Bot] = Bot(API_TOKEN, parse_mode="HTML") if API_TOKEN else None
+_BOT: Optional[Bot] = None
 
 logger = logging.getLogger(__name__)
 
 # Кешируем идентификаторы сообщений для обновления одного и того же поста
 _MESSAGE_CACHE: Dict[str, int] = {}
+
+
+def get_bot() -> Optional[Bot]:
+    """Lazily create and cache a Telegram :class:`Bot` instance.
+
+    Returns ``None`` if the required credentials are missing. Subsequent
+    calls return the cached bot until :func:`shutdown` is executed.
+    """
+
+    global _BOT
+    if _BOT is not None:
+        return _BOT
+    if not API_TOKEN or not CHAT_ID:
+        return None
+    try:
+        _BOT = Bot(API_TOKEN, parse_mode="HTML")
+    except Exception:  # pragma: no cover - defensive; aiogram raises many errors
+        logger.exception("Failed to initialize Telegram bot")
+        _BOT = None
+    return _BOT
+
+
+async def shutdown() -> None:
+    """Close the bot session if it was created."""
+    global _BOT
+    bot = _BOT
+    if bot is not None:
+        await bot.session.close()
+        _BOT = None
 
 
 def format_duration(seconds: float) -> str:
@@ -41,14 +70,15 @@ async def _send_message(text: str) -> Optional[int]:
     В случае ошибок предпринимает несколько попыток с экспоненциальной
     задержкой между ними.
     """
-    if _BOT is None or CHAT_ID is None:
+    bot = get_bot()
+    if bot is None or CHAT_ID is None:
         # Если нет конфигурации, просто выходим
         return None
 
     delay = 1
     for attempt in range(3):
         try:
-            message = await _BOT.send_message(CHAT_ID, text)
+            message = await bot.send_message(CHAT_ID, text)
             return message.message_id
         except TelegramAPIError:
             logger.exception("Failed to send Telegram message (attempt %s)", attempt + 1)
@@ -64,13 +94,14 @@ async def _edit_message(message_id: int, text: str) -> None:
     Аналогично :func:`_send_message`, выполняет несколько попыток
     при возникновении ошибок Telegram.
     """
-    if _BOT is None or CHAT_ID is None:
+    bot = get_bot()
+    if bot is None or CHAT_ID is None:
         return
 
     delay = 1
     for attempt in range(3):
         try:
-            await _BOT.edit_message_text(text, chat_id=CHAT_ID, message_id=message_id)
+            await bot.edit_message_text(text, chat_id=CHAT_ID, message_id=message_id)
             return
         except TelegramAPIError:
             logger.exception("Failed to edit Telegram message (attempt %s)", attempt + 1)


### PR DESCRIPTION
## Summary
- defer Telegram Bot creation until first use with `get_bot`
- allow cleaning up cached bot via `shutdown`
- skip Telegram notifications when credentials are missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e817b82fc8320a62dbe27cbd759aa