### PR TITLE
Include metric values in partial trigger logs

### DIFF
--- a/domain/services/signal_engine.py
+++ b/domain/services/signal_engine.py
@@ -42,6 +42,29 @@ def _meets_trigger(metrics: M.SymbolMetrics, trig: TriggerParams) -> tuple[bool,
     return all_met, met
 
 
+_CONDITION_SPEC: dict[str, tuple[str, str, str, str]] = {
+    "z_px": ("z_px", "z_px", ">=", ""),
+    "z_vol": ("z_vol", "z_vol", ">=", ""),
+    "delta_price_sigma_mult": ("delta_price_sigma_mult", "delta_price_sigma_mult", ">=", ""),
+    "delta_price_abs_pct": ("delta_price_abs_pct", "delta_price_abs_pct", ">=", "%"),
+    "upper_wick_body_ratio": (
+        "upper_wick_body_ratio",
+        "upper_wick_body_ratio_max",
+        "<=",
+        "",
+    ),
+}
+
+
+def _format_condition(name: str, metrics: M.SymbolMetrics, trig: TriggerParams) -> str:
+    metric_attr, trig_attr, op, unit = _CONDITION_SPEC[name]
+    metric_val = getattr(metrics, metric_attr)
+    trig_val = getattr(trig, trig_attr)
+    metric_s = f"{metric_val:.3f}{unit}"
+    trig_s = f"{trig_val:.3f}{unit}"
+    return f"{name} {metric_s} {op} {trig_s}"
+
+
 def _evaluate_entry(metrics: M.SymbolMetrics, entry_cfg: EntryParams) -> bool:
     low_break = metrics.low_break
     avwap_loss = metrics.avwap_loss
@@ -87,13 +110,13 @@ class SignalEngine:
                         logger.info(
                             "%s: частичная аномалия — выполнены условия %s",
                             symbol,
-                            ", ".join(info_met),
+                            ", ".join(_format_condition(c, metrics, trig) for c in info_met),
                         )
                     if debug_met:
                         logger.debug(
                             "%s: частичная аномалия — выполнены условия %s",
                             symbol,
-                            ", ".join(debug_met),
+                            ", ".join(_format_condition(c, metrics, trig) for c in debug_met),
                         )
                 else:
                     logger.debug("%s pump skipped: no trigger conditions met", symbol)

--- a/tests/test_signal_engine_logging.py
+++ b/tests/test_signal_engine_logging.py
@@ -1,0 +1,88 @@
+import logging
+import time
+
+from domain.services.signal_engine import SignalEngine, SymbolRegistry, _format_condition
+from domain.models.state import SymbolState
+from domain.models.metrics import SymbolMetrics
+from domain.models.enums import BotState, Profile
+from domain.models.config import (
+    TriggerParams,
+    ConfirmationParams,
+    EntryParams,
+    RiskParams,
+    ProfileConfig,
+)
+
+
+def _make_config() -> ProfileConfig:
+    trigger = TriggerParams(
+        z_px=1.0,
+        z_vol=1.0,
+        delta_price_sigma_mult=1.0,
+        delta_price_abs_pct=1.0,
+        upper_wick_body_ratio_max=0.8,
+    )
+    confirm = ConfirmationParams(
+        delta_oi_max_pct=1.0,
+        taker_ratio_max=1.0,
+        premium_max_pct=1.0,
+        latency_min_sec=0,
+        ask_imb_min=0.0,
+        top5ask_vs_base_min=0.0,
+        cvd_gap_pct_min=0.0,
+        cvd_gap_sec_min=0,
+    )
+    entry = EntryParams(
+        allow_low_break=False,
+        allow_avwap_loss=False,
+        require_both=False,
+    )
+    risk = RiskParams(
+        stop_abs_pct=0.0,
+        stop_sigma_mult=0.0,
+        tp1_pct=0.0,
+        tp2_pct=0.0,
+        tail_pct=0.0,
+        trail_abs_pct=0.0,
+        trail_sigma_mult=0.0,
+    )
+    return ProfileConfig(
+        profile=Profile.ACTIVE,
+        trigger=trigger,
+        confirmation=confirm,
+        entry=entry,
+        risk=risk,
+        max_margin_usdt=0.0,
+        risk_per_trade_pct=0.0,
+    )
+
+
+def test_partial_condition_logging(caplog):
+    registry = SymbolRegistry()
+    metrics = SymbolMetrics(
+        z_px=2.0,
+        z_vol=0.5,
+        delta_price_sigma_mult=1.1,
+        delta_price_abs_pct=1.2,
+        upper_wick_body_ratio=0.5,
+        end_ts=int(time.time() * 1000),
+    )
+    state = SymbolState(symbol="XYZ", state=BotState.WATCHING, metrics=metrics)
+    registry.put(state)
+
+    engine = SignalEngine(_make_config(), registry)
+    with caplog.at_level(logging.DEBUG):
+        engine.on_minute_close("XYZ")
+
+    info_record = next(
+        r for r in caplog.records if r.levelno == logging.INFO and "частичная аномалия" in r.message
+    )
+    debug_record = next(
+        r for r in caplog.records if r.levelno == logging.DEBUG and "частичная аномалия" in r.message
+    )
+
+    trig = engine._config.trigger
+    assert _format_condition("delta_price_abs_pct", metrics, trig) in info_record.message
+    assert _format_condition("z_px", metrics, trig) in info_record.message
+    assert _format_condition("delta_price_sigma_mult", metrics, trig) in debug_record.message
+    assert _format_condition("upper_wick_body_ratio", metrics, trig) in debug_record.message


### PR DESCRIPTION
## Summary
- Enhance `SignalEngine.on_minute_close` to include metric values and thresholds in partial trigger logs
- Add helper to format trigger conditions and updated log messages
- Test logging output for partially met trigger conditions

## Testing
- `pytest -q`
- Manual execution of `SignalEngine.on_minute_close` demonstrating log output

------
https://chatgpt.com/codex/tasks/task_e_68c5557dbe508320a1401f743e3d4e5a