### PR TITLE
feat: log cycle duration and passed symbols

### DIFF
--- a/main.py
+++ b/main.py
@@ -304,6 +304,8 @@ async def start_processing_loops() -> None:
     async def scan_loop() -> None:
         """Постоянно сканирует рынок в поиске входов."""
         while True:
+            cycle_start = time.perf_counter()
+            passed_symbols: list[str] = []
             thresholds = CONFIG.get("thresholds", {})
             deposit_raw = CONFIG.get("bot", {}).get("deposit_size", float("inf"))
             deposit = _parse_deposit_value(deposit_raw)
@@ -364,6 +366,7 @@ async def start_processing_loops() -> None:
                     if await strategy.check_entry_conditions(
                         symbol, quantity, metrics, thresholds, CONFIG
                     ):
+                        passed_symbols.append(f"{name}:{symbol}")
                         # Условия входа выполнены – открываем позицию
                         try:
                             await strategy.open_neutral_position(
@@ -392,6 +395,12 @@ async def start_processing_loops() -> None:
                             POSITION_TASKS[f"{name}:{symbol}"] = task
                         except Exception as exc:
                             logger.error("Ошибка открытия %s %s: %s", name, symbol, exc)
+            elapsed = time.perf_counter() - cycle_start
+            logger.info("Время цикла: %s c", format_decimal(elapsed, 2))
+            if passed_symbols:
+                logger.info("Порог пройден: %s", ", ".join(passed_symbols))
+            else:
+                logger.info("Порогов не найдено")
             await asyncio.sleep(poll_interval)
 
     async def risk_loop() -> None:

--- a/strategies/funding_arbitrage.py
+++ b/strategies/funding_arbitrage.py
@@ -360,15 +360,8 @@ def check_entry_conditions(
         slippage_limit_d = Decimal(str(slippage_limit))
 
         if metrics.funding_rate <= Decimal(0):
-            logger.info("Skipping %s: non-positive funding_rate %s", symbol, metrics.funding_rate)
             return False
         if metrics.funding_rate < Decimal(str(funding_rate_limit)):
-            logger.info(
-                "Skipping %s: funding_rate %s below threshold %s",
-                symbol,
-                metrics.funding_rate,
-                funding_rate_limit,
-            )
             return False
         if spread_pct > Decimal(str(spread_limit)):
             logger.info(


### PR DESCRIPTION
## Summary
- skip logging when funding rate is non-positive or below threshold
- log scan-loop duration and coins that pass entry thresholds

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68909b294d288320b474e011e79ef97a