### PR TITLE
Track signal direction and entry price

### DIFF
--- a/domain/services.py
+++ b/domain/services.py
@@ -345,12 +345,17 @@ class SignalEngine:
         if not allow:
             return None
 
-        price = metrics.entry_price or window.low
+        direction = metrics.direction or Side.SHORT
 
-        direction = metrics.direction
-        side = direction if direction is not None else Side.SHORT
+        if metrics.entry_price > 0:
+            price = metrics.entry_price
+        else:
+            if direction is Side.SHORT:
+                price = metrics.best_bid or window.low
+            else:
+                price = metrics.best_ask or window.high
 
-        return S.EntrySignal(symbol=symbol, side=side, price=price)
+        return S.EntrySignal(symbol=symbol, side=direction, price=price)
 
 
 class RiskManager:

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ import time
 import math
 from typing import Deque
 
-from domain.models.enums import BotState, Profile
+from domain.models.enums import BotState, Profile, Side
 from domain.models.state import GlobalState, SymbolState
 from domain.models.config import ProfileConfig
 from config import make_profile_config_balanced
@@ -136,6 +136,12 @@ async def bar_maker(ws: WsClient, registry: SymbolRegistry) -> None:
             metrics.last_price = trade.price
             metrics.low_break = low_break
             metrics.avwap_loss = avwap_loss
+            if low_break or avwap_loss:
+                metrics.entry_price = trade.price
+                metrics.direction = Side.SHORT
+            else:
+                metrics.entry_price = 0.0
+                metrics.direction = None
 
             registry.update(trade.symbol, state)
 


### PR DESCRIPTION
## Summary
- record entry price and trade direction in metrics when low breaks or AVWAP loss occurs
- use recorded direction and price, falling back to order book levels, when forming entry signals

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdca7d7c9c8320a6d5ef78f80ce5b3