### PR TITLE
Add websocket cleanup and signal-based shutdown

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -1,4 +1,5 @@
 import asyncio
+import signal
 from typing import Literal
 
 from domain.models.enums import BotState
@@ -73,9 +74,32 @@ async def run(
         notifier if notification_type == "events" else None,
     )
 
-    await asyncio.gather(
-        ws_stream(ws),
-        bar_maker(ws, registry),
-        *(p.run() for p in pollers),
-        state_machine.run(),
-    )
+    tasks = [
+        asyncio.create_task(ws_stream(ws)),
+        asyncio.create_task(bar_maker(ws, registry)),
+        *[asyncio.create_task(p.run()) for p in pollers],
+        asyncio.create_task(state_machine.run()),
+    ]
+
+    loop = asyncio.get_running_loop()
+
+    def _shutdown() -> None:
+        for t in tasks:
+            t.cancel()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, _shutdown)
+        except NotImplementedError:
+            pass
+
+    try:
+        await asyncio.gather(*tasks)
+    except asyncio.CancelledError:
+        pass
+    finally:
+        for t in tasks:
+            t.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        await rest._client.aclose()
+        await ws.close()

--- a/domain/ports/ws_client.py
+++ b/domain/ports/ws_client.py
@@ -22,3 +22,6 @@ class WsClient(Protocol):
 
     def next_liquidation(self) -> LiquidationEvent | None:
         ...
+
+    async def close(self) -> None:  # pragma: no cover - network
+        ...

--- a/infrastructure/binance/ws_client.py
+++ b/infrastructure/binance/ws_client.py
@@ -24,6 +24,7 @@ class WsClient:
         self._agg_trades: Deque[AggTrade] = deque()
         self._depths: Deque[DepthSnapshot] = deque()
         self._liqs: Deque[LiquidationEvent] = deque()
+        self._ws: websockets.WebSocketClientProtocol | None = None
 
     def subscribe_symbols(self, symbols: tuple[str, ...]) -> None:
         self._symbols = symbols
@@ -34,22 +35,21 @@ class WsClient:
         delay = 1.0
 
         while True:
-            ws = None
             try:
-                ws = await websockets.connect(BINANCE_FAPI_WS)
+                self._ws = await websockets.connect(BINANCE_FAPI_WS)
                 if params:
                     msg = {"method": "SUBSCRIBE", "params": params, "id": 1}
-                    await ws.send(json.dumps(msg))
+                    await self._ws.send(json.dumps(msg))
 
                 attempt = 0
                 delay = 1.0
 
-                async for raw in ws:
+                async for raw in self._ws:
                     self._parse_message(raw)
 
             except (websockets.exceptions.WebSocketException, OSError) as exc:
-                if ws and not ws.closed:
-                    await ws.close()
+                if self._ws and not self._ws.closed:
+                    await self._ws.close()
 
                 attempt += 1
                 logger.warning(
@@ -57,6 +57,8 @@ class WsClient:
                 )
                 await asyncio.sleep(delay)
                 delay = min(delay * 2, 60.0)
+            finally:
+                self._ws = None
 
 
     def _build_params(self) -> List[str]:
@@ -124,3 +126,8 @@ class WsClient:
 
     def next_liquidation(self) -> LiquidationEvent | None:
         return self._liqs.popleft() if self._liqs else None
+
+    async def close(self) -> None:  # pragma: no cover - network
+        if self._ws and not self._ws.closed:
+            await self._ws.close()
+            self._ws = None


### PR DESCRIPTION
## Summary
- add `WsClient.close` to terminate open websocket connections
- ensure orchestrator cancels tasks and closes clients on shutdown
- expose `close` in websocket client protocol

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf093df9d083209489b179dce242c3