### PR TITLE
Ensure make_entry direction is always a Side

### DIFF
--- a/domain/services/signal_engine.py
+++ b/domain/services/signal_engine.py
@@ -118,7 +118,9 @@ class SignalEngine:
         if not _evaluate_entry(metrics, entry_cfg):
             return None
 
-        direction = metrics.direction or Side.SHORT
+        direction: Side = (
+            metrics.direction if metrics.direction is not None else Side.SHORT
+        )
 
         if metrics.entry_price > 0:
             price = metrics.entry_price


### PR DESCRIPTION
## Summary
- ensure make_entry uses explicit Side when assigning direction

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf1731acbc8320b3ab8e2431b8c418