### PR TITLE
Add logging rotation and persistence utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 __pycache__/
 *.pyc
 
+data/cache/*
+!data/cache/.gitkeep
+data/logs/*
+!data/logs/.gitkeep
+data/runtime/*
+!data/runtime/.gitkeep
+

--- a/constants.py
+++ b/constants.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Final
 
 BINANCE_FAPI_WS: Final[str] = "wss://fstream.binance.com/stream"
@@ -19,3 +20,14 @@ GLOBAL_BTC_PAUSE_Z: Final[float] = 3.0
 GLOBAL_BTC_PAUSE_SEC: Final[int] = 180
 
 RISK_PER_TRADE_USDT: Final[float] = 100.0  # настрой под депозит
+
+# paths and limits
+BASE_DIR: Final[Path] = Path(__file__).resolve().parent
+DATA_DIR: Final[Path] = BASE_DIR / "data"
+LOG_DIR: Final[Path] = DATA_DIR / "logs"
+CACHE_DIR: Final[Path] = DATA_DIR / "cache"
+RUNTIME_DIR: Final[Path] = DATA_DIR / "runtime"
+BASELINE_DB_PATH: Final[Path] = CACHE_DIR / "baseline.sqlite"
+
+LOG_MAX_BYTES: Final[int] = 50 * 1024 * 1024  # 50 MB rotation
+LOG_BACKUP_COUNT: Final[int] = 5

--- a/log_setup.py
+++ b/log_setup.py
@@ -1,0 +1,45 @@
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from constants import LOG_DIR, LOG_MAX_BYTES, LOG_BACKUP_COUNT
+
+
+class _ExactLevelFilter(logging.Filter):
+    def __init__(self, level: int) -> None:
+        super().__init__()
+        self._level = level
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.levelno == self._level
+
+
+def setup_logging() -> None:
+    """Configure application logging with rotation."""
+    Path(LOG_DIR).mkdir(parents=True, exist_ok=True)
+
+    fmt = logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+
+    info_handler = RotatingFileHandler(
+        Path(LOG_DIR) / "info.log",
+        maxBytes=LOG_MAX_BYTES,
+        backupCount=LOG_BACKUP_COUNT,
+    )
+    info_handler.setLevel(logging.INFO)
+    info_handler.addFilter(_ExactLevelFilter(logging.INFO))
+    info_handler.setFormatter(fmt)
+
+    debug_handler = RotatingFileHandler(
+        Path(LOG_DIR) / "debug.log",
+        maxBytes=LOG_MAX_BYTES,
+        backupCount=LOG_BACKUP_COUNT,
+    )
+    debug_handler.setLevel(logging.DEBUG)
+    debug_handler.addFilter(_ExactLevelFilter(logging.DEBUG))
+    debug_handler.setFormatter(fmt)
+
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+    root.handlers.clear()
+    root.addHandler(info_handler)
+    root.addHandler(debug_handler)

--- a/main.py
+++ b/main.py
@@ -1,10 +1,21 @@
+import logging
+import os
+
 from domain.models.enums import Profile
 from domain.models.state import GlobalState
 from config import make_profile_config_balanced
 from domain.services import RestClient, WsClient, Trader, SymbolRegistry
+from log_setup import setup_logging
+from persistence import BaselineCache, write_runtime
 
 
 def main() -> None:
+    setup_logging()
+    logger = logging.getLogger(__name__)
+    write_runtime("pid", str(os.getpid()))
+    cache = BaselineCache()
+    logger.info("bot initialized")
+
     # 1) load profile
     cfg = make_profile_config_balanced()
     gstate = GlobalState(profile=Profile.BALANCED, btc_pause_until_ms=None)
@@ -18,7 +29,7 @@ def main() -> None:
     # 3) coroutines: ws_stream, bar_maker, rest_pollers, fsm_loop
     #    - strict separation: input→metrics→signals→trading
     #    - all parameters are taken only from cfg and constants
-    _ = (cfg, gstate, registry, rest, ws, trader)
+    _ = (cfg, gstate, registry, rest, ws, trader, cache, logger)
 
 
 if __name__ == "__main__":

--- a/persistence.py
+++ b/persistence.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from constants import CACHE_DIR, BASELINE_DB_PATH, RUNTIME_DIR
+
+
+def _ensure_dirs() -> None:
+    Path(CACHE_DIR).mkdir(parents=True, exist_ok=True)
+    Path(RUNTIME_DIR).mkdir(parents=True, exist_ok=True)
+
+
+class BaselineCache:
+    """Simple key-value storage backed by SQLite."""
+
+    def __init__(self, path: Path = BASELINE_DB_PATH) -> None:
+        _ensure_dirs()
+        self._path = path
+        with sqlite3.connect(self._path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS baseline (
+                    symbol TEXT PRIMARY KEY,
+                    data TEXT NOT NULL
+                )
+                """
+            )
+
+    def save(self, symbol: str, data: dict[str, Any]) -> None:
+        payload = json.dumps(data)
+        with sqlite3.connect(self._path) as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO baseline (symbol, data) VALUES (?, ?)",
+                (symbol, payload),
+            )
+
+    def load(self, symbol: str) -> dict[str, Any] | None:
+        with sqlite3.connect(self._path) as conn:
+            cur = conn.execute("SELECT data FROM baseline WHERE symbol = ?", (symbol,))
+            row = cur.fetchone()
+        if row is None:
+            return None
+        return json.loads(row[0])
+
+
+def write_runtime(name: str, content: str) -> Path:
+    _ensure_dirs()
+    path = Path(RUNTIME_DIR) / name
+    path.write_text(content)
+    return path
+
+
+def read_runtime(name: str) -> str | None:
+    path = Path(RUNTIME_DIR) / name
+    if not path.exists():
+        return None
+    return path.read_text()


### PR DESCRIPTION
## Summary
- configure rotating file logging with separate INFO and DEBUG outputs
- add SQLite baseline cache and runtime file helpers
- expose data/log directories and limits via constants

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bda34785088320a38a3ac4c7708693