### PR TITLE
Add pipeline startup logs

### DIFF
--- a/app/metrics.py
+++ b/app/metrics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import math
 import time
 from collections import deque
@@ -15,6 +16,8 @@ from domain.services.symbol_registry import SymbolRegistry
 from domain.ports.ws_client import WsClient
 from .metric_utils import update_ewma, zscore, zscore_window
 from . import baseline_store
+
+logger = logging.getLogger(__name__)
 
 
 class MetricAggregator:
@@ -188,6 +191,7 @@ class MetricAggregator:
 async def bar_maker(ws: WsClient, registry: SymbolRegistry) -> None:
     """Build per-symbol metrics from websocket events."""
 
+    logger.info("bar_maker started")
     aggregator = MetricAggregator(registry)
     symbols = registry.all_symbols()
     baselines = baseline_store.load(symbols)

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -74,18 +74,22 @@ async def run(
     if notification_type not in {"orders", "events"}:
         raise ValueError(f"Unsupported notification_type: {notification_type}")
 
+    logger.info("Orchestrator starting with profile %s", cfg.profile)
     gstate = GlobalState(profile=cfg.profile, btc_pause_until_ms=None)
 
     registry = SymbolRegistry()
     rest: RestClientPort = RestClient()
 
+    logger.info("Building trading universe")
     builder = UniverseBuilder(rest)
     symbols = await builder.build()
+    logger.info("Universe built with %d symbols", len(symbols))
     for sym in symbols:
         registry.put(SymbolState(symbol=sym, state=BotState.IDLE))
 
     ws: WsClientPort = WsClient()
     ws.subscribe_symbols(tuple(symbols))
+    logger.info("Subscribed to websocket for %d symbols", len(symbols))
     trader: TraderPort = Trader()
 
     signal_engine = SignalEngine(cfg, registry)
@@ -119,6 +123,8 @@ async def run(
     tasks: list[asyncio.Task[None]] = []
 
     loop = asyncio.get_running_loop()
+
+    logger.info("Starting pipeline tasks")
 
     def _shutdown() -> None:
         for t in tasks:
@@ -198,6 +204,7 @@ async def run(
     except asyncio.CancelledError:
         pass
     finally:
+        logger.info("Shutting down orchestrator")
         for sig in (signal.SIGINT, signal.SIGTERM):
             try:
                 loop.remove_signal_handler(sig)
@@ -209,3 +216,4 @@ async def run(
         await rest.aclose()
         await ws.close()
         await risk_manager.aclose()
+        logger.info("Orchestrator stopped")

--- a/app/pollers/base.py
+++ b/app/pollers/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import random
 from abc import ABC, abstractmethod
 
@@ -10,6 +11,9 @@ from domain.models.enums import BotState
 from domain.models.state import SymbolState
 from domain.ports.rest_client import RestClient
 from domain.services.symbol_registry import SymbolRegistry
+
+
+logger = logging.getLogger(__name__)
 
 
 class _BasePoller(ABC):
@@ -33,6 +37,7 @@ class _BasePoller(ABC):
         """Poll a single symbol and update its state."""
 
     async def run(self) -> None:
+        logger.info("%s started", self.__class__.__name__)
         while True:
             for symbol in self._registry.all_symbols():
                 state = self._registry.get(symbol)

--- a/app/state_machine.py
+++ b/app/state_machine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 
 from domain.models.enums import BotState
@@ -21,6 +22,8 @@ from .state_handlers import (
     EnteredHandler,
     IdleWatchingHandler,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class BotStateMachine:
@@ -51,6 +54,7 @@ class BotStateMachine:
     # Public API
     # ------------------------------------------------------------------
     async def run(self) -> None:
+        logger.info("BotStateMachine started")
         while True:
             now_ms = int(time.time() * 1000)
             if self._pause_guard.should_pause(now_ms):

--- a/app/ws.py
+++ b/app/ws.py
@@ -1,6 +1,11 @@
+import logging
+
 from domain.ports.ws_client import WsClient
+
+logger = logging.getLogger(__name__)
 
 
 async def ws_stream(ws: WsClient) -> None:
     """Consume websocket stream indefinitely."""
+    logger.info("ws_stream started")
     await ws.stream()


### PR DESCRIPTION
## Summary
- log orchestrator startup, universe build, task startup, and shutdown
- emit startup messages for ws stream, bar maker, pollers, and state machine

## Testing
- `python -m py_compile app/ws.py app/metrics.py app/pollers/base.py app/state_machine.py app/orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf3ad706e48320953a126c7878970a