### PR TITLE
Ensure Decimal usage for market metrics

### DIFF
--- a/main.py
+++ b/main.py
@@ -285,7 +285,7 @@ def start_processing_loops() -> None:
                         continue
                     try:
                         base_metrics = await strategy.get_market_metrics(
-                            symbol, Decimal("1"), client
+                            symbol, Decimal('1'), client
                         )
                         if base_metrics is None:
                             logger.warning(

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -773,7 +773,7 @@ async def close_neutral_position(
 async def monitor_neutral_position(
     exchange: BaseExchange,
     symbol: str,
-    quantity: float,
+    quantity: Decimal,
     exit_thresholds: Dict[str, float],
     config: Dict[str, Any],
     poll_interval: float = 5.0,
@@ -809,7 +809,7 @@ async def monitor_neutral_position(
         now = time.time()
         if entry:
             last = entry.last_funding_timestamp or now
-            quantity_d = quantity if isinstance(quantity, Decimal) else Decimal(str(quantity))
+            quantity_d = quantity
             price_d = metrics.futures_price
             elapsed = Decimal(str(now - last))
             funding_fee = (
@@ -888,7 +888,7 @@ async def monitor_neutral_position(
                 # Обновляем запись о позиции после частичного выхода
                 async with positions_lock:
                     quantity_d -= partial_qty_d
-                    quantity = float(quantity_d)
+                    quantity = quantity_d
                     entry.quantity = quantity_d
                     entry.pnl += pnl_part
                     await save_positions(config)
@@ -971,7 +971,7 @@ async def monitor_neutral_position(
                     )
                 continue
             await close_neutral_position(
-                exchange, symbol, Decimal(str(quantity)), config, pnl, final=True
+                exchange, symbol, quantity, config, pnl, final=True
             )
             if entry:
                 exit_basis = calculate_basis(


### PR DESCRIPTION
## Summary
- pass Decimal('1') and Decimal quantity to `get_market_metrics` in main scan loop
- switch `monitor_neutral_position` to use `Decimal` quantities throughout

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fb2f65b44832099bc09383c81f108