### PR TITLE
Rename Binance secret key for clarity

### DIFF
--- a/main.py
+++ b/main.py
@@ -89,7 +89,7 @@ def load_config(path: str = "config.yaml") -> None:
     # API-ключи загружаем из переменных окружения
     api_keys = {
         "binance": os.getenv("BINANCE_API_KEY"),
-        "secret": os.getenv("BINANCE_API_SECRET"),
+        "binance_secret": os.getenv("BINANCE_API_SECRET"),
         "bybit": os.getenv("BYBIT_API_KEY"),
         "bybit_secret": os.getenv("BYBIT_API_SECRET"),
     }
@@ -110,7 +110,7 @@ async def initialize_bot() -> None:
 
     # Создаём клиентов бирж, если заданы ключи
     binance_key = api_keys.get("binance")
-    binance_secret = api_keys.get("secret") or api_keys.get("binance_secret")
+    binance_secret = api_keys.get("binance_secret")
     if binance_key and binance_secret:
         CLIENTS["binance"] = BinanceExchange(binance_key, binance_secret)
 


### PR DESCRIPTION
## Summary
- Rename `secret` API key entry to `binance_secret` when loading config
- Update bot initialization to use `binance_secret`

## Testing
- `pytest -q`
- Manually verified log output listing `['binance', 'binance_secret', 'bybit', 'bybit_secret']`


------
https://chatgpt.com/codex/tasks/task_e_689062b1361c832081f00ea87e073b9b