### PR TITLE
Fix Decimal handling and WebSocket cleanup

### DIFF
--- a/exchanges/binance.py
+++ b/exchanges/binance.py
@@ -399,15 +399,17 @@ class BinanceExchange(BaseExchange):
         self._spot_ws_tasks.clear()
 
         for ws in list(self._ws.values()):
-            try:
-                await ws.close()
-            except WebSocketException:
-                pass
+            if ws is not None:
+                try:
+                    await ws.close()
+                except WebSocketException:
+                    pass
         for ws in list(self._spot_ws.values()):
-            try:
-                await ws.close()
-            except WebSocketException:
-                pass
+            if ws is not None:
+                try:
+                    await ws.close()
+                except WebSocketException:
+                    pass
         self._ws.clear()
         self._spot_ws.clear()
 

--- a/exchanges/bybit.py
+++ b/exchanges/bybit.py
@@ -413,15 +413,17 @@ class BybitExchange(BaseExchange):
         self._spot_ws_tasks.clear()
 
         for ws in list(self._ws.values()):
-            try:
-                await ws.close()
-            except WebSocketException:
-                pass
+            if ws is not None:
+                try:
+                    await ws.close()
+                except WebSocketException:
+                    pass
         for ws in list(self._spot_ws.values()):
-            try:
-                await ws.close()
-            except WebSocketException:
-                pass
+            if ws is not None:
+                try:
+                    await ws.close()
+                except WebSocketException:
+                    pass
         self._ws.clear()
         self._spot_ws.clear()
 

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -223,7 +223,9 @@ async def get_market_metrics(
         open_interest *= futures_price
     else:
         open_interest = Decimal(0)
-    liquidity = sum(q for _, q in bids) + sum(q for _, q in asks)
+    liquidity = sum((q for _, q in bids), Decimal(0)) + sum(
+        (q for _, q in asks), Decimal(0)
+    )
     basis = calculate_basis(futures_price, spot_price)
     if basis is None:
         basis = Decimal("Infinity")
@@ -812,9 +814,14 @@ async def monitor_neutral_position(
             await asyncio.sleep(poll_interval)
             continue
         now = time.time()
+        quantity_d = quantity if isinstance(quantity, Decimal) else Decimal(
+            str(quantity)
+        )
+        fut_diff = Decimal(0)
+        spot_diff = Decimal(0)
+        pnl = Decimal(0)
         if entry:
             last = entry.last_funding_timestamp or now
-            quantity_d = quantity
             price_d = metrics.futures_price
             elapsed = Decimal(str(now - last))
             funding_fee = (
@@ -875,8 +882,6 @@ async def monitor_neutral_position(
                 pnl + entry.funding_accrued - entry.commissions < Decimal(0)
             ):
                 reasons.append("pnl_vs_cost")
-        else:
-            pnl = Decimal(0)
         if reasons:
             min_trade_usd = Decimal(str(exit_thresholds.get("min_trade_size", 0.0)))
             min_trade_qty = (


### PR DESCRIPTION
## Summary
- compute liquidity using Decimal sums to avoid int mixing
- initialize trade metrics to avoid unbound local variables
- guard WebSocket closing when connections are missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689056f7009883208a4d6f5a9082c1b0