### PR TITLE
feat: load paths from config

### DIFF
--- a/ai/parameter_optimizer.py
+++ b/ai/parameter_optimizer.py
@@ -7,17 +7,27 @@ import random
 from pathlib import Path
 from typing import Callable, Dict, Optional
 
+import yaml
 import pandas as pd
 from joblib import dump, load
 from sklearn.linear_model import LinearRegression
 
 from utils.logger import LOG_PATH
 
-# Путь по умолчанию для сохранения оптимизированных порогов
-DEFAULT_OUTPUT = Path("data") / "optimized_thresholds.joblib"
+# Путь по умолчанию для сохранения оптимизированных порогов читается из конфигурации.
+_CFG_PATH = Path(__file__).resolve().parents[1] / "config.yaml"
+try:
+    with _CFG_PATH.open("r", encoding="utf-8") as _f:
+        _cfg = yaml.safe_load(_f) or {}
+except FileNotFoundError:  # pragma: no cover - defensive
+    _cfg = {}
+
+DEFAULT_OUTPUT = Path(
+    _cfg.get("paths", {}).get("thresholds", "data/optimized_thresholds.joblib")
+)
 
 
-def analyze_trade_history(log_path: Path = LOG_PATH) -> Dict[str, float]:
+def analyze_trade_history(log_path: Path | None = None) -> Dict[str, float]:
     """Анализирует историю сделок и вычисляет пороги через регрессию.
 
     Линейная регрессия оценивает, какие признаки сильнее влияют на прибыль.
@@ -25,6 +35,9 @@ def analyze_trade_history(log_path: Path = LOG_PATH) -> Dict[str, float]:
     ``volume_usd`` и ``liquidity`` берутся как медианы сделок, которые
     модель прогнозирует прибыльными.
     """
+
+    if log_path is None:
+        log_path = LOG_PATH
 
     if not log_path.exists():
         return {}
@@ -86,9 +99,13 @@ def analyze_trade_history(log_path: Path = LOG_PATH) -> Dict[str, float]:
 
 
 def optimize_and_save(
-    log_path: Path = LOG_PATH, out_path: Path = DEFAULT_OUTPUT
+    log_path: Path | None = None, out_path: Path | None = None
 ) -> Dict[str, float]:
     """Выполняет оптимизацию на истории и сохраняет результат."""
+    if log_path is None:
+        log_path = LOG_PATH
+    if out_path is None:
+        out_path = DEFAULT_OUTPUT
     thresholds = analyze_trade_history(log_path)
     if thresholds:
         out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -99,8 +116,8 @@ def optimize_and_save(
 async def periodic_optimization(
     min_hours: int = 24,
     max_hours: int = 48,
-    log_path: Path = LOG_PATH,
-    out_path: Path = DEFAULT_OUTPUT,
+    log_path: Path | None = None,
+    out_path: Path | None = None,
     on_update: Optional[Callable[[Dict[str, float]], None]] = None,
 
 ) -> None:
@@ -116,6 +133,11 @@ async def periodic_optimization(
         Необязательный колбэк, вызываемый после каждого пересчёта порогов.
     """
 
+    if log_path is None:
+        log_path = LOG_PATH
+    if out_path is None:
+        out_path = DEFAULT_OUTPUT
+
     while True:
         thresholds = optimize_and_save(log_path, out_path)
         if on_update and thresholds:
@@ -128,13 +150,16 @@ async def periodic_optimization(
 logger = logging.getLogger(__name__)
 
 
-def load_thresholds(defaults: Dict[str, float], path: Path = DEFAULT_OUTPUT) -> Dict[str, float]:
+def load_thresholds(defaults: Dict[str, float], path: Path | None = None) -> Dict[str, float]:
     """Загружает оптимизированные пороги и объединяет их с ``defaults``.
 
     Загруженные значения проверяются на корректность: принимаются только
     конечные неотрицательные числа. Неверные пороги игнорируются с
     предупреждением.
     """
+
+    if path is None:
+        path = DEFAULT_OUTPUT
 
     try:
         data = load(path)

--- a/config.yaml
+++ b/config.yaml
@@ -28,3 +28,7 @@ bot:
     - ETHUSDT
   deposit_size: 100
   positions_file: open_positions.json
+
+paths:
+  log: data/funding_bot_log.xlsx
+  thresholds: data/optimized_thresholds.joblib

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,7 +1,8 @@
 """Простые утилиты для логирования сделок в Excel.
 
 Модуль предоставляет небольшую функцию для сохранения информации о сделках
-в файл ``.xlsx``. Каждая сделка записывается одной строкой со следующими
+в файл ``.xlsx``. Путь к журналу определяется параметром ``paths.log`` в
+конфигурации. Каждая сделка записывается одной строкой со следующими
 колонками:
 
 ``symbol``
@@ -35,10 +36,10 @@
 ``notes``
     Произвольные заметки.
 
-Функция :func:`log_trade` добавляет новую строку в ``data/funding_bot_log.xlsx``,
-создавая файл и его родительский каталог при необходимости. Функция следит
-за наличием всех колонок и избегает повреждения данных, используя ``openpyxl``
-для добавления строк без полного переписывания файла через pandas.
+Функция :func:`log_trade` добавляет новую строку в журнал, создавая файл и его
+родительский каталог при необходимости. Функция следит за наличием всех колонок
+и избегает повреждения данных, используя ``openpyxl`` для добавления строк без
+полного переписывания файла через pandas.
 """
 
 from __future__ import annotations
@@ -47,10 +48,18 @@ import asyncio
 from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping
 
+import yaml
 from openpyxl import Workbook, load_workbook
 
-# Расположение файла журнала по умолчанию.
-LOG_PATH: Path = Path("data") / "funding_bot_log.xlsx"
+# Загружаем путь к журналу из конфигурации, при отсутствии используем значение по умолчанию.
+_CFG_PATH = Path(__file__).resolve().parents[1] / "config.yaml"
+try:
+    with _CFG_PATH.open("r", encoding="utf-8") as _f:
+        _cfg = yaml.safe_load(_f) or {}
+except FileNotFoundError:  # pragma: no cover - defensive
+    _cfg = {}
+
+LOG_PATH: Path = Path(_cfg.get("paths", {}).get("log", "data/funding_bot_log.xlsx"))
 
 # Упорядоченный список колонок, ожидаемых для каждой сделки.
 LOG_COLUMNS: list[str] = [
@@ -101,7 +110,7 @@ def _validate_entry(entry: Mapping[str, Any], columns: Iterable[str]) -> None:
         raise ValueError(f"Missing required columns: {', '.join(missing)}")
 
 
-async def log_trade(trade: Mapping[str, Any], path: Path = LOG_PATH) -> None:
+async def log_trade(trade: Mapping[str, Any], path: Path | None = None) -> None:
     """Добавляет информацию о сделке в Excel-журнал.
 
     Параметры
@@ -109,14 +118,14 @@ async def log_trade(trade: Mapping[str, Any], path: Path = LOG_PATH) -> None:
     trade:
         Словарь, содержащий все ключи из :data:`LOG_COLUMNS`.
     path:
-        Необязательный путь к файлу Excel. По умолчанию
-        ``data/funding_bot_log.xlsx``.
+        Необязательный путь к файлу Excel. По умолчанию используется путь из
+        конфигурации.
 
     Функция асинхронная и использует глобальную блокировку, чтобы
     предотвращать одновременную запись в файл из разных задач.
     """
 
-    path = Path(path)
+    path = Path(path) if path is not None else LOG_PATH
     _ensure_parent(path)
     _validate_entry(trade, LOG_COLUMNS)
 


### PR DESCRIPTION
## Summary
- load log and optimizer output paths from configuration
- default logging uses configurable path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f6ada56b08320803818ef6c46c396