### PR TITLE
Throttle duplicate metric warnings

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple, Sequence
 from decimal import Decimal
 import math
 
@@ -52,6 +52,43 @@ WHITELISTS: Dict[str, List[str]] = {}
 # Отслеживаем задачи мониторинга открытых позиций,
 # чтобы при необходимости отменить их при завершении работы.
 POSITION_TASKS: Dict[str, asyncio.Task] = {}
+
+# Отслеживаем последние предупреждения о неполных метриках
+# для каждого символа, чтобы подавлять повторяющиеся сообщения.
+_METRIC_WARNINGS: Dict[str, Tuple[float, int]] = {}
+# Минимальный интервал между предупреждениями по одному символу.
+_WARN_COOLDOWN = 60.0
+
+
+def _log_incomplete_metrics(exchange: str, symbol: str, missing: Sequence[str]) -> None:
+    """Логирует предупреждение о неполных метриках с учётом кулдауна."""
+    key = f"{exchange}:{symbol}"
+    now = time.time()
+    last_ts, count = _METRIC_WARNINGS.get(key, (0.0, 0))
+    if now - last_ts < _WARN_COOLDOWN:
+        _METRIC_WARNINGS[key] = (last_ts, count + 1)
+        return
+    if count:
+        logger.warning(
+            "Пропуск %s:%s из-за неполных метрик (%s) (ещё %d раз)",
+            exchange,
+            symbol,
+            ", ".join(missing),
+            count,
+        )
+    else:
+        logger.warning(
+            "Пропуск %s:%s из-за неполных метрик (%s)",
+            exchange,
+            symbol,
+            ", ".join(missing),
+        )
+    _METRIC_WARNINGS[key] = (now, 0)
+
+
+def _reset_metric_warning(exchange: str, symbol: str) -> None:
+    """Сбрасывает счётчик предупреждений для символа."""
+    _METRIC_WARNINGS.pop(f"{exchange}:{symbol}", None)
 
 
 def _parse_deposit_value(deposit_raw: Any) -> float | None:
@@ -316,12 +353,7 @@ async def start_processing_loops() -> None:
                             symbol, Decimal("1"), client
                         )
                     except strategy.MissingMetricsError as err:
-                        logger.warning(
-                            "Пропуск %s:%s из-за неполных метрик (%s)",
-                            name,
-                            symbol,
-                            ", ".join(err.missing_fields),
-                        )
+                        _log_incomplete_metrics(name, symbol, err.missing_fields)
                         continue
                     except Exception as exc:
                         logger.error("Ошибка метрик %s %s: %s", name, symbol, exc)
@@ -337,16 +369,13 @@ async def start_processing_loops() -> None:
                             symbol, quantity, client
                         )
                     except strategy.MissingMetricsError as err:
-                        logger.warning(
-                            "Пропуск %s:%s из-за неполных метрик (%s)",
-                            name,
-                            symbol,
-                            ", ".join(err.missing_fields),
-                        )
+                        _log_incomplete_metrics(name, symbol, err.missing_fields)
                         continue
                     except Exception as exc:
                         logger.error("Ошибка метрик %s %s: %s", name, symbol, exc)
                         continue
+
+                    _reset_metric_warning(name, symbol)
 
                     if await strategy.check_entry_conditions(
                         symbol, quantity, metrics, thresholds, CONFIG

--- a/tests/test_warning_cooldown.py
+++ b/tests/test_warning_cooldown.py
@@ -1,0 +1,20 @@
+import logging
+import main
+
+
+def test_warning_suppressed_within_cooldown(monkeypatch, caplog):
+    caplog.set_level(logging.WARNING)
+    main._METRIC_WARNINGS.clear()
+
+    fake_time = 1000.0
+
+    def fake_time_func():
+        return fake_time
+
+    monkeypatch.setattr(main.time, "time", fake_time_func)
+
+    main._log_incomplete_metrics("binance", "BTCUSDT", ["x"])
+    main._log_incomplete_metrics("binance", "BTCUSDT", ["x"])
+
+    warnings = [r.message for r in caplog.records if "Пропуск" in r.message]
+    assert len(warnings) == 1


### PR DESCRIPTION
## Summary
- suppress duplicate incomplete metric warnings by tracking last timestamps
- reset warning state on success
- test that repeated failures only warn once per cooldown

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68907894acfc8320877d0854ce089bd6