### PR TITLE
Improve logging for incomplete market metrics

### DIFF
--- a/main.py
+++ b/main.py
@@ -313,13 +313,16 @@ async def start_processing_loops() -> None:
                         continue
                     try:
                         base_metrics = await strategy.get_market_metrics(
-                            symbol, Decimal('1'), client
+                            symbol, Decimal("1"), client
                         )
-                        if base_metrics is None:
-                            logger.warning(
-                                "Пропуск %s:%s из-за неполных метрик", name, symbol
-                            )
-                            continue
+                    except strategy.MissingMetricsError as err:
+                        logger.warning(
+                            "Пропуск %s:%s из-за неполных метрик (%s)",
+                            name,
+                            symbol,
+                            ", ".join(err.missing_fields),
+                        )
+                        continue
                     except Exception as exc:
                         logger.error("Ошибка метрик %s %s: %s", name, symbol, exc)
                         continue
@@ -333,11 +336,14 @@ async def start_processing_loops() -> None:
                         metrics = await strategy.get_market_metrics(
                             symbol, quantity, client
                         )
-                        if metrics is None:
-                            logger.warning(
-                                "Пропуск %s:%s из-за неполных метрик", name, symbol
-                            )
-                            continue
+                    except strategy.MissingMetricsError as err:
+                        logger.warning(
+                            "Пропуск %s:%s из-за неполных метрик (%s)",
+                            name,
+                            symbol,
+                            ", ".join(err.missing_fields),
+                        )
+                        continue
                     except Exception as exc:
                         logger.error("Ошибка метрик %s %s: %s", name, symbol, exc)
                         continue

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -136,12 +136,21 @@ def calculate_basis(
     return value if signed else abs(value)
 
 
+class MissingMetricsError(Exception):
+    """Raised when required market data fields are missing."""
+
+    def __init__(self, missing_fields: list[str]):
+        self.missing_fields = missing_fields
+        message = ", ".join(missing_fields)
+        super().__init__(f"Missing metrics: {message}")
+
+
 async def get_market_metrics(
     symbol: str,
     trade_size: Decimal,
     exchange: BaseExchange | None = None,
     depth: int = 5,
-) -> MarketMetrics | None:
+) -> MarketMetrics:
     """Получает расширенные рыночные метрики для ``symbol``.
 
     ``exchange`` может быть ``None`` – в этом случае используются
@@ -176,9 +185,17 @@ async def get_market_metrics(
     spot_bids = [(Decimal(str(p)), Decimal(str(q))) for p, q in spot_book.get("bids", [])]
     spot_asks = [(Decimal(str(p)), Decimal(str(q))) for p, q in spot_book.get("asks", [])]
 
-    # If any order book side is empty, market data is incomplete
-    if not (bids and asks and spot_bids and spot_asks):
-        return None
+    missing = []
+    if not bids:
+        missing.append("perp_bids")
+    if not asks:
+        missing.append("perp_asks")
+    if not spot_bids:
+        missing.append("spot_bids")
+    if not spot_asks:
+        missing.append("spot_asks")
+    if missing:
+        raise MissingMetricsError(missing)
 
     def _calc_slippage(orders: list[tuple[Decimal, Decimal]], size: Decimal, mid: Decimal) -> Decimal:
         """Оценивает проскальзывание при выполнении ``size`` по стакану."""
@@ -215,7 +232,7 @@ async def get_market_metrics(
     else:
         stats = await get_stats(symbol)
     if not stats:
-        return None
+        raise MissingMetricsError(["stats"])
 
     volume = Decimal(str(stats.get("volume_24h", 0.0)))
     open_interest = Decimal(str(stats.get("open_interest", 0.0)))
@@ -236,10 +253,7 @@ async def get_market_metrics(
     else:
         ohlc = await get_ohlc(symbol, interval="15m", limit=1)
     if not ohlc:
-        # Without recent OHLC data we cannot estimate volatility.
-        # Returning ``None`` signals to the caller that metrics are incomplete
-        # so the strategy can skip trading for this symbol.
-        return None
+        raise MissingMetricsError(["ohlc"])
 
     candle = ohlc[0]
     o = Decimal(str(candle.get("open", "NaN")))
@@ -553,9 +567,13 @@ async def open_neutral_position(
     if symbol not in whitelists.get(exchange_name, []):
         raise RuntimeError("Символ отсутствует в белом списке")
     # Получаем метрики рынка для оценки сделки
-    entry_metrics = await get_market_metrics(symbol, quantity, exchange)
-    if entry_metrics is None:
-        raise RuntimeError("Рыночные метрики недоступны, сделка пропущена")
+    try:
+        entry_metrics = await get_market_metrics(symbol, quantity, exchange)
+    except MissingMetricsError as err:
+        raise RuntimeError(
+            "Рыночные метрики недоступны, отсутствуют поля: "
+            + ", ".join(err.missing_fields)
+        ) from err
     notional = quantity * entry_metrics.futures_price
     deposit_raw = bot_cfg.get("deposit_size", "Infinity")
     try:
@@ -805,10 +823,14 @@ async def monitor_neutral_position(
     while True:
         try:
             metrics = await get_market_metrics(symbol, quantity, exchange)
-            if metrics is None:
-                logger.warning("Неполные рыночные данные для %s", symbol)
-                await asyncio.sleep(poll_interval)
-                continue
+        except MissingMetricsError as err:
+            logger.warning(
+                "Неполные рыночные данные для %s: %s",
+                symbol,
+                ", ".join(err.missing_fields),
+            )
+            await asyncio.sleep(poll_interval)
+            continue
         except Exception as exc:
             logger.error("Ошибка мониторинга %s: %s", symbol, exc)
             await asyncio.sleep(poll_interval)

--- a/tests/test_missing_metrics.py
+++ b/tests/test_missing_metrics.py
@@ -1,0 +1,33 @@
+import pytest
+from decimal import Decimal
+
+from strategies import funding_arbitrage as fa
+
+
+@pytest.mark.asyncio
+async def test_get_market_metrics_missing_fields(monkeypatch):
+    async def fake_fetch_funding_history(symbol, hours=8, limit=3):
+        return [0.01]
+
+    async def fake_get_orderbook(symbol, depth=5):
+        return {"bids": [], "asks": [(100, 1)]}
+
+    async def fake_get_spot_orderbook(symbol, depth=5):
+        return {"bids": [(99, 1)], "asks": [(101, 1)]}
+
+    async def fake_get_stats(symbol):
+        return {"volume_24h": 0, "open_interest": 0}
+
+    async def fake_get_ohlc(symbol, interval="15m", limit=1):
+        return [{"open": 100, "close": 100}]
+
+    monkeypatch.setattr(fa, "fetch_funding_history", fake_fetch_funding_history)
+    monkeypatch.setattr(fa, "get_orderbook", fake_get_orderbook)
+    monkeypatch.setattr(fa, "get_spot_orderbook", fake_get_spot_orderbook)
+    monkeypatch.setattr(fa, "get_stats", fake_get_stats)
+    monkeypatch.setattr(fa, "get_ohlc", fake_get_ohlc)
+
+    with pytest.raises(fa.MissingMetricsError) as excinfo:
+        await fa.get_market_metrics("BTCUSDT", Decimal("1"))
+
+    assert "perp_bids" in excinfo.value.missing_fields


### PR DESCRIPTION
## Summary
- Raise `MissingMetricsError` from `get_market_metrics` when order books, stats or OHLC data are missing
- Log the missing metric fields before skipping symbols or monitoring positions
- Add tests verifying `MissingMetricsError` behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890658ed3088320a5343c35d0266501