### PR TITLE
Handle nonpositive spot price in basis calculation

### DIFF
--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -107,7 +107,7 @@ class MarketMetrics:
 
 def calculate_basis(
     futures_price: float, spot_price: float, signed: bool = False
-) -> float:
+) -> Decimal | None:
     """Расчёт процентного базиса между фьючерсом и спотом.
 
     Parameters
@@ -115,14 +115,21 @@ def calculate_basis(
     futures_price : float
         Текущая цена фьючерса.
     spot_price : float
-        Текущая цена спота.
+        Текущая цена спота. При ``spot_price <= 0`` функция возвращает
+        ``None``, что можно трактовать как бесконечный базис.
     signed : bool, optional
         Если ``True``, знак сохраняется. Иначе возвращается абсолютное значение.
+
+    Returns
+    -------
+    Decimal | None
+        Процентный базис. ``None`` при неположительной или некорректной
+        цене спота.
     """
 
-    if not spot_price:
-        return float("inf")
-    value = (futures_price - spot_price) / spot_price * 100
+    if spot_price <= 0 or not math.isfinite(spot_price):
+        return None
+    value = Decimal(str((futures_price - spot_price) / spot_price * 100))
     return value if signed else abs(value)
 
 
@@ -216,6 +223,8 @@ async def get_market_metrics(
         Decimal(str(q)) for _, q in asks
     )
     basis = calculate_basis(float(futures_price), float(spot_price))
+    if basis is None:
+        basis = Decimal("Infinity")
 
     # Изменение цены за последние 15 минут для оценки волатильности
     if exchange is not None:
@@ -831,6 +840,8 @@ async def monitor_neutral_position(
                     float(metrics.spot_price),
                     signed=True,
                 )
+                if exit_basis is None:
+                    exit_basis = Decimal("Infinity")
                 commission = Decimal(str(orders.get("commission", 0.0)))
                 pnl_net = pnl_part - commission
                 volume_usd = partial_qty_d * Decimal(str(entry.entry_futures_price))
@@ -898,6 +909,8 @@ async def monitor_neutral_position(
                     float(metrics.spot_price),
                     signed=True,
                 )
+                if exit_basis is None:
+                    exit_basis = Decimal("Infinity")
                 exit_ts = time.time()
                 total_pnl = entry.pnl + pnl
                 net_pnl = total_pnl + entry.funding_accrued - entry.commissions

--- a/tests/test_calculate_basis.py
+++ b/tests/test_calculate_basis.py
@@ -1,0 +1,38 @@
+import sys
+import pathlib
+import types
+from decimal import Decimal
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+# Stub heavy dependencies of funding_arbitrage
+ai_module = types.ModuleType("ai")
+parameter_optimizer = types.ModuleType("parameter_optimizer")
+
+
+def load_thresholds(defaults):
+    return defaults
+
+
+async def periodic_optimization():
+    return None
+
+
+parameter_optimizer.load_thresholds = load_thresholds
+parameter_optimizer.periodic_optimization = periodic_optimization
+ai_module.parameter_optimizer = parameter_optimizer
+sys.modules["ai"] = ai_module
+sys.modules["ai.parameter_optimizer"] = parameter_optimizer
+
+from strategies import funding_arbitrage as fa
+
+
+def test_calculate_basis_positive() -> None:
+    assert fa.calculate_basis(110.0, 100.0) == Decimal("10")
+
+
+def test_calculate_basis_non_positive() -> None:
+    assert fa.calculate_basis(100.0, 0.0) is None
+    assert fa.calculate_basis(100.0, -1.0) is None


### PR DESCRIPTION
## Summary
- return `None` from `calculate_basis` when spot price is not positive and document the behavior
- treat missing basis as `Decimal('Infinity')` in metrics and exit routines
- add tests for basis calculation edge cases

## Testing
- `pytest tests/test_calculate_basis.py tests/test_decimal_metrics.py tests/test_exit_conditions.py -q` *(terminated after completion)*

------
https://chatgpt.com/codex/tasks/task_e_688f6ae4c5cc8320b29fcab89fcebef1