### PR TITLE
Refactor universe creation into dedicated builder

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -16,6 +16,7 @@ from .ws import ws_stream
 from .metrics import bar_maker
 from .rest_pollers import rest_pollers
 from .state_machine import fsm_loop
+from .universe import UniverseBuilder
 
 
 def run(cfg: ProfileConfig) -> None:
@@ -23,40 +24,15 @@ def run(cfg: ProfileConfig) -> None:
 
     registry = SymbolRegistry()
     rest = RestClient()
-    ws = WsClient()
-    trader = Trader()
 
-    symbols: list[str] = []
-    r = rest._client.get("/fapi/v1/ticker/24hr")
-    r.raise_for_status()
-    for info in r.json():
-        sym = info["symbol"]
-        if not sym.endswith("USDT"):
-            continue
-
-        quote_vol, _ = rest.get_24h_stats(sym)
-        if quote_vol < constants.UNIVERSE_MIN_24H_USDT:
-            continue
-
-        bid = float(info["bidPrice"])
-        ask = float(info["askPrice"])
-        if bid <= 0:
-            continue
-        spread_bps = (ask - bid) / bid * 10_000.0
-        if spread_bps > constants.UNIVERSE_MAX_SPREAD_BPS:
-            continue
-
-        depth = rest._client.get("/fapi/v1/depth", params={"symbol": sym, "limit": 10})
-        depth.raise_for_status()
-        bids = depth.json().get("bids", [])
-        top10_bid_usdt = sum(float(p) * float(q) for p, q in bids)
-        if top10_bid_usdt < constants.UNIVERSE_MIN_TOP10_BID_USDT:
-            continue
-
+    builder = UniverseBuilder(rest)
+    symbols = builder.build()
+    for sym in symbols:
         registry.put(SymbolState(symbol=sym, state=BotState.IDLE))
-        symbols.append(sym)
 
+    ws = WsClient()
     ws.subscribe_symbols(tuple(symbols))
+    trader = Trader()
 
     signal_engine = SignalEngine(cfg, registry)
     risk_manager = RiskManager(cfg)

--- a/app/universe.py
+++ b/app/universe.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from domain.services.rest_client import RestClient
+import constants
+
+
+class UniverseBuilder:
+    def __init__(self, rest: RestClient) -> None:
+        self._rest = rest
+
+    def build(self) -> list[str]:
+        symbols: list[str] = []
+
+        r = self._rest._client.get("/fapi/v1/ticker/24hr")
+        r.raise_for_status()
+        for info in r.json():
+            sym = info["symbol"]
+            if not sym.endswith("USDT"):
+                continue
+
+            quote_vol, _ = self._rest.get_24h_stats(sym)
+            if quote_vol < constants.UNIVERSE_MIN_24H_USDT:
+                continue
+
+            bid = float(info["bidPrice"])
+            ask = float(info["askPrice"])
+            if bid <= 0:
+                continue
+            spread_bps = (ask - bid) / bid * 10_000.0
+            if spread_bps > constants.UNIVERSE_MAX_SPREAD_BPS:
+                continue
+
+            depth = self._rest._client.get(
+                "/fapi/v1/depth", params={"symbol": sym, "limit": 10}
+            )
+            depth.raise_for_status()
+            bids = depth.json().get("bids", [])
+            top10_bid_usdt = sum(float(p) * float(q) for p, q in bids)
+            if top10_bid_usdt < constants.UNIVERSE_MIN_TOP10_BID_USDT:
+                continue
+
+            symbols.append(sym)
+
+        return symbols

--- a/main.py
+++ b/main.py
@@ -3,8 +3,7 @@ from app.orchestrator import run
 
 
 def main() -> None:
-    cfg = make_profile_config_balanced()
-    run(cfg)
+    run(make_profile_config_balanced())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- create `UniverseBuilder` to fetch USDT symbols passing volume, spread, and depth filters
- integrate `UniverseBuilder` into orchestrator and register symbols in `SymbolRegistry`
- simplify `main` to only build profile config and run the orchestrator

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bddec6ae6083208eb95793b750efad