### PR TITLE
Use RestClient for ticker and depth data

### DIFF
--- a/app/universe.py
+++ b/app/universe.py
@@ -11,9 +11,8 @@ class UniverseBuilder:
     def build(self) -> list[str]:
         symbols: list[str] = []
 
-        r = self._rest._client.get("/fapi/v1/ticker/24hr")
-        r.raise_for_status()
-        for info in r.json():
+        tickers = self._rest.fetch_all_tickers()
+        for info in tickers:
             sym = info["symbol"]
             if not sym.endswith("USDT"):
                 continue
@@ -30,12 +29,8 @@ class UniverseBuilder:
             if spread_bps > constants.UNIVERSE_MAX_SPREAD_BPS:
                 continue
 
-            depth = self._rest._client.get(
-                "/fapi/v1/depth", params={"symbol": sym, "limit": 10}
-            )
-            depth.raise_for_status()
-            bids = depth.json().get("bids", [])
-            top10_bid_usdt = sum(float(p) * float(q) for p, q in bids)
+            bids = self._rest.get_depth(sym)
+            top10_bid_usdt = sum(p * q for p, q in bids)
             if top10_bid_usdt < constants.UNIVERSE_MIN_TOP10_BID_USDT:
                 continue
 

--- a/domain/services/rest_client.py
+++ b/domain/services/rest_client.py
@@ -12,6 +12,7 @@ class RestClient:
     _TAKER_RATIO_EP = "/futures/data/takerlongshortRatio"
     _PREMIUM_EP = "/fapi/v1/premiumIndex"
     _TICKER_EP = "/fapi/v1/ticker/24hr"
+    _DEPTH_EP = "/fapi/v1/depth"
 
     def __init__(self) -> None:
         self._client = httpx.Client(base_url=BINANCE_FAPI_REST, timeout=10.0)
@@ -53,3 +54,15 @@ class RestClient:
         quote_volume = float(data["quoteVolume"])
         last_price = float(data["lastPrice"])
         return quote_volume, last_price
+
+    def fetch_all_tickers(self) -> list[dict[str, str]]:
+        r = self._client.get(self._TICKER_EP)
+        r.raise_for_status()
+        return r.json()
+
+    def get_depth(self, symbol: str) -> tuple[tuple[float, float], ...]:
+        r = self._client.get(self._DEPTH_EP, params={"symbol": symbol, "limit": 10})
+        r.raise_for_status()
+        data = r.json()
+        bids = tuple((float(p), float(q)) for p, q in data.get("bids", []))
+        return bids


### PR DESCRIPTION
## Summary
- extend RestClient with fetch_all_tickers and get_depth helpers
- refactor UniverseBuilder to use RestClient's public API

## Testing
- `python -m py_compile domain/services/rest_client.py app/universe.py`


------
https://chatgpt.com/codex/tasks/task_e_68bde47c3c2483208f7fe47af1ae6640