### PR TITLE
Implement order status for Binance and Bybit

### DIFF
--- a/exchanges/binance.py
+++ b/exchanges/binance.py
@@ -44,6 +44,8 @@ class BinanceExchange(BaseExchange):
         self._spot_ws: Dict[str, Any] = {}
         self._spot_orderbooks: Dict[str, Dict[str, Any]] = {}
         self._spot_ws_tasks: Dict[str, asyncio.Task] = {}
+        # Соответствие ``orderId`` -> ``symbol`` для запросов статуса ордера
+        self._order_symbols: Dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # Утилиты REST
@@ -149,7 +151,39 @@ class BinanceExchange(BaseExchange):
             params.update({"price": price, "timeInForce": "GTC"})
         headers = {"X-MBX-APIKEY": self.api_key}
         params = self._sign(params)
-        return await self._request("POST", url, params=params, headers=headers)
+        data = await self._request("POST", url, params=params, headers=headers)
+        order_id = str(data.get("orderId") or data.get("id") or "")
+        if order_id:
+            self._order_symbols[order_id] = symbol
+        return data
+
+    async def get_order_status(self, order_id: str) -> dict:
+        """Возвращает статус ордера ``order_id``.
+
+        Сначала выполняет запрос к фьючерсному API. Если ордер не найден или
+        запрос завершился ошибкой, повторяет попытку для спотового API.
+        Повторные попытки сетевых обращений обрабатываются методом
+        :meth:`_request`.
+        """
+
+        headers = {"X-MBX-APIKEY": self.api_key}
+        symbol = self._order_symbols.get(order_id)
+        params: Dict[str, Any] = {"orderId": order_id}
+        if symbol:
+            params["symbol"] = symbol
+        params = self._sign(params)
+        url = f"{self.REST_URL}/fapi/v1/order"
+        try:
+            return await self._request("GET", url, params=params, headers=headers)
+        except aiohttp.ClientError:
+            spot_url = f"{self.SPOT_REST_URL}/api/v3/order"
+            params = {"orderId": order_id}
+            if symbol:
+                params["symbol"] = symbol
+            params = self._sign(params)
+            return await self._request(
+                "GET", spot_url, params=params, headers=headers
+            )
 
     async def cancel_order(self, symbol: str, order_id: str) -> dict:
         """Отменяет ордер по ``order_id`` для указанного ``symbol``.
@@ -240,7 +274,11 @@ class BinanceExchange(BaseExchange):
             params.update({"price": price, "timeInForce": "GTC"})
         headers = {"X-MBX-APIKEY": self.api_key}
         params = self._sign(params)
-        return await self._request("POST", url, params=params, headers=headers)
+        data = await self._request("POST", url, params=params, headers=headers)
+        order_id = str(data.get("orderId") or data.get("id") or "")
+        if order_id:
+            self._order_symbols[order_id] = symbol
+        return data
 
     async def get_spot_balance(self) -> dict:
         """Возвращает баланс спотового аккаунта."""

--- a/exchanges/bybit.py
+++ b/exchanges/bybit.py
@@ -43,6 +43,8 @@ class BybitExchange(BaseExchange):
         self._spot_ws: Dict[str, Any] = {}
         self._spot_orderbooks: Dict[str, Dict[str, Any]] = {}
         self._spot_ws_tasks: Dict[str, asyncio.Task] = {}
+        # Кэш соответствия ``orderId`` -> сведения о заказе
+        self._order_info: Dict[str, Dict[str, str]] = {}
 
     # ------------------------------------------------------------------
     # Утилиты REST
@@ -150,7 +152,40 @@ class BybitExchange(BaseExchange):
             body["price"] = price
         headers = {"Content-Type": "application/json"}
         body = self._sign("POST", url_path, body)
-        return await self._request("POST", url, json=body, headers=headers)
+        data = await self._request("POST", url, json=body, headers=headers)
+        order_id = str(
+            data.get("result", {}).get("orderId")
+            or data.get("orderId")
+            or data.get("id")
+            or ""
+        )
+        if order_id:
+            self._order_info[order_id] = {"symbol": symbol, "category": "linear"}
+        return data
+
+    async def get_order_status(self, order_id: str) -> dict:
+        """Возвращает статус ордера ``order_id``."""
+
+        url_path = "/v5/order/realtime"
+        url = f"{self.REST_URL}{url_path}"
+        info = self._order_info.get(order_id, {})
+        categories = [info.get("category", "linear")]
+        if "category" not in info:
+            categories = ["linear", "spot"]
+        symbol = info.get("symbol")
+        for category in categories:
+            params: Dict[str, Any] = {"orderId": order_id, "category": category}
+            if symbol:
+                params["symbol"] = symbol
+            params = self._sign("GET", url_path, params)
+            try:
+                data = await self._request("GET", url, params=params)
+            except aiohttp.ClientError:
+                continue
+            result = data.get("result", {}).get("list", [])
+            if result:
+                return result[0]
+        return {}
 
     async def cancel_order(self, symbol: str, order_id: str) -> dict:
         """Отменяет ордер ``order_id`` для пары ``symbol``."""
@@ -245,7 +280,16 @@ class BybitExchange(BaseExchange):
             body["price"] = price
         headers = {"Content-Type": "application/json"}
         body = self._sign("POST", url_path, body)
-        return await self._request("POST", url, json=body, headers=headers)
+        data = await self._request("POST", url, json=body, headers=headers)
+        order_id = str(
+            data.get("result", {}).get("orderId")
+            or data.get("orderId")
+            or data.get("id")
+            or ""
+        )
+        if order_id:
+            self._order_info[order_id] = {"symbol": symbol, "category": "spot"}
+        return data
 
     async def get_spot_balance(self) -> dict:
         """Получает баланс спотового аккаунта."""

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -70,10 +70,16 @@ async def _wait_filled(exchange: BaseExchange, order_id: str) -> bool:
     start = time.monotonic()
     while True:
         status = await exchange.get_order_status(order_id)
-        state = status.get("status")
-        if state == "FILLED":
+        state = (
+            status.get("status")
+            or status.get("orderStatus")
+            or status.get("result", {}).get("status")
+            or status.get("result", {}).get("orderStatus")
+        )
+        normalized = str(state or "").replace(" ", "_").upper()
+        if normalized == "FILLED":
             return True
-        if state == "PARTIALLY_FILLED":
+        if normalized in {"PARTIALLY_FILLED", "PARTIALLYFILLED"}:
             return False
         if time.monotonic() - start > API_TIMEOUT:
             raise RuntimeError(f"Ордер {order_id} не исполнен вовремя")


### PR DESCRIPTION
## Summary
- add REST-based order status lookup for Binance client with spot/futures fallback
- implement REST-based order status lookup for Bybit client
- normalize `_wait_filled` to handle varied API status fields

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f35a20b508320ad0f0e888d5247f8