### PR TITLE
Use asyncio for Binance REST and trading operations

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -32,7 +32,7 @@ def run(cfg: ProfileConfig) -> None:
     rest: RestClientPort = RestClient()
 
     builder = UniverseBuilder(rest)
-    symbols = builder.build()
+    symbols = asyncio.run(builder.build())
     for sym in symbols:
         registry.put(SymbolState(symbol=sym, state=BotState.IDLE))
 

--- a/app/state_handlers/entered.py
+++ b/app/state_handlers/entered.py
@@ -22,13 +22,13 @@ class EnteredHandler:
         self._trade_manager = trade_manager
         self._trader = trader
 
-    def handle(self, symbol: str, state: SymbolState) -> None:
+    async def handle(self, symbol: str, state: SymbolState) -> None:
         price = state.metrics.last_price
         if price <= 0.0:
             return
-        exits, new_plan = self._trade_manager.on_tick_manage(symbol, price=price)
+        exits, new_plan = await self._trade_manager.on_tick_manage(symbol, price=price)
         for _exit in exits:
-            self._trader.cancel(symbol, order_id=None)
+            await self._trader.cancel(symbol, order_id=None)
         if new_plan is None:
             state.state = BotState.COOLDOWN
             state.last_signal_ts = time.time()

--- a/app/state_handlers/idle_watching.py
+++ b/app/state_handlers/idle_watching.py
@@ -23,7 +23,7 @@ class IdleWatchingHandler:
         self._risk_manager = risk_manager
         self._trade_manager = trade_manager
 
-    def handle(self, symbol: str, state: SymbolState) -> None:
+    async def handle(self, symbol: str, state: SymbolState) -> None:
         pump = self._signal_engine.on_minute_close(symbol)
         if pump is None:
             if state.state is BotState.WATCHING:
@@ -47,7 +47,7 @@ class IdleWatchingHandler:
         if plan is None or not self._risk_manager.allow_trade(plan):
             return
 
-        self._trade_manager.open_position(plan, entry.side)
+        await self._trade_manager.open_position(plan, entry.side)
         state.state = BotState.ENTERED
         self._registry.update(symbol, state)
 

--- a/app/state_machine.py
+++ b/app/state_machine.py
@@ -63,10 +63,10 @@ class BotStateMachine:
                     continue
 
                 if state.state is BotState.ENTERED:
-                    self._entered_handler.handle(symbol, state)
+                    await self._entered_handler.handle(symbol, state)
                     continue
 
-                self._idle_watching_handler.handle(symbol, state)
+                await self._idle_watching_handler.handle(symbol, state)
 
             await asyncio.sleep(0)
 

--- a/app/universe.py
+++ b/app/universe.py
@@ -9,16 +9,16 @@ class UniverseBuilder:
     def __init__(self, rest: RestClient) -> None:
         self._rest = rest
 
-    def build(self) -> list[str]:
+    async def build(self) -> list[str]:
         symbols: list[str] = []
 
-        tickers = self._rest.fetch_all_tickers()
+        tickers = await self._rest.fetch_all_tickers()
         for info in tickers:
             sym = info["symbol"]
             if not self._is_usdt_pair(sym):
                 continue
 
-            if not self._passes_volume(sym):
+            if not await self._passes_volume(sym):
                 continue
 
             bid = float(info["bidPrice"])
@@ -26,7 +26,7 @@ class UniverseBuilder:
             if not self._within_spread(bid, ask):
                 continue
 
-            if not self._has_depth(sym):
+            if not await self._has_depth(sym):
                 continue
 
             symbols.append(sym)
@@ -36,8 +36,8 @@ class UniverseBuilder:
     def _is_usdt_pair(self, sym: str) -> bool:
         return sym.endswith("USDT")
 
-    def _passes_volume(self, sym: str) -> bool:
-        quote_vol, _ = self._rest.get_24h_stats(sym)
+    async def _passes_volume(self, sym: str) -> bool:
+        quote_vol, _ = await self._rest.get_24h_stats(sym)
         return quote_vol >= filters.MIN_24H_USDT
 
     def _within_spread(self, bid: float, ask: float) -> bool:
@@ -46,7 +46,7 @@ class UniverseBuilder:
         spread_bps = (ask - bid) / bid * 10_000.0
         return spread_bps <= filters.MAX_SPREAD_BPS
 
-    def _has_depth(self, sym: str) -> bool:
-        bids = self._rest.get_depth(sym)
+    async def _has_depth(self, sym: str) -> bool:
+        bids = await self._rest.get_depth(sym)
         top10_bid_usdt = sum(p * q for p, q in bids)
         return top10_bid_usdt >= filters.MIN_TOP10_BID_USDT

--- a/app/utils.py
+++ b/app/utils.py
@@ -10,15 +10,15 @@ from typing import Any, Callable
 async def _with_backoff(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
     """Execute ``func`` with exponential backoff on failure.
 
-    The ``func`` is expected to be a synchronous callable. Any exception will
-    trigger a retry with exponential delay capped at 60 seconds. Jitter of
-    ±20% is applied to each delay.
+    The ``func`` should be an awaitable callable. Any exception will trigger a
+    retry with exponential delay capped at 60 seconds. Jitter of ±20% is
+    applied to each delay.
     """
 
     delay = 1.0
     while True:
         try:
-            return func(*args, **kwargs)
+            return await func(*args, **kwargs)
         except Exception:
             await asyncio.sleep(delay * random.uniform(0.8, 1.2))
             delay = min(delay * 2, 60.0)

--- a/domain/ports/rest_client.py
+++ b/domain/ports/rest_client.py
@@ -7,20 +7,20 @@ from typing import Protocol, runtime_checkable
 class RestClient(Protocol):
     """Abstract interface for REST operations."""
 
-    def get_open_interest(self, symbol: str) -> float:
+    async def get_open_interest(self, symbol: str) -> float:
         ...
 
-    def get_taker_ratio(self, symbol: str) -> tuple[float, float]:
+    async def get_taker_ratio(self, symbol: str) -> tuple[float, float]:
         ...
 
-    def get_premium_pct(self, symbol: str) -> float:
+    async def get_premium_pct(self, symbol: str) -> float:
         ...
 
-    def get_24h_stats(self, symbol: str) -> tuple[float, float]:
+    async def get_24h_stats(self, symbol: str) -> tuple[float, float]:
         ...
 
-    def fetch_all_tickers(self) -> list[dict[str, str]]:
+    async def fetch_all_tickers(self) -> list[dict[str, str]]:
         ...
 
-    def get_depth(self, symbol: str) -> tuple[tuple[float, float], ...]:
+    async def get_depth(self, symbol: str) -> tuple[tuple[float, float], ...]:
         ...

--- a/domain/ports/trader.py
+++ b/domain/ports/trader.py
@@ -8,8 +8,10 @@ from domain.models.trading import OrderSpec
 class Trader(Protocol):
     """Abstract trading interface."""
 
-    def place(self, order: OrderSpec) -> None:  # pragma: no cover - network
+    async def place(self, order: OrderSpec) -> None:  # pragma: no cover - network
         ...
 
-    def cancel(self, symbol: str, order_id: int | None) -> None:  # pragma: no cover - network
+    async def cancel(
+        self, symbol: str, order_id: int | None
+    ) -> None:  # pragma: no cover - network
         ...

--- a/domain/services/trade_manager.py
+++ b/domain/services/trade_manager.py
@@ -23,17 +23,17 @@ class TradeManager:
     def _plan(plan: PositionPlan, **changes: float) -> PositionPlan:
         return replace(plan, **changes)
 
-    def open_position(self, plan: PositionPlan, side: Side) -> None:
+    async def open_position(self, plan: PositionPlan, side: Side) -> None:
         order = OrderSpec(
             symbol=plan.symbol,
             side=side,
             type=OrderType.MARKET,
             quantity=plan.quantity,
         )
-        self._trader.place(order)
+        await self._trader.place(order)
         self._positions[plan.symbol] = (side, plan)
 
-    def _close_position(self, symbol: str, side: Side, plan: PositionPlan) -> None:
+    async def _close_position(self, symbol: str, side: Side, plan: PositionPlan) -> None:
         exit_side = Side.LONG if side is Side.SHORT else Side.SHORT
         order = OrderSpec(
             symbol=plan.symbol,
@@ -41,11 +41,11 @@ class TradeManager:
             type=OrderType.MARKET,
             quantity=plan.quantity,
         )
-        self._trader.place(order)
+        await self._trader.place(order)
         self._risk_manager.release(plan)
         del self._positions[symbol]
 
-    def on_tick_manage(
+    async def on_tick_manage(
         self, symbol: str, price: float | None = None
     ) -> tuple[list[S.ExitSignal], PositionPlan | None]:
         """Manage an existing position on each price tick."""
@@ -58,24 +58,24 @@ class TradeManager:
         side, plan = record
         current_price = plan.entry_price if price is None else price
 
-        exits, plan = self._handle_tp1(plan, side, current_price)
+        exits, plan = await self._handle_tp1(plan, side, current_price)
         if exits:
             return exits, plan
 
-        exits, plan = self._handle_tp2(plan, side, current_price)
+        exits, plan = await self._handle_tp2(plan, side, current_price)
         if exits:
             return exits, plan
 
         _, plan = self._apply_trailing_stop(plan, side, current_price)
 
-        exits, plan = self._check_stop(plan, side, current_price)
+        exits, plan = await self._check_stop(plan, side, current_price)
         if exits:
             return exits, plan
 
         return exits, plan
 
     # ------------------------------------------------------------------
-    def _handle_tp1(
+    async def _handle_tp1(
         self, plan: PositionPlan, side: Side, price: float
     ) -> tuple[list[S.ExitSignal], PositionPlan | None]:
         exits: List[S.ExitSignal] = []
@@ -94,7 +94,7 @@ class TradeManager:
             type=OrderType.MARKET,
             quantity=plan.tp1_qty,
         )
-        self._trader.place(order)
+        await self._trader.place(order)
         self._risk_manager.release(replace(plan, quantity=plan.tp1_qty))
         new_plan = self._plan(
             plan,
@@ -105,7 +105,7 @@ class TradeManager:
         self._positions[plan.symbol] = (side, new_plan)
         return exits, new_plan
 
-    def _handle_tp2(
+    async def _handle_tp2(
         self, plan: PositionPlan, side: Side, price: float
     ) -> tuple[list[S.ExitSignal], PositionPlan | None]:
         exits: List[S.ExitSignal] = []
@@ -124,7 +124,7 @@ class TradeManager:
             type=OrderType.MARKET,
             quantity=plan.tp2_qty,
         )
-        self._trader.place(order)
+        await self._trader.place(order)
         self._risk_manager.release(replace(plan, quantity=plan.tp2_qty))
         remaining_qty = plan.quantity - plan.tp2_qty
         if remaining_qty <= 0.0:
@@ -162,7 +162,7 @@ class TradeManager:
             self._positions[plan.symbol] = (side, plan)
         return exits, plan
 
-    def _check_stop(
+    async def _check_stop(
         self, plan: PositionPlan, side: Side, price: float
     ) -> tuple[list[S.ExitSignal], PositionPlan | None]:
         exits: List[S.ExitSignal] = []
@@ -174,6 +174,6 @@ class TradeManager:
         if stop_hit:
             reason = "TRAIL" if trailing_active else "STOP"
             exits.append(S.ExitSignal(symbol=plan.symbol, reason=reason))
-            self._close_position(plan.symbol, side, plan)
+            await self._close_position(plan.symbol, side, plan)
             return exits, None
         return exits, plan

--- a/infrastructure/binance/rest_client.py
+++ b/infrastructure/binance/rest_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import httpx
 
 from constants import BINANCE_FAPI_REST, TAKER_RATIO_LIMIT, TAKER_RATIO_PERIOD
@@ -17,19 +18,21 @@ class RestClient:
     def __init__(self) -> None:
         self._client = httpx.Client(base_url=BINANCE_FAPI_REST, timeout=10.0)
 
-    def get_open_interest(self, symbol: str) -> float:
-        r = self._client.get(self._OPEN_INTEREST_EP, params={"symbol": symbol})
+    async def get_open_interest(self, symbol: str) -> float:
+        r = await asyncio.to_thread(
+            self._client.get, self._OPEN_INTEREST_EP, params={"symbol": symbol}
+        )
         r.raise_for_status()
         data = r.json()
         return float(data["openInterest"])
 
-    def get_taker_ratio(self, symbol: str) -> tuple[float, float]:
+    async def get_taker_ratio(self, symbol: str) -> tuple[float, float]:
         params = {
             "symbol": symbol,
             "period": TAKER_RATIO_PERIOD,
             "limit": TAKER_RATIO_LIMIT,
         }
-        r = self._client.get(self._TAKER_RATIO_EP, params=params)
+        r = await asyncio.to_thread(self._client.get, self._TAKER_RATIO_EP, params=params)
         r.raise_for_status()
         data = r.json()
         if not data:
@@ -37,8 +40,10 @@ class RestClient:
         item = data[0]
         return float(item["buyVol"]), float(item["sellVol"])
 
-    def get_premium_pct(self, symbol: str) -> float:
-        r = self._client.get(self._PREMIUM_EP, params={"symbol": symbol})
+    async def get_premium_pct(self, symbol: str) -> float:
+        r = await asyncio.to_thread(
+            self._client.get, self._PREMIUM_EP, params={"symbol": symbol}
+        )
         r.raise_for_status()
         data = r.json()
         mark_price = float(data["markPrice"])
@@ -47,21 +52,25 @@ class RestClient:
             return 0.0
         return (mark_price / index_price - 1.0) * 100.0
 
-    def get_24h_stats(self, symbol: str) -> tuple[float, float]:
-        r = self._client.get(self._TICKER_EP, params={"symbol": symbol})
+    async def get_24h_stats(self, symbol: str) -> tuple[float, float]:
+        r = await asyncio.to_thread(
+            self._client.get, self._TICKER_EP, params={"symbol": symbol}
+        )
         r.raise_for_status()
         data = r.json()
         quote_volume = float(data["quoteVolume"])
         last_price = float(data["lastPrice"])
         return quote_volume, last_price
 
-    def fetch_all_tickers(self) -> list[dict[str, str]]:
-        r = self._client.get(self._TICKER_EP)
+    async def fetch_all_tickers(self) -> list[dict[str, str]]:
+        r = await asyncio.to_thread(self._client.get, self._TICKER_EP)
         r.raise_for_status()
         return r.json()
 
-    def get_depth(self, symbol: str) -> tuple[tuple[float, float], ...]:
-        r = self._client.get(self._DEPTH_EP, params={"symbol": symbol, "limit": 10})
+    async def get_depth(self, symbol: str) -> tuple[tuple[float, float], ...]:
+        r = await asyncio.to_thread(
+            self._client.get, self._DEPTH_EP, params={"symbol": symbol, "limit": 10}
+        )
         r.raise_for_status()
         data = r.json()
         bids = tuple((float(p), float(q)) for p, q in data.get("bids", []))

--- a/infrastructure/binance/trader.py
+++ b/infrastructure/binance/trader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hmac
 import time
 from hashlib import sha256
@@ -22,7 +23,9 @@ class Trader:
     def __init__(self) -> None:
         self._client = httpx.Client(base_url=BINANCE_FAPI_REST, timeout=10.0)
 
-    def _signed_request(self, method: str, endpoint: str, params: Dict[str, str]) -> httpx.Response:
+    async def _signed_request(
+        self, method: str, endpoint: str, params: Dict[str, str]
+    ) -> httpx.Response:
         ts = int(time.time() * 1000)
         params["timestamp"] = str(ts)
         query = "&".join(f"{k}={v}" for k, v in params.items())
@@ -31,9 +34,9 @@ class Trader:
         ).hexdigest()
         headers = {"X-MBX-APIKEY": BINANCE.api_key}
         url = endpoint + f"?{query}&signature={signature}"
-        return self._client.request(method, url, headers=headers)
+        return await asyncio.to_thread(self._client.request, method, url, headers=headers)
 
-    def place(self, order: OrderSpec) -> None:  # pragma: no cover - network
+    async def place(self, order: OrderSpec) -> None:  # pragma: no cover - network
         params: Dict[str, str] = {
             "symbol": order.symbol,
             "side": order.side.value,
@@ -43,15 +46,17 @@ class Trader:
         if order.type is OrderType.LIMIT and order.price is not None:
             params["price"] = f"{order.price}"
             params["timeInForce"] = "GTC"
-        response = self._signed_request("POST", self._ORDER_ENDPOINT, params)
+        response = await self._signed_request("POST", self._ORDER_ENDPOINT, params)
         response.raise_for_status()
 
-    def cancel(self, symbol: str, order_id: int | None) -> None:  # pragma: no cover - network
+    async def cancel(
+        self, symbol: str, order_id: int | None
+    ) -> None:  # pragma: no cover - network
         if order_id is None:
             endpoint = self._CANCEL_ALL_ENDPOINT
             params = {"symbol": symbol}
         else:
             endpoint = self._ORDER_ENDPOINT
             params = {"symbol": symbol, "orderId": str(order_id)}
-        response = self._signed_request("DELETE", endpoint, params)
+        response = await self._signed_request("DELETE", endpoint, params)
         response.raise_for_status()


### PR DESCRIPTION
## Summary
- wrap Binance REST requests with `asyncio.to_thread` and expose async API
- make trading client async and await order placement/cancellation
- adjust backoff helper and state handlers to await async operations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdea51b9548320b54086169a9363bd