### PR TITLE
Use UTC-aware timestamps

### DIFF
--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -183,7 +183,7 @@ async def _handle_timeout() -> None:
             from strategies import funding_arbitrage as strategy
             from utils.logger import log_trade
             from utils.telegram import notify_close, format_duration
-            from datetime import datetime
+            from datetime import UTC, datetime
         except Exception as exc:  # pragma: no cover - defensive
             logger.error("Не удалось подготовить аварийное закрытие: %s", exc)
         else:
@@ -253,9 +253,9 @@ async def _handle_timeout() -> None:
                                 "symbol": symbol,
                                 "exchange": exchange_name,
                                 "entry_time": datetime.fromtimestamp(
-                                    entry.get("entry_timestamp", exit_ts)
+                                    entry.get("entry_timestamp", exit_ts), tz=UTC
                                 ).isoformat(),
-                                "exit_time": datetime.fromtimestamp(exit_ts).isoformat(),
+                                "exit_time": datetime.fromtimestamp(exit_ts, tz=UTC).isoformat(),
                                 "entry_futures_price": entry.get("entry_futures_price"),
                                 "exit_futures_price": exit_perp,
                                 "entry_spot_price": entry.get("entry_spot_price"),

--- a/risk/risk_control.py
+++ b/risk/risk_control.py
@@ -13,7 +13,7 @@ import asyncio
 import time
 import math
 import logging
-import datetime
+from datetime import UTC, datetime
 from decimal import Decimal, getcontext
 
 getcontext().prec = 10
@@ -55,7 +55,7 @@ def _maybe_reset_daily_loss(now: float) -> None:
     if now - _state.last_reset_ts >= 24 * 3600:
         logger.info(
             "Daily loss reset at %s. Previous loss: %s",
-            datetime.datetime.fromtimestamp(now, tz=datetime.UTC).isoformat(),
+            datetime.fromtimestamp(now, tz=UTC).isoformat(),
             _state.daily_loss,
         )
         _state.daily_loss = Decimal("0")

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -13,7 +13,7 @@ import logging
 import math
 import time
 from dataclasses import dataclass, field, asdict
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Dict
 from decimal import Decimal, getcontext
@@ -652,7 +652,7 @@ async def open_neutral_position(
             {
                 "symbol": symbol,
                 "exchange": exchange_name,
-                "entry_time": datetime.fromtimestamp(now).isoformat(),
+                "entry_time": datetime.fromtimestamp(now, tz=UTC).isoformat(),
                 "exit_time": None,
                 "entry_futures_price": entry_metrics.futures_price,
                 "exit_futures_price": None,
@@ -917,8 +917,8 @@ async def monitor_neutral_position(
                     {
                         "symbol": symbol,
                         "exchange": exchange_name,
-                        "entry_time": datetime.fromtimestamp(entry.entry_timestamp).isoformat(),
-                        "exit_time": datetime.fromtimestamp(exit_ts).isoformat(),
+                        "entry_time": datetime.fromtimestamp(entry.entry_timestamp, tz=UTC).isoformat(),
+                        "exit_time": datetime.fromtimestamp(exit_ts, tz=UTC).isoformat(),
                         "entry_futures_price": entry.entry_futures_price,
                         "exit_futures_price": metrics.futures_price,
                         "entry_spot_price": entry.entry_spot_price,
@@ -1005,8 +1005,8 @@ async def monitor_neutral_position(
                     {
                           "symbol": symbol,
                           "exchange": exchange_name,
-                          "entry_time": datetime.fromtimestamp(entry.entry_timestamp).isoformat(),
-                          "exit_time": datetime.fromtimestamp(exit_ts).isoformat(),
+                          "entry_time": datetime.fromtimestamp(entry.entry_timestamp, tz=UTC).isoformat(),
+                          "exit_time": datetime.fromtimestamp(exit_ts, tz=UTC).isoformat(),
                           "entry_futures_price": entry.entry_futures_price,
                           "exit_futures_price": metrics.futures_price,
                           "entry_spot_price": entry.entry_spot_price,


### PR DESCRIPTION
## Summary
- ensure all key logging uses timezone-aware datetimes
- include `UTC` timezone when resetting daily loss
- record trades and emergency exits with UTC timestamps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fb2f3a9fc8320a9e16cc05e915851