### PR TITLE
Align enums and configs with allowed timeframes

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -118,7 +118,7 @@ async def run_backtest(
         logger.info("Backtest disabled")
         return
     runner = BacktestRunner(selector, tp_sl_service, signal_repo, trade_repo, dedup_policy, window=int(backtest_cfg.get("window", 50)))
-    timeframe = Timeframe(backtest_cfg.get("timeframe", Timeframe.H1.value))
+    timeframe = Timeframe(backtest_cfg.get("timeframe", Timeframe.M15.value))
     limit = int(backtest_cfg.get("limit", 500))
     for symbol in backtest_cfg.get("symbols", []):
         provider = select_provider_for_symbol(providers, symbol, config)

--- a/bot/data/providers/binance.py
+++ b/bot/data/providers/binance.py
@@ -16,7 +16,7 @@ from .base import BaseExchangeProvider
 
 
 class BinanceFuturesProvider(BaseExchangeProvider):
-    exchange = Exchange.BINANCE_FUTURES
+    exchange = Exchange.BINANCE
 
     def __init__(
         self,

--- a/bot/data/providers/bybit.py
+++ b/bot/data/providers/bybit.py
@@ -14,7 +14,7 @@ from .base import BaseExchangeProvider
 
 
 class BybitPerpetualProvider(BaseExchangeProvider):
-    exchange = Exchange.BYBIT_PERPETUAL
+    exchange = Exchange.BYBIT
 
     def __init__(
         self,

--- a/bot/domain/enums.py
+++ b/bot/domain/enums.py
@@ -1,20 +1,18 @@
 from __future__ import annotations
 
-from enum import Enum
+from enum import Enum, IntEnum
 
 
 class Exchange(str, Enum):
-    BINANCE_FUTURES = "binance_futures"
-    BYBIT_PERPETUAL = "bybit_perpetual"
+    BINANCE = "binance"
+    BYBIT = "bybit"
 
 
 class Timeframe(str, Enum):
     M1 = "1m"
+    M3 = "3m"
     M5 = "5m"
     M15 = "15m"
-    H1 = "1h"
-    H4 = "4h"
-    D1 = "1d"
 
 
 class Side(str, Enum):
@@ -22,13 +20,14 @@ class Side(str, Enum):
     SHORT = "short"
 
 
-class BreakDirection(str, Enum):
-    BULLISH = "bullish"
-    BEARISH = "bearish"
+class BreakDirection(IntEnum):
+    NONE = 0
+    LOW_FIRST = -1
+    HIGH_FIRST = 1
 
 
 class TradeStatus(str, Enum):
-    PENDING = "pending"
-    OPEN = "open"
-    CLOSED = "closed"
-    CANCELLED = "cancelled"
+    OPENED = "opened"
+    CLOSED_TP = "closed_tp"
+    CLOSED_SL = "closed_sl"
+    REJECTED = "rejected"

--- a/bot/domain/services/backtest_runner.py
+++ b/bot/domain/services/backtest_runner.py
@@ -59,7 +59,7 @@ class BacktestRunner:
                     exchange=signal.candle.exchange,
                     symbol=signal.candle.symbol,
                     side=signal.side,
-                    status=TradeStatus.CLOSED,
+                    status=TradeStatus.CLOSED_TP,
                     entry_price=signal.candle.close,
                     size=1.0,
                     metadata={"mode": "backtest"},

--- a/bot/domain/services/dedup_policy.py
+++ b/bot/domain/services/dedup_policy.py
@@ -22,7 +22,9 @@ class DeduplicationPolicy:
         self._lock = Lock()
 
     def _make_key(self, signal: Signal) -> str:
-        return f"{signal.candle.symbol}:{signal.side}:{signal.candle.timeframe}:{signal.direction}"
+        return (
+            f"{signal.candle.symbol}:{signal.side}:{signal.candle.timeframe}:{signal.direction.value}"
+        )
 
     def should_accept(self, signal: Signal) -> Tuple[bool, str | None]:
         with self._lock:

--- a/bot/domain/services/live_runner.py
+++ b/bot/domain/services/live_runner.py
@@ -48,7 +48,7 @@ class LiveTradingRunner:
             exchange=signal.candle.exchange,
             symbol=signal.candle.symbol,
             side=signal.side,
-            status=TradeStatus.PENDING,
+            status=TradeStatus.OPENED,
             entry_price=signal.candle.close,
             size=1.0,
             metadata={"mode": "live"},

--- a/bot/domain/services/selector_service.py
+++ b/bot/domain/services/selector_service.py
@@ -21,9 +21,11 @@ class SignalSelectorService:
         self._metrics_service = metrics_service
 
     def _determine_side(self, momentum: float) -> tuple[Side, BreakDirection]:
-        if momentum >= 0:
-            return Side.LONG, BreakDirection.BULLISH
-        return Side.SHORT, BreakDirection.BEARISH
+        if momentum > 0:
+            return Side.LONG, BreakDirection.HIGH_FIRST
+        if momentum < 0:
+            return Side.SHORT, BreakDirection.LOW_FIRST
+        return Side.LONG, BreakDirection.NONE
 
     def select(self, symbol: str, candles: Sequence[Candle], thresholds: Thresholds) -> SelectionResult:
         metrics = self._metrics_service.calculate(candles)

--- a/settings.toml
+++ b/settings.toml
@@ -41,12 +41,12 @@ volume_multiplier = 200000.0
 breakout_threshold = 80.0
 tp_multiplier = 2.5
 sl_multiplier = 1.0
-metadata = { timeframe = "1h" }
+metadata = { timeframe = "15m" }
 
 [backtest]
 enabled = true
 symbols = ["BTCUSDT"]
-timeframe = "1h"
+timeframe = "15m"
 limit = 200
 window = 50
 


### PR DESCRIPTION
## Summary
- update the domain enums for exchanges, timeframes, break directions, and trade statuses and adjust the services to the new names and values
- normalize configuration defaults and overrides to the supported 1m/3m/5m/15m timeframes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbd4f0636883208b4e6d7eabb1b453