### PR TITLE
Add jitter and backoff to REST pollers

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ functions.
 from __future__ import annotations
 
 import asyncio
+import random
 import time
 from typing import Deque
 
@@ -147,47 +148,83 @@ async def rest_pollers(rest: RestClient, registry: SymbolRegistry) -> None:
     later consumed by the signal engine.
     """
 
+    async def _with_backoff(func, *args):
+        delay = 1.0
+        while True:
+            try:
+                return func(*args)
+            except Exception:
+                await asyncio.sleep(delay * random.uniform(0.8, 1.2))
+                delay = min(delay * 2, 60.0)
+
     async def poll_oi() -> None:
         """Poll open interest and update delta percentage metric."""
 
         last_oi: dict[str, float] = {}
+        watched_states = {
+            BotState.WATCHING,
+            BotState.CONFIRMING,
+            BotState.ENTERED,
+        }
         while True:
             for symbol in registry.all_symbols():
-                oi = rest.get_open_interest(symbol)
+                state = registry.get(symbol)
+                if state.state not in watched_states:
+                    continue
+                oi = await _with_backoff(rest.get_open_interest, symbol)
                 prev = last_oi.get(symbol)
                 delta_pct = ((oi - prev) / prev * 100.0) if prev else 0.0
                 last_oi[symbol] = oi
 
-                state = registry.get(symbol)
                 metrics = state.metrics
                 metrics.delta_oi_pct = delta_pct
                 registry.update(symbol, state)
-            await asyncio.sleep(constants.REST_POLL_SEC_OI)
+            await asyncio.sleep(
+                constants.REST_POLL_SEC_OI * random.uniform(0.8, 1.2)
+            )
 
     async def poll_taker() -> None:
         """Poll taker buy/sell volumes and store them in metrics."""
 
+        watched_states = {
+            BotState.WATCHING,
+            BotState.CONFIRMING,
+            BotState.ENTERED,
+        }
         while True:
             for symbol in registry.all_symbols():
-                buy, sell = rest.get_taker_ratio(symbol)
                 state = registry.get(symbol)
+                if state.state not in watched_states:
+                    continue
+                buy, sell = await _with_backoff(rest.get_taker_ratio, symbol)
                 metrics = state.metrics
                 metrics.taker_buy_volume = buy
                 metrics.taker_sell_volume = sell
                 registry.update(symbol, state)
-            await asyncio.sleep(constants.REST_POLL_SEC_TAKER)
+            await asyncio.sleep(
+                constants.REST_POLL_SEC_TAKER * random.uniform(0.8, 1.2)
+            )
 
     async def poll_premium() -> None:
         """Poll premium index percentage and update metric."""
 
+        watched_states = {
+            BotState.WATCHING,
+            BotState.CONFIRMING,
+            BotState.ENTERED,
+        }
         while True:
             for symbol in registry.all_symbols():
-                premium = rest.get_premium_pct(symbol)
                 state = registry.get(symbol)
+                if state.state not in watched_states:
+                    continue
+                premium = await _with_backoff(rest.get_premium_pct, symbol)
                 metrics = state.metrics
                 metrics.premium_pct = premium
                 registry.update(symbol, state)
-            await asyncio.sleep(constants.REST_POLL_SEC_PREMIUM)
+            await asyncio.sleep(
+                constants.REST_POLL_SEC_PREMIUM * random.uniform(0.8, 1.2)
+            )
 
     await asyncio.gather(poll_oi(), poll_taker(), poll_premium())
 


### PR DESCRIPTION
## Summary
- add jittered polling intervals to rest_pollers
- ignore symbols unless in active bot states
- retry REST calls with exponential backoff

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdc81a79408320a666d047d1fe2a31