### PR TITLE
Extend pump break tracking beyond rehigh lookahead

### DIFF
--- a/analysis/pump_analyzer.py
+++ b/analysis/pump_analyzer.py
@@ -298,9 +298,6 @@ def find_pumps(
             if candles[j].high >= c.high:
                 rehigh_index = j
                 break
-        lookahead_end = (
-            rehigh_index if rehigh_index is not None else i + config.rehigh_lookahead
-        )
         rehigh_hit = rehigh_index is not None
 
         pct_to_low_break = 0.0
@@ -308,7 +305,7 @@ def find_pumps(
         break_direction = 0
         low_cross_recorded = False
         high_cross_recorded = False
-        for j in range(i + 1, lookahead_end + 1):
+        for j in range(i + 1, len(candles)):
             next_candle = candles[j]
             if not low_cross_recorded and next_candle.low <= c.low:
                 if c.close:


### PR DESCRIPTION
## Summary
- allow pump break tracking to iterate through the full remaining candle history
- retain first-touch break direction logic while only limiting rehigh detection to the configured window

## Testing
- pytest *(fails: missing optional dependencies httpx, requests)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1476cb648320bd51f5d668c46076