### PR TITLE
Ensure fixed-precision numeric reporting

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,13 @@ from exchanges.bybit import BybitExchange
 from risk import risk_control
 from strategies import funding_arbitrage as strategy
 from ai.parameter_optimizer import periodic_optimization
-from utils.telegram import format_duration, notify_close, notify_open, shutdown
+from utils.telegram import (
+    format_decimal,
+    format_duration,
+    notify_close,
+    notify_open,
+    shutdown,
+)
 
 load_dotenv()
 
@@ -153,19 +159,25 @@ async def monitor_position(exchange_name: str, symbol: str, quantity: float) -> 
         entry = entry or strategy.positions.get(symbol)
         entry_ts = entry.entry_timestamp if entry else time.time()
         hold = time.time() - entry_ts
-        funding_pct = (entry.entry_funding if entry else 0.0) * 100
-        basis_pct = entry.entry_basis if entry else 0.0
-        volume_usd = (
-            entry.entry_futures_price * entry.initial_quantity if entry else 0.0
+        funding_pct = format_decimal(
+            (entry.entry_funding if entry else 0.0) * 100, 4
         )
+        basis_pct = format_decimal(entry.entry_basis if entry else 0.0, 4)
+        volume_usd = (
+            Decimal(str(entry.entry_futures_price))
+            * Decimal(str(entry.initial_quantity))
+            if entry
+            else Decimal("0")
+        )
+        volume_fmt = format_decimal(volume_usd, 2)
         asyncio.create_task(
             notify_close(
                 position_id,
                 (
                     f"Ошибка на {exchange_name} {symbol}: {exc}\n"
-                    f"Фандинг: {funding_pct:.4f}%\n"
-                    f"Базис: {basis_pct:.4f}%\n"
-                    f"Объём: ${float(volume_usd):.2f}\n"
+                    f"Фандинг: {funding_pct}%\n"
+                    f"Базис: {basis_pct}%\n"
+                    f"Объём: ${volume_fmt}\n"
                     f"Время в позиции: {format_duration(hold)}"
                 ),
             )
@@ -174,7 +186,7 @@ async def monitor_position(exchange_name: str, symbol: str, quantity: float) -> 
     else:
         if entry is None:
             entry = strategy.positions.get(symbol)
-        pnl = float(entry.pnl) if entry else 0.0
+        pnl = entry.pnl if entry else Decimal("0")
         reasons = entry.exit_reasons if entry else []
         exit_ts = entry.exit_timestamp if entry else 0
         hold = exit_ts - (entry.entry_timestamp if entry else 0)
@@ -183,22 +195,28 @@ async def monitor_position(exchange_name: str, symbol: str, quantity: float) -> 
             if entry and entry.exit_funding is not None
             else (entry.entry_funding if entry else 0.0)
         )
-        funding_pct = funding_rate * 100
-        basis_pct = entry.exit_basis if entry else 0.0
+        funding_pct = format_decimal(funding_rate * 100, 4)
+        basis_pct = format_decimal(entry.exit_basis if entry else 0.0, 4)
         volume_usd = (
-            entry.entry_futures_price * entry.initial_quantity if entry else 0.0
+            Decimal(str(entry.entry_futures_price))
+            * Decimal(str(entry.initial_quantity))
+            if entry
+            else Decimal("0")
         )
-        pnl_pct = (pnl / volume_usd * 100) if volume_usd else 0.0
+        volume_fmt = format_decimal(volume_usd, 2)
+        pnl_pct = (pnl / volume_usd * 100) if volume_usd else Decimal("0")
+        pnl_fmt = format_decimal(pnl, 4)
+        pnl_pct_fmt = format_decimal(pnl_pct, 4)
         asyncio.create_task(
             notify_close(
                 position_id,
                 (
                     f"Закрыта {symbol} на {exchange_name}\n"
-                    f"Фандинг: {funding_pct:.4f}%\n"
-                    f"Базис: {basis_pct:.4f}%\n"
-                    f"Объём: ${float(volume_usd):.2f}\n"
+                    f"Фандинг: {funding_pct}%\n"
+                    f"Базис: {basis_pct}%\n"
+                    f"Объём: ${volume_fmt}\n"
                     f"Время в позиции: {format_duration(hold)}\n"
-                    f"PnL: {pnl:.4f} ({pnl_pct:.4f}%) Причины: {reasons}"
+                    f"PnL: {pnl_fmt} ({pnl_pct_fmt}%) Причины: {reasons}"
                 ),
             )
         )
@@ -247,8 +265,8 @@ def start_processing_loops() -> None:
             if deposit_pct_raw != deposit_pct or min_trade_usd <= 0:
                 logger.warning(
                     "Некорректные параметры торговли: deposit_pct=%s, min_trade_size=%s",
-                    deposit_pct_raw,
-                    min_trade_usd,
+                    format_decimal(deposit_pct_raw, 4),
+                    format_decimal(min_trade_usd, 2),
                 )
                 await asyncio.sleep(poll_interval)
                 continue
@@ -256,7 +274,8 @@ def start_processing_loops() -> None:
             trade_value = max(min_trade_usd, deposit * deposit_pct)
             if not math.isfinite(trade_value) or trade_value <= 0:
                 logger.error(
-                    "Некорректное значение trade_value: %s", trade_value
+                    "Некорректное значение trade_value: %s",
+                    format_decimal(trade_value, 2),
                 )
                 await asyncio.sleep(poll_interval)
                 continue
@@ -302,14 +321,17 @@ def start_processing_loops() -> None:
                         try:
                             await strategy.open_neutral_position(client, symbol, quantity)
                             volume_usd = quantity * Decimal(str(metrics.futures_price))
+                            funding_pct = format_decimal(metrics.funding_rate * 100, 4)
+                            basis_pct = format_decimal(metrics.basis, 4)
+                            volume_fmt = format_decimal(volume_usd, 2)
                             asyncio.create_task(
                                 notify_open(
                                     f"{name}:{symbol}",
                                     (
                                         f"Открыта {symbol} на {name}\n"
-                                        f"Фандинг: {metrics.funding_rate * 100:.4f}%\n"
-                                        f"Базис: {metrics.basis:.4f}%\n"
-                                        f"Объём: ${float(volume_usd):.2f}\n"
+                                        f"Фандинг: {funding_pct}%\n"
+                                        f"Базис: {basis_pct}%\n"
+                                        f"Объём: ${volume_fmt}\n"
                                         f"Время в позиции: {format_duration(0)}\n"
                                         "Стратегия: Лонг спот / Шорт перп"
                                     ),

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -27,7 +27,7 @@ from risk import risk_control
 from ai.parameter_optimizer import load_thresholds as _load_thresholds
 from main import CONFIG, WHITELISTS
 from utils.logger import log_trade
-from utils.telegram import format_duration, notify_partial_close
+from utils.telegram import format_decimal, format_duration, notify_partial_close
 
 
 DEFAULT_POSITIONS_FILE = "open_positions.json"
@@ -527,10 +527,16 @@ async def open_neutral_position(
         raise RuntimeError("Некорректное значение депозита")
     deposit_pct = Decimal(str(CONFIG.get("thresholds", {}).get("deposit_pct", 1.0)))
     if deposit_pct < 0:
-        logger.warning("Некорректное значение deposit_pct=%s; устанавливаем 0", deposit_pct)
+        logger.warning(
+            "Некорректное значение deposit_pct=%s; устанавливаем 0",
+            format_decimal(deposit_pct, 4),
+        )
         deposit_pct = Decimal("0")
     elif deposit_pct > 1:
-        logger.warning("Некорректное значение deposit_pct=%s; устанавливаем 1", deposit_pct)
+        logger.warning(
+            "Некорректное значение deposit_pct=%s; устанавливаем 1",
+            format_decimal(deposit_pct, 4),
+        )
         deposit_pct = Decimal("1")
     max_trade = deposit * deposit_pct
     if notional > deposit or notional > max_trade:
@@ -605,7 +611,8 @@ async def open_neutral_position(
                 exchange=exchange_name,
             )
             await save_positions()
-        volume_usd = float(notional)
+        volume_usd_q = notional.quantize(Decimal("0.01"))
+        commission_q = commission.quantize(Decimal("0.0001"))
         await log_trade(
             {
                 "symbol": symbol,
@@ -621,10 +628,10 @@ async def open_neutral_position(
                 "basis_pct": entry_metrics.basis,
                 "funding": entry_metrics.funding_rate,
                 "quantity": float(quantity),
-                "volume_usd": volume_usd,
+                "volume_usd": float(volume_usd_q),
                 "pnl": 0.0,
                 "pnl_pct": 0.0,
-                "commissions": float(commission),
+                "commissions": float(commission_q),
                 "funding_accrued": 0.0,
                 "slippage": entry_metrics.slippage,
                 "exit_reasons": None,
@@ -839,6 +846,11 @@ async def monitor_neutral_position(
                 )
                 hold_time = exit_ts - entry.entry_timestamp
                 exchange_name = type(exchange).__name__.replace("Exchange", "").lower()
+                volume_usd_q = volume_usd.quantize(Decimal("0.01"))
+                pnl_net_q = pnl_net.quantize(Decimal("0.0001"))
+                pnl_pct_q = pnl_pct.quantize(Decimal("0.01"))
+                commission_q = commission.quantize(Decimal("0.0001"))
+                funding_accrued_q = entry.funding_accrued.quantize(Decimal("0.0001"))
                 await log_trade(
                     {
                         "symbol": symbol,
@@ -854,11 +866,11 @@ async def monitor_neutral_position(
                         "basis_pct": exit_basis,
                         "funding": entry.entry_funding,
                         "quantity": partial_qty,
-                        "volume_usd": float(volume_usd),
-                        "pnl": float(pnl_net),
-                        "pnl_pct": float(pnl_pct),
-                        "commissions": float(commission),
-                        "funding_accrued": float(entry.funding_accrued),
+                        "volume_usd": float(volume_usd_q),
+                        "pnl": float(pnl_net_q),
+                        "pnl_pct": float(pnl_pct_q),
+                        "commissions": float(commission_q),
+                        "funding_accrued": float(funding_accrued_q),
                         "slippage": exit_slippage,
                         "exit_reasons": ["partial"],
                         "notes": "частичный выход",
@@ -874,17 +886,24 @@ async def monitor_neutral_position(
                     pnl_pct_total = (
                         pnl_total / total_volume * 100 if total_volume != 0 else Decimal(0)
                     )
+                    quantity_fmt = format_decimal(quantity, 4)
+                    funding_pct = format_decimal(metrics.funding_rate * 100, 4)
+                    basis_pct = format_decimal(exit_basis, 4)
+                    volume_fmt = format_decimal(volume_usd_q, 2)
+                    funding_accrued_fmt = format_decimal(entry.funding_accrued, 4)
+                    pnl_total_fmt = format_decimal(pnl_total, 4, signed=True)
+                    pnl_pct_total_fmt = format_decimal(pnl_pct_total, 2, signed=True)
                     asyncio.create_task(
                         notify_partial_close(
                             position_id,
                             (
-                                f"Частичное закрытие {symbol}: осталось {quantity:.4f}\n"
-                                f"Фандинг: {metrics.funding_rate * 100:.4f}%\n"
-                                f"Базис: {exit_basis:.4f}%\n"
-                                f"Объём: ${float(volume_usd):.2f}\n"
+                                f"Частичное закрытие {symbol}: осталось {quantity_fmt}\n"
+                                f"Фандинг: {funding_pct}%\n"
+                                f"Базис: {basis_pct}%\n"
+                                f"Объём: ${volume_fmt}\n"
                                 f"Время в позиции: {format_duration(hold_time)}\n"
-                                f"Накопленный фандинг: {entry.funding_accrued:.4f} / "
-                                f"PnL: {pnl_total:+.4f} ({pnl_pct_total:+.2f} %)"
+                                f"Накопленный фандинг: {funding_accrued_fmt} / "
+                                f"PnL: {pnl_total_fmt} ({pnl_pct_total_fmt} %)",
                             ),
                         )
                     )
@@ -915,32 +934,37 @@ async def monitor_neutral_position(
                 pnl_pct = (
                     net_pnl / volume_usd * 100 if volume_usd != 0 else Decimal(0)
                 )
+                volume_usd_q = volume_usd.quantize(Decimal("0.01"))
+                net_pnl_q = net_pnl.quantize(Decimal("0.0001"))
+                pnl_pct_q = pnl_pct.quantize(Decimal("0.01"))
+                commissions_q = entry.commissions.quantize(Decimal("0.0001"))
+                funding_accrued_q = entry.funding_accrued.quantize(Decimal("0.0001"))
                 await log_trade(
                     {
-                        "symbol": symbol,
-                        "exchange": exchange_name,
-                        "entry_time": datetime.fromtimestamp(entry.entry_timestamp).isoformat(),
-                        "exit_time": datetime.fromtimestamp(exit_ts).isoformat(),
-                        "entry_futures_price": entry.entry_futures_price,
-                        "exit_futures_price": metrics.futures_price,
-                        "entry_spot_price": entry.entry_spot_price,
-                        "exit_spot_price": metrics.spot_price,
-                        "entry_basis": entry.entry_basis,
-                        "exit_basis": exit_basis,
-                        "basis_pct": exit_basis,
-                        "funding": entry.entry_funding,
-                        "quantity": entry.initial_quantity,
-                        "volume_usd": float(volume_usd),
-                        "pnl": float(net_pnl),
-                        "pnl_pct": float(pnl_pct),
-                        "commissions": float(entry.commissions),
-                        "funding_accrued": float(entry.funding_accrued),
-                        "slippage": exit_slippage,
-                        "exit_reasons": reasons,
-                        "notes": None,
-                    }
-                )
-            return entry
+                          "symbol": symbol,
+                          "exchange": exchange_name,
+                          "entry_time": datetime.fromtimestamp(entry.entry_timestamp).isoformat(),
+                          "exit_time": datetime.fromtimestamp(exit_ts).isoformat(),
+                          "entry_futures_price": entry.entry_futures_price,
+                          "exit_futures_price": metrics.futures_price,
+                          "entry_spot_price": entry.entry_spot_price,
+                          "exit_spot_price": metrics.spot_price,
+                          "entry_basis": entry.entry_basis,
+                          "exit_basis": exit_basis,
+                          "basis_pct": exit_basis,
+                          "funding": entry.entry_funding,
+                          "quantity": entry.initial_quantity,
+                          "volume_usd": float(volume_usd_q),
+                          "pnl": float(net_pnl_q),
+                          "pnl_pct": float(pnl_pct_q),
+                          "commissions": float(commissions_q),
+                          "funding_accrued": float(funding_accrued_q),
+                          "slippage": exit_slippage,
+                          "exit_reasons": reasons,
+                          "notes": None,
+                        }
+                    )
+                return entry
         await asyncio.sleep(poll_interval)
 
 

--- a/utils/telegram.py
+++ b/utils/telegram.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+from decimal import Decimal, ROUND_HALF_UP
 from typing import Dict, Optional
 
 from aiogram import Bot
@@ -62,6 +63,20 @@ def format_duration(seconds: float) -> str:
     if not parts:
         parts.append(f"{sec}s")
     return " ".join(parts)
+
+
+def format_decimal(value: float | Decimal, precision: int = 4, signed: bool = False) -> str:
+    """Возвращает строку с числом, округлённым до ``precision`` знаков.
+
+    Параметр ``signed`` добавляет ``+`` для положительных чисел, что удобно
+    при отображении прибыли и процентов.
+    """
+    quant = Decimal("1").scaleb(-precision)
+    number = Decimal(str(value)).quantize(quant, rounding=ROUND_HALF_UP)
+    result = f"{number:.{precision}f}"
+    if signed and not result.startswith("-"):
+        result = "+" + result
+    return result
 
 
 async def _send_message(text: str) -> Optional[int]:


### PR DESCRIPTION
## Summary
- add `format_decimal` helper for consistent rounding of numeric values
- apply fixed precision formatting for PnL, volume and percentage outputs in trading lifecycle
- log validated deposit settings with rounded values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f6aead720832094dadbb00f58bcdd