### PR TITLE
feat: manage http client in risk manager

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -208,3 +208,4 @@ async def run(
         await asyncio.gather(*tasks, return_exceptions=True)
         await rest.aclose()
         await ws.close()
+        await risk_manager.aclose()

--- a/domain/services/risk_manager.py
+++ b/domain/services/risk_manager.py
@@ -13,9 +13,13 @@ from domain.models.trading import PositionPlan
 class RiskManager:
     """Simple position sizing and risk calculations."""
 
-    def __init__(self, config: ProfileConfig) -> None:
+    def __init__(
+        self, config: ProfileConfig, http_client: httpx.AsyncClient | None = None
+    ) -> None:
         self._cfg = config
         self._open_risk_usdt: float = 0.0
+        self._client = http_client or httpx.AsyncClient(timeout=10.0)
+        self._own_client = http_client is None
 
     async def build_plan(
         self, symbol: str, entry_price: float, window: M.PumpWindow
@@ -109,14 +113,17 @@ class RiskManager:
         tail_qty = quantity - tp1_qty - tp2_qty
         return quantity, tp1_qty, tp2_qty, tail_qty
 
+    async def aclose(self) -> None:
+        if self._own_client:
+            await self._client.aclose()
+
     async def _get_symbol_filters(self, symbol: str) -> dict:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.get(
-                BINANCE_FAPI_REST + "/fapi/v1/exchangeInfo",
-                params={"symbol": symbol},
-            )
-            resp.raise_for_status()
-            info = resp.json()["symbols"][0]["filters"]
+        resp = await self._client.get(
+            BINANCE_FAPI_REST + "/fapi/v1/exchangeInfo",
+            params={"symbol": symbol},
+        )
+        resp.raise_for_status()
+        info = resp.json()["symbols"][0]["filters"]
         return {f["filterType"]: f for f in info}
 
     @staticmethod

--- a/tests/test_trade_manager.py
+++ b/tests/test_trade_manager.py
@@ -65,6 +65,7 @@ def test_open_position_releases_margin_on_error():
     with pytest.raises(RuntimeError):
         asyncio.run(tm.open_position(plan, Side.SHORT))
     assert risk._open_risk_usdt == 0.0
+    asyncio.run(risk.aclose())
 
 
 def test_open_position_uses_actual_price_and_notifies():
@@ -98,3 +99,4 @@ def test_open_position_uses_actual_price_and_notifies():
     state = registry.get("BTCUSDT")
     assert state.position is not None
     assert state.position.plan.entry_price == 105.0
+    asyncio.run(risk.aclose())


### PR DESCRIPTION
## Summary
- add optional http client to RiskManager with lifecycle management
- reuse single HTTP client when retrieving symbol filters
- close RiskManager client when orchestrator shuts down

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf1dc5a8988320ad76be3255eb5170