### PR TITLE
Refactor pump analyzer for constant config and Excel export

### DIFF
--- a/analysis/pump_analyzer.py
+++ b/analysis/pump_analyzer.py
@@ -1,18 +1,33 @@
-"""CLI for analyzing pump candles across exchanges."""
+"""Utility for analyzing pump candles across exchanges."""
 
 from __future__ import annotations
 
-import argparse
-import csv
 import logging
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from statistics import median
 from typing import List, Sequence
 
+import pandas as pd
 import requests
 
-from config.pump_analysis import PumpAnalysisConfig, load_config
+from config.pump_analysis import PumpAnalysisConfig
+
+
+# Default configuration values are defined as constants to avoid any runtime
+# dependencies on external files, environment variables, or CLI arguments.
+DEFAULT_CONFIG = PumpAnalysisConfig(
+    growth_pct=3.0,
+    wick_pct=0.3,
+    volume_mult=3.0,
+    volume_window=20,
+    rehigh_lookahead=3,
+    atr_window=14,
+)
+
+TP_BARS = 5
+SL_BARS = 5
+EXCHANGES = ["binance", "bybit"]
 
 
 @dataclass
@@ -68,7 +83,7 @@ def fetch_candles(exchange: str, symbol: str, interval: str) -> List[Candle]:
 
     if exchange == "binance":
         url = "https://fapi.binance.com/fapi/v1/klines"
-        params = {"symbol": symbol, "interval": interval, "limit": 200}
+        params = {"symbol": symbol, "interval": interval, "limit": 1500}
         resp = requests.get(url, params=params, timeout=10)
         resp.raise_for_status()
         data = resp.json()
@@ -84,23 +99,42 @@ def fetch_candles(exchange: str, symbol: str, interval: str) -> List[Candle]:
             for c in data
         ]
     if exchange == "bybit":
+        # Bybit API allows fetching up to 1000 candles per request. Loop until
+        # 1500 candles are collected (or data exhausted).
         url = "https://api.bybit.com/v5/market/kline"
-        params = {"category": "linear", "symbol": symbol, "interval": interval, "limit": 200}
-        resp = requests.get(url, params=params, timeout=10)
-        resp.raise_for_status()
-        data = resp.json().get("result", {}).get("list", [])
-        candles = [
-            Candle(
-                open_time=int(c[0]),
-                open=float(c[1]),
-                high=float(c[2]),
-                low=float(c[3]),
-                close=float(c[4]),
-                volume=float(c[5]),
+        limit = 1000
+        params = {
+            "category": "linear",
+            "symbol": symbol,
+            "interval": interval,
+            "limit": limit,
+        }
+        all_candles: List[Candle] = []
+        next_cursor: str | None = None
+        while len(all_candles) < 1500:
+            if next_cursor:
+                params["cursor"] = next_cursor
+            resp = requests.get(url, params=params, timeout=10)
+            resp.raise_for_status()
+            res = resp.json().get("result", {})
+            data = res.get("list", [])
+            next_cursor = res.get("nextPageCursor")
+            all_candles.extend(
+                [
+                    Candle(
+                        open_time=int(c[0]),
+                        open=float(c[1]),
+                        high=float(c[2]),
+                        low=float(c[3]),
+                        close=float(c[4]),
+                        volume=float(c[5]),
+                    )
+                    for c in data
+                ]
             )
-            for c in data
-        ]
-        return sorted(candles, key=lambda c: c.open_time)
+            if not next_cursor or not data:
+                break
+        return sorted(all_candles[:1500], key=lambda c: c.open_time)
     raise ValueError(f"Unsupported exchange: {exchange}")
 
 
@@ -188,7 +222,7 @@ def find_pumps(
         if not (
             pct_gain >= config.growth_pct
             and rel_vol >= config.volume_mult
-            and upper_wick_ratio <= config.wick_pct
+            and upper_wick_ratio >= config.wick_pct
         ):
             continue
         atr = compute_atr(candles, i, config.atr_window)
@@ -238,56 +272,56 @@ def analyze(
     symbols = fetch_symbols(exchange)
     out_dir = Path("data/pump_analysis")
     out_dir.mkdir(parents=True, exist_ok=True)
-    out_file = out_dir / f"{exchange}.csv"
-    fieldnames = list(PumpRecord.__annotations__.keys())
-    with out_file.open("w", newline="") as fh:
-        writer = csv.DictWriter(fh, fieldnames=fieldnames)
-        writer.writeheader()
-        pumps_total = 0
-        for symbol in symbols:
-            total_candles = 0
-            total_pumps = 0
-            for interval in ["1m", "5m"]:
-                candles = fetch_candles(
-                    exchange,
-                    symbol,
-                    interval if exchange == "binance" else interval.strip("m"),
-                )
-                total_candles += len(candles)
-                pumps = find_pumps(candles, config, tp_bars, sl_bars)
-                for pump in pumps:
-                    interval_ms = int(interval.strip("m")) * 60_000
-                    start = pump["timestamp"]
-                    end = start + interval_ms
-                    if exchange == "binance":
-                        liq = fetch_binance_liquidations(symbol, start, end)
-                    elif exchange == "bybit":
-                        liq = fetch_bybit_liquidations(symbol, start, end)
-                    else:  # pragma: no cover - safety
-                        liq = None
-                    record = PumpRecord(
-                        timestamp=pump["timestamp"],
-                        symbol=symbol,
-                        tf=interval,
-                        volume=pump["volume"],
-                        relative_volume=pump["relative_volume"],
-                        atr_mult=pump["atr_mult"],
-                        pct_move=pump["pct_move"],
-                        upper_wick_pct=pump["upper_wick_pct"],
-                        rehigh_hit=pump["rehigh_hit"],
-                        max_tp_pct=pump["max_tp_pct"],
-                        stop_loss_pct=pump["stop_loss_pct"],
-                        liquidation_volume=liq,
-                    )
-                    writer.writerow(asdict(record))
-                    total_pumps += 1
-                    pumps_total += 1
-            logging.info(
-                "Analyzing %s: processed %d candles, found %d pumps",
+    out_file = out_dir / f"{exchange}.xlsx"
+    records: List[dict] = []
+    pumps_total = 0
+    for symbol in symbols:
+        total_candles = 0
+        total_pumps = 0
+        for interval in ["1m", "5m"]:
+            candles = fetch_candles(
+                exchange,
                 symbol,
-                total_candles,
-                total_pumps,
+                interval if exchange == "binance" else interval.strip("m"),
             )
+            total_candles += len(candles)
+            pumps = find_pumps(candles, config, tp_bars, sl_bars)
+            for pump in pumps:
+                interval_ms = int(interval.strip("m")) * 60_000
+                start = pump["timestamp"]
+                end = start + interval_ms
+                if exchange == "binance":
+                    liq = fetch_binance_liquidations(symbol, start, end)
+                elif exchange == "bybit":
+                    liq = fetch_bybit_liquidations(symbol, start, end)
+                else:  # pragma: no cover - safety
+                    liq = None
+                record = PumpRecord(
+                    timestamp=pump["timestamp"],
+                    symbol=symbol,
+                    tf=interval,
+                    volume=pump["volume"],
+                    relative_volume=pump["relative_volume"],
+                    atr_mult=pump["atr_mult"],
+                    pct_move=pump["pct_move"],
+                    upper_wick_pct=pump["upper_wick_pct"],
+                    rehigh_hit=pump["rehigh_hit"],
+                    max_tp_pct=pump["max_tp_pct"],
+                    stop_loss_pct=pump["stop_loss_pct"],
+                    liquidation_volume=liq,
+                )
+                records.append(asdict(record))
+                total_pumps += 1
+                pumps_total += 1
+        logging.info(
+            "Analyzing %s: processed %d candles, found %d pumps",
+            symbol,
+            total_candles,
+            total_pumps,
+        )
+    if records:
+        df = pd.DataFrame(records, columns=list(PumpRecord.__annotations__.keys()))
+        df.to_excel(out_file, index=False)
     logging.info(
         "Processed %d symbols on %s, found %d pump candles",
         len(symbols),
@@ -297,34 +331,11 @@ def analyze(
 
 
 def main() -> None:
-    config = load_config()
-    parser = argparse.ArgumentParser(description="Analyze pump candles for an exchange")
-    parser.add_argument("exchange", choices=["binance", "bybit"], help="Exchange to analyze")
-    parser.add_argument("--pct-gain", type=float, default=config.growth_pct, help="Percent gain threshold")
-    parser.add_argument("--vol-mult", type=float, default=config.volume_mult, help="Volume multiple vs median")
-    parser.add_argument("--wick-pct", type=float, default=config.wick_pct, help="Maximum upper wick ratio")
-    parser.add_argument("--vol-window", type=int, default=config.volume_window, help="Median volume window")
-    parser.add_argument("--re-high-bars", type=int, default=config.rehigh_lookahead, help="Bars to check for re-high")
-    parser.add_argument("--atr-window", type=int, default=config.atr_window, help="ATR calculation window")
-    parser.add_argument("--tp-bars", type=int, default=5, help="Bars to check for take-profit")
-    parser.add_argument("--sl-bars", type=int, default=5, help="Bars to check for stop-loss")
-    args = parser.parse_args()
+    """Run analysis for all supported exchanges using default settings."""
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
-    cfg = PumpAnalysisConfig(
-        growth_pct=args.pct_gain,
-        wick_pct=args.wick_pct,
-        volume_mult=args.vol_mult,
-        volume_window=args.vol_window,
-        rehigh_lookahead=args.re_high_bars,
-        atr_window=args.atr_window,
-    )
-    analyze(
-        args.exchange,
-        cfg,
-        args.tp_bars,
-        args.sl_bars,
-    )
+    for exchange in EXCHANGES:
+        analyze(exchange, DEFAULT_CONFIG, TP_BARS, SL_BARS)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry


### PR DESCRIPTION
## Summary
- Hardcode pump analysis configuration and remove all CLI and env dependencies
- Fetch up to 1500 candles per symbol and require long upper wicks
- Save pump statistics to XLSX with pandas instead of CSV

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6cc9621dc8320ace1dad8411b52ae