### PR TITLE
Handle optimization retries

### DIFF
--- a/ai/parameter_optimizer.py
+++ b/ai/parameter_optimizer.py
@@ -26,6 +26,8 @@ DEFAULT_OUTPUT = Path(
     _cfg.get("paths", {}).get("thresholds", "data/optimized_thresholds.joblib")
 )
 
+RETRY_DELAY = 60  # seconds
+
 
 def analyze_trade_history(log_path: Path | None = None) -> Dict[str, float]:
     """Анализирует историю сделок и вычисляет пороги через регрессию.
@@ -139,9 +141,19 @@ async def periodic_optimization(
         out_path = DEFAULT_OUTPUT
 
     while True:
-        thresholds = optimize_and_save(log_path, out_path)
+        try:
+            thresholds = optimize_and_save(log_path, out_path)
+        except Exception as exc:
+            logger.exception("Failed to optimize thresholds: %s", exc)
+            await asyncio.sleep(RETRY_DELAY)
+            continue
         if on_update and thresholds:
-            on_update(thresholds)
+            try:
+                on_update(thresholds)
+            except Exception as exc:
+                logger.exception("on_update callback failed: %s", exc)
+                await asyncio.sleep(RETRY_DELAY)
+                continue
         wait_hours = random.randint(min_hours, max_hours)
         # Ждём случайный промежуток перед следующей оптимизацией
         await asyncio.sleep(wait_hours * 3600)

--- a/tests/test_periodic_optimization_error.py
+++ b/tests/test_periodic_optimization_error.py
@@ -1,0 +1,39 @@
+import asyncio
+import logging
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import ai.parameter_optimizer as po
+
+
+@pytest.mark.asyncio
+async def test_periodic_optimization_read_error(monkeypatch, caplog):
+    """Эмулирует ошибку чтения файла истории и проверяет повтор."""
+    # simulate read_excel raising an error
+    def _raise(*args, **kwargs):
+        raise OSError("boom")
+
+    monkeypatch.setattr(po.pd, "read_excel", _raise)
+
+    sleep_calls = []
+
+    async def fake_sleep(delay):
+        sleep_calls.append(delay)
+        raise RuntimeError
+
+    monkeypatch.setattr(po.asyncio, "sleep", fake_sleep)
+
+    # ensure log file exists so read_excel is called
+    dummy_log = pathlib.Path("dummy.xlsx")
+    dummy_log.touch()
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError):
+            await po.periodic_optimization(min_hours=1, max_hours=1, log_path=dummy_log)
+
+    assert sleep_calls and sleep_calls[0] == po.RETRY_DELAY
+    assert "Failed to optimize thresholds" in caplog.text


### PR DESCRIPTION
## Summary
- retry optimizer with minimal delay when `optimize_and_save` or `on_update` fails
- add test to cover history file read errors

## Testing
- `pytest tests/test_periodic_optimization_error.py -q`
- `pytest tests/test_calculate_basis.py tests/test_positions_file_path.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7e8efddc83209fdf8acf56f2cce1