### PR TITLE
Add debug logging to universe filters

### DIFF
--- a/app/universe.py
+++ b/app/universe.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import logging
 from domain.ports.rest_client import RestClient
 
 from . import universe_filters as filters
+
+
+logger = logging.getLogger(__name__)
 
 
 class UniverseBuilder:
@@ -20,7 +24,7 @@ class UniverseBuilder:
             if not await self._passes_volume(sym):
                 continue
 
-            if not self._within_spread(bid, ask):
+            if not self._within_spread(sym, bid, ask):
                 continue
 
             if not await self._has_depth(sym):
@@ -28,6 +32,7 @@ class UniverseBuilder:
 
             symbols.append(sym)
 
+        logger.info(":< выбрано %d монет :>", len(symbols))
         return symbols
 
     def _is_usdt_pair(self, sym: str) -> bool:
@@ -35,15 +40,27 @@ class UniverseBuilder:
 
     async def _passes_volume(self, sym: str) -> bool:
         quote_vol, _ = await self._rest.get_24h_stats(sym)
-        return quote_vol >= filters.MIN_24H_USDT
+        if quote_vol < filters.MIN_24H_USDT:
+            logger.debug("%s: объём %.0f < %.0f", sym, quote_vol, filters.MIN_24H_USDT)
+            return False
+        return True
 
-    def _within_spread(self, bid: float, ask: float) -> bool:
+    def _within_spread(self, sym: str, bid: float, ask: float) -> bool:
         if bid <= 0:
+            logger.debug("%s: неположительный bid", sym)
             return False
         spread_bps = (ask - bid) / bid * 10_000.0
-        return spread_bps <= filters.MAX_SPREAD_BPS
+        if spread_bps > filters.MAX_SPREAD_BPS:
+            logger.debug("%s: спред %.1f bps > %.1f", sym, spread_bps, filters.MAX_SPREAD_BPS)
+            return False
+        return True
 
     async def _has_depth(self, sym: str) -> bool:
         bids = await self._rest.get_depth(sym)
         top10_bid_usdt = sum(p * q for p, q in bids)
-        return top10_bid_usdt >= filters.MIN_TOP10_BID_USDT
+        if top10_bid_usdt < filters.MIN_TOP10_BID_USDT:
+            logger.debug(
+                "%s: глубина %.0f < %.0f", sym, top10_bid_usdt, filters.MIN_TOP10_BID_USDT
+            )
+            return False
+        return True


### PR DESCRIPTION
## Summary
- log selected coin count in universe builder
- add detailed debug messages for volume, spread, and depth filters

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf28e1746c8320aa4c8f0981f05ac4