### PR TITLE
Use timezone-aware timestamp when resetting daily loss

### DIFF
--- a/risk/risk_control.py
+++ b/risk/risk_control.py
@@ -13,7 +13,7 @@ import asyncio
 import time
 import math
 import logging
-from datetime import datetime
+import datetime
 from decimal import Decimal, getcontext
 
 getcontext().prec = 10
@@ -55,7 +55,7 @@ def _maybe_reset_daily_loss(now: float) -> None:
     if now - _state.last_reset_ts >= 24 * 3600:
         logger.info(
             "Daily loss reset at %s. Previous loss: %s",
-            datetime.utcfromtimestamp(now).isoformat(),
+            datetime.datetime.fromtimestamp(now, tz=datetime.UTC).isoformat(),
             _state.daily_loss,
         )
         _state.daily_loss = Decimal("0")

--- a/tests/test_risk_control.py
+++ b/tests/test_risk_control.py
@@ -1,0 +1,26 @@
+import logging
+from decimal import Decimal
+
+import pytest
+
+import risk.risk_control as rc
+
+
+def test_maybe_reset_daily_loss_uses_utc(caplog):
+    prev_last_reset_ts = rc._state.last_reset_ts
+    prev_daily_loss = rc._state.daily_loss
+    try:
+        rc._state.last_reset_ts = 0
+        rc._state.daily_loss = Decimal("5")
+        now = 24 * 3600 + 1
+
+        with caplog.at_level(logging.INFO):
+            rc._maybe_reset_daily_loss(now)
+
+        assert rc._state.daily_loss == Decimal("0")
+        assert rc._state.last_reset_ts == now
+        assert "+00:00" in caplog.text
+    finally:
+        rc._state.last_reset_ts = prev_last_reset_ts
+        rc._state.daily_loss = prev_daily_loss
+


### PR DESCRIPTION
## Summary
- ensure daily loss reset logging uses timezone-aware `datetime.fromtimestamp` with UTC
- test `_maybe_reset_daily_loss` produces `+00:00` in ISO timestamps

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f91750f408320a24a6196fbf38249