### PR TITLE
Refactor metric helpers

### DIFF
--- a/app/metric_utils.py
+++ b/app/metric_utils.py
@@ -1,0 +1,38 @@
+"""Utility functions for metric calculations."""
+"""Utility functions for metric calculations."""
+
+from typing import Deque
+
+import constants
+
+
+def update_ewma(
+    value: float, mean: float, std: float, alpha: float
+) -> tuple[float, float]:
+    """Return updated EWMA mean and std for ``value``."""
+    if mean == 0.0 and std == 0.0:
+        return value, 0.0
+    var = std**2
+    delta = value - mean
+    mean += alpha * delta
+    var = (1 - alpha) * (var + alpha * delta * delta)
+    return mean, var ** 0.5
+
+
+def zscore(
+    value: float, ewma_mean: float, ewma_std: float, window: Deque[float]
+) -> float:
+    """Return z-score of ``value`` using precomputed EWMA statistics."""
+    if len(window) < constants.Z_BASE_WINDOW_MIN or ewma_std <= 0:
+        return 0.0
+    return (value - ewma_mean) / ewma_std
+
+
+def zscore_window(value: float, window: Deque[float]) -> float:
+    """Return z-score of ``value`` within ``window`` values."""
+    if len(window) < constants.Z_BASE_WINDOW_MIN:
+        return 0.0
+    mean = sum(window) / len(window)
+    var = sum((x - mean) ** 2 for x in window) / len(window)
+    std = var ** 0.5
+    return 0.0 if std == 0 else (value - mean) / std

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import math
-from typing import Deque
-
 import constants
 from domain.models.enums import Side
 from domain.models.market_data import AggTrade, DepthSnapshot, LiquidationEvent
 from domain.services.symbol_registry import SymbolRegistry
 from domain.services.ws_client import WsClient
+from .metric_utils import update_ewma, zscore, zscore_window
 
 
 class MetricAggregator:
@@ -20,64 +19,32 @@ class MetricAggregator:
         self._registry = registry
         self._alpha = 1 - math.exp(-math.log(2) / constants.EWMA_HALF_LIFE_MIN)
 
-    @staticmethod
-    def update_ewma(
-        value: float, mean: float, std: float, alpha: float
+    def _update_price_volume_metrics(
+        self, trade: AggTrade, metrics
     ) -> tuple[float, float]:
-        """Return updated EWMA mean and std for ``value``."""
-        if mean == 0.0 and std == 0.0:
-            return value, 0.0
-        var = std**2
-        delta = value - mean
-        mean += alpha * delta
-        var = (1 - alpha) * (var + alpha * delta * delta)
-        return mean, var ** 0.5
-
-    @staticmethod
-    def zscore(
-        value: float, ewma_mean: float, ewma_std: float, window: Deque[float]
-    ) -> float:
-        """Return z-score of ``value`` using precomputed EWMA statistics."""
-        if len(window) < constants.Z_BASE_WINDOW_MIN or ewma_std <= 0:
-            return 0.0
-        return (value - ewma_mean) / ewma_std
-
-    @staticmethod
-    def zscore_window(value: float, window: Deque[float]) -> float:
-        """Return z-score of ``value`` within ``window`` values."""
-        if len(window) < constants.Z_BASE_WINDOW_MIN:
-            return 0.0
-        mean = sum(window) / len(window)
-        var = sum((x - mean) ** 2 for x in window) / len(window)
-        std = var ** 0.5
-        return 0.0 if std == 0 else (value - mean) / std
-
-    # ------------------------------------------------------------------
-    # Event handlers
-    # ------------------------------------------------------------------
-    def process_trade(self, trade: AggTrade) -> None:
-        state = self._registry.get(trade.symbol)
-        metrics = state.metrics
-
-        # ------------------------ price & volume z-scores -----------------
         price_win = metrics.price_win
         vol_win = metrics.vol_win
         price_win.append(trade.price)
         vol_win.append(trade.quantity)
-        metrics.price_ewma_mean, metrics.price_ewma_std = self.update_ewma(
+        metrics.price_ewma_mean, metrics.price_ewma_std = update_ewma(
             trade.price, metrics.price_ewma_mean, metrics.price_ewma_std, self._alpha
         )
-        metrics.vol_ewma_mean, metrics.vol_ewma_std = self.update_ewma(
+        metrics.vol_ewma_mean, metrics.vol_ewma_std = update_ewma(
             trade.quantity, metrics.vol_ewma_mean, metrics.vol_ewma_std, self._alpha
         )
-        z_px = self.zscore(
+        z_px = zscore(
             trade.price, metrics.price_ewma_mean, metrics.price_ewma_std, price_win
         )
-        z_vol = self.zscore(
+        z_vol = zscore(
             trade.quantity, metrics.vol_ewma_mean, metrics.vol_ewma_std, vol_win
         )
+        return z_px, z_vol
 
-        # ----------------------- candle construction ----------------------
+    def _update_candle(
+        self, trade: AggTrade, metrics
+    ) -> tuple[float, float, float, bool, bool]:
+        price_win = metrics.price_win
+        vol_win = metrics.vol_win
         prev_low = metrics.low
         start_ts = metrics.start_ts
         if trade.timestamp - start_ts >= 60_000 or start_ts == 0:
@@ -109,6 +76,20 @@ class MetricAggregator:
         delta_abs = (high / low - 1.0) * 100 if low > 0 else 0.0
         close_pos = (trade.price - low) / rng if rng > 0 else 0.0
 
+        return delta_sigma, delta_abs, close_pos, low_break, avwap_loss
+
+    def _update_entry_flags(
+        self,
+        trade: AggTrade,
+        metrics,
+        z_px: float,
+        z_vol: float,
+        delta_sigma: float,
+        delta_abs: float,
+        close_pos: float,
+        low_break: bool,
+        avwap_loss: bool,
+    ) -> None:
         metrics.z_px = z_px
         metrics.z_vol = z_vol
         metrics.delta_price_sigma_mult = delta_sigma
@@ -123,6 +104,21 @@ class MetricAggregator:
         else:
             metrics.entry_price = 0.0
             metrics.direction = None
+
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+    def process_trade(self, trade: AggTrade) -> None:
+        state = self._registry.get(trade.symbol)
+        metrics = state.metrics
+        z_px, z_vol = self._update_price_volume_metrics(trade, metrics)
+        delta_sigma, delta_abs, close_pos, low_break, avwap_loss = self._update_candle(
+            trade, metrics
+        )
+        self._update_entry_flags(
+            trade, metrics, z_px, z_vol, delta_sigma, delta_abs, close_pos, low_break, avwap_loss
+        )
 
         self._registry.update(trade.symbol, state)
 
@@ -147,7 +143,7 @@ class MetricAggregator:
         metrics = state.metrics
         liq_win = metrics.liq_win
         liq_win.append(liq.quantity)
-        liqs_z = self.zscore_window(liq.quantity, liq_win)
+        liqs_z = zscore_window(liq.quantity, liq_win)
         metrics.liqs_z = liqs_z
         metrics.last_liq_side = liq.side
         self._registry.update(liq.symbol, state)


### PR DESCRIPTION
## Summary
- factor out price/volume, candle, and entry-flag updates into dedicated helpers
- centralize EWMA/z-score utilities in new `metric_utils`

## Testing
- `pytest`
- `python -m py_compile app/metrics.py app/metric_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68bde2d8d8148320b19b1d14355a1b67