### PR TITLE
Add profile field to ProfileConfig

### DIFF
--- a/config/profiles/active.py
+++ b/config/profiles/active.py
@@ -7,6 +7,7 @@ from domain.models.config import (
     RiskParams,
     TriggerParams,
 )
+from domain.models.enums import Profile
 from constants import RISK_PER_TRADE_USDT
 
 DEFAULT_MARGIN_USDT = 5 * RISK_PER_TRADE_USDT
@@ -46,6 +47,7 @@ def make_profile_config_active() -> ProfileConfig:
         trail_sigma_mult=1.1,
     )
     return ProfileConfig(
+        profile=Profile.ACTIVE,
         trigger=trigger,
         confirmation=confirmation,
         entry=entry,

--- a/config/profiles/balanced.py
+++ b/config/profiles/balanced.py
@@ -7,6 +7,7 @@ from domain.models.config import (
     RiskParams,
     TriggerParams,
 )
+from domain.models.enums import Profile
 from constants import RISK_PER_TRADE_USDT
 
 DEFAULT_MARGIN_USDT = 5 * RISK_PER_TRADE_USDT
@@ -46,6 +47,7 @@ def make_profile_config_balanced() -> ProfileConfig:
         trail_sigma_mult=1.25,
     )
     return ProfileConfig(
+        profile=Profile.BALANCED,
         trigger=trigger,
         confirmation=confirmation,
         entry=entry,

--- a/config/profiles/conservative.py
+++ b/config/profiles/conservative.py
@@ -7,6 +7,7 @@ from domain.models.config import (
     RiskParams,
     TriggerParams,
 )
+from domain.models.enums import Profile
 from constants import RISK_PER_TRADE_USDT
 
 DEFAULT_MARGIN_USDT = 5 * RISK_PER_TRADE_USDT
@@ -46,6 +47,7 @@ def make_profile_config_conservative() -> ProfileConfig:
         trail_sigma_mult=1.3,
     )
     return ProfileConfig(
+        profile=Profile.CONSERVATIVE,
         trigger=trigger,
         confirmation=confirmation,
         entry=entry,

--- a/domain/models/config.py
+++ b/domain/models/config.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+from .enums import Profile
+
 
 @dataclass(frozen=True)
 class TriggerParams:
@@ -43,6 +45,7 @@ class RiskParams:
 
 @dataclass(frozen=True)
 class ProfileConfig:
+    profile: Profile
     trigger: TriggerParams
     confirmation: ConfirmationParams
     entry: EntryParams


### PR DESCRIPTION
## Summary
- include Profile enum on ProfileConfig dataclass
- set the profile value in active, balanced and conservative builders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf17410ac883208ddb8db2fcd0eee7