### PR TITLE
Refactor baseline store to reuse SQLite connection

### DIFF
--- a/app/baseline_store.py
+++ b/app/baseline_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import atexit
 import json
 import os
 import sqlite3
@@ -8,24 +9,31 @@ from typing import Deque, Dict, Iterable, Tuple
 
 import constants
 
+Baseline = Tuple[Deque[float], Deque[float]]
+
 DB_PATH = "data/cache/baseline.sqlite"
 
-
-def _connect() -> sqlite3.Connection:
-    os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
-    conn = sqlite3.connect(DB_PATH)
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS baseline (symbol TEXT PRIMARY KEY, price_win TEXT NOT NULL, vol_win TEXT NOT NULL)"
+os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+CONN: sqlite3.Connection = sqlite3.connect(DB_PATH)
+CONN.execute(
+    (
+        "CREATE TABLE IF NOT EXISTS baseline ("
+        "symbol TEXT PRIMARY KEY, "
+        "price_win TEXT NOT NULL, "
+        "vol_win TEXT NOT NULL)"
     )
-    return conn
+)
+atexit.register(CONN.close)
 
 
-def load(symbols: Iterable[str]) -> Dict[str, Tuple[Deque[float], Deque[float]]]:
-    conn = _connect()
-    cur = conn.cursor()
-    result: Dict[str, Tuple[Deque[float], Deque[float]]] = {}
+def load(symbols: Iterable[str]) -> Dict[str, Baseline]:
+    cur = CONN.cursor()
+    result: Dict[str, Baseline] = {}
     for sym in symbols:
-        cur.execute("SELECT price_win, vol_win FROM baseline WHERE symbol=?", (sym,))
+        cur.execute(
+            "SELECT price_win, vol_win FROM baseline WHERE symbol=?",
+            (sym,),
+        )
         row = cur.fetchone()
         if row:
             price = json.loads(row[0])
@@ -34,22 +42,24 @@ def load(symbols: Iterable[str]) -> Dict[str, Tuple[Deque[float], Deque[float]]]
                 deque(price, maxlen=constants.Z_BASE_WINDOW_MIN),
                 deque(vol, maxlen=constants.Z_BASE_WINDOW_MIN),
             )
-    conn.close()
+    cur.close()
     return result
 
 
-def save(baselines: Dict[str, Tuple[Deque[float], Deque[float]]]) -> None:
+def save(baselines: Dict[str, Baseline]) -> None:
     if not baselines:
         return
-    conn = _connect()
-    cur = conn.cursor()
+    cur = CONN.cursor()
     rows = [
         (sym, json.dumps(list(px)), json.dumps(list(vol)))
         for sym, (px, vol) in baselines.items()
     ]
     cur.executemany(
-        "INSERT OR REPLACE INTO baseline(symbol, price_win, vol_win) VALUES (?, ?, ?)",
+        (
+            "INSERT OR REPLACE INTO baseline(symbol, price_win, vol_win) "
+            "VALUES (?, ?, ?)"
+        ),
         rows,
     )
-    conn.commit()
-    conn.close()
+    CONN.commit()
+    cur.close()


### PR DESCRIPTION
## Summary
- initialize the baseline cache's SQLite connection once and close it at exit
- update load and save to use the shared connection
- format baseline_store for flake8 compliance

## Testing
- `flake8 app/baseline_store.py`
- `pytest`
- `python -m py_compile app/baseline_store.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2ffd28ed8832088e41dbab597725c