### PR TITLE
Add SQLite trade logging for TradeManager operations

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import signal
+from pathlib import Path
 from typing import Awaitable, Callable, Literal
 
 from domain.models.enums import BotState
@@ -18,6 +19,7 @@ from infrastructure.binance.rest_client import RestClient
 from infrastructure.binance.ws_client import WsClient
 from infrastructure.binance.trader import Trader
 from config.credentials import TELEGRAM
+from trade_log import SQLiteTradeLog
 from constants import TASK_MAX_RESTARTS, TASK_RESTART_DELAY_SEC
 
 from .ws import ws_stream
@@ -101,8 +103,13 @@ async def run(
         else TELEGRAM.events_bot_token
     )
     notifier = NotificationService(TelegramClient(token, TELEGRAM.chat_id))
+    trade_log_repo = SQLiteTradeLog(Path("data/runtime/trades.db"))
     trade_manager = TradeManager(
-        trader, risk_manager, registry, notifier if notification_type == "orders" else None
+        trader,
+        risk_manager,
+        registry,
+        notifier if notification_type == "orders" else None,
+        trade_log=trade_log_repo,
     )
 
     pollers = [
@@ -218,4 +225,5 @@ async def run(
         await rest.aclose()
         await ws.close()
         await risk_manager.aclose()
+        trade_log_repo.close()
         logger.info("Orchestrator stopped")

--- a/domain/services/trade_manager.py
+++ b/domain/services/trade_manager.py
@@ -15,6 +15,7 @@ from domain.models.state import Position
 from .risk_manager import RiskManager
 from domain.services.symbol_registry import SymbolRegistry
 from domain.ports.trader import Trader
+from trade_log import TradeLogRepository, TradeRecord
 from .notification import NotificationService
 
 
@@ -30,11 +31,43 @@ class TradeManager:
         risk_manager: RiskManager,
         registry: SymbolRegistry,
         notifier: NotificationService | None = None,
+        trade_log: TradeLogRepository | None = None,
     ) -> None:
         self._trader = trader
         self._risk_manager = risk_manager
         self._registry = registry
         self._notifier = notifier
+        self._trade_log = trade_log
+
+    def _log_trade(
+        self,
+        *,
+        symbol: str,
+        side: Side,
+        outcome: str,
+        price: float | None,
+        quantity: float,
+        take_profit: float | None = None,
+        stop_loss: float | None = None,
+        fees: float | None = None,
+    ) -> None:
+        if self._trade_log is None:
+            return
+        try:
+            record = TradeRecord(
+                timestamp=time.time(),
+                symbol=symbol,
+                side=side,
+                outcome=outcome,
+                entry=price,
+                take_profit=take_profit,
+                stop_loss=stop_loss,
+                quantity=quantity,
+                fees=fees,
+            )
+            self._trade_log.append(record)
+        except Exception:
+            logger.exception("Ошибка записи сделки %s", symbol)
 
     @staticmethod
     def _plan(plan: PositionPlan, **changes: float) -> PositionPlan:
@@ -66,13 +99,36 @@ class TradeManager:
         state.position = Position(side=side, plan=stored_plan)
         state.last_signal_ts = time.time()
         self._registry.update(plan.symbol, state)
+        self._log_trade(
+            symbol=stored_plan.symbol,
+            side=side,
+            outcome="OPEN",
+            price=actual_price if actual_price is not None else stored_plan.entry_price,
+            quantity=stored_plan.quantity,
+            take_profit=
+            (
+                stored_plan.take_profit1
+                if stored_plan.take_profit1 > 0.0
+                else stored_plan.take_profit2 if stored_plan.take_profit2 > 0.0 else None
+            ),
+            stop_loss=stored_plan.stop_loss,
+            fees=0.0,
+        )
         if self._notifier:
             try:
                 await self._notifier.notify_order_open(plan, side, actual_price)
             except Exception:
                 logger.exception("Ошибка Telegram-уведомления")
 
-    async def _close_position(self, symbol: str, side: Side, plan: PositionPlan) -> None:
+    async def _close_position(
+        self,
+        symbol: str,
+        side: Side,
+        plan: PositionPlan,
+        *,
+        outcome: str,
+        price: float | None,
+    ) -> None:
         exit_side = Side.LONG if side is Side.SHORT else Side.SHORT
         order = OrderSpec(
             symbol=plan.symbol,
@@ -86,6 +142,21 @@ class TradeManager:
             logger.exception("Ошибка _close_position %s", symbol)
             raise
         self._risk_manager.release(plan)
+        self._log_trade(
+            symbol=plan.symbol,
+            side=side,
+            outcome=outcome,
+            price=price,
+            quantity=plan.quantity,
+            take_profit=
+            (
+                plan.take_profit1
+                if plan.take_profit1 > 0.0
+                else plan.take_profit2 if plan.take_profit2 > 0.0 else None
+            ),
+            stop_loss=plan.stop_loss,
+            fees=0.0,
+        )
         state = self._registry.get(symbol)
         state.position = None
         self._registry.update(symbol, state)
@@ -126,7 +197,13 @@ class TradeManager:
                 metrics.delta_oi_pct > 0.0 or taker_ratio > 1.0
             ):
                 exits.append(S.ExitSignal(symbol=plan.symbol, reason="LONGS_RETURNED"))
-                await self._close_position(plan.symbol, side, plan)
+                await self._close_position(
+                    plan.symbol,
+                    side,
+                    plan,
+                    outcome="LONGS_RETURNED",
+                    price=current_price,
+                )
                 return exits, None
 
             exits, plan = await self._check_stop(plan, side, current_price)
@@ -142,7 +219,13 @@ class TradeManager:
             )
             if timed_out or price_invalid:
                 exits.append(S.ExitSignal(symbol=plan.symbol, reason="INVALIDATED"))
-                await self._close_position(plan.symbol, side, plan)
+                await self._close_position(
+                    plan.symbol,
+                    side,
+                    plan,
+                    outcome="INVALIDATED",
+                    price=current_price,
+                )
                 return exits, None
 
             return exits, plan
@@ -177,6 +260,16 @@ class TradeManager:
             logger.exception("Ошибка TP1 %s", plan.symbol)
             raise
         self._risk_manager.release(replace(plan, quantity=plan.tp1_qty))
+        self._log_trade(
+            symbol=plan.symbol,
+            side=side,
+            outcome="TP1",
+            price=price,
+            quantity=plan.tp1_qty,
+            take_profit=plan.take_profit1 if plan.take_profit1 > 0.0 else None,
+            stop_loss=plan.stop_loss,
+            fees=0.0,
+        )
         new_plan = self._plan(
             plan,
             take_profit1=0.0,
@@ -219,6 +312,16 @@ class TradeManager:
             logger.exception("Ошибка TP2 %s", plan.symbol)
             raise
         self._risk_manager.release(replace(plan, quantity=plan.tp2_qty))
+        self._log_trade(
+            symbol=plan.symbol,
+            side=side,
+            outcome="TP2",
+            price=price,
+            quantity=plan.tp2_qty,
+            take_profit=plan.take_profit2 if plan.take_profit2 > 0.0 else None,
+            stop_loss=plan.stop_loss,
+            fees=0.0,
+        )
         remaining_qty = plan.quantity - plan.tp2_qty
         if remaining_qty <= 0.0:
             state = self._registry.get(plan.symbol)
@@ -291,7 +394,13 @@ class TradeManager:
             reason = "TRAIL" if trailing_active else "STOP"
             exits.append(S.ExitSignal(symbol=plan.symbol, reason=reason))
             logger.info("stop %s %.2f", plan.symbol, price)
-            await self._close_position(plan.symbol, side, plan)
+            await self._close_position(
+                plan.symbol,
+                side,
+                plan,
+                outcome=reason,
+                price=price,
+            )
             if self._notifier:
                 try:
                     await self._notifier.notify_stop(plan, side, price, 0.0)

--- a/trade_log/__init__.py
+++ b/trade_log/__init__.py
@@ -1,0 +1,11 @@
+"""Trade logging components."""
+
+from .models import TradeRecord
+from .repository import TradeLogRepository
+from .sqlite_repository import SQLiteTradeLog
+
+__all__ = [
+    "TradeRecord",
+    "TradeLogRepository",
+    "SQLiteTradeLog",
+]

--- a/trade_log/models.py
+++ b/trade_log/models.py
@@ -1,0 +1,23 @@
+"""Domain models for trade logging."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from domain.models.enums import Side
+
+
+@dataclass(frozen=True, slots=True)
+class TradeRecord:
+    """A persisted snapshot of a trade event."""
+
+    timestamp: float
+    symbol: str
+    side: Side
+    outcome: str
+    entry: Optional[float]
+    take_profit: Optional[float]
+    stop_loss: Optional[float]
+    quantity: Optional[float]
+    fees: Optional[float]

--- a/trade_log/repository.py
+++ b/trade_log/repository.py
@@ -1,0 +1,17 @@
+"""Repository protocol for persisting trade records."""
+
+from __future__ import annotations
+
+from typing import Protocol, Sequence
+
+from .models import TradeRecord
+
+
+class TradeLogRepository(Protocol):
+    """Persistence interface for trade records."""
+
+    def append(self, record: TradeRecord) -> None:
+        """Persist a single trade record."""
+
+    def fetch_all(self) -> Sequence[TradeRecord]:
+        """Return the stored trade records in chronological order."""

--- a/trade_log/sqlite_repository.py
+++ b/trade_log/sqlite_repository.py
@@ -1,0 +1,105 @@
+"""SQLite-backed trade log repository."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Sequence
+
+from domain.models.enums import Side
+
+from .models import TradeRecord
+from .repository import TradeLogRepository
+
+
+class SQLiteTradeLog(TradeLogRepository):
+    """Persist :class:`TradeRecord` entries inside a SQLite database."""
+
+    def __init__(self, db_path: str | Path = Path("data/runtime/trades.db")) -> None:
+        path = Path(db_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._connection = sqlite3.connect(path, check_same_thread=False)
+        self._connection.row_factory = sqlite3.Row
+        self._ensure_schema()
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+
+        self._connection.close()
+
+    def append(self, record: TradeRecord) -> None:
+        """Persist a single trade record atomically."""
+
+        with self._connection:  # ensures atomic transaction
+            self._connection.execute(
+                """
+                INSERT INTO trade_records (
+                    timestamp,
+                    symbol,
+                    side,
+                    outcome,
+                    entry,
+                    take_profit,
+                    stop_loss,
+                    quantity,
+                    fees
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.timestamp,
+                    record.symbol,
+                    record.side.value,
+                    record.outcome,
+                    record.entry,
+                    record.take_profit,
+                    record.stop_loss,
+                    record.quantity,
+                    record.fees,
+                ),
+            )
+
+    def fetch_all(self) -> Sequence[TradeRecord]:
+        """Return stored trade history ordered by insertion time."""
+
+        cursor = self._connection.execute(
+            """
+            SELECT timestamp, symbol, side, outcome, entry, take_profit, stop_loss, quantity, fees
+            FROM trade_records
+            ORDER BY timestamp ASC, rowid ASC
+            """
+        )
+        rows = cursor.fetchall()
+        return [
+            TradeRecord(
+                timestamp=row["timestamp"],
+                symbol=row["symbol"],
+                side=Side(row["side"]),
+                outcome=row["outcome"],
+                entry=row["entry"],
+                take_profit=row["take_profit"],
+                stop_loss=row["stop_loss"],
+                quantity=row["quantity"],
+                fees=row["fees"],
+            )
+            for row in rows
+        ]
+
+    def _ensure_schema(self) -> None:
+        with self._connection:
+            self._connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS trade_records (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp REAL NOT NULL,
+                    symbol TEXT NOT NULL,
+                    side TEXT NOT NULL,
+                    outcome TEXT NOT NULL,
+                    entry REAL,
+                    take_profit REAL,
+                    stop_loss REAL,
+                    quantity REAL,
+                    fees REAL
+                )
+                """
+            )


### PR DESCRIPTION
## Summary
- add a `trade_log` package providing a `TradeRecord` dataclass and SQLite-backed repository for trade history persistence
- inject the trade log into the orchestrator and `TradeManager`, recording opens, partial exits, and closures as they occur

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'httpx'; ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68cbb13452bc8320a4ab9fda4703296f