### PR TITLE
Throttle repeated anomaly logs

### DIFF
--- a/domain/services/signal_engine.py
+++ b/domain/services/signal_engine.py
@@ -83,6 +83,8 @@ class SignalEngine:
         # ``SignalEngine`` needs access to the registry in order to retrieve
         # the latest metrics for every symbol.
         self._registry = registry
+        # track last time a partial anomaly was logged for each symbol
+        self._last_partial_log: dict[str, float] = {}
 
     def on_minute_close(self, symbol: str) -> S.PumpSignal | None:
         """Evaluate minute metrics and possibly emit a pump signal."""
@@ -92,7 +94,8 @@ class SignalEngine:
             state = self._registry.get(symbol)
             metrics = state.metrics
 
-            now_ms = int(time.time() * 1000)
+            now = time.time()
+            now_ms = int(now * 1000)
             if now_ms - metrics.end_ts >= 60_000:
                 metrics.delta_price_abs_pct = 0.0
                 self._registry.update(symbol, state)
@@ -107,11 +110,16 @@ class SignalEngine:
                     info_met = [c for c in met if c in {"delta_price_abs_pct", "z_px"}]
                     debug_met = [c for c in met if c not in {"delta_price_abs_pct", "z_px"}]
                     if info_met:
-                        logger.info(
-                            "%s: частичная аномалия — выполнены условия %s",
-                            symbol,
-                            ", ".join(_format_condition(c, metrics, trig) for c in info_met),
-                        )
+                        last = self._last_partial_log.get(symbol, 0.0)
+                        if now - last >= 60:
+                            logger.info(
+                                "%s: частичная аномалия — выполнены условия %s",
+                                symbol,
+                                ", ".join(
+                                    _format_condition(c, metrics, trig) for c in info_met
+                                ),
+                            )
+                            self._last_partial_log[symbol] = now
                     if debug_met:
                         logger.debug(
                             "%s: частичная аномалия — выполнены условия %s",

--- a/tests/test_signal_engine_logging.py
+++ b/tests/test_signal_engine_logging.py
@@ -86,3 +86,43 @@ def test_partial_condition_logging(caplog):
     assert _format_condition("z_px", metrics, trig) in info_record.message
     assert _format_condition("delta_price_sigma_mult", metrics, trig) in debug_record.message
     assert _format_condition("upper_wick_body_ratio", metrics, trig) in debug_record.message
+
+
+def test_partial_logging_rate_limit(monkeypatch, caplog):
+    registry = SymbolRegistry()
+    metrics = SymbolMetrics(
+        z_px=2.0,
+        z_vol=0.5,
+        delta_price_sigma_mult=1.1,
+        delta_price_abs_pct=1.2,
+        upper_wick_body_ratio=0.5,
+        end_ts=0,
+    )
+    state = SymbolState(symbol="XYZ", state=BotState.WATCHING, metrics=metrics)
+    registry.put(state)
+
+    engine = SignalEngine(_make_config(), registry)
+
+    current_time = 1_000.0
+
+    def fake_time():
+        return current_time
+
+    monkeypatch.setattr(time, "time", fake_time)
+
+    with caplog.at_level(logging.INFO):
+        metrics.end_ts = int(current_time * 1000)
+        engine.on_minute_close("XYZ")
+        current_time += 30
+        metrics.end_ts = int(current_time * 1000)
+        engine.on_minute_close("XYZ")
+        current_time += 31
+        metrics.end_ts = int(current_time * 1000)
+        engine.on_minute_close("XYZ")
+
+    records = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.INFO and "частичная аномалия" in r.message
+    ]
+    assert len(records) == 2


### PR DESCRIPTION
## Summary
- rate limit partial anomaly logs per symbol to one per minute
- test rate limiting of partial anomaly logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5565bffc88320bbc5204f71fbdd21