### PR TITLE
Refactor Binance websocket client

### DIFF
--- a/infrastructure/binance/ws_client.py
+++ b/infrastructure/binance/ws_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from collections import deque
-from typing import Deque, List
+from typing import Any, Deque, List
 
 import websockets
 
@@ -24,10 +24,7 @@ class WsClient:
         self._symbols = symbols
 
     async def stream(self) -> None:  # pragma: no cover - network
-        params: List[str] = []
-        for sym in self._symbols:
-            ls = sym.lower()
-            params.extend([f"{ls}@aggTrade", f"{ls}@depth20@100ms", f"{ls}@forceOrder"])
+        params = self._build_params()
 
         async with websockets.connect(BINANCE_FAPI_WS) as ws:
             if params:
@@ -35,43 +32,64 @@ class WsClient:
                 await ws.send(json.dumps(msg))
 
             async for raw in ws:
-                data = json.loads(raw)
-                stream = data.get("stream")
-                payload = data.get("data")
-                if not stream or not payload:
-                    continue
-                if stream.endswith("aggTrade"):
-                    self._agg_trades.append(
-                        AggTrade(
-                            symbol=payload["s"],
-                            price=float(payload["p"]),
-                            quantity=float(payload["q"]),
-                            timestamp=int(payload["T"]),
-                        )
-                    )
-                elif "depth" in stream:
-                    bids = tuple((float(p), float(q)) for p, q in payload["bids"])
-                    asks = tuple((float(p), float(q)) for p, q in payload["asks"])
-                    self._depths.append(
-                        DepthSnapshot(
-                            symbol=payload["s"],
-                            bids=bids,
-                            asks=asks,
-                            timestamp=int(payload["E"]),
-                        )
-                    )
-                elif stream.endswith("forceOrder"):
-                    order = payload["o"]
-                    side = Side.LONG if order["S"] == "BUY" else Side.SHORT
-                    self._liqs.append(
-                        LiquidationEvent(
-                            symbol=order["s"],
-                            side=side,
-                            price=float(order["ap"]),
-                            quantity=float(order["q"]),
-                            timestamp=int(order["T"]),
-                        )
-                    )
+                self._parse_message(raw)
+
+    def _build_params(self) -> List[str]:
+        params: List[str] = []
+        for sym in self._symbols:
+            ls = sym.lower()
+            params.extend(
+                [f"{ls}@aggTrade", f"{ls}@depth20@100ms", f"{ls}@forceOrder"]
+            )
+        return params
+
+    def _parse_message(self, raw: str) -> None:
+        data = json.loads(raw)
+        stream = data.get("stream")
+        payload = data.get("data")
+        if not stream or not payload:
+            return
+        if stream.endswith("aggTrade"):
+            self._handle_agg_trade(payload)
+        elif "depth" in stream:
+            self._handle_depth(payload)
+        elif stream.endswith("forceOrder"):
+            self._handle_liquidation(payload)
+
+    def _handle_agg_trade(self, payload: dict[str, Any]) -> None:
+        self._agg_trades.append(
+            AggTrade(
+                symbol=payload["s"],
+                price=float(payload["p"]),
+                quantity=float(payload["q"]),
+                timestamp=int(payload["T"]),
+            )
+        )
+
+    def _handle_depth(self, payload: dict[str, Any]) -> None:
+        bids = tuple((float(p), float(q)) for p, q in payload["bids"])
+        asks = tuple((float(p), float(q)) for p, q in payload["asks"])
+        self._depths.append(
+            DepthSnapshot(
+                symbol=payload["s"],
+                bids=bids,
+                asks=asks,
+                timestamp=int(payload["E"]),
+            )
+        )
+
+    def _handle_liquidation(self, payload: dict[str, Any]) -> None:
+        order = payload["o"]
+        side = Side.LONG if order["S"] == "BUY" else Side.SHORT
+        self._liqs.append(
+            LiquidationEvent(
+                symbol=order["s"],
+                side=side,
+                price=float(order["ap"]),
+                quantity=float(order["q"]),
+                timestamp=int(order["T"]),
+            )
+        )
 
     def next_agg_trade(self) -> AggTrade | None:
         return self._agg_trades.popleft() if self._agg_trades else None


### PR DESCRIPTION
## Summary
- refactor Binance WS stream to use helper methods for building params and parsing messages
- split out dedicated handlers for agg trade, depth, and liquidation events

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bde887fa108320bf7833e2c1cc570c