### PR TITLE
Use Decimal for trade size

### DIFF
--- a/main.py
+++ b/main.py
@@ -140,7 +140,7 @@ def initialize_bot() -> None:
     risk_control.configure(CONFIG.get("risk", {}), bot_cfg.get("deposit_size"))
 
 
-async def monitor_position(exchange_name: str, symbol: str, quantity: float) -> None:
+async def monitor_position(exchange_name: str, symbol: str, quantity: Decimal) -> None:
     """Следит за открытой позицией до срабатывания условий выхода."""
     poll_interval = CONFIG.get("bot", {}).get("poll_interval", 5)
     exchange = CLIENTS[exchange_name]
@@ -283,7 +283,9 @@ def start_processing_loops() -> None:
                     if await risk_control.is_paused() or await risk_control.is_symbol_open(symbol):
                         continue
                     try:
-                        base_metrics = await strategy.get_market_metrics(symbol, 1.0, client)
+                        base_metrics = await strategy.get_market_metrics(
+                            symbol, Decimal("1"), client
+                        )
                         if base_metrics is None:
                             logger.warning(
                                 "Пропуск %s:%s из-за неполных метрик", name, symbol
@@ -300,7 +302,7 @@ def start_processing_loops() -> None:
                     )
                     try:
                         metrics = await strategy.get_market_metrics(
-                            symbol, float(quantity), client
+                            symbol, quantity, client
                         )
                         if metrics is None:
                             logger.warning(
@@ -335,7 +337,7 @@ def start_processing_loops() -> None:
                                 )
                             )
                             task = asyncio.create_task(
-                                monitor_position(name, symbol, float(quantity))
+                                monitor_position(name, symbol, quantity)
                             )
                             POSITION_TASKS[f"{name}:{symbol}"] = task
                         except Exception as exc:
@@ -364,7 +366,12 @@ def start_processing_loops() -> None:
         # Возобновляем мониторинг ранее открытых позиций
         for symbol, entry in strategy.positions.items():
             exchange_name = entry.get("exchange")
-            quantity = entry.get("quantity", 0.0)
+            quantity_raw = entry.get("quantity", 0.0)
+            quantity = (
+                quantity_raw
+                if isinstance(quantity_raw, Decimal)
+                else Decimal(str(quantity_raw))
+            )
             if exchange_name in CLIENTS and quantity:
                 task = asyncio.create_task(
                     monitor_position(exchange_name, symbol, quantity)


### PR DESCRIPTION
## Summary
- ensure `monitor_position` and `scan_loop` work with `Decimal` quantities
- remove float conversions in `scan_loop`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f9169008883208756bd221b853704