### PR TITLE
Support wildcard symbol whitelist in Binance

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,9 +23,13 @@ risk:
   deposit_cap_pct: 0.3
 bot:
   poll_interval: 5
-  whitelist:
-    - BTCUSDT
-    - ETHUSDT
+  whitelist: "*"          # "*" — включить все доступные символы
+  # whitelist:
+  #   binance:              # Пример задания списка отдельно для биржи
+  #     - BTCUSDT
+  #     - ETHUSDT
+  #   bybit:
+  #     - XRPUSDT
   deposit_size: 100
   positions_file: open_positions.json
 

--- a/main.py
+++ b/main.py
@@ -165,18 +165,6 @@ async def initialize_bot() -> None:
         CLIENTS["bybit"] = BybitExchange(bybit_key, bybit_secret)
         logger.info("Создан клиент биржи Bybit")
 
-    # Загружаем белые списки символов для каждой биржи
-    bot_cfg = CONFIG.get("bot", {})
-    wl_cfg = bot_cfg.get("whitelist", {})
-    if isinstance(wl_cfg, dict):
-        WHITELISTS.update({k: list(v) for k, v in wl_cfg.items()})
-    else:
-        symbols = list(wl_cfg) if isinstance(wl_cfg, list) else []
-        for name in CLIENTS:
-            WHITELISTS[name] = symbols
-    for name, symbols in WHITELISTS.items():
-        logger.info("Белый список %s: %s", name, symbols)
-
     async def _collect(exchange: BaseExchange) -> set[str]:
         futures = await exchange.get_futures_symbols()
         spot = await exchange.get_spot_symbols()
@@ -198,6 +186,27 @@ async def initialize_bot() -> None:
         return dict(pairs)
 
     available = await _fetch_all() if CLIENTS else {}
+
+    # Загружаем белые списки символов для каждой биржи
+    bot_cfg = CONFIG.get("bot", {})
+    wl_cfg = bot_cfg.get("whitelist")
+    if isinstance(wl_cfg, dict):
+        for name in CLIENTS:
+            cfg = wl_cfg.get(name)
+            if not cfg or cfg == "*":
+                WHITELISTS[name] = sorted(available.get(name, []))
+            else:
+                WHITELISTS[name] = list(cfg)
+    elif not wl_cfg or wl_cfg == "*":
+        for name in CLIENTS:
+            WHITELISTS[name] = sorted(available.get(name, []))
+    else:
+        symbols = list(wl_cfg) if isinstance(wl_cfg, list) else []
+        for name in CLIENTS:
+            WHITELISTS[name] = symbols
+    for name, symbols in WHITELISTS.items():
+        logger.info("Белый список %s: %s", name, symbols)
+
     for name, allowed in available.items():
         configured = WHITELISTS.get(name, [])
         filtered = [s for s in configured if s in allowed]

--- a/tests/test_whitelist_wildcard.py
+++ b/tests/test_whitelist_wildcard.py
@@ -1,0 +1,39 @@
+import pytest
+import main
+
+
+@pytest.mark.asyncio
+async def test_wildcard_whitelist_populates_symbols(monkeypatch):
+    class DummyExchange:
+        name = "binance"
+
+        def __init__(self, key, secret):
+            pass
+
+        async def get_futures_symbols(self):
+            return ["BTCUSDT", "ETHUSDT"]
+
+        async def get_spot_symbols(self):
+            return ["BTCUSDT", "ETHUSDT", "XRPUSDT"]
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr(main, "BinanceExchange", DummyExchange)
+    monkeypatch.setattr(main.risk_control, "configure", lambda cfg, dep: None)
+
+    main.CONFIG = {
+        "api_keys": {"binance": "k", "binance_secret": "s"},
+        "bot": {"whitelist": "*", "deposit_size": 100},
+        "risk": {},
+    }
+    main.CLIENTS.clear()
+    main.WHITELISTS.clear()
+
+    await main.initialize_bot()
+
+    assert main.WHITELISTS["binance"] == ["BTCUSDT", "ETHUSDT"]
+
+    # cleanup
+    main.CLIENTS.clear()
+    main.WHITELISTS.clear()


### PR DESCRIPTION
## Summary
- auto-generate Binance whitelist when configuration whitelist is `*` or empty
- document wildcard and per-exchange whitelist syntax in `config.yaml`
- test wildcard whitelist generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68907e7f6ed08320beed4ee78b6e8c1a