### PR TITLE
feat: scaffold trading bot package

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import signal
 from pathlib import Path
-from typing import Awaitable, Callable, Literal
+from typing import TYPE_CHECKING, Awaitable, Callable, Literal
 
 from domain.models.enums import BotState
 from domain.models.state import GlobalState, SymbolState
@@ -31,6 +31,9 @@ from .pollers import (
 )
 from .state_machine import BotStateMachine
 from .universe import UniverseBuilder
+
+if TYPE_CHECKING:
+    from trading_bot.planning import TradePlanAssembler
 
 logger = logging.getLogger(__name__)
 

--- a/trading_bot/__init__.py
+++ b/trading_bot/__init__.py
@@ -1,0 +1,19 @@
+"""Core trading bot package scaffolding.
+
+This namespace exposes the foundational building blocks required for
+upcoming trading bot orchestration features. The modules currently provide
+strictly-typed stubs so that future work can focus on the business logic
+without restructuring the package layout again.
+"""
+
+from trading_bot import datamodels
+from trading_bot.entry_logic import EntryEvaluator
+from trading_bot.persistence import AbstractPlanRepository
+from trading_bot.planning import TradePlanAssembler
+
+__all__ = [
+    "datamodels",
+    "EntryEvaluator",
+    "AbstractPlanRepository",
+    "TradePlanAssembler",
+]

--- a/trading_bot/datamodels/__init__.py
+++ b/trading_bot/datamodels/__init__.py
@@ -1,0 +1,14 @@
+"""Typed datamodels used by the trading bot orchestration layer."""
+
+from .analyzer import AnalyzerSnapshot
+from .entry import EntryThresholds, EntryTrigger
+from .execution import ExecutionLeg, ExecutionPlan, ExecutionPlanStatus
+
+__all__ = [
+    "AnalyzerSnapshot",
+    "EntryThresholds",
+    "EntryTrigger",
+    "ExecutionLeg",
+    "ExecutionPlan",
+    "ExecutionPlanStatus",
+]

--- a/trading_bot/datamodels/analyzer.py
+++ b/trading_bot/datamodels/analyzer.py
@@ -1,0 +1,32 @@
+"""Datamodels describing analyzer output rows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Mapping
+
+from domain.models.enums import CandleInterval
+
+
+@dataclass(frozen=True, slots=True)
+class AnalyzerSnapshot:
+    """Structured representation of a row returned by the pump analyzer.
+
+    The analyzer that inspects multi-timeframe order flow and liquidation
+    telemetry emits rich rows that historically were represented as loosely
+    typed dictionaries.  The ``AnalyzerSnapshot`` dataclass captures the most
+    relevant metrics in a stable schema so the trading bot orchestration layer
+    can reason about the data without reaching into untyped payloads.
+    """
+
+    symbol: str
+    interval: CandleInterval
+    observed_at: datetime
+    metrics: Mapping[str, float] = field(default_factory=dict)
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    def get_metric(self, name: str) -> float | None:
+        """Return the value for ``name`` if present in :attr:`metrics`."""
+
+        return self.metrics.get(name)

--- a/trading_bot/datamodels/entry.py
+++ b/trading_bot/datamodels/entry.py
@@ -1,0 +1,31 @@
+"""Entry evaluation datamodels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class EntryThresholds:
+    """Quantitative thresholds required for trade entry consideration."""
+
+    min_trend_score: float
+    max_open_interest_delta_pct: float
+    max_taker_ratio: float
+    max_premium_pct: float
+    latency_sec: float
+
+
+@dataclass(frozen=True, slots=True)
+class EntryTrigger:
+    """Outcome of evaluating a snapshot against :class:`EntryThresholds`."""
+
+    meets_trend: bool
+    meets_confirmations: bool
+    rationale: tuple[str, ...]
+
+    @property
+    def is_eligible(self) -> bool:
+        """Whether both trend and confirmation gates were satisfied."""
+
+        return self.meets_trend and self.meets_confirmations

--- a/trading_bot/datamodels/execution.py
+++ b/trading_bot/datamodels/execution.py
@@ -1,0 +1,51 @@
+"""Execution plan datamodels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Iterable
+
+from domain.models.enums import Side
+
+
+class ExecutionPlanStatus(Enum):
+    """Lifecycle states for an :class:`ExecutionPlan`."""
+
+    PENDING = auto()
+    SUBMITTED = auto()
+    FILLED = auto()
+    CANCELLED = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionLeg:
+    """Single order leg that composes an execution plan."""
+
+    side: Side
+    size: float
+    price: float | None
+    order_type: str
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionPlan:
+    """Collection of :class:`ExecutionLeg` describing the target position."""
+
+    legs: tuple[ExecutionLeg, ...]
+    status: ExecutionPlanStatus = ExecutionPlanStatus.PENDING
+
+    def __post_init__(self) -> None:
+        if not self.legs:
+            msg = "ExecutionPlan requires at least one leg"
+            raise ValueError(msg)
+
+    def total_size(self) -> float:
+        """Compute the aggregate order size of the plan."""
+
+        return sum(leg.size for leg in self.legs)
+
+    def iter_legs(self) -> Iterable[ExecutionLeg]:
+        """Yield the plan legs in execution order."""
+
+        return iter(self.legs)

--- a/trading_bot/entry_logic.py
+++ b/trading_bot/entry_logic.py
@@ -1,0 +1,42 @@
+"""Entry evaluation scaffolding."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from trading_bot.datamodels.analyzer import AnalyzerSnapshot
+from trading_bot.datamodels.entry import EntryThresholds, EntryTrigger
+
+
+class ThresholdProvider(Protocol):
+    """Interface describing configuration sources for entry thresholds."""
+
+    def get_thresholds(self, symbol: str) -> EntryThresholds:
+        """Return thresholds that should be applied for ``symbol``."""
+
+
+@dataclass(slots=True)
+class EntryEvaluator:
+    """Evaluate analyzer snapshots against configured entry guardrails.
+
+    Concrete logic will be implemented in subsequent iterations.  The current
+    stub documents the orchestration-facing interface so the wider codebase can
+    reference it without immediately pulling in complex trading logic.
+    """
+
+    threshold_provider: ThresholdProvider
+
+    def evaluate(self, snapshot: AnalyzerSnapshot) -> EntryTrigger:
+        """Evaluate ``snapshot`` and return an :class:`EntryTrigger` result."""
+
+        thresholds = self.threshold_provider.get_thresholds(snapshot.symbol)
+        rationale: tuple[str, ...] = (
+            "entry logic not implemented",
+            f"thresholds: {thresholds}",
+        )
+        return EntryTrigger(
+            meets_trend=False,
+            meets_confirmations=False,
+            rationale=rationale,
+        )

--- a/trading_bot/persistence.py
+++ b/trading_bot/persistence.py
@@ -1,0 +1,40 @@
+"""Persistence adapters for trading bot plans."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from trading_bot.datamodels.execution import ExecutionPlan
+
+
+class AbstractPlanRepository(Protocol):
+    """Repository interface for storing execution plans."""
+
+    def save(self, plan: ExecutionPlan) -> None:
+        """Persist ``plan`` to the underlying storage."""
+
+    def load_latest(self) -> ExecutionPlan | None:
+        """Return the most recently stored plan, if any."""
+
+
+@dataclass(slots=True)
+class FilePlanRepository:
+    """Simple file-based repository implementation stub."""
+
+    path: Path
+
+    def save(self, plan: ExecutionPlan) -> None:  # pragma: no cover - stub
+        """Serialize ``plan`` to :attr:`path`.
+
+        The method intentionally raises :class:`NotImplementedError` until the
+        serialization format is defined by subsequent commits.
+        """
+
+        raise NotImplementedError("FilePlanRepository.save is not implemented yet")
+
+    def load_latest(self) -> ExecutionPlan | None:  # pragma: no cover - stub
+        """Load the latest plan from :attr:`path` if available."""
+
+        raise NotImplementedError("FilePlanRepository.load_latest is not implemented yet")

--- a/trading_bot/planning.py
+++ b/trading_bot/planning.py
@@ -1,0 +1,29 @@
+"""Trade plan assembly scaffolding."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from trading_bot.datamodels.analyzer import AnalyzerSnapshot
+from trading_bot.datamodels.execution import ExecutionPlan
+from trading_bot.datamodels.entry import EntryTrigger
+
+
+class PlanBuilder(Protocol):
+    """Protocol describing a component that can build execution plans."""
+
+    def build(self, snapshot: AnalyzerSnapshot, trigger: EntryTrigger) -> ExecutionPlan:
+        """Produce an execution plan for the given inputs."""
+
+
+@dataclass(slots=True)
+class TradePlanAssembler:
+    """Coordinate entry evaluation results with execution plan generation."""
+
+    builder: PlanBuilder
+
+    def assemble(self, snapshot: AnalyzerSnapshot, trigger: EntryTrigger) -> ExecutionPlan:
+        """Return an execution plan, delegating to the configured ``builder``."""
+
+        return self.builder.build(snapshot, trigger)


### PR DESCRIPTION
## Summary
- introduce a trading_bot package with typed datamodel scaffolding for analyzer output, entry thresholds, and execution plans
- add placeholder entry evaluation, trade plan assembly, and persistence adapters to stage future orchestration work
- prepare the orchestrator for future integration by wiring in TYPE_CHECKING imports without altering runtime behavior

## Testing
- pytest *(fails: missing optional dependencies `httpx` and `requests` in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbb4cf5a308320a3e214d9f0510202