### PR TITLE
Use constants for taker ratio params

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -14,6 +14,9 @@ REST_POLL_SEC_OI: Final[int] = 20
 REST_POLL_SEC_TAKER: Final[int] = 20
 REST_POLL_SEC_PREMIUM: Final[int] = 20
 
+TAKER_RATIO_PERIOD: Final[str] = "5m"
+TAKER_RATIO_LIMIT: Final[int] = 1
+
 COOLDOWN_AFTER_TRADE_SEC: Final[int] = 900
 GLOBAL_BTC_PAUSE_Z: Final[float] = 3.0
 GLOBAL_BTC_PAUSE_SEC: Final[int] = 180

--- a/domain/services.py
+++ b/domain/services.py
@@ -26,7 +26,13 @@ import httpx
 import websockets
 
 from config.credentials import BINANCE
-from constants import BINANCE_FAPI_REST, BINANCE_FAPI_WS, RISK_PER_TRADE_USDT
+from constants import (
+    BINANCE_FAPI_REST,
+    BINANCE_FAPI_WS,
+    RISK_PER_TRADE_USDT,
+    TAKER_RATIO_LIMIT,
+    TAKER_RATIO_PERIOD,
+)
 from domain.models.trading import OrderSpec, PositionPlan
 from domain.models.state import SymbolState
 from domain.models.market_data import AggTrade, DepthSnapshot, LiquidationEvent
@@ -124,7 +130,11 @@ class RestClient:
         return float(data["openInterest"])
 
     def get_taker_ratio(self, symbol: str) -> tuple[float, float]:
-        params = {"symbol": symbol, "period": "5m", "limit": 1}
+        params = {
+            "symbol": symbol,
+            "period": TAKER_RATIO_PERIOD,
+            "limit": TAKER_RATIO_LIMIT,
+        }
         r = self._client.get(self._TAKER_RATIO_EP, params=params)
         r.raise_for_status()
         data = r.json()


### PR DESCRIPTION
## Summary
- add `TAKER_RATIO_PERIOD` and `TAKER_RATIO_LIMIT` constants
- apply new constants in `RestClient.get_taker_ratio`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bda6e082a88320b926596ca8301c5d