### PR TITLE
Fix default exit thresholds for spread/volatility

### DIFF
--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -361,10 +361,10 @@ def check_exit_conditions(metrics: MarketMetrics, thresholds: Dict[str, float]) 
         return True
     return (
         abs(metrics.funding_rate) <= thresholds.get("funding_rate", float("inf"))
-        or metrics.spread >= thresholds.get("spread", float("-inf"))
+        or metrics.spread >= thresholds.get("spread", float("inf"))
         or metrics.liquidity <= thresholds.get("liquidity", float("inf"))
         or abs(metrics.volatility)
-        >= thresholds.get("volatility", float("-inf"))
+        >= thresholds.get("volatility", float("inf"))
         or abs(metrics.basis) >= thresholds.get("exit_basis", float("inf"))
     )
 

--- a/tests/test_exit_conditions.py
+++ b/tests/test_exit_conditions.py
@@ -1,0 +1,53 @@
+import sys
+import pathlib
+import types
+from decimal import Decimal
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+# Stub sklearn to avoid heavy dependency
+linear_model_stub = types.SimpleNamespace(LinearRegression=object)
+sklearn_stub = types.SimpleNamespace(linear_model=linear_model_stub)
+sys.modules.setdefault("sklearn", sklearn_stub)
+sys.modules.setdefault("sklearn.linear_model", linear_model_stub)
+
+from strategies.funding_arbitrage import MarketMetrics, check_exit_conditions
+
+
+def _sample_metrics() -> MarketMetrics:
+    return MarketMetrics(
+        funding_rate=Decimal("0.01"),
+        spread=10.0,
+        liquidity=1000.0,
+        volatility=0.02,
+        spot_price=100.0,
+        futures_price=100.0,
+        volume=10000.0,
+        open_interest=5000.0,
+        spot_slippage=0.0001,
+        futures_slippage=0.0001,
+        slippage=0.0002,
+        basis=0.1,
+    )
+
+
+def test_no_spread_threshold_does_not_trigger_exit():
+    metrics = _sample_metrics()
+    thresholds = {
+        "funding_rate": 0.0,
+        "liquidity": 0.0,
+        "volatility": 1.0,
+    }
+    assert not check_exit_conditions(metrics, thresholds)
+
+
+def test_no_volatility_threshold_does_not_trigger_exit():
+    metrics = _sample_metrics()
+    thresholds = {
+        "funding_rate": 0.0,
+        "liquidity": 0.0,
+        "spread": 1000.0,
+    }
+    assert not check_exit_conditions(metrics, thresholds)


### PR DESCRIPTION
## Summary
- prevent premature exits by defaulting spread/volatility thresholds to `inf`
- add regression tests verifying missing thresholds do not trigger exit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3a57ba6483209c8ed40c14becac4