### PR TITLE
feat: add notification service wiring

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Literal
 
 from domain.models.enums import BotState
 from domain.models.state import GlobalState, SymbolState
@@ -10,9 +11,11 @@ from domain.services.risk_manager import RiskManager
 from domain.services.signal_engine import SignalEngine
 from domain.services.symbol_registry import SymbolRegistry
 from domain.services.trade_manager import TradeManager
+from domain.services.notification import NotificationService, TelegramClient
 from infrastructure.binance.rest_client import RestClient
 from infrastructure.binance.ws_client import WsClient
 from infrastructure.binance.trader import Trader
+from config.credentials import TELEGRAM
 
 from .ws import ws_stream
 from .metrics import bar_maker
@@ -25,7 +28,9 @@ from .state_machine import BotStateMachine
 from .universe import UniverseBuilder
 
 
-def run(cfg: ProfileConfig) -> None:
+def run(
+    cfg: ProfileConfig, notification_type: Literal["orders", "events"] = "orders"
+) -> None:
     gstate = GlobalState(profile=cfg.profile, btc_pause_until_ms=None)
 
     registry = SymbolRegistry()
@@ -42,7 +47,15 @@ def run(cfg: ProfileConfig) -> None:
 
     signal_engine = SignalEngine(cfg, registry)
     risk_manager = RiskManager(cfg)
-    trade_manager = TradeManager(trader, risk_manager, registry)
+    token = (
+        TELEGRAM.orders_bot_token
+        if notification_type == "orders"
+        else TELEGRAM.events_bot_token
+    )
+    notifier = NotificationService(TelegramClient(token, TELEGRAM.chat_id))
+    trade_manager = TradeManager(
+        trader, risk_manager, registry, notifier if notification_type == "orders" else None
+    )
 
     pollers = [
         OpenInterestPoller(rest, registry),
@@ -57,6 +70,7 @@ def run(cfg: ProfileConfig) -> None:
         risk_manager,
         trade_manager,
         trader,
+        notifier if notification_type == "events" else None,
     )
 
     async def _run() -> None:

--- a/app/state_machine.py
+++ b/app/state_machine.py
@@ -12,6 +12,7 @@ from domain.services.symbol_registry import SymbolRegistry
 from domain.services.signal_engine import SignalEngine
 from domain.services.risk_manager import RiskManager
 from domain.services.trade_manager import TradeManager
+from domain.services.notification import NotificationService
 from domain.ports.trader import Trader
 
 from .global_pause_guard import GlobalPauseGuard
@@ -34,6 +35,7 @@ class BotStateMachine:
         risk_manager: RiskManager,
         trade_manager: TradeManager,
         trader: Trader,
+        notifier: NotificationService | None = None,
     ) -> None:
         self._cfg = cfg
         self._registry = registry
@@ -43,6 +45,7 @@ class BotStateMachine:
         self._idle_watching_handler = IdleWatchingHandler(
             registry, signal_engine, risk_manager, trade_manager
         )
+        self._notifier = notifier
 
     # ------------------------------------------------------------------
     # Public API

--- a/domain/services/trade_manager.py
+++ b/domain/services/trade_manager.py
@@ -13,17 +13,23 @@ from domain.models.state import Position
 from .risk_manager import RiskManager
 from domain.services.symbol_registry import SymbolRegistry
 from domain.ports.trader import Trader
+from .notification import NotificationService
 
 
 class TradeManager:
     """High level wrapper around :class:`Trader` handling position state."""
 
     def __init__(
-        self, trader: Trader, risk_manager: RiskManager, registry: SymbolRegistry
+        self,
+        trader: Trader,
+        risk_manager: RiskManager,
+        registry: SymbolRegistry,
+        notifier: NotificationService | None = None,
     ) -> None:
         self._trader = trader
         self._risk_manager = risk_manager
         self._registry = registry
+        self._notifier = notifier
 
     @staticmethod
     def _plan(plan: PositionPlan, **changes: float) -> PositionPlan:


### PR DESCRIPTION
## Summary
- wire up NotificationService in orchestrator, selecting order or event token and passing to appropriate components
- allow TradeManager and BotStateMachine to accept optional notification service

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bec58793bc8320bba6363ccb1786a1