### PR TITLE
Use WebSocketClientProtocol in Binance websocket client

### DIFF
--- a/infrastructure/binance/ws_client.py
+++ b/infrastructure/binance/ws_client.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, List
 
 import websockets
-from websockets.client import ClientProtocol
+from websockets.client import WebSocketClientProtocol
 
 from constants import BINANCE_FAPI_WS
 from domain.models.enums import Side
@@ -30,7 +30,7 @@ class WsClient:
         self._liqs: asyncio.Queue[LiquidationEvent | None] = asyncio.Queue(
             maxsize=queue_maxsize
         )
-        self._ws: ClientProtocol | None = None
+        self._ws: WebSocketClientProtocol | None = None
         # Pre-built subscribe message sent on connect/reconnect.  It is
         # created once in ``subscribe_symbols`` so that the network loop
         # does not rebuild JSON on every reconnect.


### PR DESCRIPTION
## Summary
- replace deprecated ClientProtocol with WebSocketClientProtocol
- type `_ws` attribute as `WebSocketClientProtocol | None`

## Testing
- `python -m py_compile infrastructure/binance/ws_client.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf376643c483209824615d0dcb278a