### PR TITLE
Add typed order execution handling

### DIFF
--- a/domain/models/trading.py
+++ b/domain/models/trading.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+from typing import Any
+
 from .enums import Side, OrderType
 
 
@@ -26,3 +28,26 @@ class PositionPlan:
     tp2_qty: float
     tail_qty: float
     window_high: float
+
+
+@dataclass(frozen=True)
+class OrderExecution:
+    """Execution details returned from a :class:`Trader` implementation."""
+
+    symbol: str
+    order_id: int | None = None
+    status: str | None = None
+    filled_quantity: float | None = None
+    price: float | None = None
+    average_price: float | None = None
+    raw: dict[str, Any] | None = None
+
+    @property
+    def execution_price(self) -> float | None:
+        """Best available execution price derived from exchange response."""
+
+        if self.average_price is not None and self.average_price > 0.0:
+            return self.average_price
+        if self.price is not None and self.price > 0.0:
+            return self.price
+        return None

--- a/domain/ports/trader.py
+++ b/domain/ports/trader.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
-from typing import Protocol, Any
+from typing import Protocol
 
-from domain.models.trading import OrderSpec
+from domain.models.trading import OrderExecution, OrderSpec
 
 
 class Trader(Protocol):
     """Abstract trading interface."""
 
-    async def place(self, order: OrderSpec) -> Any | None:  # pragma: no cover - network
+    async def place(
+        self, order: OrderSpec
+    ) -> OrderExecution | None:  # pragma: no cover - network
         """Place ``order`` on the exchange."""
         raise NotImplementedError
 

--- a/domain/services/trade_manager.py
+++ b/domain/services/trade_manager.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import time
 from dataclasses import replace
-from typing import List, Any
+from typing import List
 
 import logging
 
 import constants
 from domain.models import signals as S
 from domain.models.enums import OrderType, Side
-from domain.models.trading import OrderSpec, PositionPlan
+from domain.models.trading import OrderExecution, OrderSpec, PositionPlan
 from domain.models.state import Position
 
 from .risk_manager import RiskManager
@@ -47,26 +47,18 @@ class TradeManager:
             type=OrderType.MARKET,
             quantity=plan.quantity,
         )
-        result: Any | None = None
+        execution: OrderExecution | None = None
         if side is Side.SHORT:
             logger.info("Открытие шорта %s по %.2f", plan.symbol, plan.entry_price)
         try:
-            result = await self._trader.place(order)
+            execution = await self._trader.place(order)
         except Exception:
             logger.exception("Ошибка open_position %s", plan.symbol)
             self._risk_manager.release(plan)
             raise
         actual_price: float | None = None
-        if result is not None:
-            if isinstance(result, dict):
-                actual_price = result.get("price")
-            else:
-                actual_price = getattr(result, "price", None)
-        if actual_price is None and hasattr(self._trader, "get_price"):
-            try:  # type: ignore[attr-defined]
-                actual_price = await self._trader.get_price(plan.symbol)
-            except Exception:
-                actual_price = None
+        if execution is not None:
+            actual_price = execution.execution_price
         state = self._registry.get(plan.symbol)
         stored_plan = plan if actual_price is None else self._plan(plan, entry_price=actual_price)
         state.position = Position(side=side, plan=stored_plan)

--- a/infrastructure/binance/trader.py
+++ b/infrastructure/binance/trader.py
@@ -11,7 +11,7 @@ import httpx
 from config.credentials import BINANCE
 from constants import BINANCE_FAPI_REST
 from domain.models.enums import OrderType
-from domain.models.trading import OrderSpec
+from domain.models.trading import OrderExecution, OrderSpec
 
 
 class Trader:
@@ -64,7 +64,9 @@ class Trader:
         step_size = Decimal(filters["LOT_SIZE"]["stepSize"])
         return tick_size, step_size
 
-    async def place(self, order: OrderSpec) -> dict[str, Any] | None:  # pragma: no cover - network
+    async def place(
+        self, order: OrderSpec
+    ) -> OrderExecution | None:  # pragma: no cover - network
         """Submit an order to the exchange."""
 
         tick_size, step_size = await self._get_filters(order.symbol)
@@ -87,7 +89,32 @@ class Trader:
 
         response = await self._signed_request("POST", self._ORDER_ENDPOINT, params)
         response.raise_for_status()
-        return response.json()
+        payload = response.json()
+
+        def _as_float(value: Any) -> float | None:
+            try:
+                result = float(value)
+            except (TypeError, ValueError, OverflowError):
+                return None
+            if result == 0.0 and (value is None or value in ("", "0", "0.0")):
+                return None
+            return result
+
+        def _as_int(value: Any) -> int | None:
+            try:
+                return int(value)
+            except (TypeError, ValueError, OverflowError):
+                return None
+
+        return OrderExecution(
+            symbol=payload.get("symbol", order.symbol),
+            order_id=_as_int(payload.get("orderId")),
+            status=payload.get("status"),
+            filled_quantity=_as_float(payload.get("executedQty")),
+            price=_as_float(payload.get("price")),
+            average_price=_as_float(payload.get("avgPrice")),
+            raw=payload,
+        )
 
     async def cancel(
         self, symbol: str, order_id: int | None


### PR DESCRIPTION
## Summary
- add an OrderExecution dataclass to model exchange responses
- update the Trader protocol and Binance adapter to return the typed execution payload
- simplify TradeManager.open_position to depend on the typed execution price only

## Testing
- pytest *(fails: missing optional dependencies httpx, requests)*

------
https://chatgpt.com/codex/tasks/task_e_68cbaf98d4108320a82e23b4a4585941