### PR TITLE
Handle Binance depth updates without bids/asks keys

### DIFF
--- a/infrastructure/binance/ws_client.py
+++ b/infrastructure/binance/ws_client.py
@@ -143,14 +143,16 @@ class WsClient:
         )
 
     async def _handle_depth(self, payload: dict[str, Any]) -> None:
-        bids = tuple((float(p), float(q)) for p, q in payload["bids"])
-        asks = tuple((float(p), float(q)) for p, q in payload["asks"])
+        bids_raw = payload.get("bids") or payload.get("b") or []
+        asks_raw = payload.get("asks") or payload.get("a") or []
+        bids = tuple((float(p), float(q)) for p, q in bids_raw)
+        asks = tuple((float(p), float(q)) for p, q in asks_raw)
         await self._depths.put(
             DepthSnapshot(
-                symbol=payload["s"],
+                symbol=payload.get("s", ""),
                 bids=bids,
                 asks=asks,
-                timestamp=int(payload["E"]),
+                timestamp=int(payload.get("E", 0)),
             )
         )
 

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -1,0 +1,27 @@
+import asyncio
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from infrastructure.binance.ws_client import WsClient
+
+
+def test_handle_depth_accepts_short_keys():
+    client = WsClient()
+    payload = {
+        "s": "BTCUSDT",
+        "E": 123,
+        "b": [["1.0", "2.0"]],
+        "a": [["1.1", "3.0"]],
+    }
+
+    async def run_scenario():
+        await client._handle_depth(payload)
+        return await client.next_depth()
+
+    depth = asyncio.run(run_scenario())
+    assert depth.symbol == "BTCUSDT"
+    assert depth.timestamp == 123
+    assert depth.bids == ((1.0, 2.0),)
+    assert depth.asks == ((1.1, 3.0),)


### PR DESCRIPTION
## Summary
- Support depth messages using `b`/`a` keys or missing bid/ask arrays in Binance websocket client
- Add regression test for parsing depth updates with short keys

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf39b8f9848320a2031bb645635e4f