### PR TITLE
Register signal handlers after task creation

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -123,12 +123,6 @@ async def run(
         for t in tasks:
             t.cancel()
 
-    for sig in (signal.SIGINT, signal.SIGTERM):
-        try:
-            loop.add_signal_handler(sig, _shutdown)
-        except NotImplementedError:
-            pass
-
     try:
         if hasattr(asyncio, "TaskGroup"):
             try:
@@ -156,6 +150,12 @@ async def run(
                             _run_with_restart(state_machine.run, "state_machine")
                         )
                     )
+
+                    for sig in (signal.SIGINT, signal.SIGTERM):
+                        try:
+                            loop.add_signal_handler(sig, _shutdown)
+                        except NotImplementedError:
+                            pass
             except* Exception:
                 # individual tasks already log their failures
                 pass
@@ -181,6 +181,11 @@ async def run(
                     ),
                 ]
             )
+            for sig in (signal.SIGINT, signal.SIGTERM):
+                try:
+                    loop.add_signal_handler(sig, _shutdown)
+                except NotImplementedError:
+                    pass
             results = await asyncio.gather(*tasks, return_exceptions=True)
             for res in results:
                 if isinstance(res, Exception):


### PR DESCRIPTION
## Summary
- move SIGINT/SIGTERM handler registration until after tasks are created so shutdown is aware of all tasks

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf0e6297a48320a1d77ec85d0c5997