### PR TITLE
Refactor trading entities and thresholds

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -12,7 +12,7 @@ from .data.providers.bybit import BybitPerpetualProvider
 from .data.repositories.signal_repository import SignalRepository
 from .data.repositories.trade_repository import TradeRepository
 from .domain.enums import Timeframe
-from .domain.models.entities import Thresholds
+from .domain.models.entities import ThresholdMetric, Thresholds
 from .domain.services.backtest_runner import BacktestRunner
 from .domain.services.dedup_policy import DeduplicationPolicy
 from .domain.services.live_runner import LiveTradingRunner
@@ -51,13 +51,80 @@ def init_providers(config: AppConfig) -> Dict[str, BaseExchangeProvider]:
     return providers
 
 
+def _parse_threshold(raw: Dict[str, object]) -> Thresholds:
+    metrics_raw = raw.get("metrics", []) if isinstance(raw, dict) else []
+    metrics: list[ThresholdMetric] = []
+    if isinstance(metrics_raw, list):
+        for item in metrics_raw:
+            if not isinstance(item, dict):
+                continue
+            name = item.get("name")
+            if not name:
+                continue
+            metrics.append(
+                ThresholdMetric(
+                    name=str(name),
+                    min_value=float(item["min_value"]) if item.get("min_value") is not None else None,
+                    max_value=float(item["max_value"]) if item.get("max_value") is not None else None,
+                    min_abs_value=float(item["min_abs_value"]) if item.get("min_abs_value") is not None else None,
+                )
+            )
+    def _get_float(key: str, fallback: float = 0.0) -> float:
+        if not isinstance(raw, dict):
+            return fallback
+        value = raw.get(key)
+        if value is None:
+            return fallback
+        return float(value)
+
+    def _get_upper_lower(name: str, fallback: float = 0.0) -> float:
+        upper = name.upper()
+        lower = name.lower()
+        return _get_float(upper, _get_float(lower, fallback))
+
+    def _get_bool(key: str, default: bool) -> bool:
+        if not isinstance(raw, dict):
+            return default
+        value = raw.get(key)
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"true", "1", "yes"}:
+                return True
+            if lowered in {"false", "0", "no"}:
+                return False
+        return default
+
+    allow_long = _get_bool("allow_long", True)
+    allow_short = _get_bool("allow_short", True)
+    metadata = raw.get("metadata", {}) if isinstance(raw, dict) else {}
+    if not isinstance(metadata, dict):
+        metadata = {}
+    return Thresholds(
+        s=_get_upper_lower("s"),
+        t=_get_upper_lower("t"),
+        u=_get_upper_lower("u"),
+        v=_get_upper_lower("v"),
+        w=_get_upper_lower("w"),
+        x=_get_upper_lower("x"),
+        y=_get_upper_lower("y"),
+        allow_long=allow_long,
+        allow_short=allow_short,
+        metrics=metrics,
+        metadata=metadata if isinstance(metadata, dict) else {},
+    )
+
+
 def build_thresholds(config: AppConfig) -> Dict[str, Thresholds]:
     raw = config.get("thresholds", {})
+    if not isinstance(raw, dict):
+        return {"default": Thresholds()}
     thresholds: Dict[str, Thresholds] = {}
     default_raw = raw.get("default", {})
-    thresholds["default"] = Thresholds(**default_raw)
+    thresholds["default"] = _parse_threshold(default_raw)
     for symbol, data in raw.get("symbols", {}).items():
-        thresholds[symbol] = Thresholds(**data)
+        thresholds[symbol] = _parse_threshold(data)
     return thresholds
 
 

--- a/bot/data/io/storage.py
+++ b/bot/data/io/storage.py
@@ -4,10 +4,17 @@ import json
 from datetime import datetime
 from pathlib import Path
 from threading import RLock
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from ...domain.enums import BreakDirection, Exchange, Side, Timeframe, TradeStatus
-from ...domain.models.entities import Candle, Signal, Thresholds, Trade
+from ...domain.models.entities import (
+    Candle,
+    Signal,
+    SignalMetric,
+    ThresholdMetric,
+    Thresholds,
+    Trade,
+)
 
 
 class Storage:
@@ -35,6 +42,64 @@ class Storage:
         data[key] = value
         self._dump(data)
 
+    @staticmethod
+    def _to_bool(value: Any, default: bool = True) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"true", "1", "yes"}:
+                return True
+            if lowered in {"false", "0", "no"}:
+                return False
+        return default
+
+    def _deserialize_threshold_metric(self, raw: Dict[str, Any]) -> ThresholdMetric:
+        return ThresholdMetric(
+            name=raw["name"],
+            min_value=float(raw["min_value"]) if raw.get("min_value") is not None else None,
+            max_value=float(raw["max_value"]) if raw.get("max_value") is not None else None,
+            min_abs_value=float(raw["min_abs_value"]) if raw.get("min_abs_value") is not None else None,
+        )
+
+    def _deserialize_thresholds(self, raw: Dict[str, Any]) -> Thresholds:
+        metrics_raw = raw.get("metrics", [])
+        metrics: List[ThresholdMetric] = []
+        if isinstance(metrics_raw, list):
+            for metric_raw in metrics_raw:
+                if isinstance(metric_raw, dict) and "name" in metric_raw:
+                    metrics.append(self._deserialize_threshold_metric(metric_raw))
+        metadata = raw.get("metadata", {})
+        if not isinstance(metadata, dict):
+            metadata = {}
+        return Thresholds(
+            s=float(raw.get("s", 0.0)),
+            t=float(raw.get("t", 0.0)),
+            u=float(raw.get("u", 0.0)),
+            v=float(raw.get("v", 0.0)),
+            w=float(raw.get("w", 0.0)),
+            x=float(raw.get("x", 0.0)),
+            y=float(raw.get("y", 0.0)),
+            allow_long=self._to_bool(raw.get("allow_long", True)),
+            allow_short=self._to_bool(raw.get("allow_short", True)),
+            metrics=metrics,
+            metadata=metadata,
+        )
+
+    def _deserialize_signal_metric(self, raw: Dict[str, Any]) -> SignalMetric:
+        threshold_raw = raw.get("threshold")
+        threshold = (
+            self._deserialize_threshold_metric(threshold_raw)
+            if isinstance(threshold_raw, dict) and "name" in threshold_raw
+            else None
+        )
+        return SignalMetric(
+            name=raw["name"],
+            value=float(raw["value"]),
+            passed=bool(raw.get("passed", False)),
+            threshold=threshold,
+        )
+
     def deserialize_signal(self, raw: Dict[str, Any]) -> Signal:
         candle_raw = raw["candle"]
         candle = Candle(
@@ -49,8 +114,16 @@ class Storage:
             started_at=datetime.fromisoformat(candle_raw["started_at"]),
             closed_at=datetime.fromisoformat(candle_raw["closed_at"]),
         )
-        thresholds_raw = raw["thresholds"]
-        thresholds = Thresholds(**thresholds_raw)
+        thresholds = self._deserialize_thresholds(raw["thresholds"])
+        metrics_raw = raw.get("metrics", [])
+        metrics: List[SignalMetric] = []
+        if isinstance(metrics_raw, list):
+            for metric_raw in metrics_raw:
+                if isinstance(metric_raw, dict) and "name" in metric_raw:
+                    metrics.append(self._deserialize_signal_metric(metric_raw))
+        metadata = raw.get("metadata", {})
+        if not isinstance(metadata, dict):
+            metadata = {}
         return Signal(
             id=raw["id"],
             candle=candle,
@@ -59,10 +132,21 @@ class Storage:
             score=float(raw["score"]),
             triggered_at=datetime.fromisoformat(raw["triggered_at"]),
             thresholds=thresholds,
-            metadata=raw.get("metadata", {}),
+            metrics=metrics,
+            allow_long=self._to_bool(raw.get("allow_long", thresholds.allow_long), thresholds.allow_long),
+            allow_short=self._to_bool(raw.get("allow_short", thresholds.allow_short), thresholds.allow_short),
+            metadata=metadata,
         )
 
     def deserialize_trade(self, raw: Dict[str, Any]) -> Trade:
+        thresholds_snapshot = (
+            self._deserialize_thresholds(raw["thresholds_snapshot"])
+            if raw.get("thresholds_snapshot")
+            else None
+        )
+        metadata = raw.get("metadata", {})
+        if not isinstance(metadata, dict):
+            metadata = {}
         trade = Trade(
             id=raw["id"],
             signal_id=raw["signal_id"],
@@ -77,6 +161,9 @@ class Storage:
             opened_at=datetime.fromisoformat(raw["opened_at"]) if raw.get("opened_at") else None,
             closed_at=datetime.fromisoformat(raw["closed_at"]) if raw.get("closed_at") else None,
             pnl=float(raw["pnl"]) if raw.get("pnl") is not None else None,
-            metadata=raw.get("metadata", {}),
+            allow_long=self._to_bool(raw.get("allow_long", True)),
+            allow_short=self._to_bool(raw.get("allow_short", True)),
+            thresholds_snapshot=thresholds_snapshot,
+            metadata=metadata,
         )
         return trade

--- a/bot/data/repositories/trade_repository.py
+++ b/bot/data/repositories/trade_repository.py
@@ -24,6 +24,8 @@ class TradeRepository:
             data["opened_at"] = trade.opened_at.isoformat()
         if trade.closed_at:
             data["closed_at"] = trade.closed_at.isoformat()
+        if data.get("thresholds_snapshot") is None:
+            data.pop("thresholds_snapshot", None)
         return data
 
     def save(self, trade: Trade) -> None:

--- a/bot/domain/models/entities.py
+++ b/bot/domain/models/entities.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from ..enums import BreakDirection, Exchange, Side, Timeframe, TradeStatus
 
@@ -22,13 +22,34 @@ class Candle:
 
 
 @dataclass(slots=True)
+class ThresholdMetric:
+    name: str
+    min_value: Optional[float] = None
+    max_value: Optional[float] = None
+    min_abs_value: Optional[float] = None
+
+
+@dataclass(slots=True)
 class Thresholds:
-    atr_multiplier: float = 1.0
-    volume_multiplier: float = 1.0
-    breakout_threshold: float = 0.0
-    tp_multiplier: float = 1.5
-    sl_multiplier: float = 1.0
+    s: float = 0.0
+    t: float = 0.0
+    u: float = 0.0
+    v: float = 0.0
+    w: float = 0.0
+    x: float = 0.0
+    y: float = 0.0
+    allow_long: bool = True
+    allow_short: bool = True
+    metrics: List[ThresholdMetric] = field(default_factory=list)
     metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class SignalMetric:
+    name: str
+    value: float
+    passed: bool
+    threshold: Optional[ThresholdMetric] = None
 
 
 @dataclass(slots=True)
@@ -40,6 +61,9 @@ class Signal:
     score: float
     triggered_at: datetime
     thresholds: Thresholds
+    metrics: List[SignalMetric] = field(default_factory=list)
+    allow_long: bool = True
+    allow_short: bool = True
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -58,4 +82,7 @@ class Trade:
     opened_at: Optional[datetime] = None
     closed_at: Optional[datetime] = None
     pnl: Optional[float] = None
+    allow_long: bool = True
+    allow_short: bool = True
+    thresholds_snapshot: Optional[Thresholds] = None
     metadata: Dict[str, Any] = field(default_factory=dict)

--- a/bot/domain/services/backtest_runner.py
+++ b/bot/domain/services/backtest_runner.py
@@ -62,6 +62,9 @@ class BacktestRunner:
                     status=TradeStatus.CLOSED_TP,
                     entry_price=signal.candle.close,
                     size=1.0,
+                    allow_long=signal.allow_long,
+                    allow_short=signal.allow_short,
+                    thresholds_snapshot=signal.thresholds,
                     metadata={"mode": "backtest"},
                 )
                 self._tp_sl_service.assign(signal, trade)

--- a/bot/domain/services/live_runner.py
+++ b/bot/domain/services/live_runner.py
@@ -51,6 +51,9 @@ class LiveTradingRunner:
             status=TradeStatus.OPENED,
             entry_price=signal.candle.close,
             size=1.0,
+            allow_long=signal.allow_long,
+            allow_short=signal.allow_short,
+            thresholds_snapshot=signal.thresholds,
             metadata={"mode": "live"},
         )
         self._tp_sl_service.assign(signal, trade)

--- a/bot/domain/services/metrics_service.py
+++ b/bot/domain/services/metrics_service.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Sequence
+from typing import List, Sequence
 
-from ..models.entities import Candle, Thresholds
+from ..models.entities import Candle, SignalMetric, Thresholds
 from ...utils import math_ops
 
 
@@ -29,10 +29,25 @@ class MetricsService:
         momentum = closes[-1] - closes[-self._momentum_period]
         return Metrics(atr=atr, average_volume=avg_volume, momentum=momentum)
 
-    def passes_thresholds(self, metrics: Metrics, thresholds: Thresholds) -> Dict[str, bool]:
-        conditions = {
-            "atr": metrics.atr >= thresholds.atr_multiplier,
-            "volume": metrics.average_volume >= thresholds.volume_multiplier,
-            "momentum": abs(metrics.momentum) >= thresholds.breakout_threshold,
-        }
-        return conditions
+    def evaluate_thresholds(self, metrics: Metrics, thresholds: Thresholds) -> List[SignalMetric]:
+        evaluations: List[SignalMetric] = []
+        for metric_threshold in thresholds.metrics:
+            value = getattr(metrics, metric_threshold.name, None)
+            if value is None:
+                raise KeyError(f"unknown metric '{metric_threshold.name}'")
+            passed = True
+            if metric_threshold.min_value is not None and value < metric_threshold.min_value:
+                passed = False
+            if metric_threshold.max_value is not None and value > metric_threshold.max_value:
+                passed = False
+            if metric_threshold.min_abs_value is not None and abs(value) < metric_threshold.min_abs_value:
+                passed = False
+            evaluations.append(
+                SignalMetric(
+                    name=metric_threshold.name,
+                    value=value,
+                    passed=passed,
+                    threshold=metric_threshold,
+                )
+            )
+        return evaluations

--- a/bot/domain/services/selector_service.py
+++ b/bot/domain/services/selector_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Iterable, List, Sequence
 
 from ..enums import BreakDirection, Side
@@ -29,11 +29,15 @@ class SignalSelectorService:
 
     def select(self, symbol: str, candles: Sequence[Candle], thresholds: Thresholds) -> SelectionResult:
         metrics = self._metrics_service.calculate(candles)
-        checks = self._metrics_service.passes_thresholds(metrics, thresholds)
-        failed = [name for name, passed in checks.items() if not passed]
+        evaluations = self._metrics_service.evaluate_thresholds(metrics, thresholds)
+        failed = [evaluation.name for evaluation in evaluations if not evaluation.passed]
         if failed:
             return SelectionResult(signals=[], rejected=failed)
         side, direction = self._determine_side(metrics.momentum)
+        if (side == Side.LONG and not thresholds.allow_long) or (
+            side == Side.SHORT and not thresholds.allow_short
+        ):
+            return SelectionResult(signals=[], rejected=["side_not_allowed"])
         signal = Signal(
             id=ids.uuid_str(),
             candle=candles[-1],
@@ -42,9 +46,12 @@ class SignalSelectorService:
             score=abs(metrics.momentum),
             triggered_at=utcnow(),
             thresholds=thresholds,
+            metrics=evaluations,
+            allow_long=thresholds.allow_long,
+            allow_short=thresholds.allow_short,
             metadata={
                 "metrics": metrics.__dict__,
-                "checks": checks,
+                "evaluations": [asdict(evaluation) for evaluation in evaluations],
                 "symbol": symbol,
             },
         )

--- a/bot/domain/services/tp_sl_service.py
+++ b/bot/domain/services/tp_sl_service.py
@@ -19,8 +19,10 @@ class TpSlService:
     def assign(self, signal: Signal, trade: Trade) -> TpSlResult:
         thresholds: Thresholds = signal.thresholds
         atr = signal.metadata.get("metrics", {}).get("atr", 0.0)
-        risk = atr * thresholds.sl_multiplier
-        reward = risk * self._risk_reward_ratio
+        risk_multiplier = thresholds.y or 1.0
+        tp_multiplier = thresholds.x
+        risk = atr * risk_multiplier
+        reward = atr * tp_multiplier if tp_multiplier else risk * self._risk_reward_ratio
         entry_price = trade.entry_price
         if signal.side == Side.LONG:
             tp = entry_price + reward

--- a/settings.toml
+++ b/settings.toml
@@ -29,19 +29,51 @@ rate_limit_per_minute = 600
 min_quote_volume = 250000.0
 
 [thresholds.default]
-atr_multiplier = 50.0
-volume_multiplier = 100000.0
-breakout_threshold = 100.0
-tp_multiplier = 2.0
-sl_multiplier = 1.0
+S = 50.0
+T = 100000.0
+U = 100.0
+V = 0.0
+W = 0.0
+X = 2.0
+Y = 1.0
+allow_long = true
+allow_short = true
+
+[[thresholds.default.metrics]]
+name = "atr"
+min_value = 50.0
+
+[[thresholds.default.metrics]]
+name = "average_volume"
+min_value = 100000.0
+
+[[thresholds.default.metrics]]
+name = "momentum"
+min_abs_value = 100.0
 
 [thresholds.symbols.BTCUSDT]
-atr_multiplier = 25.0
-volume_multiplier = 200000.0
-breakout_threshold = 80.0
-tp_multiplier = 2.5
-sl_multiplier = 1.0
+S = 25.0
+T = 200000.0
+U = 80.0
+V = 0.0
+W = 0.0
+X = 2.5
+Y = 1.0
+allow_long = true
+allow_short = true
 metadata = { timeframe = "15m" }
+
+[[thresholds.symbols.BTCUSDT.metrics]]
+name = "atr"
+min_value = 25.0
+
+[[thresholds.symbols.BTCUSDT.metrics]]
+name = "average_volume"
+min_value = 200000.0
+
+[[thresholds.symbols.BTCUSDT.metrics]]
+name = "momentum"
+min_abs_value = 80.0
 
 [backtest]
 enabled = true


### PR DESCRIPTION
## Summary
- replace trading entities with the new threshold, signal, and trade structures and persist extra metadata in storage
- update services to evaluate metric lists, enforce allowed sides, and snapshot thresholds on generated trades
- extend configuration parsing and sample settings to populate new S–Y fields and per-metric constraints

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68cbd69d98888320aec3b6844fcf36d9