### PR TITLE
Build and subscribe universe from Binance 24h stats

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,8 +15,8 @@ from __future__ import annotations
 
 import asyncio
 
-from domain.models.enums import OrderType, Profile
-from domain.models.state import GlobalState
+from domain.models.enums import BotState, OrderType, Profile
+from domain.models.state import GlobalState, SymbolState
 from domain.models.config import ProfileConfig
 from domain.models.trading import OrderSpec
 from config import make_profile_config_balanced
@@ -162,6 +162,39 @@ def main() -> None:
     ws = WsClient()
     trader = Trader()
 
+    # Discover symbols satisfying universe requirements
+    symbols: list[str] = []
+    r = rest._client.get("/fapi/v1/ticker/24hr")
+    r.raise_for_status()
+    for info in r.json():
+        sym = info["symbol"]
+        if not sym.endswith("USDT"):
+            continue
+
+        quote_vol, _ = rest.get_24h_stats(sym)
+        if quote_vol < constants.UNIVERSE_MIN_24H_USDT:
+            continue
+
+        bid = float(info["bidPrice"])
+        ask = float(info["askPrice"])
+        if bid <= 0:
+            continue
+        spread_bps = (ask - bid) / bid * 10_000.0
+        if spread_bps > constants.UNIVERSE_MAX_SPREAD_BPS:
+            continue
+
+        depth = rest._client.get("/fapi/v1/depth", params={"symbol": sym, "limit": 10})
+        depth.raise_for_status()
+        bids = depth.json().get("bids", [])
+        top10_bid_usdt = sum(float(p) * float(q) for p, q in bids)
+        if top10_bid_usdt < constants.UNIVERSE_MIN_TOP10_BID_USDT:
+            continue
+
+        registry.put(SymbolState(symbol=sym, state=BotState.IDLE))
+        symbols.append(sym)
+
+    ws.subscribe_symbols(tuple(symbols))
+
     # Placeholder services for the FSM; in real deployment these would be
     # properly implemented classes.  They are included here to expose the
     # expected interfaces for :func:`fsm_loop`.
@@ -172,17 +205,23 @@ def main() -> None:
     # 3) coroutines: ws_stream, bar_maker, rest_pollers, fsm_loop
     #    - strict separation: input→metrics→signals→trading
     #    - all parameters are taken only from cfg and constants
-    _ = (
-        cfg,
-        gstate,
-        registry,
-        rest,
-        ws,
-        trader,
-        signal_engine,
-        risk_manager,
-        trade_manager,
-    )
+    async def run() -> None:
+        await asyncio.gather(
+            ws_stream(ws),
+            bar_maker(ws, registry),
+            rest_pollers(rest, registry),
+            fsm_loop(
+                cfg,
+                gstate,
+                registry,
+                signal_engine,
+                risk_manager,
+                trade_manager,
+                trader,
+            ),
+        )
+
+    asyncio.run(run())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- build symbol universe using 24h ticker data filtered by volume, spread and orderbook liquidity
- register qualifying symbols and subscribe websocket before runtime
- run core coroutines within asyncio loop

## Testing
- `pip install 'httpx==0.27.*' 'websockets==12.*' 'pydantic==2.*'`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bda7ccf49c8320a1ab24c32bf00880