### PR TITLE
Handle invalid deposit config values

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,6 +54,22 @@ WHITELISTS: Dict[str, List[str]] = {}
 POSITION_TASKS: Dict[str, asyncio.Task] = {}
 
 
+def _parse_deposit_value(deposit_raw: Any) -> float | None:
+    """Преобразует значение депозита в ``float``.
+
+    При некорректном значении логирует ошибку и возвращает ``None``.
+    """
+    try:
+        deposit = float(deposit_raw)
+    except (TypeError, ValueError):
+        logger.error("Некорректное значение депозита: %s", deposit_raw)
+        return None
+    if not math.isfinite(deposit) or deposit < 0:
+        logger.error("Некорректное значение депозита: %s", deposit_raw)
+        return None
+    return deposit
+
+
 def load_config(path: str = "config.yaml") -> None:
     """Загружает конфигурацию YAML в глобальную переменную ``CONFIG``.
 
@@ -252,9 +268,8 @@ def start_processing_loops() -> None:
         while True:
             thresholds = CONFIG.get("thresholds", {})
             deposit_raw = CONFIG.get("bot", {}).get("deposit_size", float("inf"))
-            deposit = float(deposit_raw)
-            if not math.isfinite(deposit) or deposit < 0:
-                logger.error("Некорректное значение депозита: %s", deposit_raw)
+            deposit = _parse_deposit_value(deposit_raw)
+            if deposit is None:
                 await asyncio.sleep(poll_interval)
                 continue
             deposit_pct_raw = thresholds.get("deposit_pct", 0.05)

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -556,10 +556,15 @@ async def open_neutral_position(
         raise RuntimeError("Рыночные метрики недоступны, сделка пропущена")
     notional = quantity * entry_metrics.futures_price
     deposit_raw = bot_cfg.get("deposit_size", "Infinity")
-    deposit = Decimal(str(deposit_raw))
-    if not deposit.is_finite() or deposit < 0:
+    try:
+        deposit_f = float(deposit_raw)
+    except (TypeError, ValueError):
         logger.error("Некорректное значение депозита: %s", deposit_raw)
         raise RuntimeError("Некорректное значение депозита")
+    if not math.isfinite(deposit_f) or deposit_f < 0:
+        logger.error("Некорректное значение депозита: %s", deposit_raw)
+        raise RuntimeError("Некорректное значение депозита")
+    deposit = Decimal(str(deposit_f))
     deposit_pct = Decimal(str(config.get("thresholds", {}).get("deposit_pct", 1.0)))
     if deposit_pct < 0:
         logger.warning(

--- a/tests/test_invalid_config.py
+++ b/tests/test_invalid_config.py
@@ -1,0 +1,41 @@
+import logging
+from decimal import Decimal
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import main
+from strategies import funding_arbitrage as fa
+
+
+def test_parse_deposit_value_invalid(caplog):
+    with caplog.at_level(logging.ERROR):
+        assert main._parse_deposit_value("oops") is None
+    assert "Некорректное значение депозита" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_open_neutral_position_invalid_deposit(monkeypatch, caplog):
+    class DummyExchange:
+        name = "dummy"
+
+    async def fake_metrics(symbol, quantity, exchange):
+        class Metrics:
+            futures_price = Decimal("100")
+        return Metrics()
+
+    monkeypatch.setattr(fa, "get_market_metrics", fake_metrics)
+
+    config = {"bot": {"deposit_size": "oops"}, "thresholds": {}}
+    whitelists = {"dummy": ["BTCUSDT"]}
+    quantity = Decimal("1")
+    exchange = DummyExchange()
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError):
+            await fa.open_neutral_position(
+                exchange, "BTCUSDT", quantity, config, whitelists
+            )
+    assert "Некорректное значение депозита" in caplog.text


### PR DESCRIPTION
## Summary
- guard deposit parsing in main scan loop with try/except and log on invalid values
- validate `deposit_size` before using Decimal in `open_neutral_position`
- add tests covering bad `deposit_size` configuration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fb2f9f7548320b66b1ecaece6f2d9