### PR TITLE
Handle non-finite decimals in formatting

### DIFF
--- a/tests/test_format_decimal.py
+++ b/tests/test_format_decimal.py
@@ -1,0 +1,17 @@
+import logging
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from utils.telegram import format_decimal
+
+
+@pytest.mark.parametrize("value", [float("inf"), float("-inf"), float("nan")])
+def test_format_decimal_non_finite_returns_nan(value, caplog):
+    with caplog.at_level(logging.ERROR):
+        result = format_decimal(value)
+    assert result == "NaN"
+    assert "Non-finite decimal value" in caplog.text

--- a/utils/telegram.py
+++ b/utils/telegram.py
@@ -72,7 +72,15 @@ def format_decimal(value: float | Decimal, precision: int = 4, signed: bool = Fa
     при отображении прибыли и процентов.
     """
     quant = Decimal("1").scaleb(-precision)
-    number = Decimal(str(value)).quantize(quant, rounding=ROUND_HALF_UP)
+    try:
+        number = Decimal(str(value))
+    except Exception:
+        logger.exception("Invalid decimal value: %s", value)
+        return "NaN"
+    if not number.is_finite():
+        logger.error("Non-finite decimal value: %s", value)
+        return "NaN"
+    number = number.quantize(quant, rounding=ROUND_HALF_UP)
     result = f"{number:.{precision}f}"
     if signed and not result.startswith("-"):
         result = "+" + result


### PR DESCRIPTION
## Summary
- validate decimal values before quantizing and log/return `NaN` when non-finite
- test `format_decimal` against `inf`, `-inf`, and `nan`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fb2fe84508320a8ace44f18991d93