### PR TITLE
Add detailed logging for signal evaluation and state handling

### DIFF
--- a/app/state_handlers/idle_watching.py
+++ b/app/state_handlers/idle_watching.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import logging
+
 from domain.models.enums import BotState
 from domain.models.state import SymbolState
 from domain.services.signal_engine import SignalEngine
 from domain.services.risk_manager import RiskManager
 from domain.services.trade_manager import TradeManager
 from domain.services.symbol_registry import SymbolRegistry
+
+logger = logging.getLogger(__name__)
 
 
 class IdleWatchingHandler:
@@ -26,30 +30,39 @@ class IdleWatchingHandler:
     async def handle(self, symbol: str, state: SymbolState) -> None:
         pump = self._signal_engine.on_minute_close(symbol)
         if pump is None:
+            reason = "no pump window"
             if state.state is BotState.WATCHING:
                 state.state = BotState.IDLE
                 self._registry.update(symbol, state)
+                logger.debug("%s -> IDLE: %s", symbol, reason)
+            else:
+                logger.debug("%s skipped: %s", symbol, reason)
             return
 
         state.state = BotState.WATCHING
         self._registry.update(symbol, state)
+        logger.debug("%s -> WATCHING: pump detected", symbol)
 
         if self._signal_engine.confirm_failure(symbol):
             state.state = BotState.IDLE
             self._registry.update(symbol, state)
+            logger.debug("%s -> IDLE: confirmation failure", symbol)
             return
 
         entry = self._signal_engine.make_entry(symbol, pump.window)
         if entry is None:
+            logger.debug("%s skipped: entry conditions", symbol)
             return
 
         plan = await self._risk_manager.build_plan(symbol, entry.price, pump.window)
         if plan is None or not self._risk_manager.allow_trade(plan):
+            logger.debug("%s skipped: risk check", symbol)
             return
 
         await self._trade_manager.open_position(plan, entry.side)
         state.state = BotState.ENTERED
         self._registry.update(symbol, state)
+        logger.debug("%s -> ENTERED", symbol)
 
 
 __all__ = ["IdleWatchingHandler"]

--- a/domain/services/signal_engine.py
+++ b/domain/services/signal_engine.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import logging
+
 from domain.models import metrics as M, signals as S
 from domain.models.config import EntryParams, ProfileConfig, TriggerParams
 from domain.models.enums import Side
 
 from .symbol_registry import SymbolRegistry
+
+logger = logging.getLogger(__name__)
 
 
 def _taker_ratio(metrics: M.SymbolMetrics) -> float:
@@ -48,6 +52,7 @@ class SignalEngine:
 
     def on_minute_close(self, symbol: str) -> S.PumpSignal | None:
         """Evaluate minute metrics and possibly emit a pump signal."""
+        logger.debug("Checking minute close for %s", symbol)
 
         state = self._registry.get(symbol)
         metrics = state.metrics
@@ -63,6 +68,7 @@ class SignalEngine:
             start_ts=int(metrics.start_ts),
             end_ts=int(metrics.end_ts),
         )
+        logger.debug("Pump window found for %s: %s", symbol, window)
         return S.PumpSignal(symbol=symbol, window=window)
 
     def confirm_failure(self, symbol: str) -> bool:
@@ -74,16 +80,40 @@ class SignalEngine:
         confirm = self._config.confirmation
 
         if metrics.delta_oi_pct > confirm.delta_oi_max_pct:
+            logger.debug(
+                "%s confirm failure: delta_oi_pct %.3f > %.3f",
+                symbol,
+                metrics.delta_oi_pct,
+                confirm.delta_oi_max_pct,
+            )
             return True
 
         taker_ratio = _taker_ratio(metrics)
         if taker_ratio > confirm.taker_ratio_max:
+            logger.debug(
+                "%s confirm failure: taker_ratio %.3f > %.3f",
+                symbol,
+                taker_ratio,
+                confirm.taker_ratio_max,
+            )
             return True
 
         if metrics.premium_pct > confirm.premium_max_pct:
+            logger.debug(
+                "%s confirm failure: premium_pct %.3f > %.3f",
+                symbol,
+                metrics.premium_pct,
+                confirm.premium_max_pct,
+            )
             return True
 
         if metrics.latency_sec < confirm.latency_min_sec:
+            logger.debug(
+                "%s confirm failure: latency_sec %.3f < %.3f",
+                symbol,
+                metrics.latency_sec,
+                confirm.latency_min_sec,
+            )
             return True
 
         lob_ok = (
@@ -91,12 +121,18 @@ class SignalEngine:
             or metrics.top5ask_vs_base >= confirm.top5ask_vs_base_min
         )
         if not lob_ok:
+            logger.debug(
+                "%s confirm failure: LOB conditions not met", symbol
+            )
             return True
 
         if (
             metrics.cvd_gap_pct < confirm.cvd_gap_pct_min
             or metrics.cvd_gap_sec < confirm.cvd_gap_sec_min
         ):
+            logger.debug(
+                "%s confirm failure: cvd_gap below threshold", symbol
+            )
             return True
 
         return False
@@ -108,14 +144,22 @@ class SignalEngine:
         metrics = state.metrics
 
         if window.high <= window.low:
+            logger.debug("%s entry skipped: invalid window", symbol)
             return None
 
         if metrics.premium_pct > self._config.confirmation.premium_max_pct:
+            logger.debug(
+                "%s entry skipped: premium_pct %.3f > %.3f",
+                symbol,
+                metrics.premium_pct,
+                self._config.confirmation.premium_max_pct,
+            )
             return None
 
         entry_cfg = self._config.entry
 
         if not _evaluate_entry(metrics, entry_cfg):
+            logger.debug("%s entry skipped: entry conditions not met", symbol)
             return None
 
         direction: Side = (


### PR DESCRIPTION
## Summary
- log minute-close checks and detected pump windows
- detail failure reasons during confirmation and entry evaluation
- track symbol state transitions and skipped trades in IdleWatchingHandler

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf28e85e888320aefae567cd35802d