### PR TITLE
Implement margin-aware trade risk checks

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -7,6 +7,9 @@ from domain.models.config import (
     RiskParams,
     TriggerParams,
 )
+from constants import RISK_PER_TRADE_USDT
+
+DEFAULT_MARGIN_USDT = 5 * RISK_PER_TRADE_USDT
 
 
 def make_profile_config_conservative() -> ProfileConfig:
@@ -42,7 +45,13 @@ def make_profile_config_conservative() -> ProfileConfig:
         trail_abs_pct=0.12,
         trail_sigma_mult=1.3,
     )
-    return ProfileConfig(trigger=trigger, confirmation=confirmation, entry=entry, risk=risk)
+    return ProfileConfig(
+        trigger=trigger,
+        confirmation=confirmation,
+        entry=entry,
+        risk=risk,
+        max_margin_usdt=DEFAULT_MARGIN_USDT,
+    )
 
 
 def make_profile_config_balanced() -> ProfileConfig:
@@ -78,7 +87,13 @@ def make_profile_config_balanced() -> ProfileConfig:
         trail_abs_pct=0.12,
         trail_sigma_mult=1.25,
     )
-    return ProfileConfig(trigger=trigger, confirmation=confirmation, entry=entry, risk=risk)
+    return ProfileConfig(
+        trigger=trigger,
+        confirmation=confirmation,
+        entry=entry,
+        risk=risk,
+        max_margin_usdt=DEFAULT_MARGIN_USDT,
+    )
 
 
 def make_profile_config_active() -> ProfileConfig:
@@ -114,4 +129,10 @@ def make_profile_config_active() -> ProfileConfig:
         trail_abs_pct=0.10,
         trail_sigma_mult=1.1,
     )
-    return ProfileConfig(trigger=trigger, confirmation=confirmation, entry=entry, risk=risk)
+    return ProfileConfig(
+        trigger=trigger,
+        confirmation=confirmation,
+        entry=entry,
+        risk=risk,
+        max_margin_usdt=DEFAULT_MARGIN_USDT,
+    )

--- a/domain/models/config.py
+++ b/domain/models/config.py
@@ -47,3 +47,4 @@ class ProfileConfig:
     confirmation: ConfirmationParams
     entry: EntryParams
     risk: RiskParams
+    max_margin_usdt: float

--- a/domain/services.py
+++ b/domain/services.py
@@ -399,6 +399,7 @@ class RiskManager:
 
     def __init__(self, config: ProfileConfig) -> None:
         self._cfg = config
+        self._open_risk_usdt: float = 0.0
 
     def build_plan(self, symbol: str, entry_price: float, window: M.PumpWindow) -> T.PositionPlan | None:
         risk = self._cfg.risk
@@ -428,8 +429,13 @@ class RiskManager:
         )
 
     def allow_trade(self, plan: T.PositionPlan) -> bool:
-        # trivial check – ensure position size is positive
-        return plan.quantity > 0
+        required_margin = plan.entry_price * plan.quantity
+        if required_margin > RISK_PER_TRADE_USDT:
+            return False
+        if self._open_risk_usdt + required_margin > self._cfg.max_margin_usdt:
+            return False
+        self._open_risk_usdt += required_margin
+        return True
 
 
 class TradeManager:


### PR DESCRIPTION
## Summary
- track cumulative risk in `RiskManager` and block trades exceeding per-trade or total margin limits
- extend profile configuration with `max_margin_usdt` and provide default margin for each profile

## Testing
- `python -m py_compile domain/services.py domain/models/config.py config/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdaf8be3a88320986e9874c50260bd