### PR TITLE
Use Decimal for trade quantities

### DIFF
--- a/main.py
+++ b/main.py
@@ -177,7 +177,7 @@ def start_processing_loops() -> None:
                         f"Ошибка на {exchange_name} {symbol}: {exc}\n"
                         f"Фандинг: {funding_pct:.4f}%\n"
                         f"Базис: {basis_pct:.4f}%\n"
-                        f"Объём: ${volume_usd:.2f}\n"
+                        f"Объём: ${float(volume_usd):.2f}\n"
                         f"Время в позиции: {format_duration(hold)}"
                     ),
                 )
@@ -204,7 +204,7 @@ def start_processing_loops() -> None:
                         f"Закрыта {symbol} на {exchange_name}\n"
                         f"Фандинг: {funding_pct:.4f}%\n"
                         f"Базис: {basis_pct:.4f}%\n"
-                        f"Объём: ${volume_usd:.2f}\n"
+                        f"Объём: ${float(volume_usd):.2f}\n"
                         f"Время в позиции: {format_duration(hold)}\n"
                         f"PnL: {pnl:.4f} ({pnl_pct:.4f}%) Причины: {reasons}"
                     ),
@@ -268,9 +268,15 @@ def start_processing_loops() -> None:
                         logger.error("Ошибка метрик %s %s: %s", name, symbol, exc)
                         continue
                     price = base_metrics.futures_price
-                    quantity = trade_value / price if price else 0.0
+                    quantity = (
+                        Decimal(str(trade_value)) / Decimal(str(price))
+                        if price
+                        else Decimal(0)
+                    )
                     try:
-                        metrics = await strategy.get_market_metrics(symbol, quantity, client)
+                        metrics = await strategy.get_market_metrics(
+                            symbol, float(quantity), client
+                        )
                         if metrics is None:
                             logger.warning(
                                 "Пропуск %s:%s из-за неполных метрик", name, symbol
@@ -286,7 +292,7 @@ def start_processing_loops() -> None:
                         # Условия входа выполнены – открываем позицию
                         try:
                             await strategy.open_neutral_position(client, symbol, quantity)
-                            volume_usd = quantity * metrics.futures_price
+                            volume_usd = quantity * Decimal(str(metrics.futures_price))
                             asyncio.create_task(
                                 notify_open(
                                     f"{name}:{symbol}",
@@ -294,14 +300,14 @@ def start_processing_loops() -> None:
                                         f"Открыта {symbol} на {name}\n"
                                         f"Фандинг: {metrics.funding_rate * 100:.4f}%\n"
                                         f"Базис: {metrics.basis:.4f}%\n"
-                                        f"Объём: ${volume_usd:.2f}\n"
+                                        f"Объём: ${float(volume_usd):.2f}\n"
                                         f"Время в позиции: {format_duration(0)}\n"
                                         "Стратегия: Лонг спот / Шорт перп"
                                     ),
                                 )
                             )
                             task = asyncio.create_task(
-                                monitor_position(name, symbol, quantity)
+                                monitor_position(name, symbol, float(quantity))
                             )
                             POSITION_TASKS[f"{name}:{symbol}"] = task
                         except Exception as exc:

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -265,7 +265,7 @@ def check_entry_conditions(
         if metrics is None:
             logger.warning("Skipping %s: incomplete market metrics", symbol)
             return False
-        quantity_d = Decimal(str(quantity))
+        quantity_d = quantity if isinstance(quantity, Decimal) else Decimal(str(quantity))
         if not quantity_d.is_finite() or quantity_d <= 0:
             logger.warning("Skipping %s: invalid quantity %s", symbol, quantity_d)
             return False
@@ -618,7 +618,7 @@ async def close_neutral_position(
     final:
         Если ``True``, позиция закрывается полностью и риски сбрасываются.
     """
-    quantity = Decimal(str(quantity))
+    quantity = quantity if isinstance(quantity, Decimal) else Decimal(str(quantity))
     pnl = Decimal(str(pnl))
     close_long = await exchange.place_order(symbol, "SELL", float(quantity))
     long_id = str(close_long.get("orderId") or close_long.get("id") or "")
@@ -689,7 +689,7 @@ async def monitor_neutral_position(
         now = time.time()
         if entry:
             last = entry.last_funding_timestamp or now
-            quantity_d = Decimal(str(quantity))
+            quantity_d = quantity if isinstance(quantity, Decimal) else Decimal(str(quantity))
             price_d = Decimal(str(metrics.futures_price))
             elapsed = Decimal(str(now - last))
             funding_fee = (
@@ -731,7 +731,7 @@ async def monitor_neutral_position(
             spot_diff = Decimal(str(metrics.spot_price)) - Decimal(
                 str(entry.entry_spot_price)
             )
-            pnl = (fut_diff - spot_diff) * Decimal(str(quantity))
+            pnl = (fut_diff - spot_diff) * quantity_d
             if (
                 pnl + entry.funding_accrued - entry.commissions < Decimal(0)
             ):


### PR DESCRIPTION
## Summary
- compute trade quantity as Decimal before evaluating entry conditions
- use Decimal-based quantity handling in entry checks and position management

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f3274bd188320afd1e6deafae0754