### PR TITLE
Validate deposit before trading

### DIFF
--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -528,9 +528,17 @@ async def save_positions(path: Path | str | None = None) -> None:
 
 async def open_neutral_position(
     exchange: BaseExchange, symbol: str, quantity: Decimal
-) -> Dict[str, Dict]:
-    """Открывает компенсирующие длинную и короткую позиции и сохраняет данные."""
+) -> Dict[str, Dict] | bool:
+    """Открывает компенсирующие длинную и короткую позиции и сохраняет данные.
+
+    При некорректном значении депозита функция возвращает ``False``.
+    """
     bot_cfg = CONFIG.get("bot", {})
+    deposit_raw = bot_cfg.get("deposit_size", "Infinity")
+    deposit = Decimal(str(deposit_raw))
+    if not deposit.is_finite() or deposit < 0:
+        logger.error("Некорректное значение депозита: %s", deposit_raw)
+        return False
     exchange_name = exchange.name
     if symbol not in WHITELISTS.get(exchange_name, []):
         raise RuntimeError("Символ отсутствует в белом списке")
@@ -539,11 +547,6 @@ async def open_neutral_position(
     if entry_metrics is None:
         raise RuntimeError("Рыночные метрики недоступны, сделка пропущена")
     notional = quantity * Decimal(str(entry_metrics.futures_price))
-    deposit_raw = bot_cfg.get("deposit_size", "Infinity")
-    deposit = Decimal(str(deposit_raw))
-    if not deposit.is_finite() or deposit < 0:
-        logger.error("Некорректное значение депозита: %s", deposit_raw)
-        raise RuntimeError("Некорректное значение депозита")
     deposit_pct = Decimal(str(CONFIG.get("thresholds", {}).get("deposit_pct", 1.0)))
     if deposit_pct < 0:
         logger.warning(

--- a/tests/test_invalid_deposit_open_position.py
+++ b/tests/test_invalid_deposit_open_position.py
@@ -64,8 +64,18 @@ class DummyExchange(BaseExchange):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("deposit", [float("inf"), -100])
-async def test_open_neutral_position_rejects_invalid_deposit(monkeypatch, caplog, deposit):
+@pytest.mark.parametrize(
+    "deposit,use_key",
+    [
+        (float("inf"), True),
+        (-100, True),
+        (float("nan"), True),
+        (None, False),
+    ],
+)
+async def test_open_neutral_position_rejects_invalid_deposit(
+    monkeypatch, caplog, deposit, use_key
+):
     exchange = DummyExchange()
 
     metrics = fa.MarketMetrics(
@@ -86,13 +96,14 @@ async def test_open_neutral_position_rejects_invalid_deposit(monkeypatch, caplog
     async def _metrics(symbol: str, trade_size: float, exch: BaseExchange):
         return metrics
 
-    monkeypatch.setattr(fa, "CONFIG", {"bot": {"deposit_size": deposit}, "thresholds": {}})
+    bot_cfg = {"deposit_size": deposit} if use_key else {}
+    monkeypatch.setattr(fa, "CONFIG", {"bot": bot_cfg, "thresholds": {}})
     monkeypatch.setattr(fa, "WHITELISTS", {exchange.name: ["BTCUSDT"]})
     monkeypatch.setattr(fa, "get_market_metrics", _metrics)
 
     caplog.set_level(logging.ERROR)
-    with pytest.raises(RuntimeError):
-        await fa.open_neutral_position(exchange, "BTCUSDT", Decimal("1"))
+    result = await fa.open_neutral_position(exchange, "BTCUSDT", Decimal("1"))
 
+    assert result is False
     assert "Некорректное значение депозита" in caplog.text
     assert exchange.orders == []

--- a/tests/test_missing_metrics.py
+++ b/tests/test_missing_metrics.py
@@ -66,7 +66,7 @@ class NoCallExchange(BaseExchange):
 async def test_open_neutral_position_skips_when_no_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
     exchange = NoCallExchange()
 
-    monkeypatch.setattr(fa, "CONFIG", {"bot": {}, "thresholds": {}})
+    monkeypatch.setattr(fa, "CONFIG", {"bot": {"deposit_size": 1000}, "thresholds": {}})
     monkeypatch.setattr(fa, "WHITELISTS", {exchange.name: ["BTCUSDT"]})
     monkeypatch.setattr(fa.risk_control, "try_open_position", lambda *_: True)
     monkeypatch.setattr(fa.risk_control, "update_position", lambda *_: None)


### PR DESCRIPTION
## Summary
- Ensure `open_neutral_position` validates `deposit_size` before metric calculations and return `False` on invalid values
- Add tests covering NaN and missing deposit size
- Adjust existing tests to use valid deposit values when needed

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f7ea69e4883208ae93148931f158b