### PR TITLE
Track actual trade price in notifications

### DIFF
--- a/domain/services/notification.py
+++ b/domain/services/notification.py
@@ -30,9 +30,17 @@ class NotificationService:
     def __init__(self, client: TelegramClient) -> None:
         self._client = client
 
-    def notify_order_open(self, plan: PositionPlan, side: Side) -> None:
-        msg = (
-            f"Open {side} {plan.symbol} @ {plan.entry_price:.4f} (0.00%)\n"
+    def notify_order_open(
+        self, plan: PositionPlan, side: Side, actual_price: float | None = None
+    ) -> None:
+        price = plan.entry_price if actual_price is None else actual_price
+        msg = f"Open {side} {plan.symbol} @ {price:.4f}"
+        if actual_price is not None:
+            pnl = self._pnl_pct(plan.entry_price, actual_price, side)
+            msg += f" ({pnl:.2f}%)\n"
+        else:
+            msg += "\n"
+        msg += (
             f"SL: {plan.stop_loss:.4f} | TP1: {plan.take_profit1:.4f} | TP2: {plan.take_profit2:.4f}\n"
             f"Qty left: {plan.quantity:.4f}"
         )

--- a/domain/services/trade_manager.py
+++ b/domain/services/trade_manager.py
@@ -42,17 +42,29 @@ class TradeManager:
             type=OrderType.MARKET,
             quantity=plan.quantity,
         )
+        actual_price: float | None = None
         try:
-            await self._trader.place(order)
+            result = await self._trader.place(order)
+            if result is not None:
+                if isinstance(result, dict):
+                    actual_price = result.get("price")
+                else:
+                    actual_price = getattr(result, "price", None)
         except Exception:
             self._risk_manager.release(plan)
             raise
+        if actual_price is None and hasattr(self._trader, "get_price"):
+            try:  # type: ignore[attr-defined]
+                actual_price = await self._trader.get_price(plan.symbol)
+            except Exception:
+                actual_price = None
         state = self._registry.get(plan.symbol)
-        state.position = Position(side=side, plan=plan)
+        stored_plan = plan if actual_price is None else self._plan(plan, entry_price=actual_price)
+        state.position = Position(side=side, plan=stored_plan)
         state.last_signal_ts = time.time()
         self._registry.update(plan.symbol, state)
         if self._notifier:
-            self._notifier.notify_order_open(plan, side)
+            self._notifier.notify_order_open(plan, side, actual_price)
 
     async def _close_position(self, symbol: str, side: Side, plan: PositionPlan) -> None:
         exit_side = Side.LONG if side is Side.SHORT else Side.SHORT

--- a/tests/test_notification_service.py
+++ b/tests/test_notification_service.py
@@ -1,0 +1,52 @@
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from domain.services.notification import NotificationService
+from domain.models.trading import PositionPlan
+from domain.models.enums import Side
+
+
+class DummyClient:
+    def __init__(self) -> None:
+        self.sent: str | None = None
+
+    def send(self, text: str) -> None:
+        self.sent = text
+
+
+def _plan() -> PositionPlan:
+    return PositionPlan(
+        symbol="BTCUSDT",
+        entry_price=100.0,
+        stop_loss=90.0,
+        take_profit1=110.0,
+        take_profit2=120.0,
+        trail_start=0.0,
+        trail_distance=0.0,
+        quantity=1.0,
+        tp1_qty=0.5,
+        tp2_qty=0.25,
+        tail_qty=0.25,
+        window_high=105.0,
+    )
+
+
+def test_notify_order_open_with_price():
+    client = DummyClient()
+    notifier = NotificationService(client)
+    plan = _plan()
+    notifier.notify_order_open(plan, Side.LONG, actual_price=101.0)
+    assert client.sent is not None
+    assert "@ 101.0000" in client.sent
+    assert "(1.00%)" in client.sent
+
+
+def test_notify_order_open_without_price():
+    client = DummyClient()
+    notifier = NotificationService(client)
+    plan = _plan()
+    notifier.notify_order_open(plan, Side.LONG)
+    assert client.sent is not None
+    assert "(0.00%)" not in client.sent

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -19,6 +19,26 @@ class FailingTrader:
         raise RuntimeError("failed")
 
 
+class DummyTrader:
+    def __init__(self, price: float) -> None:
+        self._price = price
+
+    async def place(self, order):
+        class R:
+            def __init__(self, price: float) -> None:
+                self.price = price
+
+        return R(self._price)
+
+
+class DummyNotifier:
+    def __init__(self) -> None:
+        self.args = None
+
+    def notify_order_open(self, plan, side, actual_price):
+        self.args = (plan, side, actual_price)
+
+
 def test_open_position_releases_margin_on_error():
     cfg = make_profile_config_balanced()
     risk = RiskManager(cfg)
@@ -44,3 +64,36 @@ def test_open_position_releases_margin_on_error():
     with pytest.raises(RuntimeError):
         asyncio.run(tm.open_position(plan, Side.SHORT))
     assert risk._open_risk_usdt == 0.0
+
+
+def test_open_position_uses_actual_price_and_notifies():
+    cfg = make_profile_config_balanced()
+    risk = RiskManager(cfg)
+    registry = SymbolRegistry()
+    registry.put(SymbolState(symbol="BTCUSDT", state=BotState.IDLE))
+    notifier = DummyNotifier()
+    tm = TradeManager(DummyTrader(105.0), risk, registry, notifier)
+    plan = PositionPlan(
+        symbol="BTCUSDT",
+        entry_price=100.0,
+        stop_loss=90.0,
+        take_profit1=80.0,
+        take_profit2=70.0,
+        trail_start=75.0,
+        trail_distance=5.0,
+        quantity=0.5,
+        tp1_qty=0.2,
+        tp2_qty=0.2,
+        tail_qty=0.1,
+        window_high=110.0,
+    )
+
+    asyncio.run(tm.open_position(plan, Side.LONG))
+    assert notifier.args is not None
+    notified_plan, notified_side, actual_price = notifier.args
+    assert actual_price == 105.0
+    assert notified_plan.entry_price == 100.0
+    assert notified_side is Side.LONG
+    state = registry.get("BTCUSDT")
+    assert state.position is not None
+    assert state.position.plan.entry_price == 105.0


### PR DESCRIPTION
## Summary
- capture execution price when opening positions and update state accordingly
- include actual execution price in open order notifications and compute PnL when available
- add tests for notification messaging and for passing actual price through trade manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bed08df73c832099a3625778d89e64