### PR TITLE
Add SymbolRegistry has method and guard BTCUSDT usage

### DIFF
--- a/domain/services.py
+++ b/domain/services.py
@@ -99,6 +99,9 @@ class SymbolRegistry:
     def __init__(self) -> None:
         self._states: Dict[str, SymbolState] = {}
 
+    def has(self, symbol: str) -> bool:
+        return symbol in self._states
+
     def get(self, symbol: str) -> SymbolState:
         return self._states[symbol]
 

--- a/main.py
+++ b/main.py
@@ -221,7 +221,7 @@ async def fsm_loop(
                 continue
             gstate.btc_pause_until_ms = None
 
-        try:
+        if registry.has("BTCUSDT"):
             btc_state = registry.get("BTCUSDT")
             if btc_state.metrics.z_px > constants.GLOBAL_BTC_PAUSE_Z:
                 gstate.btc_pause_until_ms = (
@@ -229,8 +229,6 @@ async def fsm_loop(
                 )
                 await asyncio.sleep(0)
                 continue
-        except KeyError:
-            pass
 
         for symbol in registry.all_symbols():
             state = registry.get(symbol)


### PR DESCRIPTION
## Summary
- add `has` method to `SymbolRegistry` for checking symbol presence
- use `registry.has` before accessing BTCUSDT state in main

## Testing
- `python -m py_compile domain/services.py main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdc5ed5dfc8320b560ce461c9a4dc0