### PR TITLE
Refactor state machine into handlers and global pause service

### DIFF
--- a/app/global_pause_guard.py
+++ b/app/global_pause_guard.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import constants
+from domain.models.state import GlobalState
+from domain.services.symbol_registry import SymbolRegistry
+
+
+class GlobalPauseGuard:
+    """Service checking for BTC-induced global pause."""
+
+    def __init__(self, gstate: GlobalState, registry: SymbolRegistry) -> None:
+        self._gstate = gstate
+        self._registry = registry
+
+    def should_pause(self, now_ms: int) -> bool:
+        """Return ``True`` if processing should pause due to BTC spike."""
+        pause_until = self._gstate.btc_pause_until_ms
+        if pause_until is not None:
+            if now_ms < pause_until:
+                return True
+            self._gstate.btc_pause_until_ms = None
+
+        if self._registry.has("BTCUSDT"):
+            btc_state = self._registry.get("BTCUSDT")
+            if btc_state.metrics.z_px > constants.GLOBAL_BTC_PAUSE_Z:
+                self._gstate.btc_pause_until_ms = (
+                    now_ms + constants.GLOBAL_BTC_PAUSE_SEC * 1000
+                )
+                return True
+        return False
+
+
+__all__ = ["GlobalPauseGuard"]

--- a/app/state_handlers/__init__.py
+++ b/app/state_handlers/__init__.py
@@ -1,0 +1,9 @@
+from .cooldown import CooldownHandler
+from .entered import EnteredHandler
+from .idle_watching import IdleWatchingHandler
+
+__all__ = [
+    "CooldownHandler",
+    "EnteredHandler",
+    "IdleWatchingHandler",
+]

--- a/app/state_handlers/cooldown.py
+++ b/app/state_handlers/cooldown.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from domain.models.enums import BotState
+from domain.models.state import SymbolState
+from domain.services.symbol_registry import SymbolRegistry
+import constants
+
+
+class CooldownHandler:
+    """Transition symbols out of cooldown when time has passed."""
+
+    def __init__(self, registry: SymbolRegistry) -> None:
+        self._registry = registry
+
+    def handle(self, symbol: str, state: SymbolState, now: float) -> None:
+        if (
+            state.last_signal_ts is not None
+            and now - state.last_signal_ts >= constants.COOLDOWN_AFTER_TRADE_SEC
+        ):
+            state.state = BotState.IDLE
+            state.last_signal_ts = None
+            self._registry.update(symbol, state)
+
+
+__all__ = ["CooldownHandler"]

--- a/app/state_handlers/entered.py
+++ b/app/state_handlers/entered.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import time
+
+from domain.models.enums import BotState
+from domain.models.state import SymbolState
+from domain.services.symbol_registry import SymbolRegistry
+from domain.services.trade_manager import TradeManager
+from domain.ports.trader import Trader
+
+
+class EnteredHandler:
+    """Manage positions while in ENTERED state."""
+
+    def __init__(
+        self,
+        registry: SymbolRegistry,
+        trade_manager: TradeManager,
+        trader: Trader,
+    ) -> None:
+        self._registry = registry
+        self._trade_manager = trade_manager
+        self._trader = trader
+
+    def handle(self, symbol: str, state: SymbolState) -> None:
+        price = state.metrics.last_price
+        if price <= 0.0:
+            return
+        exits, new_plan = self._trade_manager.on_tick_manage(symbol, price=price)
+        for _exit in exits:
+            self._trader.cancel(symbol, order_id=None)
+        if new_plan is None:
+            state.state = BotState.COOLDOWN
+            state.last_signal_ts = time.time()
+            self._registry.update(symbol, state)
+
+
+__all__ = ["EnteredHandler"]

--- a/app/state_handlers/idle_watching.py
+++ b/app/state_handlers/idle_watching.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from domain.models.enums import BotState
+from domain.models.state import SymbolState
+from domain.services.signal_engine import SignalEngine
+from domain.services.risk_manager import RiskManager
+from domain.services.trade_manager import TradeManager
+from domain.services.symbol_registry import SymbolRegistry
+
+
+class IdleWatchingHandler:
+    """Handle IDLE/WATCHING states: detect pumps and enter positions."""
+
+    def __init__(
+        self,
+        registry: SymbolRegistry,
+        signal_engine: SignalEngine,
+        risk_manager: RiskManager,
+        trade_manager: TradeManager,
+    ) -> None:
+        self._registry = registry
+        self._signal_engine = signal_engine
+        self._risk_manager = risk_manager
+        self._trade_manager = trade_manager
+
+    def handle(self, symbol: str, state: SymbolState) -> None:
+        pump = self._signal_engine.on_minute_close(symbol)
+        if pump is None:
+            if state.state is BotState.WATCHING:
+                state.state = BotState.IDLE
+                self._registry.update(symbol, state)
+            return
+
+        state.state = BotState.WATCHING
+        self._registry.update(symbol, state)
+
+        if self._signal_engine.confirm_failure(symbol, pump.window):
+            state.state = BotState.IDLE
+            self._registry.update(symbol, state)
+            return
+
+        entry = self._signal_engine.make_entry(symbol, pump.window)
+        if entry is None:
+            return
+
+        plan = self._risk_manager.build_plan(symbol, entry.price, pump.window)
+        if plan is None or not self._risk_manager.allow_trade(plan):
+            return
+
+        self._trade_manager.open_position(plan, entry.side)
+        state.state = BotState.ENTERED
+        self._registry.update(symbol, state)
+
+
+__all__ = ["IdleWatchingHandler"]

--- a/app/state_machine.py
+++ b/app/state_machine.py
@@ -13,7 +13,13 @@ from domain.services.signal_engine import SignalEngine
 from domain.services.risk_manager import RiskManager
 from domain.services.trade_manager import TradeManager
 from domain.ports.trader import Trader
-import constants
+
+from .global_pause_guard import GlobalPauseGuard
+from .state_handlers import (
+    CooldownHandler,
+    EnteredHandler,
+    IdleWatchingHandler,
+)
 
 
 class BotStateMachine:
@@ -30,12 +36,13 @@ class BotStateMachine:
         trader: Trader,
     ) -> None:
         self._cfg = cfg
-        self._gstate = gstate
         self._registry = registry
-        self._signal_engine = signal_engine
-        self._risk_manager = risk_manager
-        self._trade_manager = trade_manager
-        self._trader = trader
+        self._pause_guard = GlobalPauseGuard(gstate, registry)
+        self._cooldown_handler = CooldownHandler(registry)
+        self._entered_handler = EnteredHandler(registry, trade_manager, trader)
+        self._idle_watching_handler = IdleWatchingHandler(
+            registry, signal_engine, risk_manager, trade_manager
+        )
 
     # ------------------------------------------------------------------
     # Public API
@@ -43,7 +50,7 @@ class BotStateMachine:
     async def run(self) -> None:
         while True:
             now_ms = int(time.time() * 1000)
-            if self._check_global_pause(now_ms):
+            if self._pause_guard.should_pause(now_ms):
                 await asyncio.sleep(0)
                 continue
 
@@ -52,85 +59,16 @@ class BotStateMachine:
                 now = time.time()
 
                 if state.state is BotState.COOLDOWN:
-                    self._handle_cooldown(symbol, state, now)
+                    self._cooldown_handler.handle(symbol, state, now)
                     continue
 
                 if state.state is BotState.ENTERED:
-                    self._handle_entered(symbol, state)
+                    self._entered_handler.handle(symbol, state)
                     continue
 
-                self._handle_idle_or_watching(symbol, state)
+                self._idle_watching_handler.handle(symbol, state)
 
             await asyncio.sleep(0)
-
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-    def _check_global_pause(self, now_ms: int) -> bool:
-        """Return True if processing should pause due to BTC spike."""
-        pause_until = self._gstate.btc_pause_until_ms
-        if pause_until is not None:
-            if now_ms < pause_until:
-                return True
-            self._gstate.btc_pause_until_ms = None
-
-        if self._registry.has("BTCUSDT"):
-            btc_state = self._registry.get("BTCUSDT")
-            if btc_state.metrics.z_px > constants.GLOBAL_BTC_PAUSE_Z:
-                self._gstate.btc_pause_until_ms = (
-                    now_ms + constants.GLOBAL_BTC_PAUSE_SEC * 1000
-                )
-                return True
-        return False
-
-    def _handle_cooldown(self, symbol: str, state: SymbolState, now: float) -> None:
-        if (
-            state.last_signal_ts is not None
-            and now - state.last_signal_ts >= constants.COOLDOWN_AFTER_TRADE_SEC
-        ):
-            state.state = BotState.IDLE
-            state.last_signal_ts = None
-            self._registry.update(symbol, state)
-
-    def _handle_entered(self, symbol: str, state: SymbolState) -> None:
-        price = state.metrics.last_price
-        if price <= 0.0:
-            return
-        exits, new_plan = self._trade_manager.on_tick_manage(symbol, price=price)
-        for _exit in exits:
-            self._trader.cancel(symbol, order_id=None)
-        if new_plan is None:
-            state.state = BotState.COOLDOWN
-            state.last_signal_ts = time.time()
-            self._registry.update(symbol, state)
-
-    def _handle_idle_or_watching(self, symbol: str, state: SymbolState) -> None:
-        pump = self._signal_engine.on_minute_close(symbol)
-        if pump is None:
-            if state.state is BotState.WATCHING:
-                state.state = BotState.IDLE
-                self._registry.update(symbol, state)
-            return
-
-        state.state = BotState.WATCHING
-        self._registry.update(symbol, state)
-
-        if self._signal_engine.confirm_failure(symbol, pump.window):
-            state.state = BotState.IDLE
-            self._registry.update(symbol, state)
-            return
-
-        entry = self._signal_engine.make_entry(symbol, pump.window)
-        if entry is None:
-            return
-
-        plan = self._risk_manager.build_plan(symbol, entry.price, pump.window)
-        if plan is None or not self._risk_manager.allow_trade(plan):
-            return
-
-        self._trade_manager.open_position(plan, entry.side)
-        state.state = BotState.ENTERED
-        self._registry.update(symbol, state)
 
 
 __all__ = ["BotStateMachine"]


### PR DESCRIPTION
## Summary
- extract GlobalPauseGuard to encapsulate BTC spike pause logic
- move cooldown, entered, idle/watching logic into dedicated handlers
- streamline BotStateMachine to delegate to new services

## Testing
- `python -m py_compile app/state_machine.py app/global_pause_guard.py app/state_handlers/cooldown.py app/state_handlers/entered.py app/state_handlers/idle_watching.py app/state_handlers/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bde7a72bd48320814e8703c96c2a2b