### PR TITLE
Refactor exchange client to use Timeframe enum

### DIFF
--- a/config/constants.py
+++ b/config/constants.py
@@ -4,5 +4,4 @@ from __future__ import annotations
 ATR_PERIOD: int = 14
 ATR_BREAKOUT_MULTIPLIER: float = 2.0
 MIN_MARKET_CAP: int = 1_000_000_000  # минимальная капитализация монеты
-ANALYSIS_TIMEFRAME: str = "1h"
 

--- a/data/exchange_client.py
+++ b/data/exchange_client.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Iterable, Sequence
+from typing import Sequence
 
 from domain.bar import Bar
+from domain.timeframe import Timeframe
 
 
 class ExchangeClient(ABC):
     """Абстрактный клиент биржи."""
 
     @abstractmethod
-    async def fetch_bars(self, symbol: str, timeframe: str, limit: int) -> Sequence[Bar]:
+    async def fetch_bars(self, symbol: str, timeframe: Timeframe, limit: int) -> Sequence[Bar]:
         """Получить свечи для символа."""
 
     @abstractmethod

--- a/data/memory_client.py
+++ b/data/memory_client.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from typing import Sequence
 
 from domain.bar import Bar
+from domain.timeframe import Timeframe
 
-from .base import ExchangeClient
+from .exchange_client import ExchangeClient
 
 
 class MemoryExchangeClient(ExchangeClient):
@@ -14,7 +15,7 @@ class MemoryExchangeClient(ExchangeClient):
         self._bars = bars
         self._market_caps = market_caps
 
-    async def fetch_bars(self, symbol: str, timeframe: str, limit: int) -> Sequence[Bar]:
+    async def fetch_bars(self, symbol: str, timeframe: Timeframe, limit: int) -> Sequence[Bar]:
         return self._bars.get(symbol, [])[-limit:]
 
     async def fetch_market_caps(self) -> dict[str, float]:

--- a/domain/timeframe.py
+++ b/domain/timeframe.py
@@ -1,10 +1,27 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from enum import Enum
 
 
-@dataclass(frozen=True, slots=True)
-class Timeframe:
-    name: str
-    minutes: int
+class Timeframe(str, Enum):
+    """Enumerates supported timeframes."""
+
+    M1 = "1m"
+    M5 = "5m"
+    M15 = "15m"
+    H1 = "1h"
+    H4 = "4h"
+    D1 = "1d"
+
+    @property
+    def minutes(self) -> int:
+        mapping = {
+            Timeframe.M1: 1,
+            Timeframe.M5: 5,
+            Timeframe.M15: 15,
+            Timeframe.H1: 60,
+            Timeframe.H4: 240,
+            Timeframe.D1: 1440,
+        }
+        return mapping[self]
 

--- a/main.py
+++ b/main.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
-from config.constants import ANALYSIS_TIMEFRAME, ATR_PERIOD, MIN_MARKET_CAP
+from config.constants import MIN_MARKET_CAP
 from data.coin_info_provider import filter_by_market_cap
 from data.memory_client import MemoryExchangeClient
 from domain.detection import detect_extremums
 from domain.extremum_tracker import ExtremumTracker
+from domain.timeframe import Timeframe
 from services.plotter import Plotter
 from services.telegram import TelegramSender
 from utils.atr import atr
@@ -31,13 +32,14 @@ async def analysis_worker(
 ) -> None:
     while True:
         symbol = await symbols.get()
-        bars = await client.fetch_bars(symbol, ANALYSIS_TIMEFRAME, 100)
-        tracker = ExtremumTracker()
-        exts = detect_extremums(bars)
-        tracker.update(exts)
-        if tracker.last():
-            signal_price = tracker.last().price  # type: ignore[union-attr]
-            signals.put_nowait((symbol, signal_price))
+        for timeframe in Timeframe:
+            bars = await client.fetch_bars(symbol, timeframe, 100)
+            tracker = ExtremumTracker()
+            exts = detect_extremums(bars)
+            tracker.update(exts)
+            if tracker.last():
+                signal_price = tracker.last().price  # type: ignore[union-attr]
+                signals.put_nowait((symbol, signal_price))
         symbols.task_done()
 
 

--- a/tests/test_single_coin.py
+++ b/tests/test_single_coin.py
@@ -16,6 +16,7 @@ from data.memory_client import MemoryExchangeClient
 from domain.bar import Bar
 from domain.detection import detect_extremums
 from domain.extremum import ExtremumType
+from domain.timeframe import Timeframe
 from utils.atr import atr
 
 
@@ -43,7 +44,7 @@ def test_single_coin() -> None:
         Bar(base + timedelta(hours=4), 14.0, 14.0, 12.0, 13.0, 140),
     ]
     client = MemoryExchangeClient({"TEST": bars}, {"TEST": 2_000_000_000})
-    fetched = asyncio.run(client.fetch_bars("TEST", "1h", 10))
+    fetched = asyncio.run(client.fetch_bars("TEST", Timeframe.H1, 10))
     assert fetched == bars
 
     extremums = detect_extremums(bars)

--- a/utils/timeframes.py
+++ b/utils/timeframes.py
@@ -2,18 +2,10 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-
-_TIMEFRAME_TO_MINUTES = {
-    "1m": 1,
-    "5m": 5,
-    "15m": 15,
-    "1h": 60,
-    "4h": 240,
-    "1d": 1440,
-}
+from domain.timeframe import Timeframe
 
 
-def to_timedelta(tf: str) -> timedelta:
-    minutes = _TIMEFRAME_TO_MINUTES[tf]
+def to_timedelta(tf: Timeframe) -> timedelta:
+    minutes = tf.minutes
     return timedelta(minutes=minutes)
 


### PR DESCRIPTION
## Summary
- define a `Timeframe` enum with minute metadata
- rename `data.base` to `data.exchange_client` and update clients to accept `Timeframe`
- adjust configuration, utilities and tests to use the new enum
- drop fixed analysis timeframe constant and iterate over all timeframes in the analysis worker

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68923a2d5f808320be741f891d8e7868