### PR TITLE
Log risk plan levels and margin rejection reasons

### DIFF
--- a/domain/services/risk_manager.py
+++ b/domain/services/risk_manager.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 from decimal import Decimal, ROUND_DOWN
 
 import httpx
+import logging
 
 from constants import RISK_PER_TRADE_USDT, BINANCE_FAPI_REST
 from domain.models import metrics as M
 from domain.models.config import ProfileConfig, RiskParams
 from domain.models.trading import PositionPlan
+
+logger = logging.getLogger(__name__)
 
 
 class RiskManager:
@@ -26,7 +29,8 @@ class RiskManager:
     ) -> PositionPlan | None:
         try:
             filters = await self._get_symbol_filters(symbol)
-        except httpx.HTTPError:
+        except httpx.HTTPError as exc:
+            logger.error("Failed to fetch symbol filters for %s: %s", symbol, exc)
             return None
         step_size = Decimal(filters["LOT_SIZE"]["stepSize"])
         tick_size = Decimal(filters["PRICE_FILTER"]["tickSize"])
@@ -53,6 +57,18 @@ class RiskManager:
         tp1_qty = self._round(tp1_qty, step_size)
         tp2_qty = self._round(tp2_qty, step_size)
         tail_qty = self._round(quantity - tp1_qty - tp2_qty, step_size)
+        logger.info(
+            (
+                "Built plan for %s: SL=%.4f TP1=%.4f TP2=%.4f trail_start=%.4f "
+                "trail_distance=%.4f"
+            ),
+            symbol,
+            stop_loss,
+            take_profit1,
+            take_profit2,
+            trail_start,
+            trail_distance,
+        )
         return PositionPlan(
             symbol=symbol,
             entry_price=entry_price,
@@ -132,9 +148,22 @@ class RiskManager:
 
     def allow_trade(self, plan: PositionPlan) -> bool:
         required_margin = plan.entry_price * plan.quantity
+        logger.info("Required margin for %s: %.2f", plan.symbol, required_margin)
         if required_margin > RISK_PER_TRADE_USDT:
+            logger.warning(
+                "Trade %s rejected: margin %.2f exceeds per-trade limit %.2f",
+                plan.symbol,
+                required_margin,
+                RISK_PER_TRADE_USDT,
+            )
             return False
         if self._open_risk_usdt + required_margin > self._cfg.max_margin_usdt:
+            logger.warning(
+                "Trade %s rejected: total margin %.2f exceeds max %.2f",
+                plan.symbol,
+                self._open_risk_usdt + required_margin,
+                self._cfg.max_margin_usdt,
+            )
             return False
         self._open_risk_usdt += required_margin
         return True

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -1,0 +1,103 @@
+import asyncio
+import logging
+import pathlib
+import sys
+
+import httpx
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from config.profiles.balanced import make_profile_config_balanced
+from domain.models.metrics import PumpWindow
+from domain.models.trading import PositionPlan
+from domain.services.risk_manager import RiskManager
+
+
+class DummyHTTPClient:
+    def __init__(self, filters):
+        self._filters = filters
+
+    async def get(self, url, params=None):
+        class Resp:
+            def __init__(self, filters):
+                self._filters = filters
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"symbols": [{"filters": self._filters}]}
+
+        return Resp(self._filters)
+
+    async def aclose(self):
+        pass
+
+
+class ErrorHTTPClient:
+    async def get(self, url, params=None):
+        raise httpx.HTTPError("boom")
+
+    async def aclose(self):
+        pass
+
+
+def _make_plan(symbol="BTCUSDT", entry_price=200.0, quantity=1.0):
+    return PositionPlan(
+        symbol=symbol,
+        entry_price=entry_price,
+        stop_loss=190.0,
+        take_profit1=180.0,
+        take_profit2=170.0,
+        trail_start=175.0,
+        trail_distance=5.0,
+        quantity=quantity,
+        tp1_qty=0.4,
+        tp2_qty=0.3,
+        tail_qty=0.3,
+        window_high=210.0,
+    )
+
+
+def test_build_plan_logs_http_error(caplog):
+    cfg = make_profile_config_balanced()
+    risk = RiskManager(cfg, http_client=ErrorHTTPClient())
+    window = PumpWindow(high=110.0, low=100.0, start_ts=0, end_ts=0)
+    with caplog.at_level(logging.ERROR):
+        plan = asyncio.run(risk.build_plan("BTCUSDT", 105.0, window))
+    assert plan is None
+    assert "Failed to fetch symbol filters" in caplog.text
+    asyncio.run(risk.aclose())
+
+
+def test_build_plan_logs_levels(caplog):
+    cfg = make_profile_config_balanced()
+    filters = [
+        {"filterType": "LOT_SIZE", "stepSize": "0.001"},
+        {"filterType": "PRICE_FILTER", "tickSize": "0.01"},
+    ]
+    risk = RiskManager(cfg, http_client=DummyHTTPClient(filters))
+    window = PumpWindow(high=110.0, low=100.0, start_ts=0, end_ts=0)
+    with caplog.at_level(logging.INFO):
+        plan = asyncio.run(risk.build_plan("BTCUSDT", 105.0, window))
+    assert plan is not None
+    text = caplog.text
+    assert f"{plan.stop_loss:.4f}" in text
+    assert f"{plan.take_profit1:.4f}" in text
+    assert f"{plan.take_profit2:.4f}" in text
+    assert f"{plan.trail_start:.4f}" in text
+    assert f"{plan.trail_distance:.4f}" in text
+    asyncio.run(risk.aclose())
+
+
+def test_allow_trade_logs_margin_and_reason(caplog):
+    cfg = make_profile_config_balanced()
+    risk = RiskManager(cfg)
+    plan = _make_plan()
+    with caplog.at_level(logging.INFO):
+        allowed = risk.allow_trade(plan)
+    assert not allowed
+    text = caplog.text
+    assert f"{plan.entry_price * plan.quantity:.2f}" in text
+    assert "per-trade limit" in text


### PR DESCRIPTION
## Summary
- log HTTP errors and final SL/TP/trailing levels when building a trading plan
- record required margin and specific rejection reasons when deciding if a trade is allowed
- add tests for risk manager logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf28ec35e08320a6d3e11d855381e5