### PR TITLE
Use Side enum for metrics

### DIFF
--- a/domain/models/metrics.py
+++ b/domain/models/metrics.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import dataclass, field
-from typing import Deque, Optional
+from typing import Deque
 
 import constants
+from .enums import Side
 
 
 @dataclass(frozen=True)
@@ -57,7 +58,7 @@ class SymbolMetrics:
 
     # --- liquidation and open interest metrics -------------------------
     liqs_z: float = 0.0
-    last_liq_side: Optional[str] = None
+    last_liq_side: Side | None = None
     delta_oi_pct: float = 0.0
 
     # --- taker volume metrics ------------------------------------------
@@ -68,4 +69,4 @@ class SymbolMetrics:
     low_break: bool = False
     avwap_loss: bool = False
     entry_price: float = 0.0
-    direction: Optional[str] = None
+    direction: Side | None = None

--- a/domain/services.py
+++ b/domain/services.py
@@ -350,12 +350,7 @@ class SignalEngine:
         price = metrics.entry_price or window.low
 
         direction = metrics.direction
-        side = Side.SHORT
-        if direction:
-            try:
-                side = Side(direction)
-            except Exception:
-                side = Side.SHORT if str(direction).lower() == "short" else Side.LONG
+        side = direction if direction is not None else Side.SHORT
 
         return S.EntrySignal(symbol=symbol, side=side, price=price)
 

--- a/main.py
+++ b/main.py
@@ -133,7 +133,7 @@ async def bar_maker(ws: WsClient, registry: SymbolRegistry) -> None:
             liq_win.append(liq.quantity)
             liqs_z = _zscore(liq.quantity, liq_win) if len(liq_win) > 1 else 0.0
             metrics.liqs_z = liqs_z
-            metrics.last_liq_side = liq.side.value
+            metrics.last_liq_side = liq.side
             registry.update(liq.symbol, state)
 
         await asyncio.sleep(0)


### PR DESCRIPTION
## Summary
- type last liquidation side and entry direction as `Side` enums
- streamline signal engine entry direction handling
- store `Side` enum values in metrics instead of strings

## Testing
- `python -m py_compile domain/models/metrics.py domain/services.py main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdc5e629bc832089ef6a6473c411ac