### PR TITLE
Ensure signal handler uses callable callback

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -154,7 +154,7 @@ async def run(
 
                     for sig in (signal.SIGINT, signal.SIGTERM):
                         try:
-                            loop.add_signal_handler(sig, _shutdown)
+                            loop.add_signal_handler(sig, lambda: _shutdown())
                         except NotImplementedError:
                             pass
             except* Exception as eg:
@@ -185,7 +185,7 @@ async def run(
             )
             for sig in (signal.SIGINT, signal.SIGTERM):
                 try:
-                    loop.add_signal_handler(sig, _shutdown)
+                    loop.add_signal_handler(sig, lambda: _shutdown())
                 except NotImplementedError:
                     pass
             results = await asyncio.gather(*tasks, return_exceptions=True)


### PR DESCRIPTION
## Summary
- Wrap orchestrator shutdown handler in a lambda to satisfy `add_signal_handler`'s callback API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf375d3cbc83208d01f598919bb588