### PR TITLE
Clear order cache after status retrieval and cancellation

### DIFF
--- a/exchanges/binance.py
+++ b/exchanges/binance.py
@@ -174,16 +174,18 @@ class BinanceExchange(BaseExchange):
         params = self._sign(params)
         url = f"{self.REST_URL}/fapi/v1/order"
         try:
-            return await self._request("GET", url, params=params, headers=headers)
+            data = await self._request("GET", url, params=params, headers=headers)
         except aiohttp.ClientError:
             spot_url = f"{self.SPOT_REST_URL}/api/v3/order"
             params = {"orderId": order_id}
             if symbol:
                 params["symbol"] = symbol
             params = self._sign(params)
-            return await self._request(
+            data = await self._request(
                 "GET", spot_url, params=params, headers=headers
             )
+        self._order_symbols.pop(order_id, None)
+        return data
 
     async def cancel_order(self, symbol: str, order_id: str) -> dict:
         """Отменяет ордер по ``order_id`` для указанного ``symbol``.
@@ -197,12 +199,14 @@ class BinanceExchange(BaseExchange):
         params = self._sign({"symbol": symbol, "orderId": order_id})
         url = f"{self.REST_URL}/fapi/v1/order"
         try:
-            return await self._request("DELETE", url, params=params, headers=headers)
+            data = await self._request("DELETE", url, params=params, headers=headers)
         except aiohttp.ClientError:
             # Попытка отменить спотовый ордер
             spot_url = f"{self.SPOT_REST_URL}/api/v3/order"
             params = self._sign({"symbol": symbol, "orderId": order_id})
-            return await self._request("DELETE", spot_url, params=params, headers=headers)
+            data = await self._request("DELETE", spot_url, params=params, headers=headers)
+        self._order_symbols.pop(order_id, None)
+        return data
 
     async def get_balance(self) -> dict:
         """Возвращает баланс фьючерсного аккаунта."""

--- a/tests/test_order_status_cache.py
+++ b/tests/test_order_status_cache.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from exchanges.binance import BinanceExchange
+
+
+@pytest.mark.asyncio
+async def test_get_order_status_clears_cache(monkeypatch):
+    exchange = BinanceExchange(api_key="key", api_secret="secret")
+    exchange._order_symbols["1"] = "BTCUSDT"
+
+    async def fake_request(method, url, retries=3, **kwargs):
+        return {"status": "FILLED"}
+
+    monkeypatch.setattr(exchange, "_request", fake_request)
+
+    result = await exchange.get_order_status("1")
+    assert result["status"] == "FILLED"
+    assert exchange._order_symbols == {}


### PR DESCRIPTION
## Summary
- Clear cached order symbols after fetching status or cancelling orders in BinanceExchange
- Add regression test ensuring cache is emptied after status request

## Testing
- `pytest tests/test_order_status_cache.py`


------
https://chatgpt.com/codex/tasks/task_e_688f5e4f00488320b561b003e1ce51a7