### PR TITLE
Load Binance credentials from environment variables

### DIFF
--- a/config/credentials.py
+++ b/config/credentials.py
@@ -15,7 +15,25 @@ class TelegramCredentials:
     chat_id: str
 
 
-BINANCE = ApiCredentials(api_key="REPLACE_ME", api_secret="REPLACE_ME")
+_api_key = os.getenv("BINANCE_API_KEY")
+_api_secret = os.getenv("BINANCE_API_SECRET")
+_missing = [
+    name
+    for name, value in (
+        ("BINANCE_API_KEY", _api_key),
+        ("BINANCE_API_SECRET", _api_secret),
+    )
+    if not value
+]
+if _missing:
+    raise RuntimeError(
+        "Missing environment variable(s): {}. "
+        "Set BINANCE_API_KEY and BINANCE_API_SECRET to your Binance API credentials.".format(
+            ", ".join(_missing)
+        )
+    )
+
+BINANCE = ApiCredentials(api_key=_api_key, api_secret=_api_secret)
 
 TELEGRAM = TelegramCredentials(
     orders_bot_token=os.getenv("TELEGRAM_ORDERS_BOT_TOKEN", ""),

--- a/instruction.md
+++ b/instruction.md
@@ -576,14 +576,20 @@ def main() -> None:
 ## Конфиденшиалы (`config/credentials.py`)
 ```python
 from dataclasses import dataclass
+import os
 
 @dataclass(frozen=True)
 class ApiCredentials:
     api_key: str
     api_secret: str
 
-BINANCE = ApiCredentials(api_key="REPLACE_ME", api_secret="REPLACE_ME")
+api_key = os.getenv("BINANCE_API_KEY")
+api_secret = os.getenv("BINANCE_API_SECRET")
+# при отсутствии переменных — RuntimeError
+BINANCE = ApiCredentials(api_key=api_key, api_secret=api_secret)
 ```
+
+Ключ и секрет читаются из переменных окружения `BINANCE_API_KEY` и `BINANCE_API_SECRET`.
 
 ---
 


### PR DESCRIPTION
## Summary
- read Binance API credentials from `BINANCE_API_KEY` and `BINANCE_API_SECRET`
- document required environment variables for deployment

## Testing
- `BINANCE_API_KEY=dummy BINANCE_API_SECRET=dummy pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c16b86826c8320850ed617a7e10e33