### PR TITLE
Add logging for cooldown transitions

### DIFF
--- a/app/state_handlers/cooldown.py
+++ b/app/state_handlers/cooldown.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import logging
+
 from domain.models.enums import BotState
 from domain.models.state import SymbolState
 from domain.services.symbol_registry import SymbolRegistry
 import constants
+
+
+logger = logging.getLogger(__name__)
 
 
 class CooldownHandler:
@@ -20,6 +25,7 @@ class CooldownHandler:
             state.state = BotState.IDLE
             state.last_signal_ts = None
             self._registry.update(symbol, state)
+            logger.info(":< символ %s снова IDLE :>", symbol)
 
 
 __all__ = ["CooldownHandler"]

--- a/app/state_handlers/entered.py
+++ b/app/state_handlers/entered.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import time
 
 from domain.models.enums import BotState
@@ -7,6 +8,9 @@ from domain.models.state import SymbolState
 from domain.services.symbol_registry import SymbolRegistry
 from domain.services.trade_manager import TradeManager
 from domain.ports.trader import Trader
+
+
+logger = logging.getLogger(__name__)
 
 
 class EnteredHandler:
@@ -34,6 +38,7 @@ class EnteredHandler:
             state.state = BotState.COOLDOWN
             state.last_signal_ts = time.time()
             self._registry.update(symbol, state)
+            logger.info(":< позиция закрыта, символ в охлаждении :>")
 
 
 __all__ = ["EnteredHandler"]


### PR DESCRIPTION
## Summary
- log when position closes and symbol enters cooldown
- announce when cooldown ends and symbol returns to IDLE

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf2a8d9dd883209a3cbf115271a90a