### PR TITLE
Update TP/SL assignment and backtest outcomes

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -145,8 +145,7 @@ def init_services(config: AppConfig, storage: Storage) -> tuple[
         momentum_period=int(metrics_cfg.get("momentum_period", 5)),
     )
     selector = SignalSelectorService(metrics_service)
-    tp_sl_cfg = config.get("tp_sl", {})
-    tp_sl_service = TpSlService(risk_reward_ratio=float(tp_sl_cfg.get("risk_reward_ratio", 2.0)))
+    tp_sl_service = TpSlService()
     dedup_cfg = config.get("dedup", {})
     dedup_policy = DeduplicationPolicy(
         ttl_seconds=int(dedup_cfg.get("ttl_seconds", 1800)),

--- a/bot/domain/services/backtest_runner.py
+++ b/bot/domain/services/backtest_runner.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Sequence
 
-from ..enums import TradeStatus
+from ..enums import BreakDirection, Side, TradeStatus
 from ..models.entities import Candle, Signal, Thresholds, Trade
 from ...data.repositories.signal_repository import SignalRepository
 from ...data.repositories.trade_repository import TradeRepository
@@ -59,7 +59,7 @@ class BacktestRunner:
                     exchange=signal.candle.exchange,
                     symbol=signal.candle.symbol,
                     side=signal.side,
-                    status=TradeStatus.CLOSED_TP,
+                    status=TradeStatus.OPENED,
                     entry_price=signal.candle.close,
                     size=1.0,
                     allow_long=signal.allow_long,
@@ -69,10 +69,78 @@ class BacktestRunner:
                 )
                 self._tp_sl_service.assign(signal, trade)
                 trade.opened_at = signal.candle.closed_at
-                trade.closed_at = signal.candle.closed_at
-                trade.pnl = trade.tp_price - trade.entry_price if trade.tp_price else 0.0
+                self._apply_backtest_outcome(signal, trade, candles[index:])
                 self._signals.save(signal)
                 self._trades.save(trade)
                 generated_signals.append(signal)
                 generated_trades.append(trade)
         return BacktestResult(trades=generated_trades, signals=generated_signals)
+
+    def _apply_backtest_outcome(
+        self, signal: Signal, trade: Trade, future_candles: Sequence[Candle]
+    ) -> None:
+        for candle in future_candles:
+            hit_tp, hit_sl = self._check_thresholds(trade, candle)
+            status = self._resolve_trade_status(signal, trade, candle, hit_tp, hit_sl)
+            if status is None:
+                continue
+            trade.status = status
+            trade.closed_at = candle.closed_at
+            exit_price = trade.tp_price if status == TradeStatus.CLOSED_TP else trade.sl_price
+            trade.pnl = self._calculate_pnl(trade, exit_price)
+            return
+
+    def _check_thresholds(self, trade: Trade, candle: Candle) -> tuple[bool, bool]:
+        tp_price = trade.tp_price
+        sl_price = trade.sl_price
+        if tp_price is None or sl_price is None:
+            return False, False
+        if trade.side == Side.LONG:
+            hit_tp = candle.high >= tp_price
+            hit_sl = candle.low <= sl_price
+        else:
+            hit_tp = candle.low <= tp_price
+            hit_sl = candle.high >= sl_price
+        return hit_tp, hit_sl
+
+    def _resolve_trade_status(
+        self,
+        signal: Signal,
+        trade: Trade,
+        candle: Candle,
+        hit_tp: bool,
+        hit_sl: bool,
+    ) -> TradeStatus | None:
+        if not hit_tp and not hit_sl:
+            return None
+        if hit_tp and hit_sl:
+            direction = signal.direction
+            if direction == BreakDirection.HIGH_FIRST:
+                hit_sl = False
+            elif direction == BreakDirection.LOW_FIRST:
+                hit_tp = False
+            else:
+                tp_price = trade.tp_price
+                sl_price = trade.sl_price
+                if trade.side == Side.LONG:
+                    if tp_price is not None and candle.open >= tp_price:
+                        hit_sl = False
+                    elif sl_price is not None and candle.open <= sl_price:
+                        hit_tp = False
+                else:
+                    if tp_price is not None and candle.open <= tp_price:
+                        hit_sl = False
+                    elif sl_price is not None and candle.open >= sl_price:
+                        hit_tp = False
+        if hit_tp:
+            return TradeStatus.CLOSED_TP
+        if hit_sl:
+            return TradeStatus.CLOSED_SL
+        return None
+
+    def _calculate_pnl(self, trade: Trade, exit_price: float | None) -> float | None:
+        if exit_price is None:
+            return None
+        if trade.side == Side.LONG:
+            return exit_price - trade.entry_price
+        return trade.entry_price - exit_price

--- a/bot/domain/services/tp_sl_service.py
+++ b/bot/domain/services/tp_sl_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from ..enums import Side
-from ..models.entities import Signal, Thresholds, Trade
+from ..models.entities import Signal, Trade
 
 
 @dataclass(slots=True)
@@ -13,23 +13,14 @@ class TpSlResult:
 
 
 class TpSlService:
-    def __init__(self, risk_reward_ratio: float) -> None:
-        self._risk_reward_ratio = risk_reward_ratio
-
     def assign(self, signal: Signal, trade: Trade) -> TpSlResult:
-        thresholds: Thresholds = signal.thresholds
-        atr = signal.metadata.get("metrics", {}).get("atr", 0.0)
-        risk_multiplier = thresholds.y or 1.0
-        tp_multiplier = thresholds.x
-        risk = atr * risk_multiplier
-        reward = atr * tp_multiplier if tp_multiplier else risk * self._risk_reward_ratio
-        entry_price = trade.entry_price
+        candle = signal.candle
         if signal.side == Side.LONG:
-            tp = entry_price + reward
-            sl = entry_price - risk
+            tp = candle.high
+            sl = candle.low
         else:
-            tp = entry_price - reward
-            sl = entry_price + risk
+            tp = candle.low
+            sl = candle.high
         trade.tp_price = tp
         trade.sl_price = sl
         return TpSlResult(tp_price=tp, sl_price=sl)

--- a/settings.toml
+++ b/settings.toml
@@ -9,9 +9,6 @@ atr_period = 14
 volume_period = 20
 momentum_period = 5
 
-[tp_sl]
-risk_reward_ratio = 2.0
-
 [dedup]
 ttl_seconds = 1800
 max_records = 1000


### PR DESCRIPTION
## Summary
- set TP and SL prices directly from the signal candle
- track trade lifecycle during backtests and close on the first TP/SL touch
- remove the unused risk_reward_ratio setting and dependency

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68cbde25a4b083208f697fdb609911bb