### PR TITLE
Add async close to RestClient

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -194,5 +194,5 @@ async def run(
         for t in tasks:
             t.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)
-        await rest._client.aclose()
+        await rest.aclose()
         await ws.close()

--- a/infrastructure/binance/rest_client.py
+++ b/infrastructure/binance/rest_client.py
@@ -66,3 +66,10 @@ class RestClient:
         data = r.json()
         bids = tuple((float(p), float(q)) for p, q in data.get("bids", []))
         return bids
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+
+    async def close(self) -> None:
+        await self.aclose()


### PR DESCRIPTION
## Summary
- add async close/aclose methods to Binance RestClient
- use RestClient.aclose in orchestrator instead of reaching into internal client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf0d8cab908320b25fd7b0ef9e07f3