### PR TITLE
Return keys view from SymbolRegistry

### DIFF
--- a/app/metrics.py
+++ b/app/metrics.py
@@ -193,7 +193,7 @@ async def bar_maker(ws: WsClient, registry: SymbolRegistry) -> None:
 
     logger.info("bar_maker started")
     aggregator = MetricAggregator(registry)
-    symbols = registry.all_symbols()
+    symbols = list(registry.all_symbols())
     baselines = baseline_store.load(symbols)
     for sym in symbols:
         state = registry.get(sym)

--- a/domain/services/symbol_registry.py
+++ b/domain/services/symbol_registry.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, Iterable
 
 from domain.models.state import SymbolState
 
@@ -23,5 +23,5 @@ class SymbolRegistry:
     def update(self, symbol: str, new_state: SymbolState) -> None:
         self._states[symbol] = new_state
 
-    def all_symbols(self) -> tuple[str, ...]:
-        return tuple(self._states.keys())
+    def all_symbols(self) -> Iterable[str]:
+        return self._states.keys()


### PR DESCRIPTION
## Summary
- Return keys view from `SymbolRegistry.all_symbols` instead of allocating a tuple
- Snapshot registry symbols in `bar_maker` using a list to handle keys view

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2fff2d02483209f1966b41fff20fa