### PR TITLE
Handle optional trader response in trade manager

### DIFF
--- a/domain/ports/trader.py
+++ b/domain/ports/trader.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Protocol, Any
 
 from domain.models.trading import OrderSpec
 
@@ -8,7 +8,7 @@ from domain.models.trading import OrderSpec
 class Trader(Protocol):
     """Abstract trading interface."""
 
-    async def place(self, order: OrderSpec) -> None:  # pragma: no cover - network
+    async def place(self, order: OrderSpec) -> Any | None:  # pragma: no cover - network
         ...
 
     async def cancel(

--- a/domain/services/trade_manager.py
+++ b/domain/services/trade_manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import replace
-from typing import List
+from typing import List, Any
 
 import constants
 from domain.models import signals as S
@@ -42,17 +42,18 @@ class TradeManager:
             type=OrderType.MARKET,
             quantity=plan.quantity,
         )
-        actual_price: float | None = None
+        result: Any | None = None
         try:
             result = await self._trader.place(order)
-            if result is not None:
-                if isinstance(result, dict):
-                    actual_price = result.get("price")
-                else:
-                    actual_price = getattr(result, "price", None)
         except Exception:
             self._risk_manager.release(plan)
             raise
+        actual_price: float | None = None
+        if result is not None:
+            if isinstance(result, dict):
+                actual_price = result.get("price")
+            else:
+                actual_price = getattr(result, "price", None)
         if actual_price is None and hasattr(self._trader, "get_price"):
             try:  # type: ignore[attr-defined]
                 actual_price = await self._trader.get_price(plan.symbol)

--- a/infrastructure/binance/trader.py
+++ b/infrastructure/binance/trader.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hmac
 import time
 from hashlib import sha256
-from typing import Dict
+from typing import Dict, Any
 from decimal import Decimal, ROUND_DOWN
 
 import httpx
@@ -36,7 +36,7 @@ class Trader:
         url = endpoint + f"?{query}&signature={signature}"
         return await self._client.request(method, url, headers=headers)
 
-    async def place(self, order: OrderSpec) -> None:  # pragma: no cover - network
+    async def place(self, order: OrderSpec) -> dict[str, Any] | None:  # pragma: no cover - network
         info = await self._client.get(
             "/fapi/v1/exchangeInfo", params={"symbol": order.symbol}
         )
@@ -64,6 +64,7 @@ class Trader:
             params["timeInForce"] = "GTC"
         response = await self._signed_request("POST", self._ORDER_ENDPOINT, params)
         response.raise_for_status()
+        return response.json()
 
     async def cancel(
         self, symbol: str, order_id: int | None

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -2,6 +2,7 @@ import asyncio
 import pathlib
 import pytest
 import sys
+from typing import Any
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
@@ -15,7 +16,7 @@ from config.profiles.balanced import make_profile_config_balanced
 
 
 class FailingTrader:
-    async def place(self, order):
+    async def place(self, order: Any) -> Any | None:
         raise RuntimeError("failed")
 
 
@@ -23,7 +24,7 @@ class DummyTrader:
     def __init__(self, price: float) -> None:
         self._price = price
 
-    async def place(self, order):
+    async def place(self, order: Any) -> Any | None:
         class R:
             def __init__(self, price: float) -> None:
                 self.price = price


### PR DESCRIPTION
## Summary
- Make `Trader.place` return an optional result and update the Binance implementation to forward API JSON
- Adjust `TradeManager.open_position` to interpret the optional result and derive entry price when available
- Update test traders to match new optional return type

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf173d63a08320a152241a736d6655