### PR TITLE
Add centralized logging configuration

### DIFF
--- a/app/logger.py
+++ b/app/logger.py
@@ -1,0 +1,24 @@
+import logging
+from typing import Optional
+
+_LOG_FORMAT = ':< %(message)s :>'
+
+
+def configure(level: int = logging.INFO) -> None:
+    """Configure the root logger.
+
+    Parameters
+    ----------
+    level: int
+        Logging level. Defaults to ``logging.INFO`` but can be
+        overridden from configuration.
+    """
+    logging.basicConfig(level=level, format=_LOG_FORMAT, force=True)
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Return a logger with the given name."""
+    return logging.getLogger(name)
+
+
+__all__ = ['configure', 'get_logger']

--- a/main.py
+++ b/main.py
@@ -1,11 +1,15 @@
 import asyncio
+import logging
 
 from config import make_profile_config_balanced
+from app.logger import configure
 from app.orchestrator import run
 
 
 def main() -> None:
-    asyncio.run(run(make_profile_config_balanced()))
+    cfg = make_profile_config_balanced()
+    configure(level=getattr(cfg, "log_level", logging.INFO))
+    asyncio.run(run(cfg))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `app/logger` module for root logging configuration
- initialize logging in `main.py` with configurable level and default format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf27c24d8083209537c271bf36877b