### PR TITLE
Incorporate sigma-based risk controls

### DIFF
--- a/domain/services.py
+++ b/domain/services.py
@@ -403,8 +403,11 @@ class RiskManager:
 
     def build_plan(self, symbol: str, entry_price: float, window: M.PumpWindow) -> T.PositionPlan | None:
         risk = self._cfg.risk
-        # Stop loss is placed above the recent high by ``stop_abs_pct``.
-        stop_loss = window.high * (1.0 + risk.stop_abs_pct / 100.0)
+        # Stop loss uses the greater of absolute percent and a range based sigma.
+        range_pct = (window.high - window.low) / window.low
+        stop_abs = window.high * (risk.stop_abs_pct / 100.0)
+        sigma_stop = window.high * (risk.stop_sigma_mult * range_pct)
+        stop_loss = window.high + max(stop_abs, sigma_stop)
         # Take profit levels are computed cumulatively using configuration percentages.
         take_profit1 = entry_price * (1.0 - risk.tp1_pct / 100.0)
         tp2_total_pct = risk.tp1_pct + risk.tp2_pct
@@ -414,8 +417,9 @@ class RiskManager:
         trail_start = entry_price * (1.0 - trail_start_pct / 100.0)
         # Trailing distance is defined by the larger of absolute percent and
         # a multiple of the recent price range.
-        range_pct = (window.high - window.low) / entry_price
-        trail_distance = entry_price * max(risk.trail_abs_pct / 100.0, range_pct * risk.trail_sigma_mult)
+        trail_distance = entry_price * max(
+            risk.trail_abs_pct / 100.0, range_pct * risk.trail_sigma_mult
+        )
         quantity = RISK_PER_TRADE_USDT / entry_price
         return PositionPlan(
             symbol=symbol,


### PR DESCRIPTION
## Summary
- derive stop loss from max of absolute pct and sigma multiple of recent range
- compute trailing distance using absolute pct versus sigma-based range

## Testing
- `python -m py_compile domain/services.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdb7f99864832099944d769a7c6598