### PR TITLE
Implement dynamic Binance WS subscriptions

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -118,6 +118,7 @@ async def run(
         risk_manager,
         trade_manager,
         trader,
+        ws,
         notifier if notification_type == "events" else None,
     )
 

--- a/app/state_handlers/idle_watching.py
+++ b/app/state_handlers/idle_watching.py
@@ -8,6 +8,7 @@ from domain.services.signal_engine import SignalEngine
 from domain.services.risk_manager import RiskManager
 from domain.services.trade_manager import TradeManager
 from domain.services.symbol_registry import SymbolRegistry
+from domain.ports.ws_client import WsClient
 
 logger = logging.getLogger(__name__)
 
@@ -21,17 +22,20 @@ class IdleWatchingHandler:
         signal_engine: SignalEngine,
         risk_manager: RiskManager,
         trade_manager: TradeManager,
+        ws: WsClient,
     ) -> None:
         self._registry = registry
         self._signal_engine = signal_engine
         self._risk_manager = risk_manager
         self._trade_manager = trade_manager
+        self._ws = ws
 
     async def handle(self, symbol: str, state: SymbolState) -> None:
         pump = self._signal_engine.on_minute_close(symbol)
         if pump is None:
             reason = "no pump window"
             if state.state is BotState.WATCHING:
+                self._ws.remove_detail_streams((symbol,))
                 state.state = BotState.IDLE
                 self._registry.update(symbol, state)
                 logger.debug("%s -> IDLE: %s", symbol, reason)
@@ -39,11 +43,14 @@ class IdleWatchingHandler:
                 logger.debug("%s skipped: %s", symbol, reason)
             return
 
+        if state.state is not BotState.WATCHING:
+            self._ws.add_detail_streams((symbol,))
         state.state = BotState.WATCHING
         self._registry.update(symbol, state)
         logger.debug("%s -> WATCHING: pump detected", symbol)
 
         if self._signal_engine.confirm_failure(symbol):
+            self._ws.remove_detail_streams((symbol,))
             state.state = BotState.IDLE
             self._registry.update(symbol, state)
             logger.debug("%s -> IDLE: confirmation failure", symbol)
@@ -60,6 +67,7 @@ class IdleWatchingHandler:
             return
 
         await self._trade_manager.open_position(plan, entry.side)
+        self._ws.remove_detail_streams((symbol,))
         state.state = BotState.ENTERED
         self._registry.update(symbol, state)
         logger.debug("%s -> ENTERED", symbol)

--- a/app/state_machine.py
+++ b/app/state_machine.py
@@ -15,6 +15,7 @@ from domain.services.risk_manager import RiskManager
 from domain.services.trade_manager import TradeManager
 from domain.services.notification import NotificationService
 from domain.ports.trader import Trader
+from domain.ports.ws_client import WsClient
 
 from .global_pause_guard import GlobalPauseGuard
 from .state_handlers import (
@@ -38,6 +39,7 @@ class BotStateMachine:
         risk_manager: RiskManager,
         trade_manager: TradeManager,
         trader: Trader,
+        ws: WsClient,
         notifier: NotificationService | None = None,
     ) -> None:
         self._cfg = cfg
@@ -46,7 +48,7 @@ class BotStateMachine:
         self._cooldown_handler = CooldownHandler(registry)
         self._entered_handler = EnteredHandler(registry, trade_manager, trader)
         self._idle_watching_handler = IdleWatchingHandler(
-            registry, signal_engine, risk_manager, trade_manager
+            registry, signal_engine, risk_manager, trade_manager, ws
         )
         self._notifier = notifier
 

--- a/domain/ports/ws_client.py
+++ b/domain/ports/ws_client.py
@@ -12,6 +12,14 @@ class WsClient(Protocol):
         """Subscribe to updates for ``symbols``."""
         raise NotImplementedError
 
+    def add_detail_streams(self, symbols: tuple[str, ...]) -> None:
+        """Subscribe to depth and liquidation streams for ``symbols``."""
+        raise NotImplementedError
+
+    def remove_detail_streams(self, symbols: tuple[str, ...]) -> None:
+        """Unsubscribe from depth and liquidation streams for ``symbols``."""
+        raise NotImplementedError
+
     async def stream(self) -> None:  # pragma: no cover - network
         """Start streaming websocket data."""
         raise NotImplementedError

--- a/infrastructure/binance/ws_client.py
+++ b/infrastructure/binance/ws_client.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import logging
 from collections.abc import Awaitable, Callable
-from typing import Any, List
+from typing import Any, Dict, List, Tuple
 
 import websockets
 from websockets.client import ClientProtocol
@@ -17,52 +17,100 @@ from domain.models.market_data import AggTrade, DepthSnapshot, LiquidationEvent
 logger = logging.getLogger(__name__)
 
 
-class WsClient:
-    """Client for Binance Futures websocket streams."""
+class _WsConnection:
+    """Handle a single websocket connection for a chunk of symbols."""
 
-    def __init__(self, queue_maxsize: int = 0) -> None:
-        self._symbols: tuple[str, ...] = tuple()
-        self._agg_trades: asyncio.Queue[AggTrade | None] = asyncio.Queue(
-            maxsize=queue_maxsize
-        )
-        self._depths: asyncio.Queue[DepthSnapshot | None] = asyncio.Queue(
-            maxsize=queue_maxsize
-        )
-        self._liqs: asyncio.Queue[LiquidationEvent | None] = asyncio.Queue(
-            maxsize=queue_maxsize
-        )
+    def __init__(
+        self,
+        symbols: tuple[str, ...],
+        agg_q: asyncio.Queue[AggTrade | None],
+        depth_q: asyncio.Queue[DepthSnapshot | None],
+        liq_q: asyncio.Queue[LiquidationEvent | None],
+    ) -> None:
+        self._symbols = tuple(symbols)
+        self._detail_symbols: set[str] = set()
+        self._agg_q = agg_q
+        self._depth_q = depth_q
+        self._liq_q = liq_q
         self._ws: ClientProtocol | None = None
-        # Pre-built subscribe message sent on connect/reconnect.  It is
-        # created once in ``subscribe_symbols`` so that the network loop
-        # does not rebuild JSON on every reconnect.
         self._subscribe_msg: str | None = None
+        self._req_id = 0
+        self._update_subscribe_msg()
 
-    def subscribe_symbols(self, symbols: tuple[str, ...]) -> None:
-        """Store symbols and build subscription payload.
+    # ------------------------------------------------------------------
+    # Subscription helpers
+    # ------------------------------------------------------------------
+    def _next_id(self) -> int:
+        self._req_id += 1
+        return self._req_id
 
-        The websocket requires a subscription message with all stream names.
-        We pre-build this JSON once to reuse it on reconnects.
-        """
+    def _detail_params(self, symbols: Tuple[str, ...]) -> List[str]:
+        params: List[str] = []
+        for sym in symbols:
+            ls = sym.lower()
+            params.extend([f"{ls}@depth20@100ms", f"{ls}@forceOrder"])
+        return params
 
-        self._symbols = symbols
-        params = self._build_params(symbols)
+    def _build_params(self) -> List[str]:
+        params: List[str] = []
+        for sym in self._symbols:
+            ls = sym.lower()
+            params.append(f"{ls}@aggTrade")
+            if sym in self._detail_symbols:
+                params.extend([f"{ls}@depth20@100ms", f"{ls}@forceOrder"])
+        return params
+
+    def _update_subscribe_msg(self) -> None:
+        params = self._build_params()
         if params:
             self._subscribe_msg = json.dumps(
-                {"method": "SUBSCRIBE", "params": params, "id": 1}
+                {"method": "SUBSCRIBE", "params": params, "id": self._next_id()}
             )
         else:
             self._subscribe_msg = None
 
-    async def _connect_and_subscribe(self) -> None:  # pragma: no cover - network
-        """Establish websocket connection and send subscription message."""
+    def add_detail_streams(self, symbols: tuple[str, ...]) -> None:
+        new_syms = [s for s in symbols if s not in self._detail_symbols]
+        if not new_syms:
+            return
+        self._detail_symbols.update(new_syms)
+        self._update_subscribe_msg()
+        if self._ws:
+            msg = json.dumps(
+                {
+                    "method": "SUBSCRIBE",
+                    "params": self._detail_params(tuple(new_syms)),
+                    "id": self._next_id(),
+                }
+            )
+            asyncio.create_task(self._ws.send(msg))
 
+    def remove_detail_streams(self, symbols: tuple[str, ...]) -> None:
+        rem_syms = [s for s in symbols if s in self._detail_symbols]
+        if not rem_syms:
+            return
+        for s in rem_syms:
+            self._detail_symbols.remove(s)
+        self._update_subscribe_msg()
+        if self._ws:
+            msg = json.dumps(
+                {
+                    "method": "UNSUBSCRIBE",
+                    "params": self._detail_params(tuple(rem_syms)),
+                    "id": self._next_id(),
+                }
+            )
+            asyncio.create_task(self._ws.send(msg))
+
+    # ------------------------------------------------------------------
+    # Networking
+    # ------------------------------------------------------------------
+    async def _connect_and_subscribe(self) -> None:  # pragma: no cover - network
         self._ws = await websockets.connect(BINANCE_FAPI_WS)
         if self._subscribe_msg and self._ws:
             await self._ws.send(self._subscribe_msg)
 
     async def _consume_messages(self) -> None:  # pragma: no cover - network
-        """Read messages from the websocket and dispatch them for handling."""
-
         assert self._ws is not None
         async for raw in self._ws:
             await self._parse_message(raw)
@@ -70,19 +118,15 @@ class WsClient:
     async def stream(self) -> None:  # pragma: no cover - network
         attempt = 0
         delay = 1.0
-
         while True:
             try:
                 await self._connect_and_subscribe()
                 attempt = 0
                 delay = 1.0
-
                 await self._consume_messages()
-
             except (websockets.exceptions.WebSocketException, OSError) as exc:
                 if self._ws:
                     await self._ws.close()
-
                 attempt += 1
                 logger.exception(
                     "Ошибка WebSocket (%s). попытка переподключения %d :>",
@@ -93,16 +137,6 @@ class WsClient:
                 delay = min(delay * 2, 60.0)
             finally:
                 self._ws = None
-
-
-    def _build_params(self, symbols: tuple[str, ...]) -> List[str]:
-        params: List[str] = []
-        for sym in symbols:
-            ls = sym.lower()
-            params.extend(
-                [f"{ls}@aggTrade", f"{ls}@depth20@100ms", f"{ls}@forceOrder"]
-            )
-        return params
 
     async def _parse_message(self, raw: str) -> None:
         try:
@@ -120,20 +154,20 @@ class WsClient:
         if event not in {"aggTrade", "forceOrder"} and "depth" in stream:
             event = "depth"
 
-        handlers: dict[str, Callable[[dict[str, Any]], Awaitable[None]]] = {
+        handlers: Dict[str, Callable[[Dict[str, Any]], Awaitable[None]]] = {
             "aggTrade": self._handle_agg_trade,
             "depth": self._handle_depth,
             "forceOrder": self._handle_liquidation,
         }
 
-        handler: Callable[[dict[str, Any]], Awaitable[None]] | None = handlers.get(event)
+        handler = handlers.get(event)
         if handler:
             await handler(payload)
         else:
             logger.warning("Unknown event type: %s", event)
 
-    async def _handle_agg_trade(self, payload: dict[str, Any]) -> None:
-        await self._agg_trades.put(
+    async def _handle_agg_trade(self, payload: Dict[str, Any]) -> None:
+        await self._agg_q.put(
             AggTrade(
                 symbol=payload["s"],
                 price=float(payload["p"]),
@@ -142,12 +176,12 @@ class WsClient:
             )
         )
 
-    async def _handle_depth(self, payload: dict[str, Any]) -> None:
+    async def _handle_depth(self, payload: Dict[str, Any]) -> None:
         bids_raw = payload.get("bids") or payload.get("b") or []
         asks_raw = payload.get("asks") or payload.get("a") or []
         bids = tuple((float(p), float(q)) for p, q in bids_raw)
         asks = tuple((float(p), float(q)) for p, q in asks_raw)
-        await self._depths.put(
+        await self._depth_q.put(
             DepthSnapshot(
                 symbol=payload.get("s", ""),
                 bids=bids,
@@ -156,10 +190,10 @@ class WsClient:
             )
         )
 
-    async def _handle_liquidation(self, payload: dict[str, Any]) -> None:
+    async def _handle_liquidation(self, payload: Dict[str, Any]) -> None:
         order = payload["o"]
         side = Side.LONG if order["S"] == "BUY" else Side.SHORT
-        await self._liqs.put(
+        await self._liq_q.put(
             LiquidationEvent(
                 symbol=order["s"],
                 side=side,
@@ -168,6 +202,57 @@ class WsClient:
                 timestamp=int(order["T"]),
             )
         )
+
+    async def close(self) -> None:  # pragma: no cover - network
+        if self._ws and not self._ws.closed:
+            await self._ws.close()
+        self._ws = None
+
+
+class WsClient:
+    """Multiplex websocket client respecting Binance stream limits."""
+
+    def __init__(self, queue_maxsize: int = 0) -> None:
+        self._agg_trades: asyncio.Queue[AggTrade | None] = asyncio.Queue(
+            maxsize=queue_maxsize
+        )
+        self._depths: asyncio.Queue[DepthSnapshot | None] = asyncio.Queue(
+            maxsize=queue_maxsize
+        )
+        self._liqs: asyncio.Queue[LiquidationEvent | None] = asyncio.Queue(
+            maxsize=queue_maxsize
+        )
+        self._conns: list[_WsConnection] = []
+        self._symbol_to_conn: dict[str, _WsConnection] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def subscribe_symbols(self, symbols: tuple[str, ...]) -> None:
+        chunk_size = 66
+        self._conns.clear()
+        self._symbol_to_conn.clear()
+        for i in range(0, len(symbols), chunk_size):
+            chunk = tuple(symbols[i : i + chunk_size])
+            conn = _WsConnection(chunk, self._agg_trades, self._depths, self._liqs)
+            self._conns.append(conn)
+            for sym in chunk:
+                self._symbol_to_conn[sym] = conn
+
+    def add_detail_streams(self, symbols: tuple[str, ...]) -> None:
+        for sym in symbols:
+            conn = self._symbol_to_conn.get(sym)
+            if conn:
+                conn.add_detail_streams((sym,))
+
+    def remove_detail_streams(self, symbols: tuple[str, ...]) -> None:
+        for sym in symbols:
+            conn = self._symbol_to_conn.get(sym)
+            if conn:
+                conn.remove_detail_streams((sym,))
+
+    async def stream(self) -> None:  # pragma: no cover - network
+        await asyncio.gather(*(c.stream() for c in self._conns))
 
     async def next_agg_trade(self) -> AggTrade | None:
         return await self._agg_trades.get()
@@ -179,9 +264,8 @@ class WsClient:
         return await self._liqs.get()
 
     async def close(self) -> None:  # pragma: no cover - network
-        if self._ws and not self._ws.closed:
-            await self._ws.close()
-        self._ws = None
+        await asyncio.gather(*(c.close() for c in self._conns))
         await self._agg_trades.put(None)
         await self._depths.put(None)
         await self._liqs.put(None)
+


### PR DESCRIPTION
## Summary
- Split websocket symbol subscriptions across multiple connections to respect Binance's ~200 stream limit
- Allow adding/removing depth and liquidation streams per symbol
- Watch depth/liquidation only while a symbol is under pump evaluation and unsubscribe when no longer needed

## Testing
- `python -m py_compile domain/ports/ws_client.py infrastructure/binance/ws_client.py app/state_handlers/idle_watching.py app/state_machine.py app/orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2ee82b80c83209deb28e169a951a6