### PR TITLE
Add background task runner with logging

### DIFF
--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -188,7 +188,7 @@ async def _handle_timeout() -> None:
             from main import CLIENTS, POSITION_TASKS
             from strategies import funding_arbitrage as strategy
             from utils.logger import log_trade
-            from utils.telegram import notify_close, format_duration
+            from utils.telegram import notify_close, format_duration, run_background
             from datetime import datetime
         except Exception as exc:  # pragma: no cover - defensive
             logger.error("Не удалось подготовить аварийное закрытие: %s", exc)
@@ -219,7 +219,7 @@ async def _handle_timeout() -> None:
                         funding_pct = entry.get("entry_funding", 0.0) * 100
                         basis_pct = entry.get("entry_basis", 0.0)
                         volume_usd = quantity * entry.get("entry_futures_price", 0.0)
-                        asyncio.create_task(
+                        run_background(
                             notify_close(
                                 pid,
                                 (
@@ -283,7 +283,7 @@ async def _handle_timeout() -> None:
                         )
                         hold_time = exit_ts - entry.get("entry_timestamp", exit_ts)
                         funding_pct = entry.get("entry_funding", 0.0) * 100
-                        asyncio.create_task(
+                        run_background(
                             notify_close(
                                 pid,
                                 (

--- a/main.py
+++ b/main.py
@@ -24,7 +24,12 @@ from exchanges.bybit import BybitExchange
 from risk import risk_control
 from strategies import funding_arbitrage as strategy
 from ai.parameter_optimizer import periodic_optimization
-from utils.telegram import format_duration, notify_close, notify_open
+from utils.telegram import (
+    format_duration,
+    notify_close,
+    notify_open,
+    run_background,
+)
 
 load_dotenv()
 
@@ -173,7 +178,7 @@ def start_processing_loops() -> None:
                 if entry
                 else 0.0
             )
-            asyncio.create_task(
+            run_background(
                 notify_close(
                     position_id,
                     (
@@ -206,7 +211,7 @@ def start_processing_loops() -> None:
                 else 0.0
             )
             pnl_pct = (pnl / volume_usd * 100) if volume_usd else 0.0
-            asyncio.create_task(
+            run_background(
                 notify_close(
                     position_id,
                     (
@@ -302,7 +307,7 @@ def start_processing_loops() -> None:
                         try:
                             await strategy.open_neutral_position(client, symbol, quantity)
                             volume_usd = quantity * Decimal(str(metrics.futures_price))
-                            asyncio.create_task(
+                            run_background(
                                 notify_open(
                                     f"{name}:{symbol}",
                                     (

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -27,7 +27,7 @@ from risk import risk_control
 from ai.parameter_optimizer import load_thresholds as _load_thresholds
 from main import CONFIG, WHITELISTS
 from utils.logger import log_trade
-from utils.telegram import format_duration, notify_partial_close
+from utils.telegram import format_duration, notify_partial_close, run_background
 
 
 DEFAULT_POSITIONS_FILE = "open_positions.json"
@@ -860,7 +860,7 @@ async def monitor_neutral_position(
                     pnl_pct_total = (
                         pnl_total / total_volume * 100 if total_volume != 0 else Decimal(0)
                     )
-                    asyncio.create_task(
+                    run_background(
                         notify_partial_close(
                             position_id,
                             (

--- a/tests/test_telegram_logging.py
+++ b/tests/test_telegram_logging.py
@@ -1,0 +1,25 @@
+import asyncio
+import pathlib
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from utils import telegram
+
+
+@pytest.mark.asyncio
+async def test_run_background_logs_notification_exception(monkeypatch):
+    async def failing_notify():
+        raise RuntimeError("boom")
+
+    mock_exc = Mock()
+    monkeypatch.setattr(telegram.logger, "exception", mock_exc)
+
+    telegram.run_background(failing_notify())
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    mock_exc.assert_called_once_with("Background task failed")

--- a/utils/telegram.py
+++ b/utils/telegram.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import os
-from typing import Dict, Optional
+from typing import Any, Awaitable, Dict, Optional
 
 from aiogram import Bot
 from aiogram.exceptions import TelegramAPIError
@@ -18,6 +18,21 @@ logger = logging.getLogger(__name__)
 
 # Кешируем идентификаторы сообщений для обновления одного и того же поста
 _MESSAGE_CACHE: Dict[str, int] = {}
+
+
+def run_background(coro: Awaitable[Any]) -> asyncio.Task[Any]:
+    """Run *coro* in the background and log unhandled exceptions."""
+
+    task: asyncio.Task[Any] = asyncio.create_task(coro)
+
+    def _handle(task: asyncio.Task[Any]) -> None:
+        try:
+            task.result()
+        except Exception:  # pragma: no cover - best effort logging
+            logger.exception("Background task failed")
+
+    task.add_done_callback(_handle)
+    return task
 
 
 def get_bot() -> Optional[Bot]:


### PR DESCRIPTION
## Summary
- Add `run_background` helper to run coroutines with exception logging
- Use `run_background` for Telegram notifications in main workflow and exchanges
- Cover background logging with a new unit test

## Testing
- `pytest tests/test_telegram_logging.py tests/test_invalid_trade_config.py tests/test_positions_file_path.py tests/test_positions_lock.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f5dc3fd7483209d103a3d55512d4b