### PR TITLE
feat: compute risk per trade from balance

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -93,7 +93,8 @@ async def run(
     trader: TraderPort = Trader()
 
     signal_engine = SignalEngine(cfg, registry)
-    risk_manager = RiskManager(cfg)
+    risk_manager = RiskManager(cfg, trader)
+    await risk_manager.sync_balance()
     token = (
         TELEGRAM.orders_bot_token
         if notification_type == "orders"

--- a/config/profiles/active.py
+++ b/config/profiles/active.py
@@ -53,4 +53,5 @@ def make_profile_config_active() -> ProfileConfig:
         entry=entry,
         risk=risk,
         max_margin_usdt=DEFAULT_MARGIN_USDT,
+        risk_per_trade_pct=0.02,
     )

--- a/config/profiles/balanced.py
+++ b/config/profiles/balanced.py
@@ -53,4 +53,5 @@ def make_profile_config_balanced() -> ProfileConfig:
         entry=entry,
         risk=risk,
         max_margin_usdt=DEFAULT_MARGIN_USDT,
+        risk_per_trade_pct=0.02,
     )

--- a/config/profiles/conservative.py
+++ b/config/profiles/conservative.py
@@ -53,4 +53,5 @@ def make_profile_config_conservative() -> ProfileConfig:
         entry=entry,
         risk=risk,
         max_margin_usdt=DEFAULT_MARGIN_USDT,
+        risk_per_trade_pct=0.02,
     )

--- a/domain/models/config.py
+++ b/domain/models/config.py
@@ -51,3 +51,4 @@ class ProfileConfig:
     entry: EntryParams
     risk: RiskParams
     max_margin_usdt: float
+    risk_per_trade_pct: float

--- a/domain/ports/trader.py
+++ b/domain/ports/trader.py
@@ -17,3 +17,7 @@ class Trader(Protocol):
     ) -> None:  # pragma: no cover - network
         """Cancel an order by ``order_id`` or all orders for ``symbol``."""
         raise NotImplementedError
+
+    async def get_balance_usdt(self) -> float:  # pragma: no cover - network
+        """Return available USDT balance."""
+        raise NotImplementedError

--- a/domain/services/risk_manager.py
+++ b/domain/services/risk_manager.py
@@ -5,10 +5,11 @@ from decimal import Decimal, ROUND_DOWN
 import httpx
 import logging
 
-from constants import RISK_PER_TRADE_USDT, BINANCE_FAPI_REST
+from constants import BINANCE_FAPI_REST
 from domain.models import metrics as M
 from domain.models.config import ProfileConfig, RiskParams
 from domain.models.trading import PositionPlan
+from domain.ports.trader import Trader as TraderPort
 
 logger = logging.getLogger(__name__)
 
@@ -17,12 +18,25 @@ class RiskManager:
     """Simple position sizing and risk calculations."""
 
     def __init__(
-        self, config: ProfileConfig, http_client: httpx.AsyncClient | None = None
+        self,
+        config: ProfileConfig,
+        trader: TraderPort,
+        http_client: httpx.AsyncClient | None = None,
     ) -> None:
         self._cfg = config
+        self._trader = trader
         self._open_risk_usdt: float = 0.0
         self._client = http_client or httpx.AsyncClient(timeout=10.0)
         self._own_client = http_client is None
+        self._risk_per_trade_usdt: float = 10.0
+
+    async def sync_balance(self) -> None:
+        """Synchronize available balance and risk per trade."""
+
+        balance = await self._trader.get_balance_usdt()
+        self._risk_per_trade_usdt = max(
+            10.0, balance * self._cfg.risk_per_trade_pct
+        )
 
     async def build_plan(
         self, symbol: str, entry_price: float, window: M.PumpWindow
@@ -119,7 +133,7 @@ class RiskManager:
     def _calc_quantities(
         self, entry_price: float, risk: RiskParams
     ) -> tuple[float, float, float, float]:
-        quantity = RISK_PER_TRADE_USDT / entry_price
+        quantity = self._risk_per_trade_usdt / entry_price
         tp1_pct = risk.tp1_pct / 100.0
         tp2_pct = risk.tp2_pct / 100.0
         tail_pct = risk.tail_pct / 100.0
@@ -154,12 +168,12 @@ class RiskManager:
         try:
             required_margin = plan.entry_price * plan.quantity
             logger.info("Required margin for %s: %.2f", plan.symbol, required_margin)
-            if required_margin > RISK_PER_TRADE_USDT:
+            if required_margin > self._risk_per_trade_usdt:
                 logger.warning(
                     "Trade %s rejected: margin %.2f exceeds per-trade limit %.2f",
                     plan.symbol,
                     required_margin,
-                    RISK_PER_TRADE_USDT,
+                    self._risk_per_trade_usdt,
                 )
                 return False
             if self._open_risk_usdt + required_margin > self._cfg.max_margin_usdt:

--- a/infrastructure/binance/trader.py
+++ b/infrastructure/binance/trader.py
@@ -19,6 +19,7 @@ class Trader:
 
     _ORDER_ENDPOINT = "/fapi/v1/order"
     _CANCEL_ALL_ENDPOINT = "/fapi/v1/allOpenOrders"
+    _ACCOUNT_ENDPOINT = "/fapi/v2/account"
 
     def __init__(self) -> None:
         self._client = httpx.AsyncClient(base_url=BINANCE_FAPI_REST, timeout=10.0)
@@ -90,3 +91,14 @@ class Trader:
 
         response = await self._signed_request("DELETE", endpoint, params)
         response.raise_for_status()
+
+    async def get_balance_usdt(self) -> float:
+        """Fetch available USDT balance."""
+
+        resp = await self._signed_request("GET", self._ACCOUNT_ENDPOINT, {})
+        resp.raise_for_status()
+        data = resp.json()
+        for asset in data.get("assets", []):
+            if asset.get("asset") == "USDT":
+                return float(asset.get("availableBalance", 0.0))
+        return 0.0

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -43,6 +43,20 @@ class ErrorHTTPClient:
         pass
 
 
+class DummyTrader:
+    def __init__(self, balance: float = 0.0):
+        self._balance = balance
+
+    async def place(self, order):  # pragma: no cover - not used
+        return None
+
+    async def cancel(self, symbol, order_id):  # pragma: no cover - not used
+        return None
+
+    async def get_balance_usdt(self):
+        return self._balance
+
+
 def _make_plan(symbol="BTCUSDT", entry_price=200.0, quantity=1.0):
     return PositionPlan(
         symbol=symbol,
@@ -62,7 +76,7 @@ def _make_plan(symbol="BTCUSDT", entry_price=200.0, quantity=1.0):
 
 def test_build_plan_logs_http_error(caplog):
     cfg = make_profile_config_balanced()
-    risk = RiskManager(cfg, http_client=ErrorHTTPClient())
+    risk = RiskManager(cfg, DummyTrader(), http_client=ErrorHTTPClient())
     window = PumpWindow(high=110.0, low=100.0, start_ts=0, end_ts=0)
     with caplog.at_level(logging.ERROR):
         plan = asyncio.run(risk.build_plan("BTCUSDT", 105.0, window))
@@ -77,7 +91,7 @@ def test_build_plan_logs_levels(caplog):
         {"filterType": "LOT_SIZE", "stepSize": "0.001"},
         {"filterType": "PRICE_FILTER", "tickSize": "0.01"},
     ]
-    risk = RiskManager(cfg, http_client=DummyHTTPClient(filters))
+    risk = RiskManager(cfg, DummyTrader(), http_client=DummyHTTPClient(filters))
     window = PumpWindow(high=110.0, low=100.0, start_ts=0, end_ts=0)
     with caplog.at_level(logging.INFO):
         plan = asyncio.run(risk.build_plan("BTCUSDT", 105.0, window))
@@ -93,7 +107,9 @@ def test_build_plan_logs_levels(caplog):
 
 def test_allow_trade_logs_margin_and_reason(caplog):
     cfg = make_profile_config_balanced()
-    risk = RiskManager(cfg)
+    risk = RiskManager(cfg, DummyTrader(balance=100.0))
+    asyncio.run(risk.sync_balance())
+    assert risk._risk_per_trade_usdt == 10.0
     plan = _make_plan()
     with caplog.at_level(logging.INFO):
         allowed = risk.allow_trade(plan)
@@ -101,3 +117,4 @@ def test_allow_trade_logs_margin_and_reason(caplog):
     text = caplog.text
     assert f"{plan.entry_price * plan.quantity:.2f}" in text
     assert "per-trade limit" in text
+    assert "10.00" in text


### PR DESCRIPTION
## Summary
- fetch USDT balance via signed request in Binance trader
- compute per-trade risk dynamically from balance and profile percentage
- wire trader to risk manager and sync balance during orchestrator start

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfd02ca1c0832098488d186b7144c9