### PR TITLE
Add deposit tracking and trade sizing updates

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -10,6 +10,7 @@ from .data.providers.base import BaseExchangeProvider
 from .data.providers.binance import BinanceFuturesProvider
 from .data.providers.bybit import BybitPerpetualProvider
 from .data.repositories.signal_repository import SignalRepository
+from .data.repositories.state_repository import StateRepository
 from .data.repositories.trade_repository import TradeRepository
 from .domain.enums import Timeframe
 from .domain.models.entities import ThresholdMetric, Thresholds
@@ -131,6 +132,7 @@ def build_thresholds(config: AppConfig) -> Dict[str, Thresholds]:
 def init_services(config: AppConfig, storage: Storage) -> tuple[
     SignalRepository,
     TradeRepository,
+    StateRepository,
     MetricsService,
     SignalSelectorService,
     TpSlService,
@@ -138,6 +140,7 @@ def init_services(config: AppConfig, storage: Storage) -> tuple[
 ]:
     signal_repo = SignalRepository(storage)
     trade_repo = TradeRepository(storage)
+    state_repo = StateRepository(storage)
     metrics_cfg = config.get("metrics", {})
     metrics_service = MetricsService(
         atr_period=int(metrics_cfg.get("atr_period", 14)),
@@ -151,7 +154,15 @@ def init_services(config: AppConfig, storage: Storage) -> tuple[
         ttl_seconds=int(dedup_cfg.get("ttl_seconds", 1800)),
         max_records=int(dedup_cfg.get("max_records", 1000)),
     )
-    return signal_repo, trade_repo, metrics_service, selector, tp_sl_service, dedup_policy
+    return (
+        signal_repo,
+        trade_repo,
+        state_repo,
+        metrics_service,
+        selector,
+        tp_sl_service,
+        dedup_policy,
+    )
 
 
 def select_provider_for_symbol(
@@ -171,6 +182,7 @@ async def run_backtest(
     services: tuple[
         SignalRepository,
         TradeRepository,
+        StateRepository,
         MetricsService,
         SignalSelectorService,
         TpSlService,
@@ -178,12 +190,20 @@ async def run_backtest(
     ],
 ) -> None:
     logger = get_logger("backtest")
-    signal_repo, trade_repo, _, selector, tp_sl_service, dedup_policy = services
+    signal_repo, trade_repo, state_repo, _, selector, tp_sl_service, dedup_policy = services
     backtest_cfg = config.get("backtest", {})
     if not backtest_cfg.get("enabled", False):
         logger.info("Backtest disabled")
         return
-    runner = BacktestRunner(selector, tp_sl_service, signal_repo, trade_repo, dedup_policy, window=int(backtest_cfg.get("window", 50)))
+    runner = BacktestRunner(
+        selector,
+        tp_sl_service,
+        signal_repo,
+        state_repo,
+        trade_repo,
+        dedup_policy,
+        window=int(backtest_cfg.get("window", 50)),
+    )
     timeframe = Timeframe(backtest_cfg.get("timeframe", Timeframe.M15.value))
     limit = int(backtest_cfg.get("limit", 500))
     for symbol in backtest_cfg.get("symbols", []):
@@ -194,7 +214,7 @@ async def run_backtest(
             logger.error("Failed to fetch backtest data for %s: %s", symbol, exc)
             continue
         thresholds = thresholds_map.get(symbol) or thresholds_map["default"]
-        result = runner.run(symbol, candles, thresholds)
+        result = await runner.run(symbol, candles, thresholds, provider)
         logger.info("Backtest for %s produced %d trades", symbol, len(result.trades))
 
 
@@ -205,6 +225,7 @@ async def run_live(
     services: tuple[
         SignalRepository,
         TradeRepository,
+        StateRepository,
         MetricsService,
         SignalSelectorService,
         TpSlService,
@@ -212,7 +233,7 @@ async def run_live(
     ],
 ) -> None:
     logger = get_logger("live")
-    signal_repo, trade_repo, _, selector, tp_sl_service, dedup_policy = services
+    signal_repo, trade_repo, state_repo, _, selector, tp_sl_service, dedup_policy = services
     live_cfg = config.get("live", {})
     if not live_cfg.get("enabled", False):
         logger.info("Live trading disabled")
@@ -227,6 +248,7 @@ async def run_live(
         selector,
         tp_sl_service,
         signal_repo,
+        state_repo,
         trade_repo,
         dedup_policy,
         window=window,
@@ -234,14 +256,16 @@ async def run_live(
     )
     symbols = live_cfg.get("symbols", [])
 
+    await runner.refresh_deposit(force=True)
+
     async def deposit_monitor() -> None:
         while True:
             try:
-                balance = await provider.update_deposit()
-                logger.info("Deposit update at %s: %s", utcnow().isoformat(), balance)
+                snapshot = await runner.refresh_deposit(force=True)
+                logger.info("Deposit update at %s: %s", utcnow().isoformat(), snapshot)
             except Exception as exc:  # pragma: no cover - network errors
                 logger.warning("Failed to update deposit: %s", exc)
-            await asyncio.sleep(float(live_cfg.get("balance_interval", 60.0)))
+            await asyncio.sleep(3600.0)
 
     asyncio.create_task(deposit_monitor())
 

--- a/bot/data/io/storage.py
+++ b/bot/data/io/storage.py
@@ -155,7 +155,10 @@ class Storage:
             side=Side(raw["side"]),
             status=TradeStatus(raw["status"]),
             entry_price=float(raw["entry_price"]),
-            size=float(raw["size"]),
+            size=float(raw.get("size", 0.0)),
+            used_margin=float(
+                raw.get("used_margin", raw.get("used_amount", raw.get("size", 0.0)))
+            ),
             tp_price=float(raw["tp_price"]) if raw.get("tp_price") is not None else None,
             sl_price=float(raw["sl_price"]) if raw.get("sl_price") is not None else None,
             opened_at=datetime.fromisoformat(raw["opened_at"]) if raw.get("opened_at") else None,

--- a/bot/data/repositories/state_repository.py
+++ b/bot/data/repositories/state_repository.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import datetime
+from threading import RLock
+from typing import Any, Dict
+
+from ...domain.models.state import (
+    get_deposit_amount,
+    get_used_amount,
+    set_deposit,
+    set_used_amount,
+)
+from ...utils.clock import utcnow
+from ..io.storage import Storage
+
+
+class StateRepository:
+    """Persisted state of the trading capital."""
+
+    def __init__(self, storage: Storage) -> None:
+        self._storage = storage
+        self._lock = RLock()
+        self._asset = "USDT"
+        self._deposit_updated_at: datetime | None = None
+        self.load()
+
+    def load(self) -> None:
+        with self._lock:
+            raw = self._storage.read("state") or {}
+            deposit_raw = raw.get("deposit")
+            if isinstance(deposit_raw, dict):
+                self._asset = str(deposit_raw.get("asset") or "USDT")
+                amount = float(deposit_raw.get("amount", 0.0))
+                updated_at_raw = deposit_raw.get("updated_at")
+                updated_at = (
+                    datetime.fromisoformat(updated_at_raw)
+                    if isinstance(updated_at_raw, str)
+                    else None
+                )
+                self._deposit_updated_at = updated_at
+                set_deposit(amount, self._asset, updated_at)
+            else:
+                amount = float(raw.get("deposit_usdt", 0.0))
+                self._deposit_updated_at = None
+                set_deposit(amount, self._asset, None)
+            used_raw = raw.get("used_usdt", raw.get("used_amount", 0.0))
+            set_used_amount(float(used_raw))
+
+    def _persist(self) -> None:
+        payload: Dict[str, Any] = {
+            "deposit": {
+                "asset": self._asset,
+                "amount": get_deposit_amount(),
+            },
+            "used_usdt": get_used_amount(),
+        }
+        if self._deposit_updated_at:
+            payload["deposit"]["updated_at"] = self._deposit_updated_at.isoformat()
+        self._storage.write("state", payload)
+
+    def update_deposit(
+        self, amount: float, asset: str = "USDT", updated_at: datetime | None = None
+    ) -> None:
+        with self._lock:
+            self._asset = asset
+            self._deposit_updated_at = updated_at or utcnow()
+            set_deposit(amount, self._asset, self._deposit_updated_at)
+            self._persist()
+
+    def get_deposit(self) -> float:
+        return get_deposit_amount()
+
+    def get_deposit_asset(self) -> str:
+        return self._asset
+
+    def get_last_deposit_update(self) -> datetime | None:
+        return self._deposit_updated_at
+
+    def set_used_amount(self, amount: float) -> None:
+        with self._lock:
+            set_used_amount(amount)
+            self._persist()
+
+    def get_used_amount(self) -> float:
+        return get_used_amount()

--- a/bot/domain/models/entities.py
+++ b/bot/domain/models/entities.py
@@ -77,6 +77,7 @@ class Trade:
     status: TradeStatus
     entry_price: float
     size: float
+    used_margin: float = 0.0
     tp_price: Optional[float] = None
     sl_price: Optional[float] = None
     opened_at: Optional[datetime] = None

--- a/bot/domain/models/state.py
+++ b/bot/domain/models/state.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(slots=True)
+class DepositState:
+    """In-memory snapshot of the trading capital state."""
+
+    asset: str = "USDT"
+    amount: float = 0.0
+    updated_at: datetime | None = None
+
+
+@dataclass(slots=True)
+class UsedCapitalState:
+    """In-memory snapshot of the used part of the trading capital."""
+
+    amount: float = 0.0
+
+
+DEPOSIT_USDT = DepositState()
+USED_CAPITAL = UsedCapitalState()
+
+
+def set_deposit(amount: float, asset: str, updated_at: datetime | None) -> None:
+    """Update the in-memory deposit snapshot."""
+
+    DEPOSIT_USDT.asset = asset
+    DEPOSIT_USDT.amount = amount
+    DEPOSIT_USDT.updated_at = updated_at
+
+
+def get_deposit_amount() -> float:
+    return DEPOSIT_USDT.amount
+
+
+def set_used_amount(amount: float) -> None:
+    USED_CAPITAL.amount = amount
+
+
+def get_used_amount() -> float:
+    return USED_CAPITAL.amount

--- a/bot/domain/services/backtest_runner.py
+++ b/bot/domain/services/backtest_runner.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Sequence
+from typing import Any, Dict, Sequence
 
 from ..enums import BreakDirection, Side, TradeStatus
 from ..models.entities import Candle, Signal, Thresholds, Trade
+from ...data.providers.base import BaseExchangeProvider
 from ...data.repositories.signal_repository import SignalRepository
+from ...data.repositories.state_repository import StateRepository
 from ...data.repositories.trade_repository import TradeRepository
 from ...utils.logging import get_logger
+from ...utils.clock import utcnow
 from .dedup_policy import DeduplicationPolicy
 from .selector_service import SignalSelectorService
 from .tp_sl_service import TpSlService
@@ -25,6 +28,7 @@ class BacktestRunner:
         selector: SignalSelectorService,
         tp_sl_service: TpSlService,
         signal_repository: SignalRepository,
+        state_repository: StateRepository,
         trade_repository: TradeRepository,
         dedup_policy: DeduplicationPolicy,
         window: int = 50,
@@ -32,19 +36,25 @@ class BacktestRunner:
         self._selector = selector
         self._tp_sl_service = tp_sl_service
         self._signals = signal_repository
+        self._state = state_repository
         self._trades = trade_repository
         self._dedup = dedup_policy
         self._window = window
         self._logger = get_logger(self.__class__.__name__)
+        self._deposit_usdt = state_repository.get_deposit()
+        self._deposit_asset = state_repository.get_deposit_asset()
+        self._last_deposit_update = state_repository.get_last_deposit_update()
 
-    def run(
+    async def run(
         self,
         symbol: str,
         candles: Sequence[Candle],
         thresholds: Thresholds,
+        provider: BaseExchangeProvider,
     ) -> BacktestResult:
         generated_signals: list[Signal] = []
         generated_trades: list[Trade] = []
+        await self.refresh_deposit(provider, force=True)
         for index in range(self._window, len(candles)):
             window_candles = candles[index - self._window : index]
             future_candles = candles[index :]
@@ -59,6 +69,9 @@ class BacktestRunner:
                 if not accepted:
                     self._logger.debug("Skipping duplicate signal %s", key)
                     continue
+                await self.refresh_deposit(provider)
+                snapshot = self._deposit_snapshot()
+                trade_size = self._calculate_trade_size()
                 trade = Trade(
                     id=signal.id,
                     signal_id=signal.id,
@@ -67,20 +80,69 @@ class BacktestRunner:
                     side=signal.side,
                     status=TradeStatus.OPENED,
                     entry_price=signal.candle.close,
-                    size=1.0,
+                    size=trade_size,
+                    used_margin=trade_size,
                     allow_long=signal.allow_long,
                     allow_short=signal.allow_short,
                     thresholds_snapshot=signal.thresholds,
-                    metadata={"mode": "backtest"},
+                    metadata={"mode": "backtest", "deposit_snapshot": snapshot},
                 )
                 self._tp_sl_service.assign(signal, trade)
                 trade.opened_at = signal.candle.closed_at
                 self._apply_backtest_outcome(signal, trade, candles[index:])
                 self._signals.save(signal)
                 self._trades.save(trade)
+                self._update_used_amount()
                 generated_signals.append(signal)
                 generated_trades.append(trade)
         return BacktestResult(trades=generated_trades, signals=generated_signals)
+
+    async def refresh_deposit(
+        self, provider: BaseExchangeProvider, force: bool = False
+    ) -> None:
+        if not force and self._last_deposit_update:
+            delta = (utcnow() - self._last_deposit_update).total_seconds()
+            if delta < 3600:
+                return
+        balance = await provider.update_deposit()
+        asset, amount = self._extract_deposit(balance)
+        timestamp = utcnow()
+        self._deposit_usdt = amount
+        self._deposit_asset = asset
+        self._last_deposit_update = timestamp
+        self._state.update_deposit(amount, asset, timestamp)
+
+    def _extract_deposit(self, balance: Any) -> tuple[str, float]:
+        if isinstance(balance, dict):
+            asset = str(balance.get("asset") or self._deposit_asset or "USDT")
+            for key in ("balance", "availableBalance", "available", "amount", "equity"):
+                value = balance.get(key)
+                if value is not None:
+                    try:
+                        return asset, float(value)
+                    except (TypeError, ValueError):
+                        continue
+            try:
+                return asset, float(balance.get(asset, 0.0))
+            except (TypeError, ValueError):
+                pass
+        return self._deposit_asset or "USDT", self._deposit_usdt
+
+    def _calculate_trade_size(self) -> float:
+        return max(10.0, 0.0005 * self._deposit_usdt) if self._deposit_usdt > 0 else 10.0
+
+    def _deposit_snapshot(self) -> Dict[str, Any]:
+        return {
+            "asset": self._deposit_asset,
+            "balance": self._deposit_usdt,
+            "updated_at": self._last_deposit_update.isoformat() if self._last_deposit_update else None,
+        }
+
+    def _update_used_amount(self) -> None:
+        open_amount = sum(
+            trade.used_margin for trade in self._trades.all() if trade.status == TradeStatus.OPENED
+        )
+        self._state.set_used_amount(open_amount)
 
     def _apply_backtest_outcome(
         self, signal: Signal, trade: Trade, future_candles: Sequence[Candle]

--- a/bot/domain/services/live_runner.py
+++ b/bot/domain/services/live_runner.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import asyncio
 from collections import deque
-from typing import Deque, Dict, Iterable
+from typing import Any, Deque, Dict, Iterable
 
 from ...data.providers.base import BaseExchangeProvider
 from ...data.repositories.signal_repository import SignalRepository
+from ...data.repositories.state_repository import StateRepository
 from ...data.repositories.trade_repository import TradeRepository
 from ...utils.logging import get_logger
+from ...utils.clock import utcnow
 from ..enums import Timeframe, TradeStatus
 from ..models.entities import Candle, Signal, Thresholds, Trade
 from .dedup_policy import DeduplicationPolicy
@@ -22,6 +24,7 @@ class LiveTradingRunner:
         selector: SignalSelectorService,
         tp_sl_service: TpSlService,
         signal_repository: SignalRepository,
+        state_repository: StateRepository,
         trade_repository: TradeRepository,
         dedup_policy: DeduplicationPolicy,
         window: int,
@@ -31,17 +34,23 @@ class LiveTradingRunner:
         self._selector = selector
         self._tp_sl_service = tp_sl_service
         self._signals = signal_repository
+        self._state = state_repository
         self._trades = trade_repository
         self._dedup = dedup_policy
         self._window = window
         self._poll_interval = poll_interval
         self._logger = get_logger(self.__class__.__name__)
+        self._deposit_usdt = state_repository.get_deposit()
+        self._deposit_asset = state_repository.get_deposit_asset()
+        self._last_deposit_update = state_repository.get_last_deposit_update()
 
     async def _handle_signal(self, signal: Signal) -> None:
         accepted, key = self._dedup.should_accept(signal)
         if not accepted:
             self._logger.debug("Duplicate live signal %s skipped", key)
             return
+        snapshot = await self.refresh_deposit()
+        trade_size = self._calculate_trade_size()
         trade = Trade(
             id=signal.id,
             signal_id=signal.id,
@@ -50,15 +59,17 @@ class LiveTradingRunner:
             side=signal.side,
             status=TradeStatus.OPENED,
             entry_price=signal.candle.close,
-            size=1.0,
+            size=trade_size,
+            used_margin=trade_size,
             allow_long=signal.allow_long,
             allow_short=signal.allow_short,
             thresholds_snapshot=signal.thresholds,
-            metadata={"mode": "live"},
+            metadata={"mode": "live", "deposit_snapshot": snapshot},
         )
         self._tp_sl_service.assign(signal, trade)
         self._signals.save(signal)
         self._trades.save(trade)
+        self._update_used_amount()
         self._logger.info("Signal accepted %s", signal.id)
 
     async def _process_symbol(self, symbol: str, timeframe: Timeframe, thresholds: Thresholds) -> None:
@@ -81,6 +92,7 @@ class LiveTradingRunner:
         timeframe: Timeframe,
         thresholds_map: Dict[str, Thresholds],
     ) -> None:
+        await self.refresh_deposit(force=True)
         tasks = []
         for symbol in symbols:
             thresholds = thresholds_map.get(symbol) or thresholds_map.get("default")
@@ -89,3 +101,49 @@ class LiveTradingRunner:
                 continue
             tasks.append(asyncio.create_task(self._process_symbol(symbol, timeframe, thresholds)))
         await asyncio.gather(*tasks)
+
+    async def refresh_deposit(self, force: bool = False) -> Dict[str, Any]:
+        if not force and self._last_deposit_update:
+            delta = (utcnow() - self._last_deposit_update).total_seconds()
+            if delta < 3600:
+                return self._deposit_snapshot()
+        balance = await self._provider.update_deposit()
+        asset, amount = self._extract_deposit(balance)
+        timestamp = utcnow()
+        self._deposit_usdt = amount
+        self._deposit_asset = asset
+        self._last_deposit_update = timestamp
+        self._state.update_deposit(amount, asset, timestamp)
+        return self._deposit_snapshot()
+
+    def _extract_deposit(self, balance: Any) -> tuple[str, float]:
+        if isinstance(balance, dict):
+            asset = str(balance.get("asset") or self._deposit_asset or "USDT")
+            for key in ("balance", "availableBalance", "available", "amount", "equity"):
+                value = balance.get(key)
+                if value is not None:
+                    try:
+                        return asset, float(value)
+                    except (TypeError, ValueError):
+                        continue
+            try:
+                return asset, float(balance.get(asset, 0.0))
+            except (TypeError, ValueError):
+                pass
+        return self._deposit_asset or "USDT", self._deposit_usdt
+
+    def _calculate_trade_size(self) -> float:
+        return max(10.0, 0.0005 * self._deposit_usdt) if self._deposit_usdt > 0 else 10.0
+
+    def _deposit_snapshot(self) -> Dict[str, Any]:
+        return {
+            "asset": self._deposit_asset,
+            "balance": self._deposit_usdt,
+            "updated_at": self._last_deposit_update.isoformat() if self._last_deposit_update else None,
+        }
+
+    def _update_used_amount(self) -> None:
+        open_amount = sum(
+            trade.used_margin for trade in self._trades.all() if trade.status == TradeStatus.OPENED
+        )
+        self._state.set_used_amount(open_amount)


### PR DESCRIPTION
## Summary
- track deposit state via a dedicated repository and shared in-memory snapshot
- refresh deposit balances in backtest and live runners every hour and size trades based on the latest deposit
- persist used margin per trade and ensure the live monitor waits 3600 seconds between deposit updates

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68cbe053b9dc8320b7ecad5e3e00bc60