### PR TITLE
feat: limit coin selection to top daily volumes

### DIFF
--- a/tests/test_coin_filter.py
+++ b/tests/test_coin_filter.py
@@ -1,0 +1,30 @@
+import random
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils.coin_filter import select_top_coins, MAX_COINS
+
+
+def test_select_top_coins_limits_and_sorts():
+    # create 200 coins with increasing volume
+    coins = [
+        {"symbol": f"COIN{i}", "volume": i}
+        for i in range(200)
+    ]
+    random.shuffle(coins)  # ensure order is unsorted
+
+    result = select_top_coins(coins)
+
+    # should only keep MAX_COINS entries
+    assert len(result) == MAX_COINS
+
+    # volumes should be sorted descending
+    volumes = [c["volume"] for c in result]
+    assert volumes == sorted(volumes, reverse=True)
+
+    # top volume should be the highest available
+    assert result[0]["volume"] == 199
+    # last volume should match the cutoff point
+    assert result[-1]["volume"] == 199 - MAX_COINS + 1

--- a/utils/coin_filter.py
+++ b/utils/coin_filter.py
@@ -1,0 +1,38 @@
+"""Utility functions for selecting coins based on daily volume."""
+from typing import Iterable, Callable, Dict, List
+
+MAX_COINS = 180
+
+def select_top_coins(
+    coins: Iterable[Dict],
+    filters: Iterable[Callable[[Dict], bool]] = (),
+) -> List[Dict]:
+    """Return the top coins sorted by 24h volume.
+
+    Parameters
+    ----------
+    coins: iterable of mapping
+        Each element must contain at least ``symbol`` and ``volume`` keys.
+    filters: iterable of callables
+        Existing filter functions applied sequentially to ``coins``.
+
+    Returns
+    -------
+    list of dict
+        Coins with ``symbol`` and ``volume`` fields sorted by descending
+        volume and truncated to ``MAX_COINS`` entries.
+    """
+
+    # Apply provided filters
+    filtered = [c for c in coins if all(f(c) for f in filters)]
+
+    # Collect volume information
+    coins_with_volume = [
+        {"symbol": c["symbol"], "volume": c.get("volume", 0)}
+        for c in filtered
+        if c.get("volume") is not None
+    ]
+
+    # Sort by 24h volume and limit to MAX_COINS
+    coins_with_volume.sort(key=lambda c: c["volume"], reverse=True)
+    return coins_with_volume[:MAX_COINS]


### PR DESCRIPTION
## Summary
- add coin filtering utility with MAX_COINS = 180
- return coins sorted by 24h volume
- cover coin filter logic with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2f68a49b08320aae7a0681e23fedd