### PR TITLE
Add detailed trade notifications

### DIFF
--- a/domain/services/notification.py
+++ b/domain/services/notification.py
@@ -24,36 +24,41 @@ class NotificationService:
     def __init__(self, client: TelegramClient) -> None:
         self._client = client
 
-    def notify_order_open(self, plan: PositionPlan) -> None:
+    def notify_order_open(self, plan: PositionPlan, side: Side) -> None:
         msg = (
-            f"Open {plan.symbol} \n"
-            f"Entry: {plan.entry_price:.4f} | SL: {plan.stop_loss:.4f} \n"
-            f"TP1: {plan.take_profit1:.4f} | TP2: {plan.take_profit2:.4f} \n"
-            f"Qty: {plan.quantity:.4f}"
+            f"Open {side} {plan.symbol} @ {plan.entry_price:.4f} (0.00%)\n"
+            f"SL: {plan.stop_loss:.4f} | TP1: {plan.take_profit1:.4f} | TP2: {plan.take_profit2:.4f}\n"
+            f"Qty left: {plan.quantity:.4f}"
         )
         self._client.send(msg)
 
-    def notify_tp_hit(self, plan: PositionPlan, side: Side, price: float, level: int) -> None:
+    def notify_tp_hit(
+        self, plan: PositionPlan, side: Side, price: float, level: int, remaining: float
+    ) -> None:
         pnl = self._pnl_pct(plan.entry_price, price, side)
         msg = (
-            f"TP{level} hit {plan.symbol} @ {price:.4f} ({pnl:.2f}%)\n"
-            f"SL: {plan.stop_loss:.4f} | TP2: {plan.take_profit2:.4f}"
+            f"TP{level} hit {plan.symbol} {side} @ {price:.4f} ({pnl:.2f}%)\n"
+            f"SL: {plan.stop_loss:.4f} | TP2: {plan.take_profit2:.4f} | Qty left: {remaining:.4f}"
         )
         self._client.send(msg)
 
-    def notify_stop(self, plan: PositionPlan, side: Side, price: float) -> None:
+    def notify_stop(
+        self, plan: PositionPlan, side: Side, price: float, remaining: float
+    ) -> None:
         pnl = self._pnl_pct(plan.entry_price, price, side)
         msg = (
-            f"Stop hit {plan.symbol} @ {price:.4f} ({pnl:.2f}%)\n"
-            f"SL: {plan.stop_loss:.4f}"
+            f"Stop hit {plan.symbol} {side} @ {price:.4f} ({pnl:.2f}%)\n"
+            f"Qty left: {remaining:.4f}"
         )
         self._client.send(msg)
 
-    def notify_trail_update(self, plan: PositionPlan, side: Side, price: float) -> None:
+    def notify_trail_update(
+        self, plan: PositionPlan, side: Side, price: float, remaining: float
+    ) -> None:
         pnl = self._pnl_pct(plan.entry_price, price, side)
         msg = (
-            f"Trail update {plan.symbol} @ {price:.4f} ({pnl:.2f}%)\n"
-            f"New SL: {plan.stop_loss:.4f}"
+            f"Trail update {plan.symbol} {side} @ {price:.4f} ({pnl:.2f}%)\n"
+            f"New SL: {plan.stop_loss:.4f} | Qty left: {remaining:.4f}"
         )
         self._client.send(msg)
 

--- a/domain/services/trade_manager.py
+++ b/domain/services/trade_manager.py
@@ -51,6 +51,8 @@ class TradeManager:
         state.position = Position(side=side, plan=plan)
         state.last_signal_ts = time.time()
         self._registry.update(plan.symbol, state)
+        if self._notifier:
+            self._notifier.notify_order_open(plan, side)
 
     async def _close_position(self, symbol: str, side: Side, plan: PositionPlan) -> None:
         exit_side = Side.LONG if side is Side.SHORT else Side.SHORT
@@ -154,6 +156,8 @@ class TradeManager:
         state = self._registry.get(plan.symbol)
         state.position = Position(side=side, plan=new_plan)
         self._registry.update(plan.symbol, state)
+        if self._notifier:
+            self._notifier.notify_tp_hit(new_plan, side, price, 1, new_plan.quantity)
         return exits, new_plan
 
     async def _handle_tp2(
@@ -182,6 +186,8 @@ class TradeManager:
             state = self._registry.get(plan.symbol)
             state.position = None
             self._registry.update(plan.symbol, state)
+            if self._notifier:
+                self._notifier.notify_tp_hit(plan, side, price, 2, 0.0)
             return exits, None
         new_plan = self._plan(
             plan,
@@ -192,6 +198,8 @@ class TradeManager:
         state = self._registry.get(plan.symbol)
         state.position = Position(side=side, plan=new_plan)
         self._registry.update(plan.symbol, state)
+        if self._notifier:
+            self._notifier.notify_tp_hit(new_plan, side, price, 2, new_plan.quantity)
         return exits, new_plan
 
     def _apply_trailing_stop(
@@ -209,14 +217,17 @@ class TradeManager:
                 if side is Side.SHORT
                 else max(plan.stop_loss, price - plan.trail_distance)
             )
-            plan = self._plan(
-                plan,
-                stop_loss=new_stop,
-                trail_start=price,
-            )
-            state = self._registry.get(plan.symbol)
-            state.position = Position(side=side, plan=plan)
-            self._registry.update(plan.symbol, state)
+            if new_stop != plan.stop_loss:
+                plan = self._plan(
+                    plan,
+                    stop_loss=new_stop,
+                    trail_start=price,
+                )
+                state = self._registry.get(plan.symbol)
+                state.position = Position(side=side, plan=plan)
+                self._registry.update(plan.symbol, state)
+                if self._notifier:
+                    self._notifier.notify_trail_update(plan, side, price, plan.quantity)
         return exits, plan
 
     async def _check_stop(
@@ -232,5 +243,7 @@ class TradeManager:
             reason = "TRAIL" if trailing_active else "STOP"
             exits.append(S.ExitSignal(symbol=plan.symbol, reason=reason))
             await self._close_position(plan.symbol, side, plan)
+            if self._notifier:
+                self._notifier.notify_stop(plan, side, price, 0.0)
             return exits, None
         return exits, plan


### PR DESCRIPTION
## Summary
- notify on order open, take-profit hits, stop exits, and trailing stop updates
- extend notification messages with side, price, PnL and remaining size

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bec6622a8c8320838c91457eb053c7