### PR TITLE
Add Telegram send_message helper

### DIFF
--- a/infrastructure/telegram/__init__.py
+++ b/infrastructure/telegram/__init__.py
@@ -1,0 +1,3 @@
+from .client import send_message
+
+__all__ = ["send_message"]

--- a/infrastructure/telegram/client.py
+++ b/infrastructure/telegram/client.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+
+import requests
+
+
+def send_message(token: str, chat_id: str, text: str) -> tuple[bool, str]:
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    payload = {"chat_id": chat_id, "text": text}
+    try:
+        r = requests.post(url, json=payload, timeout=10.0)
+        r.raise_for_status()
+        data = r.json()
+        return bool(data.get("ok", False)), data.get("description", "")
+    except requests.RequestException as exc:  # pragma: no cover - network
+        return False, str(exc)
+    except ValueError as exc:  # pragma: no cover - network
+        return False, f"Invalid response: {exc}"


### PR DESCRIPTION
## Summary
- implement Telegram `send_message` using `requests.post`
- expose `send_message` from infrastructure package

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bec44b646883209dae4c065c6caa96