### PR TITLE
Add REST fallback for orderbook snapshots

### DIFF
--- a/exchanges/binance.py
+++ b/exchanges/binance.py
@@ -331,12 +331,46 @@ class BinanceExchange(BaseExchange):
                     except WebSocketException:
                         pass
 
+    async def _ensure_orderbook(self, symbol: str, depth: int, spot: bool = False) -> None:
+        """Гарантирует наличие снимка стакана в кэше.
+
+        Если для ``symbol`` ещё нет данных, выполняет REST‑запрос ``/depth``
+        (для фьючерсов) или ``/api/v3/depth`` (для спота) и сохраняет результат
+        в соответствующий кэш. При неудаче создаёт пустую запись, чтобы
+        последующие вызовы возвращали пустой стакан.
+        """
+
+        cache = self._spot_orderbooks if spot else self._orderbooks
+        book = cache.get(symbol)
+        if book and book.get("bids") and book.get("asks"):
+            return
+
+        url = (
+            f"{self.SPOT_REST_URL}/api/v3/depth"
+            if spot
+            else f"{self.REST_URL}/fapi/v1/depth"
+        )
+        params = {"symbol": symbol, "limit": depth}
+        try:
+            data = await asyncio.wait_for(
+                self._request("GET", url, params=params), timeout=5
+            )
+        except Exception:
+            cache.setdefault(symbol, {"bids": [], "asks": []})
+            return
+
+        if data and "bids" in data and "asks" in data:
+            cache[symbol] = {"bids": data["bids"], "asks": data["asks"]}
+        else:
+            cache.setdefault(symbol, {"bids": [], "asks": []})
+
     async def get_spot_orderbook(self, symbol: str, depth: int = 5) -> dict:
         """Возвращает кэшированный спотовый стакан для ``symbol``."""
         if symbol not in self._spot_ws_tasks:
             self._spot_ws_tasks[symbol] = asyncio.create_task(
                 self._listen_spot(symbol, depth)
             )
+        await self._ensure_orderbook(symbol, depth, spot=True)
         return self._spot_orderbooks.get(symbol, {"bids": [], "asks": []})
 
     # ------------------------------------------------------------------
@@ -380,6 +414,7 @@ class BinanceExchange(BaseExchange):
         """Возвращает кэшированный фьючерсный стакан."""
         if symbol not in self._ws_tasks:
             self._ws_tasks[symbol] = asyncio.create_task(self._listen(symbol))
+        await self._ensure_orderbook(symbol, depth)
         return self._orderbooks.get(symbol, {"bids": [], "asks": []})
 
     async def close(self) -> None:

--- a/exchanges/bybit.py
+++ b/exchanges/bybit.py
@@ -340,12 +340,49 @@ class BybitExchange(BaseExchange):
                     except WebSocketException:
                         pass
 
+    async def _ensure_orderbook(self, symbol: str, depth: int, spot: bool = False) -> None:
+        """Гарантирует наличие снимка стакана в кэше.
+
+        При отсутствии данных выполняет REST‑запрос ``/v5/market/orderbook`` и
+        записывает ответ в ``_orderbooks`` или ``_spot_orderbooks``. Если
+        запрос завершается ошибкой, создаёт пустую запись, чтобы метод
+        ``get_*_orderbook`` мог вернуть пустой стакан.
+        """
+
+        cache = self._spot_orderbooks if spot else self._orderbooks
+        book = cache.get(symbol)
+        if book and book.get("bids") and book.get("asks"):
+            return
+
+        url = f"{self.REST_URL}/v5/market/orderbook"
+        params = {
+            "symbol": symbol,
+            "limit": depth,
+            "category": "spot" if spot else "linear",
+        }
+        try:
+            data = await asyncio.wait_for(
+                self._request("GET", url, params=params), timeout=5
+            )
+        except Exception:
+            cache.setdefault(symbol, {"bids": [], "asks": []})
+            return
+
+        result = (data or {}).get("result", {})
+        bids = result.get("b") or result.get("bids", [])
+        asks = result.get("a") or result.get("asks", [])
+        if bids or asks:
+            cache[symbol] = {"bids": bids, "asks": asks}
+        else:
+            cache.setdefault(symbol, {"bids": [], "asks": []})
+
     async def get_spot_orderbook(self, symbol: str, depth: int = 5) -> dict:
         """Возвращает кэшированный спотовый стакан."""
         if symbol not in self._spot_ws_tasks:
             self._spot_ws_tasks[symbol] = asyncio.create_task(
                 self._listen_spot(symbol)
             )
+        await self._ensure_orderbook(symbol, depth, spot=True)
         return self._spot_orderbooks.get(symbol, {"bids": [], "asks": []})
 
     # ------------------------------------------------------------------
@@ -394,6 +431,7 @@ class BybitExchange(BaseExchange):
         """Возвращает кэшированный фьючерсный стакан."""
         if symbol not in self._ws_tasks:
             self._ws_tasks[symbol] = asyncio.create_task(self._listen(symbol))
+        await self._ensure_orderbook(symbol, depth)
         return self._orderbooks.get(symbol, {"bids": [], "asks": []})
 
     async def close(self) -> None:

--- a/tests/test_orderbook_snapshot.py
+++ b/tests/test_orderbook_snapshot.py
@@ -1,0 +1,62 @@
+import pytest
+
+from exchanges.binance import BinanceExchange
+from exchanges.bybit import BybitExchange
+
+
+@pytest.mark.asyncio
+async def test_binance_rest_snapshot_populates_cache(monkeypatch):
+    exch = BinanceExchange("", "")
+
+    snapshots = {
+        "perp": {"bids": [["100", "1"]], "asks": [["101", "1"]]},
+        "spot": {"bids": [["99", "1"]], "asks": [["102", "1"]]},
+    }
+
+    async def fake_request(method, url, **kwargs):
+        return snapshots["spot" if "api/v3" in url else "perp"]
+
+    async def dummy_listen(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(exch, "_request", fake_request)
+    monkeypatch.setattr(exch, "_listen", dummy_listen)
+    monkeypatch.setattr(exch, "_listen_spot", dummy_listen)
+
+    book = await exch.get_orderbook("BTCUSDT", depth=5)
+    assert book == snapshots["perp"]
+    assert exch._orderbooks["BTCUSDT"] == snapshots["perp"]
+
+    spot_book = await exch.get_spot_orderbook("BTCUSDT", depth=5)
+    assert spot_book == snapshots["spot"]
+    assert exch._spot_orderbooks["BTCUSDT"] == snapshots["spot"]
+
+    await exch.close()
+
+
+@pytest.mark.asyncio
+async def test_bybit_rest_snapshot_populates_cache(monkeypatch):
+    exch = BybitExchange("", "")
+
+    async def fake_request(method, url, **kwargs):
+        params = kwargs.get("params", {})
+        if params.get("category") == "spot":
+            return {"result": {"b": [["200", "1"]], "a": [["201", "1"]]}}
+        return {"result": {"b": [["300", "1"]], "a": [["301", "1"]]}}
+
+    async def dummy_listen(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(exch, "_request", fake_request)
+    monkeypatch.setattr(exch, "_listen", dummy_listen)
+    monkeypatch.setattr(exch, "_listen_spot", dummy_listen)
+
+    book = await exch.get_orderbook("BTCUSDT", depth=5)
+    assert book == {"bids": [["300", "1"]], "asks": [["301", "1"]]}
+    assert exch._orderbooks["BTCUSDT"] == {"bids": [["300", "1"]], "asks": [["301", "1"]]}
+
+    spot_book = await exch.get_spot_orderbook("BTCUSDT", depth=5)
+    assert spot_book == {"bids": [["200", "1"]], "asks": [["201", "1"]]}
+    assert exch._spot_orderbooks["BTCUSDT"] == {"bids": [["200", "1"]], "asks": [["201", "1"]]}
+
+    await exch.close()


### PR DESCRIPTION
## Summary
- ensure Binance and Bybit orderbook retrieval falls back to REST snapshots when cache is empty
- share snapshot loading via new `_ensure_orderbook` helper
- add tests for REST snapshot population when WebSocket cache is empty

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890789396988320959b63946f29b8f5