### PR TITLE
Return final Position for exits

### DIFF
--- a/main.py
+++ b/main.py
@@ -133,6 +133,90 @@ def initialize_bot() -> None:
     risk_control.configure(CONFIG.get("risk", {}), bot_cfg.get("deposit_size"))
 
 
+async def monitor_position(exchange_name: str, symbol: str, quantity: float) -> None:
+    """Следит за открытой позицией до срабатывания условий выхода."""
+    poll_interval = CONFIG.get("bot", {}).get("poll_interval", 5)
+    exchange = CLIENTS[exchange_name]
+    position_id = f"{exchange_name}:{symbol}"
+    entry: strategy.Position | None = None
+    try:
+        entry = await strategy.monitor_neutral_position(
+            exchange,
+            symbol,
+            quantity,
+            CONFIG.get("thresholds", {}),
+            poll_interval,
+            position_id=position_id,
+        )
+    except Exception as exc:
+        entry = entry or strategy.positions.get(symbol)
+        entry_ts = entry.entry_timestamp if entry else time.time()
+        hold = time.time() - entry_ts
+        funding_pct = (entry.entry_funding if entry else 0.0) * 100
+        basis_pct = entry.entry_basis if entry else 0.0
+        volume_usd = (
+            entry.entry_futures_price * entry.initial_quantity if entry else 0.0
+        )
+        asyncio.create_task(
+            notify_close(
+                position_id,
+                (
+                    f"Ошибка на {exchange_name} {symbol}: {exc}\n"
+                    f"Фандинг: {funding_pct:.4f}%\n"
+                    f"Базис: {basis_pct:.4f}%\n"
+                    f"Объём: ${float(volume_usd):.2f}\n"
+                    f"Время в позиции: {format_duration(hold)}"
+                ),
+            )
+        )
+        raise
+    else:
+        if entry is None:
+            entry = strategy.positions.get(symbol)
+        pnl = float(entry.pnl) if entry else 0.0
+        reasons = entry.exit_reasons if entry else []
+        exit_ts = entry.exit_timestamp if entry else 0
+        hold = exit_ts - (entry.entry_timestamp if entry else 0)
+        funding_rate = (
+            entry.exit_funding
+            if entry and entry.exit_funding is not None
+            else (entry.entry_funding if entry else 0.0)
+        )
+        funding_pct = funding_rate * 100
+        basis_pct = entry.exit_basis if entry else 0.0
+        volume_usd = (
+            entry.entry_futures_price * entry.initial_quantity if entry else 0.0
+        )
+        pnl_pct = (pnl / volume_usd * 100) if volume_usd else 0.0
+        asyncio.create_task(
+            notify_close(
+                position_id,
+                (
+                    f"Закрыта {symbol} на {exchange_name}\n"
+                    f"Фандинг: {funding_pct:.4f}%\n"
+                    f"Базис: {basis_pct:.4f}%\n"
+                    f"Объём: ${float(volume_usd):.2f}\n"
+                    f"Время в позиции: {format_duration(hold)}\n"
+                    f"PnL: {pnl:.4f} ({pnl_pct:.4f}%) Причины: {reasons}"
+                ),
+            )
+        )
+    finally:
+        entry_final = entry or strategy.positions.get(symbol)
+        notional = (
+            Decimal(str(entry_final.entry_futures_price))
+            * Decimal(str(entry_final.initial_quantity))
+            if entry_final
+            else Decimal("0")
+        )
+        await risk_control.update_position(-notional)
+        await risk_control.mark_symbol_closed(symbol)
+        if position_id in POSITION_TASKS:
+            del POSITION_TASKS[position_id]
+        if strategy.positions.pop(symbol, None) is not None:
+            await strategy.save_positions()
+
+
 def start_processing_loops() -> None:
     """Запускает циклы стратегии, рисков и оптимизации параметров."""
 
@@ -145,96 +229,6 @@ def start_processing_loops() -> None:
         """Обновляет пороги стратегии новыми значениями."""
         if new:
             CONFIG.setdefault("thresholds", {}).update(new)
-
-    async def monitor_position(
-        exchange_name: str, symbol: str, quantity: float
-    ) -> None:
-        """Следит за открытой позицией до срабатывания условий выхода."""
-        exchange = CLIENTS[exchange_name]
-        position_id = f"{exchange_name}:{symbol}"
-        try:
-            await strategy.monitor_neutral_position(
-                exchange,
-                symbol,
-                quantity,
-                CONFIG.get("thresholds", {}),
-                poll_interval,
-                position_id=position_id,
-            )
-        except Exception as exc:
-            # При ошибке закрываем позицию и уведомляем
-            entry = strategy.positions.get(symbol)
-            entry_ts = entry.entry_timestamp if entry else time.time()
-            hold = time.time() - entry_ts
-            funding_pct = (entry.entry_funding if entry else 0.0) * 100
-            basis_pct = entry.entry_basis if entry else 0.0
-            volume_usd = (
-                entry.entry_futures_price * entry.initial_quantity
-                if entry
-                else 0.0
-            )
-            asyncio.create_task(
-                notify_close(
-                    position_id,
-                    (
-                        f"Ошибка на {exchange_name} {symbol}: {exc}\n"
-                        f"Фандинг: {funding_pct:.4f}%\n"
-                        f"Базис: {basis_pct:.4f}%\n"
-                        f"Объём: ${float(volume_usd):.2f}\n"
-                        f"Время в позиции: {format_duration(hold)}"
-                    ),
-                )
-            )
-            raise
-        else:
-            # Успешное завершение позиции
-            entry = strategy.positions.get(symbol)
-            pnl = float(entry.pnl) if entry else 0.0
-            reasons = entry.exit_reasons if entry else []
-            exit_ts = entry.exit_timestamp if entry else 0
-            hold = exit_ts - (entry.entry_timestamp if entry else 0)
-            funding_rate = (
-                entry.exit_funding
-                if entry and entry.exit_funding is not None
-                else (entry.entry_funding if entry else 0.0)
-            )
-            funding_pct = funding_rate * 100
-            basis_pct = entry.exit_basis if entry else 0.0
-            volume_usd = (
-                entry.entry_futures_price * entry.initial_quantity
-                if entry
-                else 0.0
-            )
-            pnl_pct = (pnl / volume_usd * 100) if volume_usd else 0.0
-            asyncio.create_task(
-                notify_close(
-                    position_id,
-                    (
-                        f"Закрыта {symbol} на {exchange_name}\n"
-                        f"Фандинг: {funding_pct:.4f}%\n"
-                        f"Базис: {basis_pct:.4f}%\n"
-                        f"Объём: ${float(volume_usd):.2f}\n"
-                        f"Время в позиции: {format_duration(hold)}\n"
-                        f"PnL: {pnl:.4f} ({pnl_pct:.4f}%) Причины: {reasons}"
-                    ),
-                )
-            )
-        finally:
-            # Снимаем нагрузку по рискам и удаляем задачу из списка активных
-            entry = strategy.positions.get(symbol)
-            notional = (
-                Decimal(str(entry.entry_futures_price))
-                * Decimal(str(entry.initial_quantity))
-                if entry
-                else Decimal("0")
-            )
-            await risk_control.update_position(-notional)
-            await risk_control.mark_symbol_closed(symbol)
-            # Удаляем задачу из списка активных
-            if position_id in POSITION_TASKS:
-                del POSITION_TASKS[position_id]
-            if strategy.positions.pop(symbol, None) is not None:
-                await strategy.save_positions()
 
     async def scan_loop() -> None:
         """Постоянно сканирует рынок в поиске входов."""

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -720,7 +720,7 @@ async def monitor_neutral_position(
     exit_thresholds: Dict[str, float],
     poll_interval: float = 5.0,
     position_id: str | None = None,
-) -> None:
+) -> Position | None:
     """Следит за позицией и закрывает её при срабатывании условий выхода.
 
     В качестве одного из критериев используется ``exit_basis`` – предельное
@@ -926,7 +926,7 @@ async def monitor_neutral_position(
                         "notes": None,
                     }
                 )
-            break
+            return entry
         await asyncio.sleep(poll_interval)
 
 

--- a/tests/test_monitor_position_message.py
+++ b/tests/test_monitor_position_message.py
@@ -1,0 +1,114 @@
+import pathlib
+import sys
+import types
+from dataclasses import dataclass, field
+from decimal import Decimal
+import importlib
+import asyncio
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+
+@pytest.mark.asyncio
+async def test_monitor_position_final_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Stub heavy dependency sklearn
+    linear_model_stub = types.SimpleNamespace(LinearRegression=object)
+    sklearn_stub = types.SimpleNamespace(linear_model=linear_model_stub)
+    monkeypatch.setitem(sys.modules, "sklearn", sklearn_stub)
+    monkeypatch.setitem(sys.modules, "sklearn.linear_model", linear_model_stub)
+
+    # Stub strategy module
+    @dataclass
+    class Position:
+        entry_timestamp: float
+        entry_futures_price: float
+        entry_spot_price: float
+        entry_basis: float
+        entry_funding: float
+        quantity: float
+        initial_quantity: float
+        pnl: Decimal = Decimal(0)
+        exit_reasons: list[str] = field(default_factory=list)
+        exit_timestamp: float = 0.0
+        exit_funding: float | None = None
+        exit_basis: float | None = None
+
+    prepared = Position(
+        entry_timestamp=0.0,
+        entry_futures_price=100.0,
+        entry_spot_price=100.0,
+        entry_basis=0.0,
+        entry_funding=0.001,
+        quantity=1.0,
+        initial_quantity=1.0,
+        pnl=Decimal("2"),
+        exit_reasons=["threshold"],
+        exit_timestamp=10.0,
+        exit_funding=0.0015,
+        exit_basis=0.5,
+    )
+
+    async def monitor_neutral_position(*args, **kwargs):
+        return prepared
+
+    async def save_positions():
+        return None
+
+    strategy_stub = types.SimpleNamespace(
+        monitor_neutral_position=monitor_neutral_position,
+        positions={},
+        save_positions=save_positions,
+        Position=Position,
+    )
+    monkeypatch.setitem(sys.modules, "strategies.funding_arbitrage", strategy_stub)
+
+    # Stub risk control
+    async def _noop(*args, **kwargs):
+        return None
+
+    risk_control_stub = types.SimpleNamespace(
+        update_position=_noop,
+        mark_symbol_closed=_noop,
+        is_paused=lambda: False,
+        is_symbol_open=lambda symbol: False,
+    )
+    risk_pkg = types.SimpleNamespace(risk_control=risk_control_stub)
+    monkeypatch.setitem(sys.modules, "risk", risk_pkg)
+    monkeypatch.setitem(sys.modules, "risk.risk_control", risk_control_stub)
+
+    # Stub parameter optimizer
+    async def _noop_opt(*args, **kwargs):
+        return None
+
+    monkeypatch.setitem(
+        sys.modules,
+        "ai.parameter_optimizer",
+        types.SimpleNamespace(periodic_optimization=_noop_opt),
+    )
+
+    main = importlib.reload(importlib.import_module("main"))
+
+    main.CONFIG = {"thresholds": {}, "bot": {}}
+    main.CLIENTS = {"stub": object()}
+
+    messages: list[tuple[str, str]] = []
+
+    async def _capture(position_id: str, text: str) -> None:
+        messages.append((position_id, text))
+
+    monkeypatch.setattr(main, "notify_close", _capture)
+
+    await main.monitor_position("stub", "BTCUSDT", 1.0)
+    await asyncio.sleep(0)  # allow notify_close task to run
+
+    assert messages, "notify_close was not called"
+    position_id, text = messages[0]
+    assert position_id == "stub:BTCUSDT"
+    assert "Закрыта BTCUSDT на stub" in text
+    assert "Фандинг: 0.1500%" in text
+    assert "Базис: 0.5000%" in text
+    assert "Объём: $100.00" in text
+    assert "Время в позиции: 10s" in text
+    assert "PnL: 2.0000 (2.0000%) Причины: ['threshold']" in text


### PR DESCRIPTION
## Summary
- let `monitor_neutral_position` return a fully populated `Position` on final exit
- update `monitor_position` to consume returned `Position` for closing notifications
- add regression test to verify final Telegram message contents

## Testing
- `pytest tests/test_monitor_position_message.py -q`
- `pytest -q` *(fails: interrupted after ~2m30s)*

------
https://chatgpt.com/codex/tasks/task_e_688f5ced5ba88320a2cad61b21c431a2