### PR TITLE
Exit restart loop after successful run

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -43,6 +43,7 @@ async def _run_with_restart(
         try:
             await coro_fn()
             logger.info("%s task finished (attempt %d)", name, attempt + 1)
+            return
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -51,7 +52,7 @@ async def _run_with_restart(
                 raise
             await asyncio.sleep(TASK_RESTART_DELAY_SEC)
             logger.info("Restarting %s", name)
-        attempt += 1
+            attempt += 1
 
 
 NotificationType = Literal["orders", "events"]


### PR DESCRIPTION
## Summary
- Stop retry loop once a task completes successfully
- Only increment retry counter when a task fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf12e81b4c83209168162baf025682