### PR TITLE
Adjust signal deduplication window

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -151,7 +151,7 @@ def init_services(config: AppConfig, storage: Storage) -> tuple[
     tp_sl_service = TpSlService()
     dedup_cfg = config.get("dedup", {})
     dedup_policy = DeduplicationPolicy(
-        ttl_seconds=int(dedup_cfg.get("ttl_seconds", 1800)),
+        ttl_seconds=int(dedup_cfg.get("ttl_seconds", 14400)),
         max_records=int(dedup_cfg.get("max_records", 1000)),
     )
     return (

--- a/bot/domain/services/dedup_policy.py
+++ b/bot/domain/services/dedup_policy.py
@@ -16,15 +16,13 @@ class DedupRecord:
 
 
 class DeduplicationPolicy:
-    def __init__(self, ttl_seconds: int = 600, max_records: int = 1000) -> None:
+    def __init__(self, ttl_seconds: int = 14400, max_records: int = 1000) -> None:
         self._ttl = timedelta(seconds=ttl_seconds)
         self._records: Deque[DedupRecord] = deque(maxlen=max_records)
         self._lock = Lock()
 
     def _make_key(self, signal: Signal) -> str:
-        return (
-            f"{signal.candle.symbol}:{signal.side}:{signal.candle.timeframe}:{signal.direction.value}"
-        )
+        return f"{signal.candle.symbol}:{signal.candle.timeframe}"
 
     def should_accept(self, signal: Signal) -> Tuple[bool, str | None]:
         with self._lock:

--- a/bot/domain/services/selector_service.py
+++ b/bot/domain/services/selector_service.py
@@ -8,7 +8,6 @@ from ..enums import BreakDirection, Side
 from ..models.entities import Candle, Signal, Thresholds
 from .metrics_service import Metrics, MetricsService
 from ...utils import ids
-from ...utils.clock import utcnow
 
 
 @dataclass(slots=True)
@@ -116,13 +115,14 @@ class SignalSelectorService:
         direction = metrics.break_direction
         if direction is BreakDirection.NONE:
             direction = BreakDirection.HIGH_FIRST if side == Side.LONG else BreakDirection.LOW_FIRST
+        candle = candles[-1]
         signal = Signal(
             id=ids.uuid_str(),
-            candle=candles[-1],
+            candle=candle,
             side=side,
             direction=direction,
             score=fabs(metrics.pct_move),
-            triggered_at=utcnow(),
+            triggered_at=candle.closed_at,
             thresholds=thresholds,
             metrics=evaluations,
             allow_long=allow_long,

--- a/settings.toml
+++ b/settings.toml
@@ -10,7 +10,7 @@ volume_period = 20
 momentum_period = 5
 
 [dedup]
-ttl_seconds = 1800
+ttl_seconds = 14400
 max_records = 1000
 
 [providers.binance]


### PR DESCRIPTION
## Summary
- key deduplicated signals by symbol and timeframe while extending the TTL to four hours
- align selector timestamps with candle close time so the four-hour window behaves consistently in backtests and live trading
- update application defaults and configuration to match the new deduplication TTL

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68cbe44d1ca883209fb50f19d07ad688