### PR TITLE
feat: restart tasks after completion

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -39,19 +39,19 @@ async def _run_with_restart(
     retries: int = TASK_MAX_RESTARTS,
 ) -> None:
     attempt = 0
-    while True:
+    while attempt <= retries:
         try:
             await coro_fn()
-            break
+            logger.info("%s task finished (attempt %d)", name, attempt + 1)
         except asyncio.CancelledError:
             raise
         except Exception:
             logger.exception("%s task failed (attempt %d)", name, attempt + 1)
-            if attempt >= retries:
+            if attempt == retries:
                 raise
-            attempt += 1
             await asyncio.sleep(TASK_RESTART_DELAY_SEC)
             logger.info("Restarting %s", name)
+        attempt += 1
 
 
 NotificationType = Literal["orders", "events"]


### PR DESCRIPTION
## Summary
- restart completed tasks in orchestrator and log each run

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf1174c14c832092fce4c4dd54c4f1