### PR TITLE
Add invalidation checks to TradeManager

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -22,3 +22,4 @@ GLOBAL_BTC_PAUSE_Z: Final[float] = 3.0
 GLOBAL_BTC_PAUSE_SEC: Final[int] = 180
 
 RISK_PER_TRADE_USDT: Final[float] = 100.0  # настрой под депозит
+TRADE_INVALIDATION_SEC: Final[int] = 180

--- a/domain/models/trading.py
+++ b/domain/models/trading.py
@@ -25,3 +25,4 @@ class PositionPlan:
     tp1_qty: float
     tp2_qty: float
     tail_qty: float
+    window_high: float

--- a/domain/services/risk_manager.py
+++ b/domain/services/risk_manager.py
@@ -38,6 +38,7 @@ class RiskManager:
             tp1_qty=tp1_qty,
             tp2_qty=tp2_qty,
             tail_qty=tail_qty,
+            window_high=window.high,
         )
 
     def _calc_stop_loss(

--- a/domain/services/trade_manager.py
+++ b/domain/services/trade_manager.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import time
 from dataclasses import replace
 from typing import List
 
+import constants
 from domain.models import signals as S
 from domain.models.enums import OrderType, Side
 from domain.models.trading import OrderSpec, PositionPlan
@@ -37,6 +39,7 @@ class TradeManager:
         await self._trader.place(order)
         state = self._registry.get(plan.symbol)
         state.position = Position(side=side, plan=plan)
+        state.last_signal_ts = time.time()
         self._registry.update(plan.symbol, state)
 
     async def _close_position(self, symbol: str, side: Side, plan: PositionPlan) -> None:
@@ -95,6 +98,18 @@ class TradeManager:
         exits, plan = await self._check_stop(plan, side, current_price)
         if exits:
             return exits, plan
+
+        timed_out = (
+            state.last_signal_ts is not None
+            and time.time() - state.last_signal_ts > constants.TRADE_INVALIDATION_SEC
+        )
+        price_invalid = side is Side.SHORT and (
+            current_price > plan.entry_price or current_price > plan.window_high
+        )
+        if timed_out or price_invalid:
+            exits.append(S.ExitSignal(symbol=plan.symbol, reason="INVALIDATED"))
+            await self._close_position(plan.symbol, side, plan)
+            return exits, None
 
         return exits, plan
 


### PR DESCRIPTION
## Summary
- add `TRADE_INVALIDATION_SEC` constant and track pump high in `PositionPlan`
- record entry timestamp and check for price/time invalidation in `TradeManager`

## Testing
- `python -m py_compile constants.py domain/models/trading.py domain/services/risk_manager.py domain/services/trade_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68beb0e61694832084b84d0601875f36