### PR TITLE
Handle invalid deposit values and trade limits

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List
 from decimal import Decimal
+import math
 
 import yaml
 from dotenv import load_dotenv
@@ -240,7 +241,12 @@ def start_processing_loops() -> None:
         """Постоянно сканирует рынок в поиске входов."""
         while True:
             thresholds = CONFIG.get("thresholds", {})
-            deposit = CONFIG.get("bot", {}).get("deposit_size", float("inf"))
+            deposit_raw = CONFIG.get("bot", {}).get("deposit_size", float("inf"))
+            deposit = float(deposit_raw)
+            if not math.isfinite(deposit) or deposit < 0:
+                logger.error("Некорректное значение депозита: %s", deposit_raw)
+                await asyncio.sleep(poll_interval)
+                continue
             deposit_pct_raw = thresholds.get("deposit_pct", 0.05)
             deposit_pct = max(0.0, min(1.0, deposit_pct_raw))
             min_trade_usd = thresholds.get("min_trade_size", float("inf"))
@@ -254,7 +260,7 @@ def start_processing_loops() -> None:
                 continue
             # Торгуем не меньше минимального порога: выбираем большую величину
             trade_value = max(min_trade_usd, deposit * deposit_pct)
-            if trade_value in (0.0, float("inf")):
+            if not math.isfinite(trade_value) or trade_value <= 0:
                 logger.error(
                     "Некорректное значение trade_value: %s", trade_value
                 )

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -520,7 +520,11 @@ async def open_neutral_position(
     if entry_metrics is None:
         raise RuntimeError("Рыночные метрики недоступны, сделка пропущена")
     notional = quantity * Decimal(str(entry_metrics.futures_price))
-    deposit = Decimal(str(bot_cfg.get("deposit_size", "Infinity")))
+    deposit_raw = bot_cfg.get("deposit_size", "Infinity")
+    deposit = Decimal(str(deposit_raw))
+    if not deposit.is_finite() or deposit < 0:
+        logger.error("Некорректное значение депозита: %s", deposit_raw)
+        raise RuntimeError("Некорректное значение депозита")
     deposit_pct = Decimal(str(CONFIG.get("thresholds", {}).get("deposit_pct", 1.0)))
     if deposit_pct < 0:
         logger.warning("Некорректное значение deposit_pct=%s; устанавливаем 0", deposit_pct)

--- a/tests/test_cancel_first_leg.py
+++ b/tests/test_cancel_first_leg.py
@@ -73,7 +73,7 @@ class SecondLegFailExchange(BaseExchange):
 async def test_cancel_first_leg_on_second_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     exchange = SecondLegFailExchange()
 
-    monkeypatch.setattr(fa, "CONFIG", {"bot": {}, "thresholds": {}})
+    monkeypatch.setattr(fa, "CONFIG", {"bot": {"deposit_size": 1000}, "thresholds": {}})
     monkeypatch.setattr(fa, "WHITELISTS", {exchange.name: ["BTCUSDT"]})
     async def _true(*args, **kwargs):
         return True

--- a/tests/test_invalid_deposit_open_position.py
+++ b/tests/test_invalid_deposit_open_position.py
@@ -1,0 +1,98 @@
+import pathlib
+import sys
+import types
+import logging
+from decimal import Decimal
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+# Stub sklearn to avoid heavy dependency
+linear_model_stub = types.SimpleNamespace(LinearRegression=object)
+sklearn_stub = types.SimpleNamespace(linear_model=linear_model_stub)
+sys.modules.setdefault("sklearn", sklearn_stub)
+sys.modules.setdefault("sklearn.linear_model", linear_model_stub)
+
+from strategies import funding_arbitrage as fa
+from exchanges import BaseExchange
+
+
+class DummyExchange(BaseExchange):
+    name = "stub"
+
+    def __init__(self) -> None:
+        self.orders: list[tuple[str, str, float]] = []
+
+    async def fetch_funding(self, symbol: str) -> float:
+        return 0.0
+
+    async def place_order(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
+        self.orders.append(("perp", side, quantity))
+        return {"id": "perp1"}
+
+    async def get_orderbook(self, symbol: str, depth: int = 5) -> dict:
+        return {}
+
+    async def get_balance(self) -> dict:
+        return {}
+
+    async def place_spot_order(self, symbol: str, side: str, quantity: float, price: float | None = None) -> dict:
+        self.orders.append(("spot", side, quantity))
+        return {"id": "spot1"}
+
+    async def get_spot_orderbook(self, symbol: str, depth: int = 5) -> dict:
+        return {}
+
+    async def get_spot_balance(self) -> dict:
+        return {}
+
+    async def fetch_funding_history(self, symbol: str, hours: int = 8, limit: int = 3) -> list[float]:
+        return []
+
+    async def get_stats(self, symbol: str) -> dict:
+        return {"volume_24h": 0, "open_interest": 0}
+
+    async def get_futures_symbols(self) -> list[str]:
+        return []
+
+    async def get_spot_symbols(self) -> list[str]:
+        return []
+
+    async def get_ohlc(self, symbol: str, interval: str = "15m", limit: int = 1) -> list[dict]:
+        return [{"open": 0, "close": 0, "high": 0, "low": 0}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("deposit", [float("inf"), -100])
+async def test_open_neutral_position_rejects_invalid_deposit(monkeypatch, caplog, deposit):
+    exchange = DummyExchange()
+
+    metrics = fa.MarketMetrics(
+        funding_rate=Decimal("0"),
+        spread=Decimal("0"),
+        liquidity=Decimal("0"),
+        volatility=0.0,
+        spot_price=Decimal("100"),
+        futures_price=Decimal("100"),
+        volume=Decimal("0"),
+        open_interest=Decimal("0"),
+        spot_slippage=0.0,
+        futures_slippage=0.0,
+        slippage=0.0,
+        basis=0.0,
+    )
+
+    async def _metrics(symbol: str, trade_size: float, exch: BaseExchange):
+        return metrics
+
+    monkeypatch.setattr(fa, "CONFIG", {"bot": {"deposit_size": deposit}, "thresholds": {}})
+    monkeypatch.setattr(fa, "WHITELISTS", {exchange.name: ["BTCUSDT"]})
+    monkeypatch.setattr(fa, "get_market_metrics", _metrics)
+
+    caplog.set_level(logging.ERROR)
+    with pytest.raises(RuntimeError):
+        await fa.open_neutral_position(exchange, "BTCUSDT", Decimal("1"))
+
+    assert "Некорректное значение депозита" in caplog.text
+    assert exchange.orders == []

--- a/tests/test_invalid_trade_config.py
+++ b/tests/test_invalid_trade_config.py
@@ -84,5 +84,5 @@ def test_no_trade_on_invalid_config(monkeypatch, caplog):
     with pytest.raises(asyncio.CancelledError):
         asyncio.run(scan_coro)
 
-    assert "Некорректное значение trade_value" in caplog.text
+    assert "Некорректное значение депозита" in caplog.text
     strategy_stub.get_market_metrics.assert_not_called()

--- a/tests/test_partial_fill.py
+++ b/tests/test_partial_fill.py
@@ -77,7 +77,7 @@ async def test_open_neutral_position_partial_fill(monkeypatch: pytest.MonkeyPatc
     exchange = PartialFillExchange()
 
     # Настраиваем окружение
-    monkeypatch.setattr(fa, "CONFIG", {"bot": {}, "thresholds": {}})
+    monkeypatch.setattr(fa, "CONFIG", {"bot": {"deposit_size": 1000}, "thresholds": {}})
     monkeypatch.setattr(fa, "WHITELISTS", {exchange.name: ["BTCUSDT"]})
     async def _true(*args, **kwargs):
         return True


### PR DESCRIPTION
## Summary
- validate deposit size in `open_neutral_position` to reject non-finite or negative values
- guard scan loop against invalid deposit and trade values
- add tests covering invalid deposit scenarios

## Testing
- `pytest tests/test_invalid_deposit_open_position.py tests/test_cancel_first_leg.py tests/test_partial_fill.py tests/test_invalid_trade_config.py tests/test_missing_metrics.py tests/test_decimal_metrics.py::test_get_market_metrics_decimal -q`

------
https://chatgpt.com/codex/tasks/task_e_688f5dc1ae8c832096e29569d8cb02f4