### PR TITLE
refactor: pass config and whitelists explicitly

### DIFF
--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -200,7 +200,11 @@ async def _handle_timeout() -> None:
                     )
                     try:
                         orders = await strategy.close_neutral_position(
-                            client, symbol, quantity, CONFIG, final=True
+                            client,
+                            symbol,
+                            quantity,
+                            config=CONFIG,
+                            final=True,
                         )
                     except Exception as exc_close:
                         logger.error(

--- a/main.py
+++ b/main.py
@@ -152,8 +152,8 @@ async def monitor_position(exchange_name: str, symbol: str, quantity: Decimal) -
             symbol,
             quantity,
             CONFIG.get("thresholds", {}),
-            CONFIG,
-            poll_interval,
+            config=CONFIG,
+            poll_interval=poll_interval,
             position_id=position_id,
         )
     except Exception as exc:
@@ -315,12 +315,20 @@ def start_processing_loops() -> None:
                         continue
 
                     if await strategy.check_entry_conditions(
-                        symbol, quantity, metrics, thresholds, CONFIG
+                        symbol,
+                        quantity,
+                        metrics,
+                        thresholds,
+                        config=CONFIG,
                     ):
                         # Условия входа выполнены – открываем позицию
                         try:
                             await strategy.open_neutral_position(
-                                client, symbol, quantity, CONFIG, WHITELISTS
+                                client,
+                                symbol,
+                                quantity,
+                                config=CONFIG,
+                                whitelists=WHITELISTS,
                             )
                             volume_usd = quantity * Decimal(str(metrics.futures_price))
                             funding_pct = format_decimal(metrics.funding_rate * 100, 4)

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -274,6 +274,7 @@ def check_entry_conditions(
     quantity: Decimal,
     metrics: MarketMetrics | None,
     thresholds: Dict[str, float],
+    *,
     config: Dict[str, Any],
 ) -> bool | asyncio.Future:
     """Возвращает ``True`` при выполнении всех условий входа.
@@ -542,6 +543,7 @@ async def open_neutral_position(
     exchange: BaseExchange,
     symbol: str,
     quantity: Decimal,
+    *,
     config: Dict[str, Any],
     whitelists: Dict[str, list[str]],
 ) -> Dict[str, Dict]:
@@ -690,6 +692,7 @@ async def close_neutral_position(
     exchange: BaseExchange,
     symbol: str,
     quantity: Decimal,
+    *,
     config: Dict[str, Any],
     pnl: Decimal = Decimal(0),
     final: bool = True,
@@ -775,6 +778,7 @@ async def monitor_neutral_position(
     symbol: str,
     quantity: float,
     exit_thresholds: Dict[str, float],
+    *,
     config: Dict[str, Any],
     poll_interval: float = 5.0,
     position_id: str | None = None,
@@ -883,7 +887,12 @@ async def monitor_neutral_position(
                 partial_qty_d = quantity_d / Decimal(2)
                 pnl_part = (fut_diff - spot_diff) * partial_qty_d
                 orders = await close_neutral_position(
-                    exchange, symbol, partial_qty_d, config, pnl_part, final=False
+                    exchange,
+                    symbol,
+                    partial_qty_d,
+                    config=config,
+                    pnl=pnl_part,
+                    final=False,
                 )
                 # Обновляем запись о позиции после частичного выхода
                 async with positions_lock:
@@ -971,7 +980,12 @@ async def monitor_neutral_position(
                     )
                 continue
             await close_neutral_position(
-                exchange, symbol, Decimal(str(quantity)), config, pnl, final=True
+                exchange,
+                symbol,
+                Decimal(str(quantity)),
+                config=config,
+                pnl=pnl,
+                final=True,
             )
             if entry:
                 exit_basis = calculate_basis(


### PR DESCRIPTION
## Summary
- make funding arbitrage helpers require config and whitelists as keyword arguments
- call strategy helpers with explicit config and whitelist data
- adapt emergency close to new API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fb2e9b8088320a3efd5ad419e185c