### PR TITLE
feat: add atomic position reservation

### DIFF
--- a/risk/risk_control.py
+++ b/risk/risk_control.py
@@ -142,6 +142,27 @@ async def can_open_position(notional: Decimal) -> bool:
         return True
 
 
+async def try_open_position(symbol: str, notional: Decimal) -> bool:
+    """Атомарно проверяет лимиты и помечает ``symbol`` как открытую позицию."""
+
+    async with _lock:
+        if _state.paused:
+            return False
+        if _state.open_positions >= _limits.max_open_positions:
+            return False
+        if _state.total_notional + notional > _limits.deposit_cap:
+            return False
+        if _state.total_notional + notional > _limits.max_position_size:
+            return False
+        if _state.daily_loss >= _limits.max_daily_loss:
+            return False
+        if symbol in _state.open_symbols:
+            return False
+        _state.open_symbols.add(symbol)
+        _state.open_positions = len(_state.open_symbols)
+        return True
+
+
 async def update_position(delta_notional: Decimal) -> None:
     """Обновляет учёт текущей нагрузки на депозит на ``delta_notional`` USD."""
 

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -505,6 +505,7 @@ async def save_positions(path: Path | str | None = None) -> None:
                     pass
 
 
+
 async def open_neutral_position(
     exchange: BaseExchange, symbol: str, quantity: Decimal
 ) -> Dict[str, Dict]:
@@ -529,101 +530,103 @@ async def open_neutral_position(
     max_trade = deposit * deposit_pct
     if notional > deposit or notional > max_trade:
         raise RuntimeError("Размер сделки превышает лимиты депозита")
-    if not await risk_control.can_open_position(notional) or await risk_control.is_symbol_open(symbol):
+    if not await risk_control.try_open_position(symbol, notional):
         raise RuntimeError(
             "Превышены лимиты риска, торговля приостановлена или позиция уже открыта"
         )
-    # Хеджируем позицию на споте и фьючерсе
-    spot_order = await exchange.place_spot_order(symbol, "BUY", float(quantity))
-    spot_id = str(spot_order.get("orderId") or spot_order.get("id") or "")
-    if not await _wait_filled(exchange, spot_id):
-        await exchange.cancel_order(symbol, spot_id)
-        raise RuntimeError("Спотовый ордер выполнен частично")
-
     try:
-        perp_order = await exchange.place_order(symbol, "SELL", float(quantity))
-    except Exception as exc:
-        # При ошибке размещения второй ноги отменяем первую
-        await exchange.cancel_order(symbol, spot_id)
-        raise RuntimeError(
-            "Не удалось разместить хедж; спотовый ордер отменён"
-        ) from exc
-    perp_id = str(perp_order.get("orderId") or perp_order.get("id") or "")
-    if not await _wait_filled(exchange, perp_id):
-        await exchange.cancel_order(symbol, perp_id)
-        # Откатываем спотовую позицию
+        # Хеджируем позицию на споте и фьючерсе
+        spot_order = await exchange.place_spot_order(symbol, "BUY", float(quantity))
+        spot_id = str(spot_order.get("orderId") or spot_order.get("id") or "")
+        if not await _wait_filled(exchange, spot_id):
+            await exchange.cancel_order(symbol, spot_id)
+            raise RuntimeError("Спотовый ордер выполнен частично")
         try:
-            rollback_order = await exchange.place_spot_order(
-                symbol, "SELL", float(quantity)
-            )
-            rollback_id = str(
-                rollback_order.get("orderId")
-                or rollback_order.get("id")
-                or ""
-            )
-            if not await _wait_filled(exchange, rollback_id):
-                logger.error(
-                    "Откат спотовой позиции %s исполнен частично", rollback_id
-                )
-                raise RuntimeError(
-                    "Не удалось полностью откатить спотовую позицию"
-                )
+            perp_order = await exchange.place_order(symbol, "SELL", float(quantity))
         except Exception as exc:
-            logger.error("Ошибка отката спотовой позиции: %s", exc)
+            # При ошибке размещения второй ноги отменяем первую
+            await exchange.cancel_order(symbol, spot_id)
             raise RuntimeError(
-                "Не удалось откатить спотовую позицию"
+                "Не удалось разместить хедж; спотовый ордер отменён"
             ) from exc
-        raise RuntimeError(
-            "Не удалось полностью захеджировать позицию; спот откатан"
+        perp_id = str(perp_order.get("orderId") or perp_order.get("id") or "")
+        if not await _wait_filled(exchange, perp_id):
+            await exchange.cancel_order(symbol, perp_id)
+            # Откатываем спотовую позицию
+            try:
+                rollback_order = await exchange.place_spot_order(
+                    symbol, "SELL", float(quantity)
+                )
+                rollback_id = str(
+                    rollback_order.get("orderId")
+                    or rollback_order.get("id")
+                    or ""
+                )
+                if not await _wait_filled(exchange, rollback_id):
+                    logger.error(
+                        "Откат спотовой позиции %s исполнен частично", rollback_id
+                    )
+                    raise RuntimeError(
+                        "Не удалось полностью откатить спотовую позицию"
+                    )
+            except Exception as exc:
+                logger.error("Ошибка отката спотовой позиции: %s", exc)
+                raise RuntimeError(
+                    "Не удалось откатить спотовую позицию"
+                ) from exc
+            raise RuntimeError(
+                "Не удалось полностью захеджировать позицию; спот откатан"
+            )
+        orders = {"spot": spot_order, "perp": perp_order}
+        commission = sum(Decimal(str(o.get("fee", 0.0))) for o in orders.values())
+        now = time.time()
+        async with positions_lock:
+            await risk_control.update_position(notional)
+            positions[symbol] = Position(
+                entry_timestamp=now,
+                entry_futures_price=entry_metrics.futures_price,
+                entry_spot_price=entry_metrics.spot_price,
+                entry_basis=entry_metrics.basis,
+                entry_funding=float(entry_metrics.funding_rate),
+                quantity=float(quantity),
+                initial_quantity=float(quantity),
+                pnl=Decimal(0),
+                funding_accrued=Decimal(0),
+                commissions=commission,
+                last_funding_timestamp=now,
+                exchange=exchange_name,
+            )
+            await save_positions()
+        volume_usd = float(notional)
+        await log_trade(
+            {
+                "symbol": symbol,
+                "exchange": exchange_name,
+                "entry_time": datetime.fromtimestamp(now).isoformat(),
+                "exit_time": None,
+                "entry_futures_price": entry_metrics.futures_price,
+                "exit_futures_price": None,
+                "entry_spot_price": entry_metrics.spot_price,
+                "exit_spot_price": None,
+                "entry_basis": entry_metrics.basis,
+                "exit_basis": None,
+                "basis_pct": entry_metrics.basis,
+                "funding": entry_metrics.funding_rate,
+                "quantity": float(quantity),
+                "volume_usd": volume_usd,
+                "pnl": 0.0,
+                "pnl_pct": 0.0,
+                "commissions": float(commission),
+                "funding_accrued": 0.0,
+                "slippage": entry_metrics.slippage,
+                "exit_reasons": None,
+                "notes": "open",
+            }
         )
-    orders = {"spot": spot_order, "perp": perp_order}
-    commission = sum(Decimal(str(o.get("fee", 0.0))) for o in orders.values())
-    now = time.time()
-    async with positions_lock:
-        await risk_control.update_position(notional)
-        await risk_control.mark_symbol_open(symbol)
-        positions[symbol] = Position(
-            entry_timestamp=now,
-            entry_futures_price=entry_metrics.futures_price,
-            entry_spot_price=entry_metrics.spot_price,
-            entry_basis=entry_metrics.basis,
-            entry_funding=float(entry_metrics.funding_rate),
-            quantity=float(quantity),
-            initial_quantity=float(quantity),
-            pnl=Decimal(0),
-            funding_accrued=Decimal(0),
-            commissions=commission,
-            last_funding_timestamp=now,
-            exchange=exchange_name,
-        )
-        await save_positions()
-    volume_usd = float(notional)
-    await log_trade(
-        {
-            "symbol": symbol,
-            "exchange": exchange_name,
-            "entry_time": datetime.fromtimestamp(now).isoformat(),
-            "exit_time": None,
-            "entry_futures_price": entry_metrics.futures_price,
-            "exit_futures_price": None,
-            "entry_spot_price": entry_metrics.spot_price,
-            "exit_spot_price": None,
-            "entry_basis": entry_metrics.basis,
-            "exit_basis": None,
-            "basis_pct": entry_metrics.basis,
-            "funding": entry_metrics.funding_rate,
-            "quantity": float(quantity),
-            "volume_usd": volume_usd,
-            "pnl": 0.0,
-            "pnl_pct": 0.0,
-            "commissions": float(commission),
-            "funding_accrued": 0.0,
-            "slippage": entry_metrics.slippage,
-            "exit_reasons": None,
-            "notes": "open",
-        }
-    )
-    return orders
+        return orders
+    except Exception:
+        await risk_control.mark_symbol_closed(symbol)
+        raise
 
 
 async def close_neutral_position(

--- a/tests/test_cancel_first_leg.py
+++ b/tests/test_cancel_first_leg.py
@@ -78,16 +78,12 @@ async def test_cancel_first_leg_on_second_failure(monkeypatch: pytest.MonkeyPatc
     async def _true(*args, **kwargs):
         return True
 
-    async def _false(*args, **kwargs):
-        return False
-
     async def _noop(*args, **kwargs):
         return None
 
-    monkeypatch.setattr(fa.risk_control, "can_open_position", _true)
-    monkeypatch.setattr(fa.risk_control, "is_symbol_open", _false)
+    monkeypatch.setattr(fa.risk_control, "try_open_position", _true)
     monkeypatch.setattr(fa.risk_control, "update_position", _noop)
-    monkeypatch.setattr(fa.risk_control, "mark_symbol_open", _noop)
+    monkeypatch.setattr(fa.risk_control, "mark_symbol_closed", _noop)
 
     metrics = fa.MarketMetrics(
         funding_rate=Decimal("0"),

--- a/tests/test_missing_metrics.py
+++ b/tests/test_missing_metrics.py
@@ -68,10 +68,9 @@ async def test_open_neutral_position_skips_when_no_metrics(monkeypatch: pytest.M
 
     monkeypatch.setattr(fa, "CONFIG", {"bot": {}, "thresholds": {}})
     monkeypatch.setattr(fa, "WHITELISTS", {exchange.name: ["BTCUSDT"]})
-    monkeypatch.setattr(fa.risk_control, "can_open_position", lambda *_: True)
-    monkeypatch.setattr(fa.risk_control, "is_symbol_open", lambda *_: False)
+    monkeypatch.setattr(fa.risk_control, "try_open_position", lambda *_: True)
     monkeypatch.setattr(fa.risk_control, "update_position", lambda *_: None)
-    monkeypatch.setattr(fa.risk_control, "mark_symbol_open", lambda *_: None)
+    monkeypatch.setattr(fa.risk_control, "mark_symbol_closed", lambda *_: None)
 
     async def _metrics_none(symbol: str, trade_size: float, exchange: BaseExchange) -> fa.MarketMetrics | None:
         return None

--- a/tests/test_partial_fill.py
+++ b/tests/test_partial_fill.py
@@ -88,10 +88,9 @@ async def test_open_neutral_position_partial_fill(monkeypatch: pytest.MonkeyPatc
     async def _noop(*args, **kwargs):
         return None
 
-    monkeypatch.setattr(fa.risk_control, "can_open_position", _true)
-    monkeypatch.setattr(fa.risk_control, "is_symbol_open", _false)
+    monkeypatch.setattr(fa.risk_control, "try_open_position", _true)
     monkeypatch.setattr(fa.risk_control, "update_position", _noop)
-    monkeypatch.setattr(fa.risk_control, "mark_symbol_open", _noop)
+    monkeypatch.setattr(fa.risk_control, "mark_symbol_closed", _noop)
 
     metrics = fa.MarketMetrics(
         funding_rate=Decimal("0"),

--- a/tests/test_risk_control.py
+++ b/tests/test_risk_control.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 from risk import risk_control as rc
 from decimal import Decimal
@@ -85,3 +86,14 @@ async def test_daily_loss_resets_after_24h_is_paused(monkeypatch):
     await rc.is_paused()
     assert rc._state.daily_loss == Decimal("0")
     assert rc._state.last_reset_ts == now + 24 * 3600 + 1
+
+
+@pytest.mark.asyncio
+async def test_try_open_position_atomic():
+    rc._state = rc.RiskState()
+    async def attempt():
+        return await rc.try_open_position("BTCUSDT", Decimal("1"))
+    results = await asyncio.gather(attempt(), attempt())
+    assert sum(results) == 1
+    assert await rc.is_symbol_open("BTCUSDT")
+    await rc.mark_symbol_closed("BTCUSDT")


### PR DESCRIPTION
## Summary
- add try_open_position to atomically verify limits and mark a symbol open
- rely on try_open_position in open_neutral_position and ensure cleanup on failure
- cover concurrent position attempts with new risk control test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3a69e48c8320a03983c6af3cdc05