### PR TITLE
Add Telegram credentials configuration

### DIFF
--- a/config/credentials.py
+++ b/config/credentials.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import os
 
 
 @dataclass(frozen=True)
@@ -7,4 +8,17 @@ class ApiCredentials:
     api_secret: str
 
 
+@dataclass(frozen=True)
+class TelegramCredentials:
+    orders_bot_token: str
+    events_bot_token: str
+    chat_id: str
+
+
 BINANCE = ApiCredentials(api_key="REPLACE_ME", api_secret="REPLACE_ME")
+
+TELEGRAM = TelegramCredentials(
+    orders_bot_token=os.getenv("TELEGRAM_ORDERS_BOT_TOKEN", ""),
+    events_bot_token=os.getenv("TELEGRAM_EVENTS_BOT_TOKEN", ""),
+    chat_id=os.getenv("TELEGRAM_BOT_CHAT_ID", ""),
+)


### PR DESCRIPTION
## Summary
- add `TelegramCredentials` dataclass for Telegram bot settings
- load Telegram credentials from environment variables and expose `TELEGRAM` object

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bec10bbf708320a9f3e0a9da443c62