### PR TITLE
feat: make REST client timeouts configurable

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -3,6 +3,11 @@ from typing import Final
 BINANCE_FAPI_WS: Final[str] = "wss://fstream.binance.com/stream"
 BINANCE_FAPI_REST: Final[str] = "https://fapi.binance.com"
 
+HTTP_TIMEOUT_CONNECT_SEC: Final[float] = 5.0
+HTTP_TIMEOUT_READ_SEC: Final[float] = 15.0
+HTTP_TIMEOUT_WRITE_SEC: Final[float] = 5.0
+HTTP_TIMEOUT_POOL_SEC: Final[float] = 5.0
+
 UNIVERSE_MIN_24H_USDT: Final[float] = 20_000_000.0
 UNIVERSE_MAX_SPREAD_BPS: Final[float] = 4.0
 UNIVERSE_MIN_TOP10_BID_USDT: Final[float] = 80_000.0

--- a/infrastructure/binance/rest_client.py
+++ b/infrastructure/binance/rest_client.py
@@ -5,7 +5,15 @@ import logging
 
 import httpx
 
-from constants import BINANCE_FAPI_REST, TAKER_RATIO_LIMIT, TAKER_RATIO_PERIOD
+from constants import (
+    BINANCE_FAPI_REST,
+    HTTP_TIMEOUT_CONNECT_SEC,
+    HTTP_TIMEOUT_POOL_SEC,
+    HTTP_TIMEOUT_READ_SEC,
+    HTTP_TIMEOUT_WRITE_SEC,
+    TAKER_RATIO_LIMIT,
+    TAKER_RATIO_PERIOD,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -22,7 +30,13 @@ class RestClient:
     _DEPTH_EP = "/fapi/v1/depth"
 
     def __init__(self) -> None:
-        self._client = httpx.AsyncClient(base_url=BINANCE_FAPI_REST, timeout=10.0)
+        timeout = httpx.Timeout(
+            connect=HTTP_TIMEOUT_CONNECT_SEC,
+            read=HTTP_TIMEOUT_READ_SEC,
+            write=HTTP_TIMEOUT_WRITE_SEC,
+            pool=HTTP_TIMEOUT_POOL_SEC,
+        )
+        self._client = httpx.AsyncClient(base_url=BINANCE_FAPI_REST, timeout=timeout)
 
     async def _get_with_retry(
         self, path: str, params: dict | None = None

--- a/instruction.md
+++ b/instruction.md
@@ -41,6 +41,11 @@ from typing import Final
 BINANCE_FAPI_WS: Final[str] = "wss://fstream.binance.com/stream"
 BINANCE_FAPI_REST: Final[str] = "https://fapi.binance.com"
 
+HTTP_TIMEOUT_CONNECT_SEC: Final[float] = 5.0
+HTTP_TIMEOUT_READ_SEC: Final[float] = 15.0
+HTTP_TIMEOUT_WRITE_SEC: Final[float] = 5.0
+HTTP_TIMEOUT_POOL_SEC: Final[float] = 5.0
+
 UNIVERSE_MIN_24H_USDT: Final[float] = 20_000_000.0
 UNIVERSE_MAX_SPREAD_BPS: Final[float] = 4.0
 UNIVERSE_MIN_TOP10_BID_USDT: Final[float] = 80_000.0
@@ -58,6 +63,8 @@ GLOBAL_BTC_PAUSE_SEC: Final[int] = 180
 
 RISK_PER_TRADE_USDT: Final[float] = 100.0  # настрой под депозит
 ```
+
+`HTTP_TIMEOUT_*` параметры задают таймауты REST‑клиента (connect/read/write/pool, сек).
 
 ---
 


### PR DESCRIPTION
## Summary
- use `httpx.Timeout` in Binance REST client with configurable parts
- expose HTTP timeout values via constants
- document new timeout settings in project README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1609532ec832094f84961f6cf1510