### PR TITLE
Protect position loading with lock and add concurrency test

### DIFF
--- a/main.py
+++ b/main.py
@@ -241,9 +241,6 @@ def start_processing_loops() -> None:
 
     poll_interval = CONFIG.get("bot", {}).get("poll_interval", 5)
 
-    # Восстанавливаем ранее сохранённые позиции
-    asyncio.run(strategy.load_positions())
-
     def _update_thresholds(new: Dict[str, float]) -> None:
         """Обновляет пороги стратегии новыми значениями."""
         if new:
@@ -402,6 +399,7 @@ def main() -> None:
     """Запускает загрузку конфигурации и основной цикл работы бота."""
     load_config()
     initialize_bot()
+    asyncio.run(strategy.load_positions())
     start_processing_loops()
 
 

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -486,18 +486,19 @@ async def load_positions(path: Path | str | None = None) -> None:
     except json.JSONDecodeError:
         logger.warning("Некорректный файл позиций %s, начинаем с пустого", path)
         data = {}
-    positions.clear()
-    for symbol, entry in data.items():
-        try:
-            pos = Position.from_dict(entry)
-        except (ValueError, TypeError) as exc:
-            logger.warning("Invalid position for %s: %s", symbol, exc)
-            continue
-        positions[symbol] = pos
-        notional = pos.quantity * pos.entry_futures_price
-        if notional:
-            await risk_control.update_position(Decimal(str(notional)))
-        await risk_control.mark_symbol_open(symbol)
+    async with positions_lock:
+        positions.clear()
+        for symbol, entry in data.items():
+            try:
+                pos = Position.from_dict(entry)
+            except (ValueError, TypeError) as exc:
+                logger.warning("Invalid position for %s: %s", symbol, exc)
+                continue
+            positions[symbol] = pos
+            notional = pos.quantity * pos.entry_futures_price
+            if notional:
+                await risk_control.update_position(Decimal(str(notional)))
+            await risk_control.mark_symbol_open(symbol)
 
 
 async def save_positions(path: Path | str | None = None) -> None:

--- a/tests/test_positions_concurrency.py
+++ b/tests/test_positions_concurrency.py
@@ -1,0 +1,68 @@
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Stub sklearn to avoid heavy dependency during import
+sklearn = types.ModuleType("sklearn")
+linear_model = types.ModuleType("linear_model")
+
+class _LR:
+    def fit(self, *args, **kwargs):
+        return None
+
+    def predict(self, x):
+        return [0] * len(x)
+
+linear_model.LinearRegression = _LR
+sklearn.linear_model = linear_model
+sys.modules.setdefault("sklearn", sklearn)
+sys.modules.setdefault("sklearn.linear_model", linear_model)
+
+import strategies.funding_arbitrage as fa
+from strategies.funding_arbitrage import Position
+from risk import risk_control
+
+
+async def _noop(*args, **kwargs):
+    return None
+
+
+def _patch_risk(monkeypatch):
+    monkeypatch.setattr(risk_control, "update_position", _noop)
+    monkeypatch.setattr(risk_control, "mark_symbol_open", _noop)
+
+
+def test_parallel_load_save(tmp_path, monkeypatch):
+    _patch_risk(monkeypatch)
+    file_path = tmp_path / "open_positions.json"
+    fa.positions.clear()
+    fa.positions["BTCUSDT"] = Position(
+        entry_timestamp=0.0,
+        entry_futures_price=1.0,
+        entry_spot_price=1.0,
+        entry_basis=0.0,
+        entry_funding=0.0,
+        quantity=1.0,
+        initial_quantity=1.0,
+        exchange="test",
+    )
+    asyncio.run(fa.save_positions(file_path))
+
+    async def writer():
+        for _ in range(5):
+            async with fa.positions_lock:
+                fa.positions["BTCUSDT"].quantity += 1.0
+                await fa.save_positions(file_path)
+
+    async def reader():
+        for _ in range(5):
+            await fa.load_positions(file_path)
+    async def runner():
+        await asyncio.gather(writer(), reader())
+
+    asyncio.run(runner())
+    assert "BTCUSDT" in fa.positions
+    assert isinstance(fa.positions["BTCUSDT"], Position)


### PR DESCRIPTION
## Summary
- safeguard in-memory positions updates during load by wrapping `positions.clear()` and subsequent population in `positions_lock`
- load saved positions before starting worker loops to avoid concurrent mutation
- exercise concurrent load/save of positions to confirm locking correctness

## Testing
- `pytest tests/test_positions.py tests/test_positions_lock.py -q`
- `pytest tests/test_positions_concurrency.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7e7a95fc83209ffa9a9525caf8cb