### PR TITLE
Add aclose to RestClient protocol

### DIFF
--- a/domain/ports/rest_client.py
+++ b/domain/ports/rest_client.py
@@ -24,3 +24,6 @@ class RestClient(Protocol):
 
     async def get_depth(self, symbol: str) -> tuple[tuple[float, float], ...]:
         ...
+
+    async def aclose(self) -> None:
+        ...


### PR DESCRIPTION
## Summary
- expose `aclose` in the `RestClient` protocol to standardize async cleanup
- ensure Binance REST client already implements `aclose`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf174453cc8320bacf70a8915442fd