### PR TITLE
Ensure directory exists before saving positions

### DIFF
--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -491,6 +491,7 @@ async def save_positions(path: Path | str | None = None) -> None:
         tmp_name: str | None = None
         try:
             dir_path = Path(path).resolve().parent
+            dir_path.mkdir(parents=True, exist_ok=True)
             with NamedTemporaryFile(
                 "w", dir=dir_path, delete=False, encoding="utf-8"
             ) as fh:


### PR DESCRIPTION
## Summary
- guarantee parent directories exist before writing temporary position files

## Testing
- `pytest tests/test_positions.py -q`
- `pytest tests/test_positions_file_path.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f6ab997788320bd5667d1501e684e