### PR TITLE
Implement abstract port methods

### DIFF
--- a/domain/ports/rest_client.py
+++ b/domain/ports/rest_client.py
@@ -8,22 +8,29 @@ class RestClient(Protocol):
     """Abstract interface for REST operations."""
 
     async def get_open_interest(self, symbol: str) -> float:
-        ...
+        """Return the current open interest for ``symbol``."""
+        raise NotImplementedError
 
     async def get_taker_ratio(self, symbol: str) -> tuple[float, float]:
-        ...
+        """Return taker buy/sell ratio for ``symbol`` as a tuple."""
+        raise NotImplementedError
 
     async def get_premium_pct(self, symbol: str) -> float:
-        ...
+        """Return funding premium percentage for ``symbol``."""
+        raise NotImplementedError
 
     async def get_24h_stats(self, symbol: str) -> tuple[float, float]:
-        ...
+        """Return 24h quote volume and last price for ``symbol``."""
+        raise NotImplementedError
 
     async def fetch_all_tickers(self) -> list[tuple[str, float, float]]:
-        ...
+        """Fetch bid/ask data for all tickers."""
+        raise NotImplementedError
 
     async def get_depth(self, symbol: str) -> tuple[tuple[float, float], ...]:
-        ...
+        """Return top of book depth levels for ``symbol``."""
+        raise NotImplementedError
 
     async def aclose(self) -> None:
-        ...
+        """Release any network resources held by the client."""
+        raise NotImplementedError

--- a/domain/ports/trader.py
+++ b/domain/ports/trader.py
@@ -9,9 +9,11 @@ class Trader(Protocol):
     """Abstract trading interface."""
 
     async def place(self, order: OrderSpec) -> Any | None:  # pragma: no cover - network
-        ...
+        """Place ``order`` on the exchange."""
+        raise NotImplementedError
 
     async def cancel(
         self, symbol: str, order_id: int | None
     ) -> None:  # pragma: no cover - network
-        ...
+        """Cancel an order by ``order_id`` or all orders for ``symbol``."""
+        raise NotImplementedError

--- a/domain/ports/ws_client.py
+++ b/domain/ports/ws_client.py
@@ -9,19 +9,25 @@ class WsClient(Protocol):
     """Abstract interface for websocket client."""
 
     def subscribe_symbols(self, symbols: tuple[str, ...]) -> None:
-        ...
+        """Subscribe to updates for ``symbols``."""
+        raise NotImplementedError
 
     async def stream(self) -> None:  # pragma: no cover - network
-        ...
+        """Start streaming websocket data."""
+        raise NotImplementedError
 
     async def next_agg_trade(self) -> AggTrade | None:
-        ...
+        """Return the next aggregated trade event."""
+        raise NotImplementedError
 
     async def next_depth(self) -> DepthSnapshot | None:
-        ...
+        """Return the next order book depth snapshot."""
+        raise NotImplementedError
 
     async def next_liquidation(self) -> LiquidationEvent | None:
-        ...
+        """Return the next liquidation event."""
+        raise NotImplementedError
 
     async def close(self) -> None:  # pragma: no cover - network
-        ...
+        """Close the websocket connection."""
+        raise NotImplementedError


### PR DESCRIPTION
## Summary
- add explicit NotImplementedError implementations to REST, trader, and websocket port protocols
- document each abstract method

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf359880048320898095b3ecc5d0cd