### PR TITLE
Make orchestrator run asynchronous

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -28,7 +28,7 @@ from .state_machine import BotStateMachine
 from .universe import UniverseBuilder
 
 
-def run(
+async def run(
     cfg: ProfileConfig, notification_type: Literal["orders", "events"] = "orders"
 ) -> None:
     gstate = GlobalState(profile=cfg.profile, btc_pause_until_ms=None)
@@ -37,7 +37,7 @@ def run(
     rest: RestClientPort = RestClient()
 
     builder = UniverseBuilder(rest)
-    symbols = asyncio.run(builder.build())
+    symbols = await builder.build()
     for sym in symbols:
         registry.put(SymbolState(symbol=sym, state=BotState.IDLE))
 
@@ -73,12 +73,9 @@ def run(
         notifier if notification_type == "events" else None,
     )
 
-    async def _run() -> None:
-        await asyncio.gather(
-            ws_stream(ws),
-            bar_maker(ws, registry),
-            *(p.run() for p in pollers),
-            state_machine.run(),
-        )
-
-    asyncio.run(_run())
+    await asyncio.gather(
+        ws_stream(ws),
+        bar_maker(ws, registry),
+        *(p.run() for p in pollers),
+        state_machine.run(),
+    )

--- a/main.py
+++ b/main.py
@@ -1,9 +1,11 @@
+import asyncio
+
 from config import make_profile_config_balanced
 from app.orchestrator import run
 
 
 def main() -> None:
-    run(make_profile_config_balanced())
+    asyncio.run(run(make_profile_config_balanced()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- refactor `app.orchestrator.run` into an async function and await universe building
- inline internal coroutine and directly await async tasks
- call `asyncio.run()` on `run()` from `main.py`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf0889c5188320b764aefcc6725d5c