### PR TITLE
Add side-aware plan calculations in risk manager

### DIFF
--- a/app/state_handlers/idle_watching.py
+++ b/app/state_handlers/idle_watching.py
@@ -62,7 +62,9 @@ class IdleWatchingHandler:
             logger.info(f"{symbol}: сигнал отклонён — условия входа")
             return
 
-        plan = await self._risk_manager.build_plan(symbol, entry.price, pump.window)
+        plan = await self._risk_manager.build_plan(
+            symbol, entry.price, pump.window, entry.side
+        )
         if plan is None or not self._risk_manager.allow_trade(plan):
             logger.info(f"{symbol}: сигнал отклонён — риски превышены")
             return

--- a/domain/models/trading.py
+++ b/domain/models/trading.py
@@ -26,3 +26,4 @@ class PositionPlan:
     tp2_qty: float
     tail_qty: float
     window_high: float
+    window_low: float

--- a/domain/services/risk_manager.py
+++ b/domain/services/risk_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from decimal import Decimal, ROUND_DOWN
 
 import httpx
@@ -9,6 +10,7 @@ from constants import BINANCE_FAPI_REST
 from domain.models import metrics as M
 from domain.models.config import ProfileConfig, RiskParams
 from domain.models.trading import PositionPlan
+from domain.models.enums import Side
 from domain.ports.trader import Trader as TraderPort
 
 logger = logging.getLogger(__name__)
@@ -40,7 +42,11 @@ class RiskManager:
         )
 
     async def build_plan(
-        self, symbol: str, entry_price: float, window: M.PumpWindow
+        self,
+        symbol: str,
+        entry_price: float,
+        window: M.PumpWindow,
+        side: Side,
     ) -> PositionPlan | None:
         try:
             filters = await self._get_symbol_filters(symbol)
@@ -48,23 +54,51 @@ class RiskManager:
             tick_size = Decimal(filters["PRICE_FILTER"]["tickSize"])
 
             risk = self._cfg.risk
-            range_pct = (window.high - window.low) / window.low
-            stop_loss = self._round(
-                self._calc_stop_loss(window.high, range_pct, risk), tick_size
+            context = _PlanContext(
+                side=side,
+                entry_price=entry_price,
+                window_high=window.high,
+                window_low=window.low,
             )
-            take_profit1, take_profit2, tp_total_pct = self._calc_take_profits(
-                entry_price, risk
-            )
+            range_pct = context.calc_range_pct()
+            if side is Side.SHORT:
+                stop_loss = self._calc_stop_loss_short(context, range_pct, risk)
+                (
+                    take_profit1,
+                    take_profit2,
+                    tp_total_pct,
+                ) = self._calc_take_profits_short(context, risk)
+                trail_start, trail_distance = self._calc_trailing_short(
+                    context, range_pct, risk, tp_total_pct
+                )
+                (
+                    quantity,
+                    tp1_qty,
+                    tp2_qty,
+                    tail_qty,
+                ) = self._calc_quantities_short(context, risk)
+            else:
+                stop_loss = self._calc_stop_loss_long(context, range_pct, risk)
+                (
+                    take_profit1,
+                    take_profit2,
+                    tp_total_pct,
+                ) = self._calc_take_profits_long(context, risk)
+                trail_start, trail_distance = self._calc_trailing_long(
+                    context, range_pct, risk, tp_total_pct
+                )
+                (
+                    quantity,
+                    tp1_qty,
+                    tp2_qty,
+                    tail_qty,
+                ) = self._calc_quantities_long(context, risk)
+
+            stop_loss = self._round(stop_loss, tick_size)
             take_profit1 = self._round(take_profit1, tick_size)
             take_profit2 = self._round(take_profit2, tick_size)
-            trail_start, trail_distance = self._calc_trailing(
-                entry_price, range_pct, risk, tp_total_pct
-            )
             trail_start = self._round(trail_start, tick_size)
             trail_distance = self._round(trail_distance, tick_size)
-            quantity, tp1_qty, tp2_qty, tail_qty = self._calc_quantities(
-                entry_price, risk
-            )
             quantity = self._round(quantity, step_size)
             tp1_qty = self._round(tp1_qty, step_size)
             tp2_qty = self._round(tp2_qty, step_size)
@@ -94,47 +128,97 @@ class RiskManager:
                 tp2_qty=tp2_qty,
                 tail_qty=tail_qty,
                 window_high=window.high,
+                window_low=window.low,
             )
         except Exception:
             logger.exception("Ошибка build_plan %s", symbol)
             return None
 
-    def _calc_stop_loss(
-        self, high: float, range_pct: float, risk: RiskParams
+    def _calc_stop_loss_short(
+        self, context: "_PlanContext", range_pct: float, risk: RiskParams
     ) -> float:
-        stop_abs = high * (risk.stop_abs_pct / 100.0)
-        sigma_stop = high * (risk.stop_sigma_mult * range_pct)
-        return high + max(stop_abs, sigma_stop)
+        return self._calc_stop_loss_common(context, range_pct, risk)
 
-    def _calc_take_profits(
-        self, entry_price: float, risk: RiskParams
+    def _calc_stop_loss_long(
+        self, context: "_PlanContext", range_pct: float, risk: RiskParams
+    ) -> float:
+        return self._calc_stop_loss_common(context, range_pct, risk)
+
+    def _calc_take_profits_short(
+        self, context: "_PlanContext", risk: RiskParams
+    ) -> tuple[float, float, float]:
+        return self._calc_take_profits_common(context, risk)
+
+    def _calc_take_profits_long(
+        self, context: "_PlanContext", risk: RiskParams
+    ) -> tuple[float, float, float]:
+        return self._calc_take_profits_common(context, risk)
+
+    def _calc_trailing_short(
+        self,
+        context: "_PlanContext",
+        range_pct: float,
+        risk: RiskParams,
+        tp_total_pct: float,
+    ) -> tuple[float, float]:
+        return self._calc_trailing_common(context, range_pct, risk, tp_total_pct)
+
+    def _calc_trailing_long(
+        self,
+        context: "_PlanContext",
+        range_pct: float,
+        risk: RiskParams,
+        tp_total_pct: float,
+    ) -> tuple[float, float]:
+        return self._calc_trailing_common(context, range_pct, risk, tp_total_pct)
+
+    def _calc_quantities_short(
+        self, context: "_PlanContext", risk: RiskParams
+    ) -> tuple[float, float, float, float]:
+        return self._calc_quantities_common(context, risk)
+
+    def _calc_quantities_long(
+        self, context: "_PlanContext", risk: RiskParams
+    ) -> tuple[float, float, float, float]:
+        return self._calc_quantities_common(context, risk)
+
+    def _calc_stop_loss_common(
+        self, context: "_PlanContext", range_pct: float, risk: RiskParams
+    ) -> float:
+        base = context.stop_reference
+        stop_abs = base * (risk.stop_abs_pct / 100.0)
+        sigma_stop = base * (risk.stop_sigma_mult * range_pct)
+        return context.offset_from_reference(max(stop_abs, sigma_stop))
+
+    def _calc_take_profits_common(
+        self, context: "_PlanContext", risk: RiskParams
     ) -> tuple[float, float, float]:
         tp1_pct = risk.tp1_pct / 100.0
         tp2_pct = risk.tp2_pct / 100.0
         tp_total_pct = tp1_pct + tp2_pct
-        take_profit1 = entry_price * (1.0 - tp1_pct)
-        take_profit2 = entry_price * (1.0 - tp_total_pct)
+        take_profit1 = context.apply_entry_pct(tp1_pct)
+        take_profit2 = context.apply_entry_pct(tp_total_pct)
         return take_profit1, take_profit2, tp_total_pct
 
-    def _calc_trailing(
+    def _calc_trailing_common(
         self,
-        entry_price: float,
+        context: "_PlanContext",
         range_pct: float,
         risk: RiskParams,
         tp_total_pct: float,
     ) -> tuple[float, float]:
         tail_pct = risk.tail_pct / 100.0
         trail_start_pct = tp_total_pct + tail_pct
-        trail_start = entry_price * (1.0 - trail_start_pct)
-        trail_distance = entry_price * max(
+        trail_start = context.apply_entry_pct(trail_start_pct)
+        trail_distance = context.entry_price * max(
             risk.trail_abs_pct / 100.0, range_pct * risk.trail_sigma_mult
         )
         return trail_start, trail_distance
 
-    def _calc_quantities(
-        self, entry_price: float, risk: RiskParams
+    def _calc_quantities_common(
+        self, context: "_PlanContext", risk: RiskParams
     ) -> tuple[float, float, float, float]:
-        quantity = self._risk_per_trade_usdt / entry_price
+        quantity = self._risk_per_trade_usdt / context.entry_price
         tp1_pct = risk.tp1_pct / 100.0
         tp2_pct = risk.tp2_pct / 100.0
         tail_pct = risk.tail_pct / 100.0
@@ -201,3 +285,32 @@ class RiskManager:
             self._open_risk_usdt = max(0.0, self._open_risk_usdt - margin)
         except Exception:
             logger.exception("Ошибка release %s", plan.symbol)
+
+
+@dataclass(frozen=True)
+class _PlanContext:
+    side: Side
+    entry_price: float
+    window_high: float
+    window_low: float
+
+    def calc_range_pct(self) -> float:
+        base = self.stop_reference
+        if base == 0.0:
+            return 0.0
+        return (self.window_high - self.window_low) / base
+
+    @property
+    def stop_reference(self) -> float:
+        return self.window_high if self.side is Side.SHORT else self.window_low
+
+    def apply_entry_pct(self, pct: float) -> float:
+        if self.side is Side.SHORT:
+            return self.entry_price * (1.0 - pct)
+        return self.entry_price * (1.0 + pct)
+
+    def offset_from_reference(self, offset: float) -> float:
+        reference = self.stop_reference
+        if self.side is Side.SHORT:
+            return reference + offset
+        return reference - offset

--- a/domain/services/trade_manager.py
+++ b/domain/services/trade_manager.py
@@ -143,8 +143,18 @@ class TradeManager:
                 state.last_signal_ts is not None
                 and time.time() - state.last_signal_ts > constants.TRADE_INVALIDATION_SEC
             )
-            price_invalid = side is Side.SHORT and (
-                current_price > plan.entry_price or current_price > plan.window_high
+            price_invalid = (
+                (side is Side.SHORT and (
+                    current_price > plan.entry_price
+                    or current_price > plan.window_high
+                ))
+                or (
+                    side is Side.LONG
+                    and (
+                        current_price < plan.entry_price
+                        or current_price < plan.window_low
+                    )
+                )
             )
             if timed_out or price_invalid:
                 exits.append(S.ExitSignal(symbol=plan.symbol, reason="INVALIDATED"))


### PR DESCRIPTION
## Summary
- refactor risk plan building so RiskManager routes through side-specific helpers backed by a shared dataclass context
- compute long-position stops, take profits, trailing levels, and quantities with mirrored formulas and round the results
- include window bounds on PositionPlan, update invalidation logic, and pass the trade side when building plans

## Testing
- pytest *(fails: tests/test_pump_analyzer_tp_sl.py::test_tp_sl_calculation – KeyError: 'max_tp_pct')*

------
https://chatgpt.com/codex/tasks/task_e_68cbaf8754d083208eee1641fc172e6f