### PR TITLE
Handle Telegram send failures

### DIFF
--- a/domain/services/notification.py
+++ b/domain/services/notification.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 from domain.models.trading import PositionPlan
 from domain.models.enums import Side
 from infrastructure.telegram import send_message
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -15,7 +18,10 @@ class TelegramClient:
     chat_id: str
 
     def send(self, text: str) -> None:
-        send_message(self.token, self.chat_id, text)
+        ok, desc = send_message(self.token, self.chat_id, text)
+        if not ok:
+            logger.error("Failed to send Telegram message: %s", desc)
+            raise RuntimeError(desc)
 
 
 class NotificationService:


### PR DESCRIPTION
## Summary
- add logging for Telegram client
- raise error when Telegram message send fails so callers can react

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68becc00a144832089dd9c69e3384cd3