### PR TITLE
Add exit management logic to TradeManager

### DIFF
--- a/domain/services.py
+++ b/domain/services.py
@@ -316,7 +316,95 @@ class TradeManager:
         self._trader.place(order)
         self._positions[plan.symbol] = plan
 
-    def on_tick_manage(self, symbol: str) -> tuple[list[S.ExitSignal], T.PositionPlan | None]:
+    def on_tick_manage(
+        self, symbol: str, price: float | None = None
+    ) -> tuple[list[S.ExitSignal], T.PositionPlan | None]:
+        """Manage an existing position on each price tick.
+
+        The method checks whether any exit conditions have been met for the
+        position associated with ``symbol``.  It returns a list of exit signals
+        and the possibly updated position plan.  If the position is fully
+        closed, ``None`` is returned for the plan.
+        """
+
         plan = self._positions.get(symbol)
         exits: List[S.ExitSignal] = []
+        if plan is None:
+            return exits, None
+
+        current_price = plan.entry_price if price is None else price
+
+        # ------------------------------------------------------------------
+        # Trailing stop management (active after both take profits executed)
+        trailing_active = plan.take_profit1 <= 0.0 and plan.take_profit2 <= 0.0
+        if trailing_active and current_price <= plan.trail_start:
+            new_stop = min(plan.stop_loss, current_price + plan.trail_distance)
+            plan = T.PositionPlan(
+                symbol=plan.symbol,
+                entry_price=plan.entry_price,
+                stop_loss=new_stop,
+                take_profit1=plan.take_profit1,
+                take_profit2=plan.take_profit2,
+                trail_start=current_price,
+                trail_distance=plan.trail_distance,
+                quantity=plan.quantity,
+            )
+            self._positions[symbol] = plan
+            trailing_active = True
+
+        # ------------------------------------------------------------------
+        # Stop loss or trailing stop hit
+        if current_price >= plan.stop_loss:
+            reason = "TRAIL" if trailing_active else "STOP"
+            exits.append(S.ExitSignal(symbol=symbol, reason=reason))
+            del self._positions[symbol]
+            return exits, None
+
+        # ------------------------------------------------------------------
+        # Take profit levels
+        if plan.take_profit1 > 0.0 and current_price <= plan.take_profit1:
+            exits.append(S.ExitSignal(symbol=symbol, reason="TP1"))
+            plan = T.PositionPlan(
+                symbol=plan.symbol,
+                entry_price=plan.entry_price,
+                stop_loss=plan.entry_price,  # move to break-even
+                take_profit1=0.0,
+                take_profit2=plan.take_profit2,
+                trail_start=plan.trail_start,
+                trail_distance=plan.trail_distance,
+                quantity=plan.quantity,
+            )
+            self._positions[symbol] = plan
+
+        if plan.take_profit2 > 0.0 and current_price <= plan.take_profit2:
+            exits.append(S.ExitSignal(symbol=symbol, reason="TP2"))
+            plan = T.PositionPlan(
+                symbol=plan.symbol,
+                entry_price=plan.entry_price,
+                stop_loss=plan.stop_loss,
+                take_profit1=plan.take_profit1,
+                take_profit2=0.0,
+                trail_start=plan.trail_start,
+                trail_distance=plan.trail_distance,
+                quantity=plan.quantity,
+            )
+            self._positions[symbol] = plan
+
+        # ------------------------------------------------------------------
+        # Activate trailing after both take profits have been executed
+        trailing_active = plan.take_profit1 <= 0.0 and plan.take_profit2 <= 0.0
+        if trailing_active and current_price <= plan.trail_start:
+            new_stop = min(plan.stop_loss, current_price + plan.trail_distance)
+            plan = T.PositionPlan(
+                symbol=plan.symbol,
+                entry_price=plan.entry_price,
+                stop_loss=new_stop,
+                take_profit1=plan.take_profit1,
+                take_profit2=plan.take_profit2,
+                trail_start=current_price,
+                trail_distance=plan.trail_distance,
+                quantity=plan.quantity,
+            )
+            self._positions[symbol] = plan
+
         return exits, plan


### PR DESCRIPTION
## Summary
- Track stop losses, take-profit levels, and trailing stops in `TradeManager.on_tick_manage`
- Return appropriate `ExitSignal`s and update/close position plans

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdaabe93d0832087a482faaa2bf677