### PR TITLE
Use retry helper for Binance depth

### DIFF
--- a/infrastructure/binance/rest_client.py
+++ b/infrastructure/binance/rest_client.py
@@ -127,8 +127,11 @@ class RestClient:
         return tickers
 
     async def get_depth(self, symbol: str) -> tuple[tuple[float, float], ...]:
-        r = await self._client.get(self._DEPTH_EP, params={"symbol": symbol, "limit": 10})
-        r.raise_for_status()
+        r = await self._get_with_retry(
+            self._DEPTH_EP, params={"symbol": symbol, "limit": 10}
+        )
+        if r is None:
+            return ()
         data = r.json()
         bids = tuple((float(p), float(q)) for p, q in data.get("bids", []))
         return bids


### PR DESCRIPTION
## Summary
- use retry helper for depth requests to gracefully handle HTTP failures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c315c7b1c08320bbfe371c1621595d