### PR TITLE
Switch position model to Decimal amounts

### DIFF
--- a/main.py
+++ b/main.py
@@ -164,8 +164,7 @@ async def monitor_position(exchange_name: str, symbol: str, quantity: float) -> 
         )
         basis_pct = format_decimal(entry.entry_basis if entry else 0.0, 4)
         volume_usd = (
-            Decimal(str(entry.entry_futures_price))
-            * Decimal(str(entry.initial_quantity))
+            entry.entry_futures_price * entry.initial_quantity
             if entry
             else Decimal("0")
         )
@@ -198,8 +197,7 @@ async def monitor_position(exchange_name: str, symbol: str, quantity: float) -> 
         funding_pct = format_decimal(funding_rate * 100, 4)
         basis_pct = format_decimal(entry.exit_basis if entry else 0.0, 4)
         volume_usd = (
-            Decimal(str(entry.entry_futures_price))
-            * Decimal(str(entry.initial_quantity))
+            entry.entry_futures_price * entry.initial_quantity
             if entry
             else Decimal("0")
         )
@@ -223,8 +221,7 @@ async def monitor_position(exchange_name: str, symbol: str, quantity: float) -> 
     finally:
         entry_final = entry or strategy.positions.get(symbol)
         notional = (
-            Decimal(str(entry_final.entry_futures_price))
-            * Decimal(str(entry_final.initial_quantity))
+            entry_final.entry_futures_price * entry_final.initial_quantity
             if entry_final
             else Decimal("0")
         )

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -398,12 +398,12 @@ class Position:
     """Модель открытой позиции."""
 
     entry_timestamp: float
-    entry_futures_price: float
-    entry_spot_price: float
-    entry_basis: float
-    entry_funding: float
-    quantity: float
-    initial_quantity: float
+    entry_futures_price: Decimal
+    entry_spot_price: Decimal
+    entry_basis: Decimal
+    entry_funding: Decimal
+    quantity: Decimal
+    initial_quantity: Decimal
     pnl: Decimal = Decimal(0)
     funding_accrued: Decimal = Decimal(0)
     commissions: Decimal = Decimal(0)
@@ -418,9 +418,19 @@ class Position:
 
     def to_dict(self) -> Dict[str, Any]:
         data = asdict(self)
-        data["pnl"] = float(self.pnl)
-        data["funding_accrued"] = float(self.funding_accrued)
-        data["commissions"] = float(self.commissions)
+        for key in (
+            "entry_futures_price",
+            "entry_spot_price",
+            "entry_basis",
+            "entry_funding",
+            "quantity",
+            "initial_quantity",
+            "pnl",
+            "funding_accrued",
+            "commissions",
+        ):
+            if key in data:
+                data[key] = float(data[key])
         return data
 
     @classmethod
@@ -429,12 +439,14 @@ class Position:
             raise ValueError("missing field quantity")
         return cls(
             entry_timestamp=float(data.get("entry_timestamp", 0.0)),
-            entry_futures_price=float(data.get("entry_futures_price", 0.0)),
-            entry_spot_price=float(data.get("entry_spot_price", 0.0)),
-            entry_basis=float(data.get("entry_basis", 0.0)),
-            entry_funding=float(data.get("entry_funding", 0.0)),
-            quantity=float(data["quantity"]),
-            initial_quantity=float(data.get("initial_quantity", data["quantity"])),
+            entry_futures_price=Decimal(str(data.get("entry_futures_price", 0.0))),
+            entry_spot_price=Decimal(str(data.get("entry_spot_price", 0.0))),
+            entry_basis=Decimal(str(data.get("entry_basis", 0.0))),
+            entry_funding=Decimal(str(data.get("entry_funding", 0.0))),
+            quantity=Decimal(str(data["quantity"])),
+            initial_quantity=Decimal(
+                str(data.get("initial_quantity", data["quantity"]))
+            ),
             pnl=Decimal(str(data.get("pnl", 0.0))),
             funding_accrued=Decimal(str(data.get("funding_accrued", 0.0))),
             commissions=Decimal(str(data.get("commissions", 0.0))),
@@ -496,7 +508,7 @@ async def load_positions(path: Path | str | None = None) -> None:
         positions[symbol] = pos
         notional = pos.quantity * pos.entry_futures_price
         if notional:
-            await risk_control.update_position(Decimal(str(notional)))
+            await risk_control.update_position(notional)
         await risk_control.mark_symbol_open(symbol)
 
 
@@ -538,7 +550,7 @@ async def open_neutral_position(
     entry_metrics = await get_market_metrics(symbol, quantity, exchange)
     if entry_metrics is None:
         raise RuntimeError("Рыночные метрики недоступны, сделка пропущена")
-    notional = quantity * Decimal(str(entry_metrics.futures_price))
+    notional = quantity * entry_metrics.futures_price
     deposit_raw = bot_cfg.get("deposit_size", "Infinity")
     deposit = Decimal(str(deposit_raw))
     if not deposit.is_finite() or deposit < 0:
@@ -620,9 +632,9 @@ async def open_neutral_position(
                 entry_futures_price=entry_metrics.futures_price,
                 entry_spot_price=entry_metrics.spot_price,
                 entry_basis=entry_metrics.basis,
-                entry_funding=float(entry_metrics.funding_rate),
-                quantity=float(quantity),
-                initial_quantity=float(quantity),
+                entry_funding=entry_metrics.funding_rate,
+                quantity=quantity,
+                initial_quantity=quantity,
                 pnl=Decimal(0),
                 funding_accrued=Decimal(0),
                 commissions=commission,
@@ -740,7 +752,7 @@ async def close_neutral_position(
         entry = positions.get(symbol)
         if entry is not None:
             entry.commissions += commission
-            ref_price = Decimal(str(entry.entry_futures_price))
+            ref_price = entry.entry_futures_price
         else:
             ref_price = Decimal(0)
         await risk_control.update_position(-(quantity * ref_price))
@@ -812,7 +824,7 @@ async def monitor_neutral_position(
         if abs(metrics.basis) >= exit_basis_limit:
             reasons.append("basis")
         if entry:
-            entry_price_d = Decimal(str(entry.entry_futures_price))
+            entry_price_d = entry.entry_futures_price
             exit_slippage = abs(
                 metrics.futures_price - entry_price_d
             ) / max(entry_price_d, Decimal("1e-9"))
@@ -830,8 +842,8 @@ async def monitor_neutral_position(
             max_hold = exit_thresholds.get("holding_time")
             if max_hold is not None and hold_time > max_hold:
                 reasons.append("time")
-            fut_diff = metrics.futures_price - Decimal(str(entry.entry_futures_price))
-            spot_diff = metrics.spot_price - Decimal(str(entry.entry_spot_price))
+            fut_diff = metrics.futures_price - entry.entry_futures_price
+            spot_diff = metrics.spot_price - entry.entry_spot_price
             pnl = (fut_diff - spot_diff) * quantity_d
             if (
                 pnl + entry.funding_accrued - entry.commissions < Decimal(0)
@@ -856,7 +868,7 @@ async def monitor_neutral_position(
                 async with positions_lock:
                     quantity_d -= partial_qty_d
                     quantity = float(quantity_d)
-                    entry.quantity = quantity
+                    entry.quantity = quantity_d
                     entry.pnl += pnl_part
                     await save_positions()
                 exit_ts = time.time()
@@ -869,7 +881,7 @@ async def monitor_neutral_position(
                     exit_basis = Decimal("Infinity")
                 commission = Decimal(str(orders.get("commission", 0.0)))
                 pnl_net = pnl_part - commission
-                volume_usd = partial_qty_d * Decimal(str(entry.entry_futures_price))
+                volume_usd = partial_qty_d * entry.entry_futures_price
                 pnl_pct = (
                     pnl_net / volume_usd * Decimal(100) if volume_usd != 0 else Decimal(0)
                 )
@@ -906,9 +918,7 @@ async def monitor_neutral_position(
                     }
                 )
                 if position_id:
-                    total_volume = Decimal(str(entry.entry_futures_price)) * Decimal(
-                        str(entry.initial_quantity)
-                    )
+                    total_volume = entry.entry_futures_price * entry.initial_quantity
                     pnl_total = (
                         entry.pnl + entry.funding_accrued - entry.commissions
                     )
@@ -961,9 +971,7 @@ async def monitor_neutral_position(
                 entry.exit_funding = float(metrics.funding_rate)
                 entry.pnl = net_pnl
                 exchange_name = type(exchange).__name__.replace("Exchange", "").lower()
-                volume_usd = Decimal(str(entry.entry_futures_price)) * Decimal(
-                    str(entry.initial_quantity)
-                )
+                volume_usd = entry.entry_futures_price * entry.initial_quantity
                 pnl_pct = (
                     net_pnl / volume_usd * Decimal(100) if volume_usd != 0 else Decimal(0)
                 )

--- a/tests/test_decimal_metrics.py
+++ b/tests/test_decimal_metrics.py
@@ -108,12 +108,12 @@ async def test_monitor_neutral_position_decimal(monkeypatch: pytest.MonkeyPatch)
 
     entry = fa.Position(
         entry_timestamp=0.0,
-        entry_futures_price=100.0,
-        entry_spot_price=100.0,
-        entry_basis=0.0,
-        entry_funding=0.01,
-        quantity=1.0,
-        initial_quantity=1.0,
+        entry_futures_price=Decimal("100.0"),
+        entry_spot_price=Decimal("100.0"),
+        entry_basis=Decimal("0.0"),
+        entry_funding=Decimal("0.01"),
+        quantity=Decimal("1.0"),
+        initial_quantity=Decimal("1.0"),
     )
     fa.positions["BTCUSDT"] = entry
 

--- a/tests/test_monitor_position_message.py
+++ b/tests/test_monitor_position_message.py
@@ -23,12 +23,12 @@ async def test_monitor_position_final_message(monkeypatch: pytest.MonkeyPatch) -
     @dataclass
     class Position:
         entry_timestamp: float
-        entry_futures_price: float
-        entry_spot_price: float
-        entry_basis: float
-        entry_funding: float
-        quantity: float
-        initial_quantity: float
+        entry_futures_price: Decimal
+        entry_spot_price: Decimal
+        entry_basis: Decimal
+        entry_funding: Decimal
+        quantity: Decimal
+        initial_quantity: Decimal
         pnl: Decimal = Decimal(0)
         exit_reasons: list[str] = field(default_factory=list)
         exit_timestamp: float = 0.0
@@ -37,12 +37,12 @@ async def test_monitor_position_final_message(monkeypatch: pytest.MonkeyPatch) -
 
     prepared = Position(
         entry_timestamp=0.0,
-        entry_futures_price=100.0,
-        entry_spot_price=100.0,
-        entry_basis=0.0,
-        entry_funding=0.001,
-        quantity=1.0,
-        initial_quantity=1.0,
+        entry_futures_price=Decimal("100.0"),
+        entry_spot_price=Decimal("100.0"),
+        entry_basis=Decimal("0.0"),
+        entry_funding=Decimal("0.001"),
+        quantity=Decimal("1.0"),
+        initial_quantity=Decimal("1.0"),
         pnl=Decimal("2"),
         exit_reasons=["threshold"],
         exit_timestamp=10.0,

--- a/tests/test_positions.py
+++ b/tests/test_positions.py
@@ -49,12 +49,12 @@ def test_save_and_load_roundtrip(tmp_path, monkeypatch):
     positions.clear()
     pos = Position(
         entry_timestamp=1.0,
-        entry_futures_price=2.0,
-        entry_spot_price=1.5,
-        entry_basis=0.5,
-        entry_funding=0.01,
-        quantity=3.0,
-        initial_quantity=3.0,
+        entry_futures_price=Decimal("2.0"),
+        entry_spot_price=Decimal("1.5"),
+        entry_basis=Decimal("0.5"),
+        entry_funding=Decimal("0.01"),
+        quantity=Decimal("3.0"),
+        initial_quantity=Decimal("3.0"),
         commissions=Decimal("0.1"),
         last_funding_timestamp=1.0,
         exchange="binance",
@@ -66,7 +66,7 @@ def test_save_and_load_roundtrip(tmp_path, monkeypatch):
     assert "BTCUSDT" in positions
     loaded = positions["BTCUSDT"]
     assert isinstance(loaded, Position)
-    assert loaded.quantity == 3.0
+    assert loaded.quantity == Decimal("3.0")
     assert loaded.commissions == Decimal("0.1")
     assert isinstance(loaded.pnl, Decimal)
     assert loaded.pnl == Decimal(0)

--- a/tests/test_positions_lock.py
+++ b/tests/test_positions_lock.py
@@ -64,12 +64,12 @@ def test_concurrent_close(monkeypatch):
     monkeypatch.setattr(fa, "positions", test_positions)
     test_positions["BTCUSDT"] = Position(
         entry_timestamp=0.0,
-        entry_futures_price=1.0,
-        entry_spot_price=1.0,
-        entry_basis=0.0,
-        entry_funding=0.0,
-        quantity=1.0,
-        initial_quantity=1.0,
+        entry_futures_price=Decimal("1.0"),
+        entry_spot_price=Decimal("1.0"),
+        entry_basis=Decimal("0.0"),
+        entry_funding=Decimal("0.0"),
+        quantity=Decimal("1.0"),
+        initial_quantity=Decimal("1.0"),
         exchange="dummy",
     )
     exchange = DummyExchange()


### PR DESCRIPTION
## Summary
- Use `Decimal` for all monetary and size fields in `Position`
- Serialize/deserialize `Position` with `Decimal` fields and update open/close helpers
- Adjust main logic and tests to handle Decimal quantities and PnL calculations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7e7fc0fc8320871ffe051ded7aa3