### PR TITLE
Persist baseline windows for symbols

### DIFF
--- a/app/baseline_store.py
+++ b/app/baseline_store.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from collections import deque
+from typing import Deque, Dict, Iterable, Tuple
+
+import constants
+
+DB_PATH = "data/cache/baseline.sqlite"
+
+
+def _connect() -> sqlite3.Connection:
+    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS baseline (symbol TEXT PRIMARY KEY, price_win TEXT NOT NULL, vol_win TEXT NOT NULL)"
+    )
+    return conn
+
+
+def load(symbols: Iterable[str]) -> Dict[str, Tuple[Deque[float], Deque[float]]]:
+    conn = _connect()
+    cur = conn.cursor()
+    result: Dict[str, Tuple[Deque[float], Deque[float]]] = {}
+    for sym in symbols:
+        cur.execute("SELECT price_win, vol_win FROM baseline WHERE symbol=?", (sym,))
+        row = cur.fetchone()
+        if row:
+            price = json.loads(row[0])
+            vol = json.loads(row[1])
+            result[sym] = (
+                deque(price, maxlen=constants.Z_BASE_WINDOW_MIN),
+                deque(vol, maxlen=constants.Z_BASE_WINDOW_MIN),
+            )
+    conn.close()
+    return result
+
+
+def save(baselines: Dict[str, Tuple[Deque[float], Deque[float]]]) -> None:
+    if not baselines:
+        return
+    conn = _connect()
+    cur = conn.cursor()
+    rows = [
+        (sym, json.dumps(list(px)), json.dumps(list(vol)))
+        for sym, (px, vol) in baselines.items()
+    ]
+    cur.executemany(
+        "INSERT OR REPLACE INTO baseline(symbol, price_win, vol_win) VALUES (?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import asyncio
 import math
+import time
+from collections import deque
+
 import constants
 from domain.models.enums import Side
 from domain.models.market_data import AggTrade, DepthSnapshot, LiquidationEvent
 from domain.services.symbol_registry import SymbolRegistry
 from domain.ports.ws_client import WsClient
 from .metric_utils import update_ewma, zscore, zscore_window
+from . import baseline_store
 
 
 class MetricAggregator:
@@ -153,6 +157,21 @@ async def bar_maker(ws: WsClient, registry: SymbolRegistry) -> None:
     """Build per-symbol metrics from websocket events."""
 
     aggregator = MetricAggregator(registry)
+    symbols = registry.all_symbols()
+    baselines = baseline_store.load(symbols)
+    for sym in symbols:
+        state = registry.get(sym)
+        price_win, vol_win = baselines.get(
+            sym,
+            (
+                deque(maxlen=constants.Z_BASE_WINDOW_MIN),
+                deque(maxlen=constants.Z_BASE_WINDOW_MIN),
+            ),
+        )
+        state.metrics.price_win = price_win
+        state.metrics.vol_win = vol_win
+
+    next_persist = time.time() + 60
     while True:
         trade = ws.next_agg_trade()
         if trade:
@@ -165,6 +184,18 @@ async def bar_maker(ws: WsClient, registry: SymbolRegistry) -> None:
         liq = ws.next_liquidation()
         if liq:
             aggregator.process_liquidation(liq)
+
+        if time.time() >= next_persist:
+            baseline_store.save(
+                {
+                    sym: (
+                        registry.get(sym).metrics.price_win,
+                        registry.get(sym).metrics.vol_win,
+                    )
+                    for sym in symbols
+                }
+            )
+            next_persist = time.time() + 60
 
         await asyncio.sleep(0)
 


### PR DESCRIPTION
## Summary
- add SQLite-backed baseline store for price and volume windows
- initialize and persist metric windows in bar maker using the new store

## Testing
- `python -m py_compile app/baseline_store.py app/metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdea735b1c8320afdf5b179faa0b5d