### PR TITLE
Handle missing entry metrics in funding arbitrage

### DIFF
--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -438,6 +438,8 @@ async def open_neutral_position(
         raise RuntimeError("Символ отсутствует в белом списке")
     # Получаем метрики рынка для оценки сделки
     entry_metrics = await get_market_metrics(symbol, float(quantity), exchange)
+    if entry_metrics is None:
+        raise RuntimeError("Рыночные метрики недоступны, сделка пропущена")
     notional = quantity * Decimal(str(entry_metrics.futures_price))
     deposit = Decimal(str(bot_cfg.get("deposit_size", "Infinity")))
     deposit_pct = Decimal(str(CONFIG.get("thresholds", {}).get("deposit_pct", 1.0)))

--- a/tests/test_missing_metrics.py
+++ b/tests/test_missing_metrics.py
@@ -1,0 +1,84 @@
+import sys
+import pathlib
+from decimal import Decimal
+import types
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+# Stub sklearn to avoid heavy dependency
+linear_model_stub = types.SimpleNamespace(LinearRegression=object)
+sklearn_stub = types.SimpleNamespace(linear_model=linear_model_stub)
+sys.modules.setdefault("sklearn", sklearn_stub)
+sys.modules.setdefault("sklearn.linear_model", linear_model_stub)
+
+from strategies import funding_arbitrage as fa
+from exchanges import BaseExchange
+
+
+class NoCallExchange(BaseExchange):
+    name = "stub"
+
+    def __init__(self) -> None:
+        self.orders = []
+
+    async def fetch_funding(self, symbol: str) -> float:
+        return 0.0
+
+    async def place_order(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
+        self.orders.append(("perp", side, quantity))
+        return {"id": "perp1"}
+
+    async def get_orderbook(self, symbol: str, depth: int = 5) -> dict:
+        return {}
+
+    async def get_balance(self) -> dict:
+        return {}
+
+    async def place_spot_order(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
+        self.orders.append(("spot", side, quantity))
+        return {"id": "spot1"}
+
+    async def get_spot_orderbook(self, symbol: str, depth: int = 5) -> dict:
+        return {}
+
+    async def get_spot_balance(self) -> dict:
+        return {}
+
+    async def fetch_funding_history(self, symbol: str, hours: int = 8, limit: int = 3) -> list[float]:
+        return []
+
+    async def get_stats(self, symbol: str) -> dict:
+        return {"volume_24h": 0, "open_interest": 0}
+
+    async def get_futures_symbols(self) -> list[str]:
+        return []
+
+    async def get_spot_symbols(self) -> list[str]:
+        return []
+
+    async def get_ohlc(self, symbol: str, interval: str = "15m", limit: int = 1) -> list[dict]:
+        return [{"open": 0, "close": 0, "high": 0, "low": 0}]
+
+
+@pytest.mark.asyncio
+async def test_open_neutral_position_skips_when_no_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    exchange = NoCallExchange()
+
+    monkeypatch.setattr(fa, "CONFIG", {"bot": {}, "thresholds": {}})
+    monkeypatch.setattr(fa, "WHITELISTS", {exchange.name: ["BTCUSDT"]})
+    monkeypatch.setattr(fa.risk_control, "can_open_position", lambda *_: True)
+    monkeypatch.setattr(fa.risk_control, "is_symbol_open", lambda *_: False)
+    monkeypatch.setattr(fa.risk_control, "update_position", lambda *_: None)
+    monkeypatch.setattr(fa.risk_control, "mark_symbol_open", lambda *_: None)
+
+    async def _metrics_none(symbol: str, trade_size: float, exchange: BaseExchange) -> fa.MarketMetrics | None:
+        return None
+
+    monkeypatch.setattr(fa, "get_market_metrics", _metrics_none)
+
+    with pytest.raises(RuntimeError):
+        await fa.open_neutral_position(exchange, "BTCUSDT", Decimal("1"))
+
+    assert exchange.orders == []


### PR DESCRIPTION
## Summary
- safeguard neutral position opening by checking for missing market metrics
- add test verifying trade is skipped when metrics are unavailable

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f2c69b0248320bb1056fe0ae10c6b