### PR TITLE
Compute price delta from open baseline

### DIFF
--- a/app/metrics.py
+++ b/app/metrics.py
@@ -68,6 +68,11 @@ class MetricAggregator:
         metrics.start_ts = start_ts
         metrics.end_ts = trade.timestamp
 
+        baseline = metrics.open if metrics.open > 0 else metrics.price_ewma_mean
+        delta_abs = (
+            abs((trade.price - baseline) / baseline) * 100 if baseline > 0 else 0.0
+        )
+
         high = metrics.high
         low = metrics.low
         rng = high - low
@@ -82,7 +87,6 @@ class MetricAggregator:
 
         std_price = metrics.price_ewma_std
         delta_sigma = rng / std_price if std_price > 0 else 0.0
-        delta_abs = (high / low - 1.0) * 100 if low > 0 else 0.0
         body = abs(trade.price - metrics.open)
         upper_wick = high - max(metrics.open, trade.price)
         uw_ratio = upper_wick / body if body > 0 else float("inf")

--- a/domain/services/signal_engine.py
+++ b/domain/services/signal_engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 
 from domain.models import metrics as M, signals as S
 from domain.models.config import EntryParams, ProfileConfig, TriggerParams
@@ -67,6 +68,13 @@ class SignalEngine:
         try:
             state = self._registry.get(symbol)
             metrics = state.metrics
+
+            now_ms = int(time.time() * 1000)
+            if now_ms - metrics.end_ts >= 60_000:
+                metrics.delta_price_abs_pct = 0.0
+                self._registry.update(symbol, state)
+                logger.debug("%s pump skipped: no recent trades", symbol)
+                return None
 
             trig = self._config.trigger
 

--- a/tests/test_metrics_delta.py
+++ b/tests/test_metrics_delta.py
@@ -1,0 +1,52 @@
+import time
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.metrics import MetricAggregator
+from config.profiles.balanced import make_profile_config_balanced
+from domain.models.market_data import AggTrade
+from domain.models.state import SymbolState
+from domain.models.enums import BotState
+from domain.services.signal_engine import SignalEngine
+from domain.services.symbol_registry import SymbolRegistry
+
+
+def _setup_registry() -> SymbolRegistry:
+    registry = SymbolRegistry()
+    state = SymbolState(symbol="ABCUSDT", state=BotState.IDLE)
+    registry.put(state)
+    return registry
+
+
+def test_stable_price_minute(monkeypatch):
+    registry = _setup_registry()
+    agg = MetricAggregator(registry)
+    base_ts = 1_000_000
+    price = 100.0
+    agg.process_trade(AggTrade("ABCUSDT", price, 1.0, base_ts))
+    agg.process_trade(AggTrade("ABCUSDT", price, 1.0, base_ts + 30_000))
+    config = make_profile_config_balanced()
+    engine = SignalEngine(config, registry)
+    monkeypatch.setattr(time, "time", lambda: (base_ts + 30_000 + 1) / 1000)
+    signal = engine.on_minute_close("ABCUSDT")
+    metrics = registry.get("ABCUSDT").metrics
+    assert signal is None
+    assert metrics.delta_price_abs_pct < config.trigger.delta_price_abs_pct
+
+
+def test_delta_resets_when_no_trades(monkeypatch):
+    registry = _setup_registry()
+    agg = MetricAggregator(registry)
+    base_ts = 1_000_000
+    agg.process_trade(AggTrade("ABCUSDT", 100.0, 1.0, base_ts))
+    agg.process_trade(AggTrade("ABCUSDT", 105.0, 1.0, base_ts + 30_000))
+    metrics = registry.get("ABCUSDT").metrics
+    assert metrics.delta_price_abs_pct > 0
+    config = make_profile_config_balanced()
+    engine = SignalEngine(config, registry)
+    monkeypatch.setattr(time, "time", lambda: (base_ts + 120_000) / 1000)
+    signal = engine.on_minute_close("ABCUSDT")
+    assert signal is None
+    assert registry.get("ABCUSDT").metrics.delta_price_abs_pct == 0.0


### PR DESCRIPTION
## Summary
- compute candle price delta as absolute change from open (or EWMA baseline)
- reset stale delta metrics when no trades occur for a minute
- add tests for stable price window and inactivity reset

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c551315534832082f48de114ce7711