### PR TITLE
Log task exceptions in orchestrator

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -156,9 +156,10 @@ async def run(
                             loop.add_signal_handler(sig, _shutdown)
                         except NotImplementedError:
                             pass
-            except* Exception:
-                # individual tasks already log their failures
-                pass
+            except* Exception as eg:
+                for exc in eg.exceptions:
+                    logger.exception("Task failed", exc_info=exc)
+                raise
         else:
             tasks.extend(
                 [


### PR DESCRIPTION
## Summary
- log each exception when TaskGroup exits and re-raise

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf1106695483208718cfb404bfcfc1