### PR TITLE
Ensure risk control cleanup on position monitoring

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ import os
 import time
 from pathlib import Path
 from typing import Any, Dict, List
+from decimal import Decimal
 
 import yaml
 from dotenv import load_dotenv
@@ -210,6 +211,16 @@ def start_processing_loops() -> None:
                 )
             )
         finally:
+            # Снимаем нагрузку по рискам и удаляем задачу из списка активных
+            entry = strategy.positions.get(symbol, {})
+            notional = (
+                Decimal(str(entry.get("entry_futures_price", 0.0)))
+                * Decimal(
+                    str(entry.get("initial_quantity", entry.get("quantity", 0.0)))
+                )
+            )
+            await risk_control.update_position(-notional)
+            await risk_control.mark_symbol_closed(symbol)
             # Удаляем задачу из списка активных
             if position_id in POSITION_TASKS:
                 del POSITION_TASKS[position_id]


### PR DESCRIPTION
## Summary
- Compute notional from stored entry when cleaning up monitored positions
- Update risk control and close symbol tracking even if monitoring fails

## Testing
- `pytest` *(fails: test_check_entry_conditions_invalid_thresholds, test_check_entry_conditions_non_finite_metrics, test_check_entry_conditions_invalid_quantity)*

------
https://chatgpt.com/codex/tasks/task_e_688f3003d9d08320a4134636466bd4be