### PR TITLE
Implement retry helper for Binance REST client

### DIFF
--- a/infrastructure/binance/rest_client.py
+++ b/infrastructure/binance/rest_client.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import asyncio
+import logging
+
 import httpx
 
 from constants import BINANCE_FAPI_REST, TAKER_RATIO_LIMIT, TAKER_RATIO_PERIOD
+
+
+logger = logging.getLogger(__name__)
 
 
 class RestClient:
@@ -17,6 +23,30 @@ class RestClient:
 
     def __init__(self) -> None:
         self._client = httpx.AsyncClient(base_url=BINANCE_FAPI_REST, timeout=10.0)
+
+    async def _get_with_retry(
+        self, path: str, params: dict | None = None
+    ) -> httpx.Response | None:
+        delay = 1.0
+        max_attempts = 3
+        for attempt in range(1, max_attempts + 1):
+            try:
+                r = await self._client.get(path, params=params)
+                r.raise_for_status()
+                return r
+            except (httpx.TimeoutException, httpx.HTTPError) as exc:
+                logger.warning(
+                    "GET %s failed on attempt %d/%d: %s",
+                    path,
+                    attempt,
+                    max_attempts,
+                    exc,
+                )
+                if attempt == max_attempts:
+                    break
+                await asyncio.sleep(delay)
+                delay *= 2
+        return None
 
     async def get_open_interest(self, symbol: str) -> float:
         r = await self._client.get(self._OPEN_INTEREST_EP, params={"symbol": symbol})
@@ -57,8 +87,9 @@ class RestClient:
         return quote_volume, last_price
 
     async def fetch_all_tickers(self) -> list[tuple[str, float, float]]:
-        r = await self._client.get(self._TICKER_EP)
-        r.raise_for_status()
+        r = await self._get_with_retry(self._TICKER_EP)
+        if r is None:
+            return []
         data = r.json()
 
         tickers: list[tuple[str, float, float]] = []
@@ -68,8 +99,11 @@ class RestClient:
                 bid = float(item["bidPrice"])
                 ask = float(item["askPrice"])
             else:
-                r_book = await self._client.get(self._BOOK_TICKER_EP, params={"symbol": symbol})
-                r_book.raise_for_status()
+                r_book = await self._get_with_retry(
+                    self._BOOK_TICKER_EP, params={"symbol": symbol}
+                )
+                if r_book is None:
+                    continue
                 book = r_book.json()
                 bid = float(book.get("bidPrice", 0.0))
                 ask = float(book.get("askPrice", 0.0))


### PR DESCRIPTION
## Summary
- add `_get_with_retry` with exponential backoff to handle transient HTTP failures
- use `_get_with_retry` in `fetch_all_tickers` and skip symbols when book ticker fetch fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c15d1f1a4c8320bab177e120507a27