### PR TITLE
Introduce class-based bot state machine

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -10,7 +10,6 @@ from domain.services.symbol_registry import SymbolRegistry
 from domain.services.trade_manager import TradeManager
 from domain.services.trader import Trader
 from domain.services.ws_client import WsClient
-import constants
 
 from .ws import ws_stream
 from .metrics import bar_maker
@@ -19,7 +18,7 @@ from .rest_pollers import (
     TakerRatioPoller,
     PremiumIndexPoller,
 )
-from .state_machine import fsm_loop
+from .state_machine import BotStateMachine
 from .universe import UniverseBuilder
 
 
@@ -47,21 +46,22 @@ def run(cfg: ProfileConfig) -> None:
         TakerRatioPoller(rest, registry),
         PremiumIndexPoller(rest, registry),
     ]
+    state_machine = BotStateMachine(
+        cfg,
+        gstate,
+        registry,
+        signal_engine,
+        risk_manager,
+        trade_manager,
+        trader,
+    )
 
     async def _run() -> None:
         await asyncio.gather(
             ws_stream(ws),
             bar_maker(ws, registry),
             *(p.run() for p in pollers),
-            fsm_loop(
-                cfg,
-                gstate,
-                registry,
-                signal_engine,
-                risk_manager,
-                trade_manager,
-                trader,
-            ),
+            state_machine.run(),
         )
 
     asyncio.run(_run())

--- a/app/state_machine.py
+++ b/app/state_machine.py
@@ -1,8 +1,12 @@
+"""Finite-state machine orchestrating signal flow and trading."""
+
+from __future__ import annotations
+
 import asyncio
 import time
 
 from domain.models.enums import BotState
-from domain.models.state import GlobalState
+from domain.models.state import GlobalState, SymbolState
 from domain.models.config import ProfileConfig
 from domain.services.symbol_registry import SymbolRegistry
 from domain.services.signal_engine import SignalEngine
@@ -12,94 +16,122 @@ from domain.services.trader import Trader
 import constants
 
 
-async def fsm_loop(
-    cfg: ProfileConfig,
-    gstate: GlobalState,
-    registry: SymbolRegistry,
-    signal_engine: SignalEngine,
-    risk_manager: RiskManager,
-    trade_manager: TradeManager,
-    trader: Trader,
-) -> None:
-    """Finite-state machine coordinating signals and trading."""
+class BotStateMachine:
+    """Coordinate signals, risk checks and trading actions."""
 
-    while True:
-        now_ms = int(time.time() * 1000)
+    def __init__(
+        self,
+        cfg: ProfileConfig,
+        gstate: GlobalState,
+        registry: SymbolRegistry,
+        signal_engine: SignalEngine,
+        risk_manager: RiskManager,
+        trade_manager: TradeManager,
+        trader: Trader,
+    ) -> None:
+        self._cfg = cfg
+        self._gstate = gstate
+        self._registry = registry
+        self._signal_engine = signal_engine
+        self._risk_manager = risk_manager
+        self._trade_manager = trade_manager
+        self._trader = trader
 
-        # --------------------------------------------------------------
-        # Global BTC pause – skip processing when active or trigger pause
-        pause_until = gstate.btc_pause_until_ms
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    async def run(self) -> None:
+        while True:
+            now_ms = int(time.time() * 1000)
+            if self._check_global_pause(now_ms):
+                await asyncio.sleep(0)
+                continue
+
+            for symbol in self._registry.all_symbols():
+                state = self._registry.get(symbol)
+                now = time.time()
+
+                if state.state is BotState.COOLDOWN:
+                    self._handle_cooldown(symbol, state, now)
+                    continue
+
+                if state.state is BotState.ENTERED:
+                    self._handle_entered(symbol, state)
+                    continue
+
+                self._handle_idle_or_watching(symbol, state)
+
+            await asyncio.sleep(0)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _check_global_pause(self, now_ms: int) -> bool:
+        """Return True if processing should pause due to BTC spike."""
+        pause_until = self._gstate.btc_pause_until_ms
         if pause_until is not None:
             if now_ms < pause_until:
-                await asyncio.sleep(0)
-                continue
-            gstate.btc_pause_until_ms = None
+                return True
+            self._gstate.btc_pause_until_ms = None
 
-        if registry.has("BTCUSDT"):
-            btc_state = registry.get("BTCUSDT")
+        if self._registry.has("BTCUSDT"):
+            btc_state = self._registry.get("BTCUSDT")
             if btc_state.metrics.z_px > constants.GLOBAL_BTC_PAUSE_Z:
-                gstate.btc_pause_until_ms = (
+                self._gstate.btc_pause_until_ms = (
                     now_ms + constants.GLOBAL_BTC_PAUSE_SEC * 1000
                 )
-                await asyncio.sleep(0)
-                continue
+                return True
+        return False
 
-        for symbol in registry.all_symbols():
-            state = registry.get(symbol)
-            now = time.time()
+    def _handle_cooldown(self, symbol: str, state: SymbolState, now: float) -> None:
+        if (
+            state.last_signal_ts is not None
+            and now - state.last_signal_ts >= constants.COOLDOWN_AFTER_TRADE_SEC
+        ):
+            state.state = BotState.IDLE
+            state.last_signal_ts = None
+            self._registry.update(symbol, state)
 
-            # -------------------------------------------------- cooldown
-            if state.state is BotState.COOLDOWN:
-                if (
-                    state.last_signal_ts is not None
-                    and now - state.last_signal_ts >= constants.COOLDOWN_AFTER_TRADE_SEC
-                ):
-                    state.state = BotState.IDLE
-                    state.last_signal_ts = None
-                    registry.update(symbol, state)
-                continue
+    def _handle_entered(self, symbol: str, state: SymbolState) -> None:
+        price = state.metrics.last_price
+        if price <= 0.0:
+            return
+        exits, new_plan = self._trade_manager.on_tick_manage(symbol, price=price)
+        for _exit in exits:
+            self._trader.cancel(symbol, order_id=None)
+        if new_plan is None:
+            state.state = BotState.COOLDOWN
+            state.last_signal_ts = time.time()
+            self._registry.update(symbol, state)
 
-            # -------------------------------------------------- in position
-            if state.state is BotState.ENTERED:
-                price = state.metrics.last_price
-                if price <= 0.0:
-                    continue
-                exits, new_plan = trade_manager.on_tick_manage(symbol, price=price)
-                for _exit in exits:
-                    trader.cancel(symbol, order_id=None)
-                if new_plan is None:
-                    state.state = BotState.COOLDOWN
-                    state.last_signal_ts = now
-                    registry.update(symbol, state)
-                continue
-
-            # -------------------------------------------------- idle/watching
-            pump = signal_engine.on_minute_close(symbol)
-            if pump is None:
-                if state.state is BotState.WATCHING:
-                    state.state = BotState.IDLE
-                    registry.update(symbol, state)
-                continue
-
-            state.state = BotState.WATCHING
-            registry.update(symbol, state)
-
-            if signal_engine.confirm_failure(symbol, pump.window):
+    def _handle_idle_or_watching(self, symbol: str, state: SymbolState) -> None:
+        pump = self._signal_engine.on_minute_close(symbol)
+        if pump is None:
+            if state.state is BotState.WATCHING:
                 state.state = BotState.IDLE
-                registry.update(symbol, state)
-                continue
+                self._registry.update(symbol, state)
+            return
 
-            entry = signal_engine.make_entry(symbol, pump.window)
-            if entry is None:
-                continue
+        state.state = BotState.WATCHING
+        self._registry.update(symbol, state)
 
-            plan = risk_manager.build_plan(symbol, entry.price, pump.window)
-            if plan is None or not risk_manager.allow_trade(plan):
-                continue
+        if self._signal_engine.confirm_failure(symbol, pump.window):
+            state.state = BotState.IDLE
+            self._registry.update(symbol, state)
+            return
 
-            trade_manager.open_position(plan, entry.side)
+        entry = self._signal_engine.make_entry(symbol, pump.window)
+        if entry is None:
+            return
 
-            state.state = BotState.ENTERED
-            registry.update(symbol, state)
+        plan = self._risk_manager.build_plan(symbol, entry.price, pump.window)
+        if plan is None or not self._risk_manager.allow_trade(plan):
+            return
 
-        await asyncio.sleep(0)
+        self._trade_manager.open_position(plan, entry.side)
+        state.state = BotState.ENTERED
+        self._registry.update(symbol, state)
+
+
+__all__ = ["BotStateMachine"]
+


### PR DESCRIPTION
## Summary
- Implement `BotStateMachine` to encapsulate trading state transitions
- Update orchestrator to run the new state machine

## Testing
- `python -m py_compile app/state_machine.py app/orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_68bddafec1ec8320a5edaef9b6a13fa4