### PR TITLE
Implement extended metrics and breakout entry rules

### DIFF
--- a/bot/domain/services/backtest_runner.py
+++ b/bot/domain/services/backtest_runner.py
@@ -47,7 +47,13 @@ class BacktestRunner:
         generated_trades: list[Trade] = []
         for index in range(self._window, len(candles)):
             window_candles = candles[index - self._window : index]
-            result = self._selector.select(symbol, window_candles, thresholds)
+            future_candles = candles[index :]
+            result = self._selector.select(
+                symbol,
+                window_candles,
+                thresholds,
+                future_candles=future_candles,
+            )
             for signal in result.signals:
                 accepted, key = self._dedup.should_accept(signal)
                 if not accepted:

--- a/bot/domain/services/metrics_service.py
+++ b/bot/domain/services/metrics_service.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Sequence
+from typing import Dict, List, Sequence
 
+from ..enums import BreakDirection
 from ..models.entities import Candle, SignalMetric, Thresholds
 from ...utils import math_ops
 
@@ -12,6 +13,29 @@ class Metrics:
     atr: float
     average_volume: float
     momentum: float
+    pct_move: float
+    relative_volume: float
+    atr_multiple: float
+    upper_wick_pct: float
+    lower_wick_pct: float
+    pct_to_high: float
+    pct_to_low: float
+    break_direction: BreakDirection
+
+    def as_dict(self) -> Dict[str, float]:
+        return {
+            "atr": self.atr,
+            "average_volume": self.average_volume,
+            "momentum": self.momentum,
+            "pct_move": self.pct_move,
+            "relative_volume": self.relative_volume,
+            "atr_multiple": self.atr_multiple,
+            "upper_wick_pct": self.upper_wick_pct,
+            "lower_wick_pct": self.lower_wick_pct,
+            "pct_to_high": self.pct_to_high,
+            "pct_to_low": self.pct_to_low,
+            "break_direction": float(self.break_direction.value),
+        }
 
 
 class MetricsService:
@@ -20,19 +44,74 @@ class MetricsService:
         self._volume_period = volume_period
         self._momentum_period = momentum_period
 
-    def calculate(self, candles: Sequence[Candle]) -> Metrics:
+    def calculate(
+        self, candles: Sequence[Candle], future_candles: Sequence[Candle] | None = None
+    ) -> Metrics:
         if len(candles) < max(self._atr_period, self._volume_period, self._momentum_period):
             raise ValueError("not enough candles to compute metrics")
         atr = math_ops.average_true_range(candles, self._atr_period)
         avg_volume = math_ops.rolling_volume(candles, self._volume_period)
         closes = [c.close for c in candles]
         momentum = closes[-1] - closes[-self._momentum_period]
-        return Metrics(atr=atr, average_volume=avg_volume, momentum=momentum)
+        current = candles[-1]
+        body = current.close - current.open
+        body_abs = abs(body)
+        pct_move = (body / current.open) * 100 if current.open else 0.0
+        relative_volume = current.volume / avg_volume if avg_volume else 0.0
+        atr_multiple = body_abs / atr if atr else 0.0
+        upper_wick = current.high - max(current.open, current.close)
+        lower_wick = min(current.open, current.close) - current.low
+        upper_wick_pct = (upper_wick / body_abs * 100) if body_abs else 0.0
+        lower_wick_pct = (lower_wick / body_abs * 100) if body_abs else 0.0
+
+        future = list(future_candles or [])
+        pct_to_high = float("nan")
+        pct_to_low = float("nan")
+        break_direction = BreakDirection.NONE
+        if future:
+            max_future_high = max(c.high for c in future)
+            min_future_low = min(c.low for c in future)
+            pct_to_high = (
+                (max_future_high - current.close) / current.close * 100
+                if current.close
+                else 0.0
+            )
+            pct_to_low = (
+                (min_future_low - current.close) / current.close * 100
+                if current.close
+                else 0.0
+            )
+            for candle in future:
+                broke_high = candle.high >= current.high
+                broke_low = candle.low <= current.low
+                if broke_high and broke_low:
+                    break_direction = BreakDirection.NONE
+                    break
+                if broke_high:
+                    break_direction = BreakDirection.HIGH_FIRST
+                    break
+                if broke_low:
+                    break_direction = BreakDirection.LOW_FIRST
+                    break
+        return Metrics(
+            atr=atr,
+            average_volume=avg_volume,
+            momentum=momentum,
+            pct_move=pct_move,
+            relative_volume=relative_volume,
+            atr_multiple=atr_multiple,
+            upper_wick_pct=upper_wick_pct,
+            lower_wick_pct=lower_wick_pct,
+            pct_to_high=pct_to_high,
+            pct_to_low=pct_to_low,
+            break_direction=break_direction,
+        )
 
     def evaluate_thresholds(self, metrics: Metrics, thresholds: Thresholds) -> List[SignalMetric]:
+        metrics_map = metrics.as_dict()
         evaluations: List[SignalMetric] = []
         for metric_threshold in thresholds.metrics:
-            value = getattr(metrics, metric_threshold.name, None)
+            value = metrics_map.get(metric_threshold.name)
             if value is None:
                 raise KeyError(f"unknown metric '{metric_threshold.name}'")
             passed = True
@@ -48,6 +127,18 @@ class MetricsService:
                     value=value,
                     passed=passed,
                     threshold=metric_threshold,
+                )
+            )
+        existing_names = {metric.name for metric in evaluations}
+        for name, value in metrics_map.items():
+            if name in existing_names:
+                continue
+            evaluations.append(
+                SignalMetric(
+                    name=name,
+                    value=value,
+                    passed=True,
+                    threshold=None,
                 )
             )
         return evaluations

--- a/bot/domain/services/selector_service.py
+++ b/bot/domain/services/selector_service.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+from math import fabs, isnan
 from typing import Iterable, List, Sequence
 
 from ..enums import BreakDirection, Side
 from ..models.entities import Candle, Signal, Thresholds
-from .metrics_service import MetricsService
+from .metrics_service import Metrics, MetricsService
 from ...utils import ids
 from ...utils.clock import utcnow
 
@@ -20,37 +21,114 @@ class SignalSelectorService:
     def __init__(self, metrics_service: MetricsService) -> None:
         self._metrics_service = metrics_service
 
-    def _determine_side(self, momentum: float) -> tuple[Side, BreakDirection]:
-        if momentum > 0:
-            return Side.LONG, BreakDirection.HIGH_FIRST
-        if momentum < 0:
-            return Side.SHORT, BreakDirection.LOW_FIRST
-        return Side.LONG, BreakDirection.NONE
+    def _evaluate_long_rules(
+        self, metrics: Metrics, thresholds: Thresholds, reasons: List[str]
+    ) -> bool:
+        if not thresholds.allow_long:
+            reasons.append("long_disabled")
+            return False
+        if metrics.pct_move <= 0:
+            reasons.append("long_negative_body")
+            return False
+        if thresholds.s > 0 and metrics.pct_move < thresholds.s:
+            reasons.append("long_pct_move")
+            return False
+        if thresholds.t > 0 and metrics.relative_volume < thresholds.t:
+            reasons.append("long_relative_volume")
+            return False
+        if thresholds.u > 0 and metrics.atr_multiple < thresholds.u:
+            reasons.append("long_atr_mult")
+            return False
+        if thresholds.v > 0 and metrics.upper_wick_pct > thresholds.v:
+            reasons.append("long_upper_wick")
+            return False
+        if thresholds.w > 0 and metrics.lower_wick_pct > thresholds.w:
+            reasons.append("long_lower_wick")
+            return False
+        if thresholds.x > 0 and not isnan(metrics.pct_to_high) and metrics.pct_to_high < thresholds.x:
+            reasons.append("long_pct_to_high")
+            return False
+        if thresholds.y > 0 and not isnan(metrics.pct_to_low) and fabs(metrics.pct_to_low) > thresholds.y:
+            reasons.append("long_pct_to_low")
+            return False
+        return True
 
-    def select(self, symbol: str, candles: Sequence[Candle], thresholds: Thresholds) -> SelectionResult:
-        metrics = self._metrics_service.calculate(candles)
+    def _evaluate_short_rules(
+        self, metrics: Metrics, thresholds: Thresholds, reasons: List[str]
+    ) -> bool:
+        if not thresholds.allow_short:
+            reasons.append("short_disabled")
+            return False
+        if metrics.pct_move >= 0:
+            reasons.append("short_positive_body")
+            return False
+        if thresholds.s > 0 and fabs(metrics.pct_move) < thresholds.s:
+            reasons.append("short_pct_move")
+            return False
+        if thresholds.t > 0 and metrics.relative_volume < thresholds.t:
+            reasons.append("short_relative_volume")
+            return False
+        if thresholds.u > 0 and metrics.atr_multiple < thresholds.u:
+            reasons.append("short_atr_mult")
+            return False
+        if thresholds.v > 0 and metrics.lower_wick_pct > thresholds.v:
+            reasons.append("short_lower_wick")
+            return False
+        if thresholds.w > 0 and metrics.upper_wick_pct > thresholds.w:
+            reasons.append("short_upper_wick")
+            return False
+        if thresholds.x > 0 and not isnan(metrics.pct_to_low) and fabs(metrics.pct_to_low) < thresholds.x:
+            reasons.append("short_pct_to_low")
+            return False
+        if thresholds.y > 0 and not isnan(metrics.pct_to_high) and metrics.pct_to_high > thresholds.y:
+            reasons.append("short_pct_to_high")
+            return False
+        return True
+
+    def select(
+        self,
+        symbol: str,
+        candles: Sequence[Candle],
+        thresholds: Thresholds,
+        future_candles: Sequence[Candle] | None = None,
+    ) -> SelectionResult:
+        metrics = self._metrics_service.calculate(candles, future_candles)
         evaluations = self._metrics_service.evaluate_thresholds(metrics, thresholds)
         failed = [evaluation.name for evaluation in evaluations if not evaluation.passed]
         if failed:
             return SelectionResult(signals=[], rejected=failed)
-        side, direction = self._determine_side(metrics.momentum)
-        if (side == Side.LONG and not thresholds.allow_long) or (
-            side == Side.SHORT and not thresholds.allow_short
-        ):
-            return SelectionResult(signals=[], rejected=["side_not_allowed"])
+        entry_failures: List[str] = []
+        allow_long = self._evaluate_long_rules(metrics, thresholds, entry_failures)
+        allow_short = self._evaluate_short_rules(metrics, thresholds, entry_failures)
+        if not allow_long and not allow_short:
+            return SelectionResult(signals=[], rejected=failed + entry_failures)
+        side: Side | None = None
+        if metrics.pct_move > 0 and allow_long:
+            side = Side.LONG
+        elif metrics.pct_move < 0 and allow_short:
+            side = Side.SHORT
+        elif allow_long:
+            side = Side.LONG
+        elif allow_short:
+            side = Side.SHORT
+        if side is None:
+            return SelectionResult(signals=[], rejected=failed + entry_failures + ["no_side"])
+        direction = metrics.break_direction
+        if direction is BreakDirection.NONE:
+            direction = BreakDirection.HIGH_FIRST if side == Side.LONG else BreakDirection.LOW_FIRST
         signal = Signal(
             id=ids.uuid_str(),
             candle=candles[-1],
             side=side,
             direction=direction,
-            score=abs(metrics.momentum),
+            score=fabs(metrics.pct_move),
             triggered_at=utcnow(),
             thresholds=thresholds,
             metrics=evaluations,
-            allow_long=thresholds.allow_long,
-            allow_short=thresholds.allow_short,
+            allow_long=allow_long,
+            allow_short=allow_short,
             metadata={
-                "metrics": metrics.__dict__,
+                "metrics": metrics.as_dict(),
                 "evaluations": [asdict(evaluation) for evaluation in evaluations],
                 "symbol": symbol,
             },


### PR DESCRIPTION
## Summary
- extend the metrics service to compute pct_move, relative volume, ATR multiple, wick percentages, pct_to_* values and backtest break direction
- surface the expanded metrics in signal metadata/evaluations and drive long/short eligibility using thresholds S–Y while persisting allow_long/allow_short
- during backtests supply future candles for pct_to_* and break direction calculations so the derived values reflect subsequent price action

## Testing
- python -m compileall bot/domain/services

------
https://chatgpt.com/codex/tasks/task_e_68cbdde6f9ec832091bc77199b100dea