### PR TITLE
Manage open positions each tick in FSM loop

### DIFF
--- a/domain/services.py
+++ b/domain/services.py
@@ -437,6 +437,11 @@ class RiskManager:
         self._open_risk_usdt += required_margin
         return True
 
+    def notify_close(self, plan: T.PositionPlan) -> None:
+        """Release risk when a position is closed."""
+        margin = plan.entry_price * plan.quantity
+        self._open_risk_usdt = max(0.0, self._open_risk_usdt - margin)
+
 
 class TradeManager:
     """High level wrapper around :class:`Trader` handling position state."""
@@ -444,6 +449,10 @@ class TradeManager:
     def __init__(self, trader: Trader) -> None:
         self._trader = trader
         self._positions: Dict[str, PositionPlan] = {}
+
+    def get_plan(self, symbol: str) -> T.PositionPlan | None:
+        """Return current plan for ``symbol`` if any."""
+        return self._positions.get(symbol)
 
     def open_position(self, plan: T.PositionPlan, side: Side) -> None:
         order = OrderSpec(

--- a/main.py
+++ b/main.py
@@ -233,6 +233,21 @@ async def fsm_loop(
 
     while True:
         for symbol in registry.all_symbols():
+            state = registry.get(symbol)
+            metrics = getattr(state, "metrics", {}) or {}
+            price = metrics.get("last_price")
+
+            # Manage existing position on every iteration
+            plan_before = trade_manager.get_plan(symbol)
+            if plan_before is not None:
+                exits, new_plan = trade_manager.on_tick_manage(symbol, price)
+                if exits:
+                    for _exit in exits:
+                        trader.cancel(symbol, all_for_symbol=False)
+                    if new_plan is None:
+                        risk_manager.notify_close(plan_before)
+
+            # Evaluate potential new entry
             pump = signal_engine.on_minute_close(symbol)
             if pump is None:
                 continue
@@ -248,10 +263,6 @@ async def fsm_loop(
                 continue
 
             trade_manager.open_position(plan, entry.side)
-
-            exits, new_plan = trade_manager.on_tick_manage(symbol)
-            for _exit in exits:
-                trader.cancel(symbol, all_for_symbol=False)
 
         await asyncio.sleep(0)
 


### PR DESCRIPTION
## Summary
- Track per-symbol price and feed it to `TradeManager.on_tick_manage`
- Manage open positions every cycle and inform `RiskManager` on exits
- Expose `TradeManager.get_plan` and `RiskManager.notify_close` helpers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdb7f765588320b60fc132aa6bbd2b