### PR TITLE
Refactor metrics into SymbolMetrics dataclass

### DIFF
--- a/domain/models/metrics.py
+++ b/domain/models/metrics.py
@@ -1,4 +1,10 @@
-from dataclasses import dataclass
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Deque, Optional
+
+import constants
 
 
 @dataclass(frozen=True)
@@ -7,3 +13,59 @@ class PumpWindow:
     low: float
     start_ts: int
     end_ts: int
+
+
+@dataclass
+class SymbolMetrics:
+    """Container for all per-symbol metrics used by the engine.
+
+    The actual project derives a large number of attributes from the raw
+    market data stream.  Only the subset exercised by the simplified runtime
+    is modelled here.  All fields are initialised with neutral defaults so
+    that missing data is handled gracefully.
+    """
+
+    # --- rolling windows for z-score calculations -----------------------
+    price_win: Deque[float] = field(
+        default_factory=lambda: deque(maxlen=constants.Z_BASE_WINDOW_MIN)
+    )
+    vol_win: Deque[float] = field(
+        default_factory=lambda: deque(maxlen=constants.Z_BASE_WINDOW_MIN)
+    )
+    liq_win: Deque[float] = field(
+        default_factory=lambda: deque(maxlen=constants.Z_BASE_WINDOW_MIN)
+    )
+
+    # --- minute candle stats --------------------------------------------
+    start_ts: int = 0
+    end_ts: int = 0
+    high: float = 0.0
+    low: float = 0.0
+    last_price: float = 0.0
+
+    # --- derived z-scores and price delta metrics -----------------------
+    z_px: float = 0.0
+    z_vol: float = 0.0
+    delta_price_sigma_mult: float = 0.0
+    delta_price_abs_pct: float = 0.0
+    close_pos: float = 0.0
+
+    # --- orderbook / premium related metrics ---------------------------
+    best_bid: float = 0.0
+    best_ask: float = 0.0
+    premium_pct: float = 0.0
+
+    # --- liquidation and open interest metrics -------------------------
+    liqs_z: float = 0.0
+    last_liq_side: Optional[str] = None
+    delta_oi_pct: float = 0.0
+
+    # --- taker volume metrics ------------------------------------------
+    taker_buy_volume: float = 0.0
+    taker_sell_volume: float = 0.0
+
+    # --- entry helpers --------------------------------------------------
+    low_break: bool = False
+    avwap_loss: bool = False
+    entry_price: float = 0.0
+    direction: Optional[str] = None

--- a/domain/models/state.py
+++ b/domain/models/state.py
@@ -1,7 +1,8 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 from .enums import BotState, Profile, Side
+from .metrics import SymbolMetrics
 
 
 @dataclass
@@ -15,6 +16,7 @@ class Position:
 class SymbolState:
     symbol: str
     state: BotState
+    metrics: SymbolMetrics = field(default_factory=SymbolMetrics)
     position: Optional[Position] = None
     last_signal_ts: Optional[float] = None
 

--- a/domain/services.py
+++ b/domain/services.py
@@ -251,13 +251,6 @@ class SignalEngine:
         # the latest metrics for every symbol.
         self._registry = registry
 
-    def _get_metric(self, metrics: object, name: str, default: float = 0.0) -> float:
-        """Helper to read metric ``name`` from either an object or a dict."""
-
-        if isinstance(metrics, dict):
-            return float(metrics.get(name, default))
-        return float(getattr(metrics, name, default))
-
     def on_minute_close(self, symbol: str) -> S.PumpSignal | None:
         """Evaluate minute metrics and possibly emit a pump signal.
 
@@ -268,38 +261,27 @@ class SignalEngine:
         """
 
         state = self._registry.get(symbol)
-        metrics = getattr(state, "metrics", None)
-        if metrics is None:
-            return None
+        metrics = state.metrics
 
         trig = self._config.trigger
 
-        z_px = self._get_metric(metrics, "z_px")
-        z_vol = self._get_metric(metrics, "z_vol")
-        d_sigma = self._get_metric(metrics, "delta_price_sigma_mult")
-        d_abs = self._get_metric(metrics, "delta_price_abs_pct")
-        close_pos = self._get_metric(metrics, "close_pos")
-        liqs_z = self._get_metric(metrics, "liqs_z")
-
         conditions_met = (
-            z_px >= trig.z_px
-            and z_vol >= trig.z_vol
-            and d_sigma >= trig.delta_price_sigma_mult
-            and d_abs >= trig.delta_price_abs_pct
-            and close_pos >= trig.close_pos
-            and liqs_z >= trig.liqs_z
+            metrics.z_px >= trig.z_px
+            and metrics.z_vol >= trig.z_vol
+            and metrics.delta_price_sigma_mult >= trig.delta_price_sigma_mult
+            and metrics.delta_price_abs_pct >= trig.delta_price_abs_pct
+            and metrics.close_pos >= trig.close_pos
+            and metrics.liqs_z >= trig.liqs_z
         )
         if not conditions_met:
             return None
 
-        # Construct the pump window from metrics.  The exact names of the
-        # stored attributes may vary so we try a few common alternatives.
-        high = self._get_metric(metrics, "high", self._get_metric(metrics, "high_price"))
-        low = self._get_metric(metrics, "low", self._get_metric(metrics, "low_price"))
-        start_ts = int(self._get_metric(metrics, "start_ts", self._get_metric(metrics, "start_ts_ms")))
-        end_ts = int(self._get_metric(metrics, "end_ts", self._get_metric(metrics, "end_ts_ms")))
-
-        window = M.PumpWindow(high=high, low=low, start_ts=start_ts, end_ts=end_ts)
+        window = M.PumpWindow(
+            high=metrics.high,
+            low=metrics.low,
+            start_ts=int(metrics.start_ts),
+            end_ts=int(metrics.end_ts),
+        )
         return S.PumpSignal(symbol=symbol, window=window)
 
     def confirm_failure(self, symbol: str, window: M.PumpWindow) -> bool:
@@ -312,20 +294,15 @@ class SignalEngine:
         """
 
         state = self._registry.get(symbol)
-        metrics = getattr(state, "metrics", None)
-        if metrics is None:
-            return False
+        metrics = state.metrics
 
         confirm = self._config.confirmation
 
-        # Change in open interest expressed as percentage.
-        delta_oi_pct = self._get_metric(metrics, "delta_oi_pct")
-        if delta_oi_pct > confirm.delta_oi_max_pct:
+        if metrics.delta_oi_pct > confirm.delta_oi_max_pct:
             return True
 
-        # Taker buy/sell ratio derived from respective volumes.
-        taker_buy = self._get_metric(metrics, "taker_buy_volume")
-        taker_sell = self._get_metric(metrics, "taker_sell_volume")
+        taker_buy = metrics.taker_buy_volume
+        taker_sell = metrics.taker_sell_volume
         if taker_sell > 0:
             taker_ratio = taker_buy / taker_sell
         else:
@@ -333,9 +310,7 @@ class SignalEngine:
         if taker_ratio > confirm.taker_ratio_max:
             return True
 
-        # Premium index percentage relative to mark price.
-        premium = self._get_metric(metrics, "premium_pct")
-        if premium > confirm.premium_max_pct:
+        if metrics.premium_pct > confirm.premium_max_pct:
             return True
 
         return False
@@ -351,26 +326,18 @@ class SignalEngine:
         """
 
         state = self._registry.get(symbol)
-        metrics = getattr(state, "metrics", None)
-        if metrics is None:
-            return None
+        metrics = state.metrics
 
-        # Basic sanity: window must have a positive height.
         if window.high <= window.low:
             return None
 
-        # ------------------------------------------------------------------
-        # Check premium against confirmation limits.  ``_get_metric`` gracefully
-        # handles both dicts and objects with missing attributes.
-        premium = self._get_metric(metrics, "premium_pct")
-        if premium > self._config.confirmation.premium_max_pct:
+        if metrics.premium_pct > self._config.confirmation.premium_max_pct:
             return None
 
         entry_cfg = self._config.entry
-        low_break = bool(self._get_metric(metrics, "low_break"))
-        avwap_loss = bool(self._get_metric(metrics, "avwap_loss"))
+        low_break = metrics.low_break
+        avwap_loss = metrics.avwap_loss
 
-        allow = False
         if entry_cfg.require_both:
             allow = low_break and avwap_loss
         else:
@@ -380,10 +347,9 @@ class SignalEngine:
         if not allow:
             return None
 
-        price = self._get_metric(metrics, "entry_price", window.low)
+        price = metrics.entry_price or window.low
 
-        # Determine side/direction; default to SHORT if unspecified.
-        direction = getattr(metrics, "direction", None)
+        direction = metrics.direction
         side = Side.SHORT
         if direction:
             try:

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ functions.
 from __future__ import annotations
 
 import asyncio
-from collections import deque
+from typing import Deque
 
 from domain.models.enums import BotState, Profile
 from domain.models.state import GlobalState, SymbolState
@@ -52,17 +52,7 @@ async def bar_maker(ws: WsClient, registry: SymbolRegistry) -> None:
     making decisions.
     """
 
-    # Rolling windows used for z-score calculations are kept per symbol inside
-    # the ``metrics`` object stored in ``SymbolState``.  The helper below
-    # retrieves such a window or creates a new one when necessary.
-    def _window(metrics: dict, name: str) -> deque:
-        win = metrics.get(name)
-        if win is None:
-            win = deque(maxlen=constants.Z_BASE_WINDOW_MIN)
-            metrics[name] = win
-        return win
-
-    def _zscore(value: float, window: deque) -> float:
+    def _zscore(value: float, window: Deque[float]) -> float:
         """Return z-score of ``value`` within ``window`` values."""
         if len(window) < 2:
             return 0.0
@@ -75,31 +65,30 @@ async def bar_maker(ws: WsClient, registry: SymbolRegistry) -> None:
         trade = ws.next_agg_trade()
         if trade:
             state = registry.get(trade.symbol)
-            metrics = getattr(state, "metrics", {})
+            metrics = state.metrics
 
             # ------------------------ price & volume z-scores -----------------
-            price_win = _window(metrics, "price_win")
-            vol_win = _window(metrics, "vol_win")
+            price_win = metrics.price_win
+            vol_win = metrics.vol_win
             price_win.append(trade.price)
             vol_win.append(trade.quantity)
             z_px = _zscore(trade.price, price_win)
             z_vol = _zscore(trade.quantity, vol_win)
 
             # ----------------------- candle construction ----------------------
-            start_ts = metrics.get("start_ts", trade.timestamp)
-            # Reset the candle every minute
-            if trade.timestamp - start_ts >= 60_000:
+            start_ts = metrics.start_ts
+            if trade.timestamp - start_ts >= 60_000 or start_ts == 0:
                 start_ts = trade.timestamp
-                metrics["high"] = trade.price
-                metrics["low"] = trade.price
+                metrics.high = trade.price
+                metrics.low = trade.price
             else:
-                metrics["high"] = max(metrics.get("high", trade.price), trade.price)
-                metrics["low"] = min(metrics.get("low", trade.price), trade.price)
-            metrics["start_ts"] = start_ts
-            metrics["end_ts"] = trade.timestamp
+                metrics.high = max(metrics.high, trade.price)
+                metrics.low = min(metrics.low, trade.price)
+            metrics.start_ts = start_ts
+            metrics.end_ts = trade.timestamp
 
-            high = metrics["high"]
-            low = metrics["low"]
+            high = metrics.high
+            low = metrics.low
             rng = high - low
 
             mean_price = sum(price_win) / len(price_win)
@@ -109,50 +98,41 @@ async def bar_maker(ws: WsClient, registry: SymbolRegistry) -> None:
             delta_abs = (high / low - 1.0) * 100 if low > 0 else 0.0
             close_pos = (trade.price - low) / rng if rng > 0 else 0.0
 
-            metrics.update(
-                {
-                    "z_px": z_px,
-                    "z_vol": z_vol,
-                    "delta_price_sigma_mult": delta_sigma,
-                    "delta_price_abs_pct": delta_abs,
-                    "close_pos": close_pos,
-                    "last_price": trade.price,
-                }
-            )
-            state.metrics = metrics
+            metrics.z_px = z_px
+            metrics.z_vol = z_vol
+            metrics.delta_price_sigma_mult = delta_sigma
+            metrics.delta_price_abs_pct = delta_abs
+            metrics.close_pos = close_pos
+            metrics.last_price = trade.price
+
             registry.update(trade.symbol, state)
 
         depth = ws.next_depth()
         if depth:
             state = registry.get(depth.symbol)
-            metrics = getattr(state, "metrics", {})
+            metrics = state.metrics
             if depth.bids and depth.asks:
                 best_bid = depth.bids[0][0]
                 best_ask = depth.asks[0][0]
                 mid = (best_bid + best_ask) / 2.0
-                last_price = metrics.get("last_price", mid)
+                last_price = metrics.last_price if metrics.last_price > 0 else mid
                 premium_pct = (
                     (mid - last_price) / last_price * 100.0 if last_price > 0 else 0.0
                 )
-                metrics.update(
-                    {
-                        "best_bid": best_bid,
-                        "best_ask": best_ask,
-                        "premium_pct": premium_pct,
-                    }
-                )
-            state.metrics = metrics
+                metrics.best_bid = best_bid
+                metrics.best_ask = best_ask
+                metrics.premium_pct = premium_pct
             registry.update(depth.symbol, state)
 
         liq = ws.next_liquidation()
         if liq:
             state = registry.get(liq.symbol)
-            metrics = getattr(state, "metrics", {})
-            liq_win = _window(metrics, "liq_win")
+            metrics = state.metrics
+            liq_win = metrics.liq_win
             liq_win.append(liq.quantity)
             liqs_z = _zscore(liq.quantity, liq_win) if len(liq_win) > 1 else 0.0
-            metrics.update({"liqs_z": liqs_z, "last_liq_side": liq.side.value})
-            state.metrics = metrics
+            metrics.liqs_z = liqs_z
+            metrics.last_liq_side = liq.side.value
             registry.update(liq.symbol, state)
 
         await asyncio.sleep(0)
@@ -178,9 +158,8 @@ async def rest_pollers(rest: RestClient, registry: SymbolRegistry) -> None:
                 last_oi[symbol] = oi
 
                 state = registry.get(symbol)
-                metrics = getattr(state, "metrics", {}) or {}
-                metrics["delta_oi_pct"] = delta_pct
-                state.metrics = metrics
+                metrics = state.metrics
+                metrics.delta_oi_pct = delta_pct
                 registry.update(symbol, state)
             await asyncio.sleep(constants.REST_POLL_SEC_OI)
 
@@ -191,10 +170,9 @@ async def rest_pollers(rest: RestClient, registry: SymbolRegistry) -> None:
             for symbol in registry.all_symbols():
                 buy, sell = rest.get_taker_ratio(symbol)
                 state = registry.get(symbol)
-                metrics = getattr(state, "metrics", {}) or {}
-                metrics["taker_buy_volume"] = buy
-                metrics["taker_sell_volume"] = sell
-                state.metrics = metrics
+                metrics = state.metrics
+                metrics.taker_buy_volume = buy
+                metrics.taker_sell_volume = sell
                 registry.update(symbol, state)
             await asyncio.sleep(constants.REST_POLL_SEC_TAKER)
 
@@ -205,9 +183,8 @@ async def rest_pollers(rest: RestClient, registry: SymbolRegistry) -> None:
             for symbol in registry.all_symbols():
                 premium = rest.get_premium_pct(symbol)
                 state = registry.get(symbol)
-                metrics = getattr(state, "metrics", {}) or {}
-                metrics["premium_pct"] = premium
-                state.metrics = metrics
+                metrics = state.metrics
+                metrics.premium_pct = premium
                 registry.update(symbol, state)
             await asyncio.sleep(constants.REST_POLL_SEC_PREMIUM)
 


### PR DESCRIPTION
## Summary
- add SymbolMetrics dataclass capturing all per-symbol metrics
- store metrics on SymbolState and switch bar maker, REST pollers and SignalEngine to use it

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bdb7e63598832086639e5fb6b131da