### PR TITLE
Reset daily loss every 24h

### DIFF
--- a/risk/risk_control.py
+++ b/risk/risk_control.py
@@ -13,6 +13,7 @@ import asyncio
 import time
 import math
 import logging
+from datetime import datetime
 from decimal import Decimal, getcontext
 
 getcontext().prec = 10
@@ -42,11 +43,23 @@ class RiskState:
     open_symbols: Set[str] = field(default_factory=set)
     open_positions: int = 0
     pause_until: Optional[float] = None
+    last_reset_ts: float = field(default_factory=time.time)
 
 
 _limits = RiskLimits()
 _state = RiskState()
 _lock = asyncio.Lock()
+
+
+def _maybe_reset_daily_loss(now: float) -> None:
+    if now - _state.last_reset_ts >= 24 * 3600:
+        logger.info(
+            "Daily loss reset at %s. Previous loss: %s",
+            datetime.utcfromtimestamp(now).isoformat(),
+            _state.daily_loss,
+        )
+        _state.daily_loss = Decimal("0")
+        _state.last_reset_ts = now
 
 
 def configure(config: Dict[str, Optional[float]], deposit_size: Optional[float] = None) -> None:
@@ -174,6 +187,8 @@ async def record_pnl(pnl: Decimal) -> None:
 
     should_pause = False
     async with _lock:
+        now = time.time()
+        _maybe_reset_daily_loss(now)
         if pnl < 0:
             _state.daily_loss += abs(pnl)
             _state.consecutive_losses += 1
@@ -189,7 +204,9 @@ async def is_paused() -> bool:
     """Возвращает ``True``, если торговля сейчас приостановлена."""
 
     async with _lock:
-        if _state.paused and _state.pause_until and time.time() >= _state.pause_until:
+        now = time.time()
+        _maybe_reset_daily_loss(now)
+        if _state.paused and _state.pause_until and now >= _state.pause_until:
             # Истёк таймер паузы — возобновляем торговлю
             _state.paused = False
             _state.pause_until = None

--- a/tests/test_risk_control.py
+++ b/tests/test_risk_control.py
@@ -1,10 +1,13 @@
 import pytest
 from risk import risk_control as rc
+from decimal import Decimal
+import time
 
 
 def teardown_module(module):
     # Reset configuration after tests
     rc.configure({})
+    rc._state = rc.RiskState()
 
 
 def test_deposit_cap_pct_applied():
@@ -60,3 +63,25 @@ def test_configure_deposit_cap_pct_out_of_range_ignored():
 def test_configure_negative_deposit_size_ignored():
     rc.configure({"deposit_cap_pct": 0.1}, deposit_size=-100)
     assert rc._limits.deposit_cap.is_infinite()
+
+
+@pytest.mark.asyncio
+async def test_daily_loss_resets_after_24h_record_pnl(monkeypatch):
+    rc._state.daily_loss = Decimal("5")
+    now = time.time()
+    rc._state.last_reset_ts = now
+    monkeypatch.setattr(rc.time, "time", lambda: now + 24 * 3600 + 1)
+    await rc.record_pnl(Decimal("0"))
+    assert rc._state.daily_loss == Decimal("0")
+    assert rc._state.last_reset_ts == now + 24 * 3600 + 1
+
+
+@pytest.mark.asyncio
+async def test_daily_loss_resets_after_24h_is_paused(monkeypatch):
+    rc._state.daily_loss = Decimal("5")
+    now = time.time()
+    rc._state.last_reset_ts = now
+    monkeypatch.setattr(rc.time, "time", lambda: now + 24 * 3600 + 1)
+    await rc.is_paused()
+    assert rc._state.daily_loss == Decimal("0")
+    assert rc._state.last_reset_ts == now + 24 * 3600 + 1


### PR DESCRIPTION
## Summary
- track last risk reset time and log daily loss resets
- refresh daily loss in `record_pnl` and `is_paused`
- test daily loss reset logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f358b37448320b1bf9f2a45b16692