### PR TITLE
Use asyncio queues for Binance WS client

### DIFF
--- a/app/metrics.py
+++ b/app/metrics.py
@@ -204,18 +204,31 @@ async def bar_maker(ws: WsClient, registry: SymbolRegistry) -> None:
         state.metrics.vol_win = vol_win
 
     next_persist = time.time() + 60
+    trade_task = asyncio.create_task(ws.next_agg_trade())
+    depth_task = asyncio.create_task(ws.next_depth())
+    liq_task = asyncio.create_task(ws.next_liquidation())
     while True:
-        trade = ws.next_agg_trade()
-        if trade:
-            aggregator.process_trade(trade)
+        done, _ = await asyncio.wait(
+            [trade_task, depth_task, liq_task], return_when=asyncio.FIRST_COMPLETED
+        )
 
-        depth = ws.next_depth()
-        if depth:
-            aggregator.process_depth(depth)
+        if trade_task in done:
+            trade = trade_task.result()
+            if trade:
+                aggregator.process_trade(trade)
+            trade_task = asyncio.create_task(ws.next_agg_trade())
 
-        liq = ws.next_liquidation()
-        if liq:
-            aggregator.process_liquidation(liq)
+        if depth_task in done:
+            depth = depth_task.result()
+            if depth:
+                aggregator.process_depth(depth)
+            depth_task = asyncio.create_task(ws.next_depth())
+
+        if liq_task in done:
+            liq = liq_task.result()
+            if liq:
+                aggregator.process_liquidation(liq)
+            liq_task = asyncio.create_task(ws.next_liquidation())
 
         if time.time() >= next_persist:
             baseline_store.save(
@@ -228,6 +241,4 @@ async def bar_maker(ws: WsClient, registry: SymbolRegistry) -> None:
                 }
             )
             next_persist = time.time() + 60
-
-        await asyncio.sleep(0)
 

--- a/domain/ports/ws_client.py
+++ b/domain/ports/ws_client.py
@@ -14,13 +14,13 @@ class WsClient(Protocol):
     async def stream(self) -> None:  # pragma: no cover - network
         ...
 
-    def next_agg_trade(self) -> AggTrade | None:
+    async def next_agg_trade(self) -> AggTrade | None:
         ...
 
-    def next_depth(self) -> DepthSnapshot | None:
+    async def next_depth(self) -> DepthSnapshot | None:
         ...
 
-    def next_liquidation(self) -> LiquidationEvent | None:
+    async def next_liquidation(self) -> LiquidationEvent | None:
         ...
 
     async def close(self) -> None:  # pragma: no cover - network

--- a/domain/services/notification.py
+++ b/domain/services/notification.py
@@ -86,9 +86,9 @@ class NotificationService:
     async def _send(self, msg: str) -> None:
         try:
             if not await self._client.send(msg):
-                logger.error(":< ошибка отправки Telegram-уведомления :>")
+                logger.error("Failed to send notification")
         except Exception:
-            logger.exception(":< ошибка Telegram-уведомления :>")
+            logger.exception("Failed to send notification")
 
     @staticmethod
     def _pnl_pct(entry: float, price: float, side: Side) -> float:

--- a/domain/services/risk_manager.py
+++ b/domain/services/risk_manager.py
@@ -143,7 +143,7 @@ class RiskManager:
             info = resp.json()["symbols"][0]["filters"]
             return {f["filterType"]: f for f in info}
         except Exception:
-            logger.exception(":< ошибка запроса фильтров %s :>", symbol)
+            logger.exception("Failed to fetch symbol filters %s", symbol)
             raise
 
     @staticmethod

--- a/infrastructure/binance/ws_client.py
+++ b/infrastructure/binance/ws_client.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from collections import deque
-from typing import Any, Deque, List
+from typing import Any, List
 
 import websockets
 from websockets.client import WebSocketClientProtocol
@@ -20,11 +19,17 @@ logger = logging.getLogger(__name__)
 class WsClient:
     """Client for Binance Futures websocket streams."""
 
-    def __init__(self) -> None:
+    def __init__(self, queue_maxsize: int = 0) -> None:
         self._symbols: tuple[str, ...] = tuple()
-        self._agg_trades: Deque[AggTrade] = deque()
-        self._depths: Deque[DepthSnapshot] = deque()
-        self._liqs: Deque[LiquidationEvent] = deque()
+        self._agg_trades: asyncio.Queue[AggTrade | None] = asyncio.Queue(
+            maxsize=queue_maxsize
+        )
+        self._depths: asyncio.Queue[DepthSnapshot | None] = asyncio.Queue(
+            maxsize=queue_maxsize
+        )
+        self._liqs: asyncio.Queue[LiquidationEvent | None] = asyncio.Queue(
+            maxsize=queue_maxsize
+        )
         self._ws: WebSocketClientProtocol | None = None
         # Pre-built subscribe message sent on connect/reconnect.  It is
         # created once in ``subscribe_symbols`` so that the network loop
@@ -61,7 +66,7 @@ class WsClient:
                 delay = 1.0
 
                 async for raw in self._ws:
-                    self._parse_message(raw)
+                    await self._parse_message(raw)
 
             except (websockets.exceptions.WebSocketException, OSError) as exc:
                 if self._ws and not self._ws.closed:
@@ -88,7 +93,7 @@ class WsClient:
             )
         return params
 
-    def _parse_message(self, raw: str) -> None:
+    async def _parse_message(self, raw: str) -> None:
         try:
             data = json.loads(raw)
         except json.JSONDecodeError:
@@ -112,12 +117,12 @@ class WsClient:
 
         handler = handlers.get(event)
         if handler:
-            handler(payload)
+            await handler(payload)
         else:
             logger.warning("Unknown event type: %s", event)
 
-    def _handle_agg_trade(self, payload: dict[str, Any]) -> None:
-        self._agg_trades.append(
+    async def _handle_agg_trade(self, payload: dict[str, Any]) -> None:
+        await self._agg_trades.put(
             AggTrade(
                 symbol=payload["s"],
                 price=float(payload["p"]),
@@ -126,10 +131,10 @@ class WsClient:
             )
         )
 
-    def _handle_depth(self, payload: dict[str, Any]) -> None:
+    async def _handle_depth(self, payload: dict[str, Any]) -> None:
         bids = tuple((float(p), float(q)) for p, q in payload["bids"])
         asks = tuple((float(p), float(q)) for p, q in payload["asks"])
-        self._depths.append(
+        await self._depths.put(
             DepthSnapshot(
                 symbol=payload["s"],
                 bids=bids,
@@ -138,10 +143,10 @@ class WsClient:
             )
         )
 
-    def _handle_liquidation(self, payload: dict[str, Any]) -> None:
+    async def _handle_liquidation(self, payload: dict[str, Any]) -> None:
         order = payload["o"]
         side = Side.LONG if order["S"] == "BUY" else Side.SHORT
-        self._liqs.append(
+        await self._liqs.put(
             LiquidationEvent(
                 symbol=order["s"],
                 side=side,
@@ -151,16 +156,19 @@ class WsClient:
             )
         )
 
-    def next_agg_trade(self) -> AggTrade | None:
-        return self._agg_trades.popleft() if self._agg_trades else None
+    async def next_agg_trade(self) -> AggTrade | None:
+        return await self._agg_trades.get()
 
-    def next_depth(self) -> DepthSnapshot | None:
-        return self._depths.popleft() if self._depths else None
+    async def next_depth(self) -> DepthSnapshot | None:
+        return await self._depths.get()
 
-    def next_liquidation(self) -> LiquidationEvent | None:
-        return self._liqs.popleft() if self._liqs else None
+    async def next_liquidation(self) -> LiquidationEvent | None:
+        return await self._liqs.get()
 
     async def close(self) -> None:  # pragma: no cover - network
         if self._ws and not self._ws.closed:
             await self._ws.close()
-            self._ws = None
+        self._ws = None
+        await self._agg_trades.put(None)
+        await self._depths.put(None)
+        await self._liqs.put(None)


### PR DESCRIPTION
## Summary
- switch Binance websocket client to asyncio queues with configurable size
- expose async next_* accessors and event handlers
- update metrics loop and interface for async queues
- translate notification and risk manager errors to English

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf30565e8c832098b2de408fd98b6e