### PR TITLE
Ensure Decimal quantity handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 import os
 import time
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -257,9 +258,15 @@ def start_processing_loops() -> None:
                         logger.error("Ошибка метрик %s %s: %s", name, symbol, exc)
                         continue
                     price = base_metrics.futures_price
-                    quantity = trade_value / price if price else 0.0
+                    quantity = (
+                        Decimal(str(trade_value)) / Decimal(str(price))
+                        if price
+                        else Decimal(0)
+                    )
                     try:
-                        metrics = await strategy.get_market_metrics(symbol, quantity, client)
+                        metrics = await strategy.get_market_metrics(
+                            symbol, float(quantity), client
+                        )
                         if metrics is None:
                             logger.warning(
                                 "Пропуск %s:%s из-за неполных метрик", name, symbol
@@ -274,8 +281,12 @@ def start_processing_loops() -> None:
                     ):
                         # Условия входа выполнены – открываем позицию
                         try:
-                            await strategy.open_neutral_position(client, symbol, quantity)
-                            volume_usd = quantity * metrics.futures_price
+                            await strategy.open_neutral_position(
+                                client, symbol, quantity
+                            )
+                            volume_usd = float(
+                                quantity * Decimal(str(metrics.futures_price))
+                            )
                             asyncio.create_task(
                                 notify_open(
                                     f"{name}:{symbol}",
@@ -290,7 +301,7 @@ def start_processing_loops() -> None:
                                 )
                             )
                             task = asyncio.create_task(
-                                monitor_position(name, symbol, quantity)
+                                monitor_position(name, symbol, float(quantity))
                             )
                             POSITION_TASKS[f"{name}:{symbol}"] = task
                         except Exception as exc:

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -249,7 +249,7 @@ async def get_market_metrics(
 # Проверка условий
 # ---------------------------------------------------------------------------
 
-async def check_entry_conditions(
+async def _check_entry_conditions(
     symbol: str,
     quantity: Decimal,
     metrics: MarketMetrics | None,
@@ -333,6 +333,22 @@ async def check_entry_conditions(
         and notional <= max_deposit_trade
         and not await risk_control.is_symbol_open(symbol)
     )
+
+
+def check_entry_conditions(
+    symbol: str,
+    quantity: Decimal,
+    metrics: MarketMetrics | None,
+    thresholds: Dict[str, float],
+) -> bool:
+    """Wrapper allowing sync or async usage of ``_check_entry_conditions``."""
+    coro = _check_entry_conditions(symbol, quantity, metrics, thresholds)
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    else:
+        return coro
 
 
 def check_exit_conditions(metrics: MarketMetrics, thresholds: Dict[str, float]) -> bool:
@@ -473,6 +489,7 @@ async def open_neutral_position(
     exchange: BaseExchange, symbol: str, quantity: Decimal
 ) -> Dict[str, Dict]:
     """Открывает компенсирующие длинную и короткую позиции и сохраняет данные."""
+    quantity = Decimal(str(quantity))
     bot_cfg = CONFIG.get("bot", {})
     exchange_name = exchange.name
     if symbol not in WHITELISTS.get(exchange_name, []):


### PR DESCRIPTION
## Summary
- convert trade quantity to `Decimal` in `scan_loop`
- allow `check_entry_conditions` to be used sync or async and convert quantities in `open_neutral_position`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f302a07c483209997f72327202f91