### PR TITLE
Handle dict or object order results

### DIFF
--- a/domain/services/trade_manager.py
+++ b/domain/services/trade_manager.py
@@ -45,14 +45,14 @@ class TradeManager:
         actual_price: float | None = None
         try:
             result = await self._trader.place(order)
-            if result is not None:
-                if isinstance(result, dict):
-                    actual_price = result.get("price")
-                else:
-                    actual_price = getattr(result, "price", None)
         except Exception:
             self._risk_manager.release(plan)
             raise
+        if result is not None:
+            if isinstance(result, dict):
+                actual_price = result.get("price")
+            elif hasattr(result, "price"):
+                actual_price = result.price
         if actual_price is None and hasattr(self._trader, "get_price"):
             try:  # type: ignore[attr-defined]
                 actual_price = await self._trader.get_price(plan.symbol)

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -31,6 +31,14 @@ class DummyTrader:
         return R(self._price)
 
 
+class DictTrader:
+    def __init__(self, price: float) -> None:
+        self._price = price
+
+    async def place(self, order):
+        return {"price": self._price}
+
+
 class DummyNotifier:
     def __init__(self) -> None:
         self.args = None
@@ -97,3 +105,34 @@ def test_open_position_uses_actual_price_and_notifies():
     state = registry.get("BTCUSDT")
     assert state.position is not None
     assert state.position.plan.entry_price == 105.0
+
+
+def test_open_position_handles_dict_result():
+    cfg = make_profile_config_balanced()
+    risk = RiskManager(cfg)
+    registry = SymbolRegistry()
+    registry.put(SymbolState(symbol="BTCUSDT", state=BotState.IDLE))
+    notifier = DummyNotifier()
+    tm = TradeManager(DictTrader(95.0), risk, registry, notifier)
+    plan = PositionPlan(
+        symbol="BTCUSDT",
+        entry_price=100.0,
+        stop_loss=110.0,
+        take_profit1=90.0,
+        take_profit2=80.0,
+        trail_start=85.0,
+        trail_distance=5.0,
+        quantity=0.5,
+        tp1_qty=0.2,
+        tp2_qty=0.2,
+        tail_qty=0.1,
+        window_high=110.0,
+    )
+
+    asyncio.run(tm.open_position(plan, Side.SHORT))
+    assert notifier.args is not None
+    _, _, actual_price = notifier.args
+    assert actual_price == 95.0
+    state = registry.get("BTCUSDT")
+    assert state.position is not None
+    assert state.position.plan.entry_price == 95.0


### PR DESCRIPTION
## Summary
- handle dict or object results returned from Trader.place in TradeManager.open_position
- test TradeManager.open_position with both object and dict order responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf17457ac08320834f14e61df32703