### PR TITLE
Protect risk control state with asyncio lock

### DIFF
--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -303,7 +303,7 @@ async def _handle_timeout() -> None:
                         await task
                     strategy.positions.pop(symbol, None)
 
-    risk_control.pause()
+    await risk_control.pause()
 
 
 async def _await_with_timeout(coro: Coroutine[Any, Any, Any]) -> Any:

--- a/main.py
+++ b/main.py
@@ -244,7 +244,7 @@ def start_processing_loops() -> None:
             for name, client in CLIENTS.items():
                 # Перебираем символы из белого списка
                 for symbol in WHITELISTS.get(name, []):
-                    if risk_control.is_paused() or risk_control.is_symbol_open(symbol):
+                    if await risk_control.is_paused() or await risk_control.is_symbol_open(symbol):
                         continue
                     try:
                         base_metrics = await strategy.get_market_metrics(symbol, 1.0, client)
@@ -269,7 +269,7 @@ def start_processing_loops() -> None:
                         logger.error("Ошибка метрик %s %s: %s", name, symbol, exc)
                         continue
 
-                    if strategy.check_entry_conditions(
+                    if await strategy.check_entry_conditions(
                         symbol, quantity, metrics, thresholds
                     ):
                         # Условия входа выполнены – открываем позицию
@@ -300,7 +300,7 @@ def start_processing_loops() -> None:
     async def risk_loop() -> None:
         """Периодически проверяет, нужно ли приостановить торговлю."""
         while True:
-            if risk_control.is_paused():
+            if await risk_control.is_paused():
                 logger.warning("Торговля приостановлена из-за ограничений риска")
             await asyncio.sleep(poll_interval)
 

--- a/risk/risk_control.py
+++ b/risk/risk_control.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict, Optional, Set
+import asyncio
 import time
 from decimal import Decimal, getcontext
 
@@ -41,6 +42,7 @@ class RiskState:
 
 _limits = RiskLimits()
 _state = RiskState()
+_lock = asyncio.Lock()
 
 
 def configure(config: Dict[str, Optional[float]], deposit_size: Optional[float] = None) -> None:
@@ -101,73 +103,86 @@ def configure(config: Dict[str, Optional[float]], deposit_size: Optional[float] 
     )
 
 
-def can_open_position(notional: Decimal) -> bool:
+async def can_open_position(notional: Decimal) -> bool:
     """Возвращает ``True``, если позицию на ``notional`` USD можно открыть."""
 
-    if _state.paused:
-        return False
-    if _state.open_positions >= _limits.max_open_positions:
-        return False
-    if _state.total_notional + notional > _limits.deposit_cap:
-        return False
-    if _state.total_notional + notional > _limits.max_position_size:
-        return False
-    if _state.daily_loss >= _limits.max_daily_loss:
-        return False
-    return True
+    async with _lock:
+        if _state.paused:
+            return False
+        if _state.open_positions >= _limits.max_open_positions:
+            return False
+        if _state.total_notional + notional > _limits.deposit_cap:
+            return False
+        if _state.total_notional + notional > _limits.max_position_size:
+            return False
+        if _state.daily_loss >= _limits.max_daily_loss:
+            return False
+        return True
 
 
-def update_position(delta_notional: Decimal) -> None:
+async def update_position(delta_notional: Decimal) -> None:
     """Обновляет учёт текущей нагрузки на депозит на ``delta_notional`` USD."""
 
-    _state.total_notional = max(_state.total_notional + delta_notional, Decimal("0"))
+    async with _lock:
+        _state.total_notional = max(
+            _state.total_notional + delta_notional, Decimal("0")
+        )
 
 
-def is_symbol_open(symbol: str) -> bool:
+async def is_symbol_open(symbol: str) -> bool:
     """Возвращает ``True``, если позиция по ``symbol`` уже открыта."""
 
-    return symbol in _state.open_symbols
+    async with _lock:
+        return symbol in _state.open_symbols
 
 
-def mark_symbol_open(symbol: str) -> None:
+async def mark_symbol_open(symbol: str) -> None:
     """Помечает ``symbol`` как открытую позицию."""
 
-    _state.open_symbols.add(symbol)
-    _state.open_positions = len(_state.open_symbols)
+    async with _lock:
+        _state.open_symbols.add(symbol)
+        _state.open_positions = len(_state.open_symbols)
 
 
-def mark_symbol_closed(symbol: str) -> None:
+async def mark_symbol_closed(symbol: str) -> None:
     """Удаляет ``symbol`` из набора открытых позиций."""
 
-    _state.open_symbols.discard(symbol)
-    _state.open_positions = len(_state.open_symbols)
+    async with _lock:
+        _state.open_symbols.discard(symbol)
+        _state.open_positions = len(_state.open_symbols)
 
 
-def pause(duration: Optional[float] = None) -> None:
+async def pause(duration: Optional[float] = None) -> None:
     """Приостанавливает торговлю на ``duration`` секунд или бессрочно."""
 
-    _state.paused = True
-    _state.pause_until = time.time() + duration if duration else None
+    async with _lock:
+        _state.paused = True
+        _state.pause_until = time.time() + duration if duration else None
 
 
-def record_pnl(pnl: Decimal) -> None:
+async def record_pnl(pnl: Decimal) -> None:
     """Фиксирует прибыль или убыток по завершённой сделке."""
 
-    if pnl < 0:
-        _state.daily_loss += abs(pnl)
-        _state.consecutive_losses += 1
-        if _state.consecutive_losses >= _limits.max_consecutive_losses:
-            pause(24 * 3600)
-    else:
-        _state.consecutive_losses = 0
+    should_pause = False
+    async with _lock:
+        if pnl < 0:
+            _state.daily_loss += abs(pnl)
+            _state.consecutive_losses += 1
+            if _state.consecutive_losses >= _limits.max_consecutive_losses:
+                should_pause = True
+        else:
+            _state.consecutive_losses = 0
+    if should_pause:
+        await pause(24 * 3600)
 
 
-def is_paused() -> bool:
+async def is_paused() -> bool:
     """Возвращает ``True``, если торговля сейчас приостановлена."""
 
-    if _state.paused and _state.pause_until and time.time() >= _state.pause_until:
-        # Истёк таймер паузы — возобновляем торговлю
-        _state.paused = False
-        _state.pause_until = None
-        _state.consecutive_losses = 0
-    return _state.paused
+    async with _lock:
+        if _state.paused and _state.pause_until and time.time() >= _state.pause_until:
+            # Истёк таймер паузы — возобновляем торговлю
+            _state.paused = False
+            _state.pause_until = None
+            _state.consecutive_losses = 0
+        return _state.paused

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -249,12 +249,12 @@ async def get_market_metrics(
 # Проверка условий
 # ---------------------------------------------------------------------------
 
-def check_entry_conditions(
+async def check_entry_conditions(
     symbol: str,
     quantity: Decimal,
     metrics: MarketMetrics | None,
     thresholds: Dict[str, float],
-    ) -> bool:
+) -> bool:
     """Возвращает ``True``, если выполнены все условия входа.
 
     Порог ``basis`` задаётся в процентных пунктах.
@@ -290,7 +290,7 @@ def check_entry_conditions(
         and combined_slippage <= slippage_limit
         and notional <= Decimal(str(thresholds.get("max_trade_size", float("inf"))))
         and notional <= max_deposit_trade
-        and not risk_control.is_symbol_open(symbol)
+        and not await risk_control.is_symbol_open(symbol)
     )
 
 
@@ -415,8 +415,8 @@ async def load_positions(path: Path | str | None = None) -> None:
         positions[symbol] = pos
         notional = pos.quantity * pos.entry_futures_price
         if notional:
-            risk_control.update_position(Decimal(str(notional)))
-        risk_control.mark_symbol_open(symbol)
+            await risk_control.update_position(Decimal(str(notional)))
+        await risk_control.mark_symbol_open(symbol)
 
 
 async def save_positions(path: Path | str | None = None) -> None:
@@ -444,8 +444,10 @@ async def open_neutral_position(
     max_trade = deposit * deposit_pct
     if notional > deposit or notional > max_trade:
         raise RuntimeError("Размер сделки превышает лимиты депозита")
-    if not risk_control.can_open_position(notional) or risk_control.is_symbol_open(symbol):
-        raise RuntimeError("Превышены лимиты риска, торговля приостановлена или позиция уже открыта")
+    if not await risk_control.can_open_position(notional) or await risk_control.is_symbol_open(symbol):
+        raise RuntimeError(
+            "Превышены лимиты риска, торговля приостановлена или позиция уже открыта"
+        )
     # Хеджируем позицию на споте и фьючерсе
     spot_order = await exchange.place_spot_order(symbol, "BUY", float(quantity))
     spot_id = str(spot_order.get("orderId") or spot_order.get("id") or "")
@@ -471,8 +473,8 @@ async def open_neutral_position(
     commission = sum(Decimal(str(o.get("fee", 0.0))) for o in orders.values())
     now = time.time()
     async with positions_lock:
-        risk_control.update_position(notional)
-        risk_control.mark_symbol_open(symbol)
+        await risk_control.update_position(notional)
+        await risk_control.mark_symbol_open(symbol)
         positions[symbol] = Position(
             entry_timestamp=now,
             entry_futures_price=entry_metrics.futures_price,
@@ -566,11 +568,11 @@ async def close_neutral_position(
             ref_price = Decimal(str(entry.entry_futures_price))
         else:
             ref_price = Decimal(0)
-        risk_control.update_position(-(quantity * ref_price))
+        await risk_control.update_position(-(quantity * ref_price))
         net_pnl = pnl - commission
-        risk_control.record_pnl(net_pnl)
+        await risk_control.record_pnl(net_pnl)
         if final:
-            risk_control.mark_symbol_closed(symbol)
+            await risk_control.mark_symbol_closed(symbol)
             positions.pop(symbol, None)
             await save_positions()
     return {"long": close_long, "short": close_short, "commission": float(commission)}

--- a/tests/test_cancel_first_leg.py
+++ b/tests/test_cancel_first_leg.py
@@ -75,10 +75,19 @@ async def test_cancel_first_leg_on_second_failure(monkeypatch: pytest.MonkeyPatc
 
     monkeypatch.setattr(fa, "CONFIG", {"bot": {}, "thresholds": {}})
     monkeypatch.setattr(fa, "WHITELISTS", {exchange.name: ["BTCUSDT"]})
-    monkeypatch.setattr(fa.risk_control, "can_open_position", lambda *_: True)
-    monkeypatch.setattr(fa.risk_control, "is_symbol_open", lambda *_: False)
-    monkeypatch.setattr(fa.risk_control, "update_position", lambda *_: None)
-    monkeypatch.setattr(fa.risk_control, "mark_symbol_open", lambda *_: None)
+    async def _true(*args, **kwargs):
+        return True
+
+    async def _false(*args, **kwargs):
+        return False
+
+    async def _noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(fa.risk_control, "can_open_position", _true)
+    monkeypatch.setattr(fa.risk_control, "is_symbol_open", _false)
+    monkeypatch.setattr(fa.risk_control, "update_position", _noop)
+    monkeypatch.setattr(fa.risk_control, "mark_symbol_open", _noop)
 
     metrics = fa.MarketMetrics(
         funding_rate=Decimal("0"),

--- a/tests/test_invalid_trade_config.py
+++ b/tests/test_invalid_trade_config.py
@@ -48,14 +48,19 @@ def test_no_trade_on_invalid_config(monkeypatch, caplog):
     main.CLIENTS = {"x": object()}
     main.WHITELISTS = {"x": ["BTCUSDT"]}
 
-    monkeypatch.setattr(main.risk_control, "is_paused", lambda: False)
-    monkeypatch.setattr(main.risk_control, "is_symbol_open", lambda symbol: False)
+    async def _false(*args, **kwargs):
+        return False
+
+    monkeypatch.setattr(main.risk_control, "is_paused", _false)
+    monkeypatch.setattr(main.risk_control, "is_symbol_open", _false)
 
     captured = {}
 
     def fake_create_task(coro, *args, **kwargs):
         if "scan_loop" in getattr(coro, "__qualname__", ""):
             captured["scan_loop"] = coro
+        else:
+            coro.close()
         loop = asyncio.get_event_loop()
         fut = loop.create_future()
         return fut

--- a/tests/test_partial_fill.py
+++ b/tests/test_partial_fill.py
@@ -79,10 +79,19 @@ async def test_open_neutral_position_partial_fill(monkeypatch: pytest.MonkeyPatc
     # Настраиваем окружение
     monkeypatch.setattr(fa, "CONFIG", {"bot": {}, "thresholds": {}})
     monkeypatch.setattr(fa, "WHITELISTS", {exchange.name: ["BTCUSDT"]})
-    monkeypatch.setattr(fa.risk_control, "can_open_position", lambda *_: True)
-    monkeypatch.setattr(fa.risk_control, "is_symbol_open", lambda *_: False)
-    monkeypatch.setattr(fa.risk_control, "update_position", lambda *_: None)
-    monkeypatch.setattr(fa.risk_control, "mark_symbol_open", lambda *_: None)
+    async def _true(*args, **kwargs):
+        return True
+
+    async def _false(*args, **kwargs):
+        return False
+
+    async def _noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(fa.risk_control, "can_open_position", _true)
+    monkeypatch.setattr(fa.risk_control, "is_symbol_open", _false)
+    monkeypatch.setattr(fa.risk_control, "update_position", _noop)
+    monkeypatch.setattr(fa.risk_control, "mark_symbol_open", _noop)
 
     metrics = fa.MarketMetrics(
         funding_rate=Decimal("0"),

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -36,8 +36,11 @@ from risk import risk_control
 
 
 def _patch_risk(monkeypatch):
-    monkeypatch.setattr(risk_control, "update_position", lambda *_: None)
-    monkeypatch.setattr(risk_control, "mark_symbol_open", lambda *_: None)
+    async def _noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(risk_control, "update_position", _noop)
+    monkeypatch.setattr(risk_control, "mark_symbol_open", _noop)
 
 
 def test_save_and_load_roundtrip(tmp_path, monkeypatch):

--- a/tests/test_positions_lock.py
+++ b/tests/test_positions_lock.py
@@ -33,9 +33,12 @@ async def _async_noop(*args, **kwargs):
 
 
 def _patch_risk(monkeypatch):
-    monkeypatch.setattr(risk_control, "update_position", lambda *_: None)
-    monkeypatch.setattr(risk_control, "record_pnl", lambda *_: None)
-    monkeypatch.setattr(risk_control, "mark_symbol_closed", lambda *_: None)
+    async def _noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(risk_control, "update_position", _noop)
+    monkeypatch.setattr(risk_control, "record_pnl", _noop)
+    monkeypatch.setattr(risk_control, "mark_symbol_closed", _noop)
 
 
 class DummyExchange:

--- a/tests/test_slippage_volume.py
+++ b/tests/test_slippage_volume.py
@@ -140,9 +140,10 @@ async def test_returns_none_on_missing_ohlc(monkeypatch: pytest.MonkeyPatch) -> 
     assert metrics is None
 
 
-def test_check_entry_conditions_none_metrics(caplog: pytest.LogCaptureFixture) -> None:
+@pytest.mark.asyncio
+async def test_check_entry_conditions_none_metrics(caplog: pytest.LogCaptureFixture) -> None:
     with caplog.at_level(logging.WARNING):
-        result = check_entry_conditions("BTCUSDT", Decimal("1"), None, {})
+        result = await check_entry_conditions("BTCUSDT", Decimal("1"), None, {})
     assert not result
     assert "incomplete" in caplog.text.lower()
 


### PR DESCRIPTION
## Summary
- guard shared risk state with an asyncio.Lock and refactor helpers into async functions
- await risk control operations throughout strategy, main loops and exchange timeout handling
- update tests for the async risk-control API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f2ca013fc832089bf997ef43f1ebf