### PR TITLE
Refactor pollers into abstract loop

### DIFF
--- a/app/pollers/base.py
+++ b/app/pollers/base.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import asyncio
 import random
+from abc import ABC, abstractmethod
 
 from domain.models.enums import BotState
+from domain.models.state import SymbolState
 from domain.ports.rest_client import RestClient
 from domain.services.symbol_registry import SymbolRegistry
 
 
-class _BasePoller:
+class _BasePoller(ABC):
     """Base class for REST pollers with common logic."""
 
     _WATCHED_STATES = {
@@ -26,5 +28,18 @@ class _BasePoller:
     async def _sleep(self) -> None:
         await asyncio.sleep(self._delay_sec * random.uniform(0.8, 1.2))
 
-    async def run(self) -> None:  # pragma: no cover - to be implemented by subclasses
-        raise NotImplementedError
+    @abstractmethod
+    async def _poll(self, symbol: str, state: SymbolState) -> None:
+        """Poll a single symbol and update its state."""
+
+    async def run(self) -> None:
+        while True:
+            for symbol in self._registry.all_symbols():
+                state = self._registry.get(symbol)
+                if state.state not in self._WATCHED_STATES:
+                    continue
+
+                await self._poll(symbol, state)
+                self._registry.update(symbol, state)
+
+            await self._sleep()

--- a/app/pollers/open_interest.py
+++ b/app/pollers/open_interest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from domain.models.state import SymbolState
 from domain.ports.rest_client import RestClient
 from domain.services.symbol_registry import SymbolRegistry
 
@@ -18,20 +19,11 @@ class OpenInterestPoller(_BasePoller):
         super().__init__(rest, registry, constants.REST_POLL_SEC_OI)
         self._last_oi: dict[str, float] = {}
 
-    async def run(self) -> None:
-        while True:
-            for symbol in self._registry.all_symbols():
-                state = self._registry.get(symbol)
-                if state.state not in self._WATCHED_STATES:
-                    continue
+    async def _poll(self, symbol: str, state: SymbolState) -> None:
+        oi = await _with_backoff(self._rest.get_open_interest, symbol)
+        prev = self._last_oi.get(symbol)
+        delta_pct = ((oi - prev) / prev * 100.0) if prev else 0.0
+        self._last_oi[symbol] = oi
 
-                oi = await _with_backoff(self._rest.get_open_interest, symbol)
-                prev = self._last_oi.get(symbol)
-                delta_pct = ((oi - prev) / prev * 100.0) if prev else 0.0
-                self._last_oi[symbol] = oi
-
-                metrics = state.metrics
-                metrics.delta_oi_pct = delta_pct
-                self._registry.update(symbol, state)
-
-            await self._sleep()
+        metrics = state.metrics
+        metrics.delta_oi_pct = delta_pct

--- a/app/pollers/premium_index.py
+++ b/app/pollers/premium_index.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from domain.models.state import SymbolState
 from domain.ports.rest_client import RestClient
 from domain.services.symbol_registry import SymbolRegistry
 
@@ -17,16 +18,7 @@ class PremiumIndexPoller(_BasePoller):
     def __init__(self, rest: RestClient, registry: SymbolRegistry) -> None:
         super().__init__(rest, registry, constants.REST_POLL_SEC_PREMIUM)
 
-    async def run(self) -> None:
-        while True:
-            for symbol in self._registry.all_symbols():
-                state = self._registry.get(symbol)
-                if state.state not in self._WATCHED_STATES:
-                    continue
-
-                premium = await _with_backoff(self._rest.get_premium_pct, symbol)
-                metrics = state.metrics
-                metrics.premium_pct = premium
-                self._registry.update(symbol, state)
-
-            await self._sleep()
+    async def _poll(self, symbol: str, state: SymbolState) -> None:
+        premium = await _with_backoff(self._rest.get_premium_pct, symbol)
+        metrics = state.metrics
+        metrics.premium_pct = premium

--- a/app/pollers/taker_ratio.py
+++ b/app/pollers/taker_ratio.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from domain.models.state import SymbolState
 from domain.ports.rest_client import RestClient
 from domain.services.symbol_registry import SymbolRegistry
 
@@ -17,17 +18,8 @@ class TakerRatioPoller(_BasePoller):
     def __init__(self, rest: RestClient, registry: SymbolRegistry) -> None:
         super().__init__(rest, registry, constants.REST_POLL_SEC_TAKER)
 
-    async def run(self) -> None:
-        while True:
-            for symbol in self._registry.all_symbols():
-                state = self._registry.get(symbol)
-                if state.state not in self._WATCHED_STATES:
-                    continue
-
-                buy, sell = await _with_backoff(self._rest.get_taker_ratio, symbol)
-                metrics = state.metrics
-                metrics.taker_buy_volume = buy
-                metrics.taker_sell_volume = sell
-                self._registry.update(symbol, state)
-
-            await self._sleep()
+    async def _poll(self, symbol: str, state: SymbolState) -> None:
+        buy, sell = await _with_backoff(self._rest.get_taker_ratio, symbol)
+        metrics = state.metrics
+        metrics.taker_buy_volume = buy
+        metrics.taker_sell_volume = sell

--- a/tests/test_base_poller_run.py
+++ b/tests/test_base_poller_run.py
@@ -1,0 +1,39 @@
+import asyncio
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.pollers.base import _BasePoller
+from domain.models.enums import BotState
+from domain.models.state import SymbolState
+from domain.services.symbol_registry import SymbolRegistry
+
+
+class DummyPoller(_BasePoller):
+    def __init__(self, registry: SymbolRegistry) -> None:
+        super().__init__(rest=None, registry=registry, delay_sec=0)
+        self.polled: list[str] = []
+
+    async def _sleep(self) -> None:  # pragma: no cover - replaced in tests
+        raise asyncio.CancelledError
+
+    async def _poll(self, symbol: str, state: SymbolState) -> None:
+        self.polled.append(symbol)
+
+
+def test_run_polls_only_watched_states() -> None:
+    registry = SymbolRegistry()
+    registry.put(SymbolState(symbol="A", state=BotState.WATCHING))
+    registry.put(SymbolState(symbol="B", state=BotState.IDLE))
+    registry.put(SymbolState(symbol="C", state=BotState.ENTERED))
+
+    poller = DummyPoller(registry)
+
+    try:
+        asyncio.run(poller.run())
+    except asyncio.CancelledError:
+        pass
+
+    assert poller.polled == ["A", "C"]
+


### PR DESCRIPTION
## Summary
- Add an abstract `_poll` method and asynchronous run loop to `_BasePoller`
- Update poller implementations to use `_poll` and central scheduling
- Introduce tests ensuring the base poller only processes watched states

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf1ea492408320bb56283c199db804