### PR TITLE
Support long entry direction detection

### DIFF
--- a/app/metrics.py
+++ b/app/metrics.py
@@ -50,10 +50,11 @@ class MetricAggregator:
 
     def _update_candle(
         self, trade: AggTrade, metrics
-    ) -> tuple[float, float, float, bool, bool]:
+    ) -> tuple[float, float, float, bool, bool, bool, bool]:
         price_win = metrics.price_win
         vol_win = metrics.vol_win
         prev_low = metrics.low
+        prev_high = metrics.high
         start_ts = metrics.start_ts
         if trade.timestamp - start_ts >= 60_000 or start_ts == 0:
             start_ts = trade.timestamp
@@ -61,10 +62,12 @@ class MetricAggregator:
             metrics.low = trade.price
             metrics.open = trade.price
             low_break = False
+            high_break = False
         else:
             metrics.high = max(metrics.high, trade.price)
             metrics.low = min(metrics.low, trade.price)
             low_break = prev_low > 0 and trade.price < prev_low
+            high_break = prev_high > 0 and trade.price > prev_high
         metrics.start_ts = start_ts
         metrics.end_ts = trade.timestamp
 
@@ -84,6 +87,7 @@ class MetricAggregator:
             else 0.0
         )
         avwap_loss = total_vol > 0 and trade.price < avwap
+        avwap_gain = total_vol > 0 and trade.price > avwap
 
         std_price = metrics.price_ewma_std
         delta_sigma = rng / std_price if std_price > 0 else 0.0
@@ -91,7 +95,23 @@ class MetricAggregator:
         upper_wick = high - max(metrics.open, trade.price)
         uw_ratio = upper_wick / body if body > 0 else float("inf")
 
-        return delta_sigma, delta_abs, uw_ratio, low_break, avwap_loss
+        return (
+            delta_sigma,
+            delta_abs,
+            uw_ratio,
+            low_break,
+            avwap_loss,
+            high_break,
+            avwap_gain,
+        )
+
+    @staticmethod
+    def _should_enter_short(low_break: bool, avwap_loss: bool) -> bool:
+        return low_break or avwap_loss
+
+    @staticmethod
+    def _should_enter_long(high_break: bool, avwap_gain: bool) -> bool:
+        return high_break or avwap_gain
 
     def _update_entry_flags(
         self,
@@ -104,6 +124,8 @@ class MetricAggregator:
         upper_wick_ratio: float,
         low_break: bool,
         avwap_loss: bool,
+        high_break: bool,
+        avwap_gain: bool,
     ) -> None:
         metrics.z_px = z_px
         metrics.z_vol = z_vol
@@ -113,12 +135,17 @@ class MetricAggregator:
         metrics.last_price = trade.price
         metrics.low_break = low_break
         metrics.avwap_loss = avwap_loss
-        if low_break or avwap_loss:
+        metrics.high_break = high_break
+        metrics.avwap_gain = avwap_gain
+
+        metrics.entry_price = 0.0
+        metrics.direction = None
+        if self._should_enter_short(low_break, avwap_loss):
             metrics.entry_price = trade.price
             metrics.direction = Side.SHORT
-        else:
-            metrics.entry_price = 0.0
-            metrics.direction = None
+        elif self._should_enter_long(high_break, avwap_gain):
+            metrics.entry_price = trade.price
+            metrics.direction = Side.LONG
 
 
     # ------------------------------------------------------------------
@@ -128,9 +155,15 @@ class MetricAggregator:
         state = self._registry.get(trade.symbol)
         metrics = state.metrics
         z_px, z_vol = self._update_price_volume_metrics(trade, metrics)
-        delta_sigma, delta_abs, uw_ratio, low_break, avwap_loss = self._update_candle(
-            trade, metrics
-        )
+        (
+            delta_sigma,
+            delta_abs,
+            uw_ratio,
+            low_break,
+            avwap_loss,
+            high_break,
+            avwap_gain,
+        ) = self._update_candle(trade, metrics)
         self._update_entry_flags(
             trade,
             metrics,
@@ -141,6 +174,8 @@ class MetricAggregator:
             uw_ratio,
             low_break,
             avwap_loss,
+            high_break,
+            avwap_gain,
         )
 
         self._registry.update(trade.symbol, state)

--- a/domain/models/metrics.py
+++ b/domain/models/metrics.py
@@ -86,5 +86,7 @@ class SymbolMetrics:
     # --- entry helpers --------------------------------------------------
     low_break: bool = False
     avwap_loss: bool = False
+    high_break: bool = False
+    avwap_gain: bool = False
     entry_price: float = 0.0
     direction: Side | None = None

--- a/domain/services/signal_engine.py
+++ b/domain/services/signal_engine.py
@@ -65,13 +65,32 @@ def _format_condition(name: str, metrics: M.SymbolMetrics, trig: TriggerParams) 
     return f"{name} {metric_s} {op} {trig_s}"
 
 
+def _resolve_direction(metrics: M.SymbolMetrics) -> Side | None:
+    if metrics.direction is not None:
+        return metrics.direction
+    if metrics.low_break or metrics.avwap_loss:
+        return Side.SHORT
+    if metrics.high_break or metrics.avwap_gain:
+        return Side.LONG
+    return None
+
+
 def _evaluate_entry(metrics: M.SymbolMetrics, entry_cfg: EntryParams) -> bool:
-    low_break = metrics.low_break
-    avwap_loss = metrics.avwap_loss
+    direction = _resolve_direction(metrics)
+    if direction is Side.LONG:
+        primary_trigger = metrics.high_break
+        secondary_trigger = metrics.avwap_gain
+    else:
+        primary_trigger = metrics.low_break
+        secondary_trigger = metrics.avwap_loss
+
     if entry_cfg.require_both:
-        return low_break and avwap_loss
-    return (entry_cfg.allow_low_break and low_break) or (
-        entry_cfg.allow_avwap_loss and avwap_loss
+        return primary_trigger and secondary_trigger
+
+    allow_primary = entry_cfg.allow_low_break
+    allow_secondary = entry_cfg.allow_avwap_loss
+    return (allow_primary and primary_trigger) or (
+        allow_secondary and secondary_trigger
     )
 
 
@@ -220,17 +239,19 @@ class SignalEngine:
                 logger.info(f"{symbol}: сигнал отклонён — условия входа не выполнены")
                 return None
 
-            direction: Side = (
-                metrics.direction if metrics.direction is not None else Side.SHORT
-            )
+            direction = _resolve_direction(metrics)
+            if direction is None:
+                logger.info(f"{symbol}: сигнал отклонён — направление не определено")
+                return None
 
             if metrics.entry_price > 0:
                 price = metrics.entry_price
             else:
-                if direction is Side.SHORT:
-                    price = metrics.best_bid or window.low
-                else:
-                    price = metrics.best_ask or window.high
+                price = (
+                    metrics.best_bid or window.low
+                    if direction is Side.SHORT
+                    else metrics.best_ask or window.high
+                )
 
             return S.EntrySignal(symbol=symbol, side=direction, price=price)
         except Exception:

--- a/domain/services/trade_manager.py
+++ b/domain/services/trade_manager.py
@@ -50,6 +50,8 @@ class TradeManager:
         result: Any | None = None
         if side is Side.SHORT:
             logger.info("Открытие шорта %s по %.2f", plan.symbol, plan.entry_price)
+        else:
+            logger.info("Открытие лонга %s по %.2f", plan.symbol, plan.entry_price)
         try:
             result = await self._trader.place(order)
         except Exception:


### PR DESCRIPTION
## Summary
- extend `MetricAggregator` to mirror the long-side entry conditions and set both direction and entry price
- add long trigger fields to symbol metrics and update `SignalEngine` to infer direction-specific entry prices
- update trade manager logging so long entries are reported distinctly

## Testing
- pytest *(fails: tests/test_pump_analyzer_tp_sl.py::test_tp_sl_calculation - KeyError: 'max_tp_pct')*


------
https://chatgpt.com/codex/tasks/task_e_68cbaf8413248320a5af5966dcd52a11