### PR TITLE
Refactor Trader.cancel to support optional order id

### DIFF
--- a/domain/services.py
+++ b/domain/services.py
@@ -77,20 +77,15 @@ class Trader:
         response.raise_for_status()
 
     # ------------------------------------------------------------------
-    def cancel(self, symbol: str, all_for_symbol: bool) -> None:  # pragma: no cover - network
-        if all_for_symbol:
+    def cancel(self, symbol: str, order_id: int | None) -> None:  # pragma: no cover - network
+        if order_id is None:
             endpoint = self._CANCEL_ALL_ENDPOINT
             params = {"symbol": symbol}
-            response = self._signed_request("DELETE", endpoint, params)
-            response.raise_for_status()
         else:
-            # The simplified interface allows cancelling all orders for a
-            # symbol only.  For single order cancel, a more specific order id
-            # would be required, which is outside the scope of this example.
-            endpoint = self._CANCEL_ALL_ENDPOINT
-            params = {"symbol": symbol}
-            response = self._signed_request("DELETE", endpoint, params)
-            response.raise_for_status()
+            endpoint = self._ORDER_ENDPOINT
+            params = {"symbol": symbol, "orderId": str(order_id)}
+        response = self._signed_request("DELETE", endpoint, params)
+        response.raise_for_status()
 
 
 class SymbolRegistry:

--- a/main.py
+++ b/main.py
@@ -249,7 +249,7 @@ async def fsm_loop(
             if state.state is BotState.ENTERED:
                 exits, new_plan = trade_manager.on_tick_manage(symbol)
                 for _exit in exits:
-                    trader.cancel(symbol, all_for_symbol=False)
+                    trader.cancel(symbol, order_id=None)
                 if new_plan is None:
                     state.state = BotState.COOLDOWN
                     state.last_signal_ts = now


### PR DESCRIPTION
## Summary
- broaden `Trader.cancel` to accept an optional order id and route to the right Binance Futures endpoint
- update FSM loop to use new cancel signature

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdc7e4640883209eccb4b0aebf514e