### PR TITLE
Use async lock for logging trades

### DIFF
--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -254,7 +254,7 @@ async def _handle_timeout() -> None:
                             if exit_spot
                             else float("inf")
                         )
-                        log_trade(
+                        await log_trade(
                             {
                                 "symbol": symbol,
                                 "exchange": exchange_name,

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -489,7 +489,7 @@ async def open_neutral_position(
         )
         await save_positions()
     volume_usd = float(notional)
-    log_trade(
+    await log_trade(
         {
             "symbol": symbol,
             "exchange": exchange_name,
@@ -687,7 +687,7 @@ async def monitor_neutral_position(
                 )
                 hold_time = exit_ts - entry.entry_timestamp
                 exchange_name = type(exchange).__name__.replace("Exchange", "").lower()
-                log_trade(
+                await log_trade(
                     {
                         "symbol": symbol,
                         "exchange": exchange_name,
@@ -761,7 +761,7 @@ async def monitor_neutral_position(
                 pnl_pct = (
                     net_pnl / volume_usd * 100 if volume_usd != 0 else Decimal(0)
                 )
-                log_trade(
+                await log_trade(
                     {
                         "symbol": symbol,
                         "exchange": exchange_name,

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -43,6 +43,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping
 
@@ -76,6 +77,9 @@ LOG_COLUMNS: list[str] = [
     "notes",
 ]
 
+# Глобальная блокировка для сериализации доступа к файлу журнала.
+_log_lock = asyncio.Lock()
+
 
 def _ensure_parent(path: Path) -> None:
     """Создаёт родительскую директорию для ``path``, если она не существует."""
@@ -97,7 +101,7 @@ def _validate_entry(entry: Mapping[str, Any], columns: Iterable[str]) -> None:
         raise ValueError(f"Missing required columns: {', '.join(missing)}")
 
 
-def log_trade(trade: Mapping[str, Any], path: Path = LOG_PATH) -> None:
+async def log_trade(trade: Mapping[str, Any], path: Path = LOG_PATH) -> None:
     """Добавляет информацию о сделке в Excel-журнал.
 
     Параметры
@@ -108,8 +112,8 @@ def log_trade(trade: Mapping[str, Any], path: Path = LOG_PATH) -> None:
         Необязательный путь к файлу Excel. По умолчанию
         ``data/funding_bot_log.xlsx``.
 
-    Функция намеренно небольшая и синхронная; её предполагается вызывать
-    вне критичных по производительности участков.
+    Функция асинхронная и использует глобальную блокировку, чтобы
+    предотвращать одновременную запись в файл из разных задач.
     """
 
     path = Path(path)
@@ -124,18 +128,19 @@ def log_trade(trade: Mapping[str, Any], path: Path = LOG_PATH) -> None:
             val = ",".join(map(str, val))
         normalized[col] = val
 
-    if path.exists():
-        wb = load_workbook(path)
-        ws = wb.active
-        # Повторно создаём заголовок, если файл был изменён вручную
-        if ws.max_row == 0 or [cell.value for cell in ws[1]] != LOG_COLUMNS:
-            ws.delete_rows(1, ws.max_row)
+    async with _log_lock:
+        if path.exists():
+            wb = load_workbook(path)
+            ws = wb.active
+            # Повторно создаём заголовок, если файл был изменён вручную
+            if ws.max_row == 0 or [cell.value for cell in ws[1]] != LOG_COLUMNS:
+                ws.delete_rows(1, ws.max_row)
+                ws.append(LOG_COLUMNS)
+        else:
+            wb = Workbook()
+            ws = wb.active
             ws.append(LOG_COLUMNS)
-    else:
-        wb = Workbook()
-        ws = wb.active
-        ws.append(LOG_COLUMNS)
 
-    ws.append([normalized[col] for col in LOG_COLUMNS])
-    wb.save(path)
-    wb.close()
+        ws.append([normalized[col] for col in LOG_COLUMNS])
+        wb.save(path)
+        wb.close()


### PR DESCRIPTION
## Summary
- serialize trade log writes with a module-level `asyncio.Lock`
- add async `log_trade` and await its use in strategy and exchange modules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f2cab447c8320832f980a828709a9