### PR TITLE
Drop CONFIRMING state from REST pollers

### DIFF
--- a/app/pollers/base.py
+++ b/app/pollers/base.py
@@ -15,7 +15,6 @@ class _BasePoller:
 
     _WATCHED_STATES = {
         BotState.WATCHING,
-        BotState.CONFIRMING,
         BotState.ENTERED,
     }
 

--- a/instruction.md
+++ b/instruction.md
@@ -372,7 +372,7 @@ class GlobalState:
 
 ## Эндпоинты и потоки (фиксировано)
 - WS (combined): `@aggTrade`, `@depth@100ms`, `!forceOrder@arr`.
-- REST (только по кандидат-символам в фазах WATCHING/CONFIRMING/ENTERED):
+- REST (только по кандидат-символам в фазах WATCHING/ENTERED):
   - `/fapi/v1/openInterest`
   - `/futures/data/takerlongshortRatio`
   - `/fapi/v1/premiumIndex` (или экв. премия/фандинг)
@@ -420,7 +420,7 @@ class GlobalState:
 ### 4) Детектор «аномальный лонг»
 - На закрытии 1м бара: вычислить `Δp`, `z_px`, `z_vol`, `close_pos`.
 - Сравнить с `ProfileConfig.pump`.
-- TRUE → `SymbolState.state=CONFIRMING`, `pump=PumpWindow(...)`, старт окна 180с; включить REST-опросы и расчёт LOB/CVD.
+- TRUE → `SymbolState.state=CONFIRMING`, `pump=PumpWindow(...)`, старт окна 180с.
 
 ### 5) Подтверждение «толпа не пришла / flip не состоялся» (60–180с)
 - Булевы признаки из `ProfileConfig.confirm`:

--- a/tests/test_poller_states.py
+++ b/tests/test_poller_states.py
@@ -1,0 +1,12 @@
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.pollers.base import _BasePoller
+from domain.models.enums import BotState
+
+
+def test_base_poller_watched_states_excludes_confirming():
+    assert _BasePoller._WATCHED_STATES == {BotState.WATCHING, BotState.ENTERED}
+


### PR DESCRIPTION
## Summary
- remove `BotState.CONFIRMING` from REST pollers' watched states
- document that REST polling runs only in WATCHING and ENTERED
- cover poller state list with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bebb963f148320b3d8d529f6f31b70