### PR TITLE
Include quote volume in ticker fetch

### DIFF
--- a/app/universe.py
+++ b/app/universe.py
@@ -18,6 +18,7 @@ class UniverseBuilder:
 
     async def build(self) -> list[str]:
         skipped_usdt = 0
+        skipped_volume = 0
         skipped_spread = 0
         skipped_depth = 0
 
@@ -28,6 +29,10 @@ class UniverseBuilder:
         for sym, bid, ask, qvol in tickers:
             if not self._is_usdt_pair(sym):
                 skipped_usdt += 1
+                continue
+
+            if qvol < filters.MIN_24H_USDT:
+                skipped_volume += 1
                 continue
 
             if not self._within_spread(sym, bid, ask):
@@ -53,8 +58,14 @@ class UniverseBuilder:
 
         logger.info("Выбрано %d монет (лимит %d), всего после отсева: %d",
                     len(symbols), MAX_SYMBOLS, len(survivors))
-        logger.info("Скипы: !USDT=%d, спред=%d, глубина=%d, по_лимиту=%d",
-                    skipped_usdt, skipped_spread, skipped_depth, trimmed_by_limit)
+        logger.info(
+            "Скипы: !USDT=%d, объём=%d, спред=%d, глубина=%d, по_лимиту=%d",
+            skipped_usdt,
+            skipped_volume,
+            skipped_spread,
+            skipped_depth,
+            trimmed_by_limit,
+        )
         return symbols
 
     def _is_usdt_pair(self, sym: str) -> bool:

--- a/domain/ports/rest_client.py
+++ b/domain/ports/rest_client.py
@@ -23,8 +23,8 @@ class RestClient(Protocol):
         """Return 24h quote volume and last price for ``symbol``."""
         raise NotImplementedError
 
-    async def fetch_all_tickers(self) -> list[tuple[str, float, float]]:
-        """Fetch bid/ask data for all tickers."""
+    async def fetch_all_tickers(self) -> list[tuple[str, float, float, float]]:
+        """Fetch bid/ask data and quote volume for all tickers."""
         raise NotImplementedError
 
     async def get_depth(self, symbol: str) -> tuple[tuple[float, float], ...]:

--- a/infrastructure/binance/rest_client.py
+++ b/infrastructure/binance/rest_client.py
@@ -100,13 +100,13 @@ class RestClient:
         last_price = float(data["lastPrice"])
         return quote_volume, last_price
 
-    async def fetch_all_tickers(self) -> list[tuple[str, float, float]]:
+    async def fetch_all_tickers(self) -> list[tuple[str, float, float, float]]:
         r = await self._get_with_retry(self._TICKER_EP)
         if r is None:
             return []
         data = r.json()
 
-        tickers: list[tuple[str, float, float]] = []
+        tickers: list[tuple[str, float, float, float]] = []
         for item in data:
             symbol = item["symbol"]
             if "bidPrice" in item and "askPrice" in item:
@@ -121,7 +121,8 @@ class RestClient:
                 book = r_book.json()
                 bid = float(book.get("bidPrice", 0.0))
                 ask = float(book.get("askPrice", 0.0))
-            tickers.append((symbol, bid, ask))
+            qvol = float(item.get("quoteVolume", 0.0))
+            tickers.append((symbol, bid, ask, qvol))
 
         return tickers
 


### PR DESCRIPTION
## Summary
- expose quote volume from `RestClient.fetch_all_tickers`
- parse `quoteVolume` in Binance REST client and return with each ticker
- filter universe symbols by 24h quote volume threshold

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c30c89728c83209e027a3136fdbd1c