### PR TITLE
feat: expand metrics with orderbook and cvd

### DIFF
--- a/app/metrics.py
+++ b/app/metrics.py
@@ -6,6 +6,7 @@ import asyncio
 import math
 import time
 from collections import deque
+from statistics import median
 
 import constants
 from domain.models.enums import Side
@@ -136,6 +137,37 @@ class MetricAggregator:
             last_price = metrics.last_price if metrics.last_price > 0 else mid
             premium_pct = (
                 (mid - last_price) / last_price * 100.0 if last_price > 0 else 0.0
+            )
+            # Orderbook imbalance top-10
+            ask_sum = sum(q for _, q in depth.asks[:10])
+            bid_sum = sum(q for _, q in depth.bids[:10])
+            total = ask_sum + bid_sum
+            metrics.ask_imb = ask_sum / total if total > 0 else 0.0
+            # Top-5 ask vs baseline median
+            ask_top5 = sum(q for _, q in depth.asks[:5])
+            metrics.ask_top5_win.append(ask_top5)
+            base = median(metrics.ask_top5_win) if metrics.ask_top5_win else 0.0
+            metrics.top5ask_vs_base = ask_top5 / base if base > 0 else 0.0
+            # CVD divergence and latency
+            cvd = metrics.taker_buy_volume - metrics.taker_sell_volume
+            price = metrics.last_price if metrics.last_price > 0 else mid
+            if cvd > metrics.cvd_peak:
+                metrics.cvd_peak = cvd
+                metrics.cvd_peak_price = price
+                metrics.cvd_peak_ts = depth.timestamp
+                metrics.cvd_gap_pct = 0.0
+                metrics.cvd_gap_sec = 0
+            else:
+                metrics.cvd_gap_pct = (
+                    (metrics.cvd_peak_price - price) / price * 100 if price > 0 else 0.0
+                )
+                metrics.cvd_gap_sec = (
+                    (depth.timestamp - metrics.cvd_peak_ts) // 1000
+                    if metrics.cvd_peak_ts > 0
+                    else 0
+                )
+            metrics.latency_sec = (
+                (depth.timestamp - metrics.end_ts) // 1000 if metrics.end_ts > 0 else 0
             )
             metrics.best_bid = best_bid
             metrics.best_ask = best_ask

--- a/domain/models/metrics.py
+++ b/domain/models/metrics.py
@@ -36,6 +36,9 @@ class SymbolMetrics:
     liq_win: Deque[float] = field(
         default_factory=lambda: deque(maxlen=constants.Z_BASE_WINDOW_MIN)
     )
+    ask_top5_win: Deque[float] = field(
+        default_factory=lambda: deque(maxlen=constants.Z_BASE_WINDOW_MIN)
+    )
 
     # --- EWMA statistics -------------------------------------------------
     price_ewma_mean: float = 0.0
@@ -61,6 +64,8 @@ class SymbolMetrics:
     best_bid: float = 0.0
     best_ask: float = 0.0
     premium_pct: float = 0.0
+    ask_imb: float = 0.0
+    top5ask_vs_base: float = 0.0
 
     # --- liquidation and open interest metrics -------------------------
     liqs_z: float = 0.0
@@ -70,6 +75,12 @@ class SymbolMetrics:
     # --- taker volume metrics ------------------------------------------
     taker_buy_volume: float = 0.0
     taker_sell_volume: float = 0.0
+    cvd_gap_pct: float = 0.0
+    cvd_gap_sec: int = 0
+    latency_sec: int = 0
+    cvd_peak: float = 0.0
+    cvd_peak_price: float = 0.0
+    cvd_peak_ts: int = 0
 
     # --- entry helpers --------------------------------------------------
     low_break: bool = False

--- a/domain/services/signal_engine.py
+++ b/domain/services/signal_engine.py
@@ -83,6 +83,22 @@ class SignalEngine:
         if metrics.premium_pct > confirm.premium_max_pct:
             return True
 
+        if metrics.latency_sec < confirm.latency_min_sec:
+            return True
+
+        lob_ok = (
+            metrics.ask_imb >= confirm.ask_imb_min
+            or metrics.top5ask_vs_base >= confirm.top5ask_vs_base_min
+        )
+        if not lob_ok:
+            return True
+
+        if (
+            metrics.cvd_gap_pct < confirm.cvd_gap_pct_min
+            or metrics.cvd_gap_sec < confirm.cvd_gap_sec_min
+        ):
+            return True
+
         return False
 
     def make_entry(self, symbol: str, window: M.PumpWindow) -> S.EntrySignal | None:


### PR DESCRIPTION
## Summary
- track ask imbalance, top-5 ask ratios, CVD gaps, and latency in metrics
- compute orderbook imbalance, CVD divergence, and latency when processing depth
- enforce new metrics thresholds during failure confirmation

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bea84c777c83208a2885acfe382891