### PR TITLE
Align confirm_failure placeholder with comment

### DIFF
--- a/domain/services.py
+++ b/domain/services.py
@@ -243,7 +243,7 @@ class SignalEngine:
 
     def confirm_failure(self, symbol: str, window: M.PumpWindow) -> bool:
         # Placeholder – assume confirmation never fails.
-        return True
+        return False
 
     def make_entry(self, symbol: str, window: M.PumpWindow) -> S.EntrySignal | None:
         # A real implementation would check additional criteria from the


### PR DESCRIPTION
## Summary
- ensure SignalEngine.confirm_failure returns False

## Testing
- `python -m py_compile domain/services.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bda6f7683c8320a32765f99f62f91c