### PR TITLE
Use async Telegram client for notifications

### DIFF
--- a/domain/services/notification.py
+++ b/domain/services/notification.py
@@ -17,8 +17,8 @@ class TelegramClient:
     token: str
     chat_id: str
 
-    def send(self, text: str) -> bool:
-        ok, desc = send_message(self.token, self.chat_id, text)
+    async def send(self, text: str) -> bool:
+        ok, desc = await send_message(self.token, self.chat_id, text)
         if not ok:
             logger.error("Failed to send Telegram message: %s", desc)
             return False
@@ -31,7 +31,7 @@ class NotificationService:
     def __init__(self, client: TelegramClient) -> None:
         self._client = client
 
-    def notify_order_open(
+    async def notify_order_open(
         self, plan: PositionPlan, side: Side, actual_price: float | None = None
     ) -> None:
         price = plan.entry_price if actual_price is None else actual_price
@@ -45,9 +45,9 @@ class NotificationService:
             f"SL: {plan.stop_loss:.4f} | TP1: {plan.take_profit1:.4f} | TP2: {plan.take_profit2:.4f}\n"
             f"Qty left: {plan.quantity:.4f}"
         )
-        self._send(msg)
+        await self._send(msg)
 
-    def notify_tp_hit(
+    async def notify_tp_hit(
         self, plan: PositionPlan, side: Side, price: float, level: int, remaining: float
     ) -> None:
         pnl = self._pnl_pct(plan.entry_price, price, side)
@@ -61,9 +61,9 @@ class NotificationService:
                 msg += f"\nQty left: {remaining:.4f}"
             else:
                 msg += "\nPosition closed"
-        self._send(msg)
+        await self._send(msg)
 
-    def notify_stop(
+    async def notify_stop(
         self, plan: PositionPlan, side: Side, price: float, remaining: float
     ) -> None:
         pnl = self._pnl_pct(plan.entry_price, price, side)
@@ -71,9 +71,9 @@ class NotificationService:
             f"Stop hit {plan.symbol} {side} @ {price:.4f} ({pnl:.2f}%)\n"
             f"Qty left: {remaining:.4f}"
         )
-        self._send(msg)
+        await self._send(msg)
 
-    def notify_trail_update(
+    async def notify_trail_update(
         self, plan: PositionPlan, side: Side, price: float, remaining: float
     ) -> None:
         pnl = self._pnl_pct(plan.entry_price, price, side)
@@ -81,10 +81,10 @@ class NotificationService:
             f"Trail update {plan.symbol} {side} @ {price:.4f} ({pnl:.2f}%)\n"
             f"New SL: {plan.stop_loss:.4f} | Qty left: {remaining:.4f}"
         )
-        self._send(msg)
+        await self._send(msg)
 
-    def _send(self, msg: str) -> None:
-        if not self._client.send(msg):
+    async def _send(self, msg: str) -> None:
+        if not await self._client.send(msg):
             logger.error("Failed to send notification")
 
     @staticmethod

--- a/domain/services/trade_manager.py
+++ b/domain/services/trade_manager.py
@@ -64,7 +64,7 @@ class TradeManager:
         state.last_signal_ts = time.time()
         self._registry.update(plan.symbol, state)
         if self._notifier:
-            self._notifier.notify_order_open(plan, side, actual_price)
+            await self._notifier.notify_order_open(plan, side, actual_price)
 
     async def _close_position(self, symbol: str, side: Side, plan: PositionPlan) -> None:
         exit_side = Side.LONG if side is Side.SHORT else Side.SHORT
@@ -103,7 +103,7 @@ class TradeManager:
         if exits:
             return exits, plan
 
-        _, plan = self._apply_trailing_stop(plan, side, current_price)
+        _, plan = await self._apply_trailing_stop(plan, side, current_price)
 
         taker_buy = metrics.taker_buy_volume
         taker_sell = metrics.taker_sell_volume
@@ -169,7 +169,7 @@ class TradeManager:
         state.position = Position(side=side, plan=new_plan)
         self._registry.update(plan.symbol, state)
         if self._notifier:
-            self._notifier.notify_tp_hit(new_plan, side, price, 1, new_plan.quantity)
+            await self._notifier.notify_tp_hit(new_plan, side, price, 1, new_plan.quantity)
         return exits, new_plan
 
     async def _handle_tp2(
@@ -199,7 +199,7 @@ class TradeManager:
             state.position = None
             self._registry.update(plan.symbol, state)
             if self._notifier:
-                self._notifier.notify_tp_hit(plan, side, price, 2, 0.0)
+                await self._notifier.notify_tp_hit(plan, side, price, 2, 0.0)
             return exits, None
         new_plan = self._plan(
             plan,
@@ -211,10 +211,10 @@ class TradeManager:
         state.position = Position(side=side, plan=new_plan)
         self._registry.update(plan.symbol, state)
         if self._notifier:
-            self._notifier.notify_tp_hit(new_plan, side, price, 2, new_plan.quantity)
+            await self._notifier.notify_tp_hit(new_plan, side, price, 2, new_plan.quantity)
         return exits, new_plan
 
-    def _apply_trailing_stop(
+    async def _apply_trailing_stop(
         self, plan: PositionPlan, side: Side, price: float
     ) -> tuple[list[S.ExitSignal], PositionPlan]:
         exits: List[S.ExitSignal] = []
@@ -239,7 +239,7 @@ class TradeManager:
                 state.position = Position(side=side, plan=plan)
                 self._registry.update(plan.symbol, state)
                 if self._notifier:
-                    self._notifier.notify_trail_update(plan, side, price, plan.quantity)
+                    await self._notifier.notify_trail_update(plan, side, price, plan.quantity)
         return exits, plan
 
     async def _check_stop(
@@ -256,6 +256,6 @@ class TradeManager:
             exits.append(S.ExitSignal(symbol=plan.symbol, reason=reason))
             await self._close_position(plan.symbol, side, plan)
             if self._notifier:
-                self._notifier.notify_stop(plan, side, price, 0.0)
+                await self._notifier.notify_stop(plan, side, price, 0.0)
             return exits, None
         return exits, plan

--- a/infrastructure/telegram/client.py
+++ b/infrastructure/telegram/client.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
-
+import asyncio
 import requests
 
 
-def send_message(token: str, chat_id: str, text: str) -> tuple[bool, str]:
+async def send_message(token: str, chat_id: str, text: str) -> tuple[bool, str]:
     url = f"https://api.telegram.org/bot{token}/sendMessage"
     payload = {"chat_id": chat_id, "text": text}
     try:
-        r = requests.post(url, json=payload, timeout=10.0)
+        r = await asyncio.to_thread(
+            requests.post, url, json=payload, timeout=10.0
+        )
         r.raise_for_status()
         data = r.json()
         return bool(data.get("ok", False)), data.get("description", "")

--- a/tests/test_notification_service.py
+++ b/tests/test_notification_service.py
@@ -1,6 +1,7 @@
-import sys
-import pathlib
+import asyncio
 import logging
+import pathlib
+import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
@@ -13,7 +14,7 @@ class DummyClient:
     def __init__(self) -> None:
         self.sent: str | None = None
 
-    def send(self, text: str) -> bool:
+    async def send(self, text: str) -> bool:
         self.sent = text
         return True
 
@@ -39,7 +40,7 @@ def test_notify_order_open_with_price():
     client = DummyClient()
     notifier = NotificationService(client)
     plan = _plan()
-    notifier.notify_order_open(plan, Side.LONG, actual_price=101.0)
+    asyncio.run(notifier.notify_order_open(plan, Side.LONG, actual_price=101.0))
     assert client.sent is not None
     assert "@ 101.0000" in client.sent
     assert "(1.00%)" in client.sent
@@ -49,18 +50,18 @@ def test_notify_order_open_without_price():
     client = DummyClient()
     notifier = NotificationService(client)
     plan = _plan()
-    notifier.notify_order_open(plan, Side.LONG)
+    asyncio.run(notifier.notify_order_open(plan, Side.LONG))
     assert client.sent is not None
     assert "(0.00%)" not in client.sent
 
 
 def test_send_failure_does_not_raise(caplog):
     class FailingClient:
-        def send(self, text: str) -> bool:
+        async def send(self, text: str) -> bool:
             return False
 
     notifier = NotificationService(FailingClient())
     plan = _plan()
     with caplog.at_level(logging.ERROR):
-        notifier.notify_order_open(plan, Side.LONG)
+        asyncio.run(notifier.notify_order_open(plan, Side.LONG))
     assert "Failed to send notification" in caplog.text

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -1,7 +1,7 @@
-import sys
-import pathlib
 import asyncio
+import pathlib
 import pytest
+import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
@@ -35,7 +35,7 @@ class DummyNotifier:
     def __init__(self) -> None:
         self.args = None
 
-    def notify_order_open(self, plan, side, actual_price):
+    async def notify_order_open(self, plan, side, actual_price):
         self.args = (plan, side, actual_price)
 
 


### PR DESCRIPTION
## Summary
- run Telegram API calls in a background thread and expose an async client
- make notification service and trade manager await asynchronous sends
- adjust tests for new async interfaces

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf04d5a9cc8320996237a886835599