### PR TITLE
Persist accrued funding periodically

### DIFF
--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -771,6 +771,12 @@ async def monitor_neutral_position(
     отправки новых.
     """
     entry = positions.get(symbol)
+    save_interval = float(CONFIG.get("bot", {}).get("funding_save_interval", 300))
+    funding_threshold = Decimal(
+        str(CONFIG.get("bot", {}).get("funding_save_threshold", 0))
+    )
+    last_save = time.time()
+    last_saved_funding = entry.funding_accrued if entry else Decimal(0)
     while True:
         try:
             metrics = await get_market_metrics(symbol, quantity, exchange)
@@ -798,6 +804,17 @@ async def monitor_neutral_position(
             # Накапливаем полученное фондирование
             entry.funding_accrued += funding_fee
             entry.last_funding_timestamp = now
+            if (
+                now - last_save >= save_interval
+                or (
+                    funding_threshold > 0
+                    and abs(entry.funding_accrued - last_saved_funding)
+                    >= funding_threshold
+                )
+            ):
+                await save_positions()
+                last_save = now
+                last_saved_funding = entry.funding_accrued
         reasons: list[str] = []
         exit_slippage = Decimal(0)
         if check_exit_conditions(metrics, exit_thresholds):

--- a/tests/test_funding_save.py
+++ b/tests/test_funding_save.py
@@ -1,0 +1,76 @@
+import asyncio
+import types
+import sys
+import pathlib
+import time
+from decimal import Decimal
+
+import pytest
+
+# Stub sklearn to avoid heavy dependency
+linear_model_stub = types.SimpleNamespace(LinearRegression=object)
+sklearn_stub = types.SimpleNamespace(linear_model=linear_model_stub)
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+sys.modules.setdefault("sklearn", sklearn_stub)
+sys.modules.setdefault("sklearn.linear_model", linear_model_stub)
+
+import strategies.funding_arbitrage as fa
+
+
+@pytest.mark.asyncio
+async def test_funding_saved_on_cancel(monkeypatch: pytest.MonkeyPatch) -> None:
+    entry = fa.Position(
+        entry_timestamp=0.0,
+        entry_futures_price=100.0,
+        entry_spot_price=100.0,
+        entry_basis=0.0,
+        entry_funding=0.0,
+        quantity=1.0,
+        initial_quantity=1.0,
+        pnl=Decimal(0),
+        funding_accrued=Decimal(0),
+        commissions=Decimal(0),
+        last_funding_timestamp=time.time() - 1,
+        exchange="stub",
+    )
+    fa.positions["BTCUSDT"] = entry
+
+    metrics = types.SimpleNamespace(
+        futures_price=Decimal("100"),
+        spot_price=Decimal("100"),
+        funding_rate=Decimal("0.01"),
+        basis=Decimal("0"),
+    )
+
+    async def fake_get_market_metrics(symbol, qty, exchange):
+        return metrics
+
+    monkeypatch.setattr(fa, "get_market_metrics", fake_get_market_metrics)
+    monkeypatch.setattr(fa, "check_exit_conditions", lambda m, t: False)
+
+    fa.CONFIG = {"bot": {"funding_save_interval": 0, "funding_save_threshold": 0}}
+
+    saved: dict[str, Decimal] = {}
+
+    async def fake_save_positions(path=None):
+        saved["funding"] = fa.positions["BTCUSDT"].funding_accrued
+
+    monkeypatch.setattr(fa, "save_positions", fake_save_positions)
+
+    async def run():
+        await fa.monitor_neutral_position(
+            exchange=types.SimpleNamespace(name="stub"),
+            symbol="BTCUSDT",
+            quantity=1.0,
+            exit_thresholds={},
+            poll_interval=0,
+        )
+
+    task = asyncio.create_task(run())
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert saved["funding"] > Decimal(0)
+    fa.positions.clear()


### PR DESCRIPTION
## Summary
- periodically persist funding accruals when monitoring positions
- add regression test ensuring funding is saved on cancellation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7e882f788320b63b71b4350383c9