### PR TITLE
Move universe filter thresholds to constants

### DIFF
--- a/app/universe_filters.py
+++ b/app/universe_filters.py
@@ -1,5 +1,5 @@
-from typing import Final
-
-MIN_24H_USDT: Final[float] = 20_000_000.0
-MAX_SPREAD_BPS: Final[float] = 4.0
-MIN_TOP10_BID_USDT: Final[float] = 80_000.0
+from constants import (
+    UNIVERSE_MIN_24H_USDT as MIN_24H_USDT,
+    UNIVERSE_MAX_SPREAD_BPS as MAX_SPREAD_BPS,
+    UNIVERSE_MIN_TOP10_BID_USDT as MIN_TOP10_BID_USDT,
+)

--- a/constants.py
+++ b/constants.py
@@ -3,6 +3,10 @@ from typing import Final
 BINANCE_FAPI_WS: Final[str] = "wss://fstream.binance.com/stream"
 BINANCE_FAPI_REST: Final[str] = "https://fapi.binance.com"
 
+UNIVERSE_MIN_24H_USDT: Final[float] = 20_000_000.0
+UNIVERSE_MAX_SPREAD_BPS: Final[float] = 4.0
+UNIVERSE_MIN_TOP10_BID_USDT: Final[float] = 80_000.0
+
 EWMA_HALF_LIFE_MIN: Final[int] = 45
 Z_BASE_WINDOW_MIN: Final[int] = 60
 


### PR DESCRIPTION
## Summary
- expose universe filter thresholds in constants
- import universe filter thresholds from central constants module

## Testing
- `pytest`
- `python -m py_compile constants.py app/universe_filters.py app/universe.py`


------
https://chatgpt.com/codex/tasks/task_e_68bea49728f08320943d5f5bedd619af