### PR TITLE
Refine partial anomaly logging in signal engine

### DIFF
--- a/domain/services/signal_engine.py
+++ b/domain/services/signal_engine.py
@@ -73,11 +73,20 @@ class SignalEngine:
             ok, met = _meets_trigger(metrics, trig)
             if not ok:
                 if met:
-                    logger.info(
-                        "%s: частичная аномалия — выполнены условия %s",
-                        symbol,
-                        ", ".join(met),
-                    )
+                    info_met = [c for c in met if c in {"delta_price_abs_pct", "z_px"}]
+                    debug_met = [c for c in met if c not in {"delta_price_abs_pct", "z_px"}]
+                    if info_met:
+                        logger.info(
+                            "%s: частичная аномалия — выполнены условия %s",
+                            symbol,
+                            ", ".join(info_met),
+                        )
+                    if debug_met:
+                        logger.debug(
+                            "%s: частичная аномалия — выполнены условия %s",
+                            symbol,
+                            ", ".join(debug_met),
+                        )
                 else:
                     logger.debug("%s pump skipped: no trigger conditions met", symbol)
                 return None


### PR DESCRIPTION
## Summary
- Limit partial anomaly INFO logging to `z_px` and `delta_price_abs_pct`
- Downgrade other partial anomaly logs to DEBUG

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c540a8f7c88320b16fc37cd841830b