### PR TITLE
Clean up signal handlers after orchestrator run

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -198,6 +198,11 @@ async def run(
     except asyncio.CancelledError:
         pass
     finally:
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            try:
+                loop.remove_signal_handler(sig)
+            except NotImplementedError:
+                pass
         for t in tasks:
             t.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)


### PR DESCRIPTION
## Summary
- ensure SIGINT and SIGTERM handlers are removed during orchestrator shutdown

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf13b8a7fc8320984ed531e8c74385