### PR TITLE
feat: enrich core entities with identity and audit fields

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
 from pathlib import Path
 from typing import Dict
 
@@ -102,7 +103,10 @@ def _parse_threshold(raw: Dict[str, object]) -> Thresholds:
     metadata = raw.get("metadata", {}) if isinstance(raw, dict) else {}
     if not isinstance(metadata, dict):
         metadata = {}
+    created_at_raw = raw.get("created_at") if isinstance(raw, dict) else None
+    updated_at_raw = raw.get("updated_at") if isinstance(raw, dict) else None
     return Thresholds(
+        id=str(raw.get("id")) if isinstance(raw, dict) and raw.get("id") is not None else None,
         s=_get_upper_lower("s"),
         t=_get_upper_lower("t"),
         u=_get_upper_lower("u"),
@@ -114,6 +118,8 @@ def _parse_threshold(raw: Dict[str, object]) -> Thresholds:
         allow_short=allow_short,
         metrics=metrics,
         metadata=metadata if isinstance(metadata, dict) else {},
+        created_at=datetime.fromisoformat(created_at_raw) if isinstance(created_at_raw, str) else None,
+        updated_at=datetime.fromisoformat(updated_at_raw) if isinstance(updated_at_raw, str) else None,
     )
 
 

--- a/bot/data/io/storage.py
+++ b/bot/data/io/storage.py
@@ -72,7 +72,10 @@ class Storage:
         metadata = raw.get("metadata", {})
         if not isinstance(metadata, dict):
             metadata = {}
+        created_at_raw = raw.get("created_at")
+        updated_at_raw = raw.get("updated_at")
         return Thresholds(
+            id=str(raw["id"]) if raw.get("id") is not None else None,
             s=float(raw.get("s", 0.0)),
             t=float(raw.get("t", 0.0)),
             u=float(raw.get("u", 0.0)),
@@ -84,6 +87,8 @@ class Storage:
             allow_short=self._to_bool(raw.get("allow_short", True)),
             metrics=metrics,
             metadata=metadata,
+            created_at=datetime.fromisoformat(created_at_raw) if isinstance(created_at_raw, str) else None,
+            updated_at=datetime.fromisoformat(updated_at_raw) if isinstance(updated_at_raw, str) else None,
         )
 
     def _deserialize_signal_metric(self, raw: Dict[str, Any]) -> SignalMetric:
@@ -102,7 +107,19 @@ class Storage:
 
     def deserialize_signal(self, raw: Dict[str, Any]) -> Signal:
         candle_raw = raw["candle"]
+        candle_id = candle_raw.get("id")
+        if candle_id is None:
+            try:
+                candle_timestamp = datetime.fromisoformat(candle_raw["started_at"])
+            except (KeyError, ValueError):
+                candle_timestamp = None
+            if candle_timestamp is not None:
+                candle_id = (
+                    f"{candle_raw['exchange']}:{candle_raw['symbol']}:{candle_raw['timeframe']}:"
+                    f"{int(candle_timestamp.timestamp())}"
+                )
         candle = Candle(
+            id=candle_id,
             symbol=candle_raw["symbol"],
             exchange=Exchange(candle_raw["exchange"]),
             timeframe=Timeframe(candle_raw["timeframe"]),
@@ -124,13 +141,27 @@ class Storage:
         metadata = raw.get("metadata", {})
         if not isinstance(metadata, dict):
             metadata = {}
+        created_at_raw = raw.get("created_at")
+        updated_at_raw = raw.get("updated_at")
+        timeframe_raw = raw.get("timeframe")
+        timeframe = Timeframe(timeframe_raw) if isinstance(timeframe_raw, str) else candle.timeframe
+        candle_ref = raw.get("candle_id") or candle.id
+        if candle_ref is None and isinstance(candle.started_at, datetime):
+            candle_ref = (
+                f"{candle.exchange.value}:{candle.symbol}:{candle.timeframe.value}:"
+                f"{int(candle.started_at.timestamp())}"
+            )
         return Signal(
             id=raw["id"],
+            candle_id=candle_ref,
             candle=candle,
+            timeframe=timeframe,
             side=Side(raw["side"]),
             direction=BreakDirection(raw["direction"]),
             score=float(raw["score"]),
             triggered_at=datetime.fromisoformat(raw["triggered_at"]),
+            created_at=datetime.fromisoformat(created_at_raw) if isinstance(created_at_raw, str) else None,
+            updated_at=datetime.fromisoformat(updated_at_raw) if isinstance(updated_at_raw, str) else None,
             thresholds=thresholds,
             metrics=metrics,
             allow_long=self._to_bool(raw.get("allow_long", thresholds.allow_long), thresholds.allow_long),
@@ -147,11 +178,34 @@ class Storage:
         metadata = raw.get("metadata", {})
         if not isinstance(metadata, dict):
             metadata = {}
+        created_at_raw = raw.get("created_at")
+        updated_at_raw = raw.get("updated_at")
+        timeframe_raw = raw.get("timeframe")
+        timeframe = Timeframe(timeframe_raw) if isinstance(timeframe_raw, str) else None
+        if timeframe is None and thresholds_snapshot and isinstance(thresholds_snapshot.metadata, dict):
+            meta_tf = thresholds_snapshot.metadata.get("timeframe")
+            if isinstance(meta_tf, str):
+                try:
+                    timeframe = Timeframe(meta_tf)
+                except ValueError:
+                    timeframe = None
+        if timeframe is None:
+            meta = raw.get("metadata")
+            if isinstance(meta, dict):
+                meta_tf = meta.get("timeframe")
+                if isinstance(meta_tf, str):
+                    try:
+                        timeframe = Timeframe(meta_tf)
+                    except ValueError:
+                        timeframe = None
+        source_signal_id = raw.get("source_signal_id") or raw.get("signal_id")
         trade = Trade(
             id=raw["id"],
             signal_id=raw["signal_id"],
+            source_signal_id=source_signal_id,
             exchange=Exchange(raw["exchange"]),
             symbol=raw["symbol"],
+            timeframe=timeframe,
             side=Side(raw["side"]),
             status=TradeStatus(raw["status"]),
             entry_price=float(raw["entry_price"]),
@@ -164,6 +218,9 @@ class Storage:
             opened_at=datetime.fromisoformat(raw["opened_at"]) if raw.get("opened_at") else None,
             closed_at=datetime.fromisoformat(raw["closed_at"]) if raw.get("closed_at") else None,
             pnl=float(raw["pnl"]) if raw.get("pnl") is not None else None,
+            pnl_pct=float(raw["pnl_pct"]) if raw.get("pnl_pct") is not None else None,
+            created_at=datetime.fromisoformat(created_at_raw) if isinstance(created_at_raw, str) else None,
+            updated_at=datetime.fromisoformat(updated_at_raw) if isinstance(updated_at_raw, str) else None,
             allow_long=self._to_bool(raw.get("allow_long", True)),
             allow_short=self._to_bool(raw.get("allow_short", True)),
             thresholds_snapshot=thresholds_snapshot,

--- a/bot/data/mappers/ohlcv_mapper.py
+++ b/bot/data/mappers/ohlcv_mapper.py
@@ -16,7 +16,9 @@ def map_ohlcv(
     if len(raw) < 6:
         raise ValueError("raw OHLCV should have at least 6 elements")
     timestamp = datetime.fromtimestamp(raw[0] / 1000 if raw[0] > 1e12 else raw[0], tz=timezone.utc)
+    candle_id = f"{exchange.value}:{symbol}:{timeframe.value}:{int(timestamp.timestamp())}"
     return Candle(
+        id=candle_id,
         symbol=symbol,
         exchange=exchange,
         timeframe=timeframe,

--- a/bot/data/repositories/signal_repository.py
+++ b/bot/data/repositories/signal_repository.py
@@ -17,13 +17,27 @@ class SignalRepository:
 
     def _serialize(self, signal: Signal) -> Dict[str, object]:
         data = asdict(signal)
+        if signal.timeframe:
+            data["timeframe"] = signal.timeframe.value
+        else:
+            data.pop("timeframe", None)
         data["candle"]["started_at"] = signal.candle.started_at.isoformat()
         data["candle"]["closed_at"] = signal.candle.closed_at.isoformat()
         data["candle"]["exchange"] = signal.candle.exchange.value
         data["candle"]["timeframe"] = signal.candle.timeframe.value
+        if signal.created_at:
+            data["created_at"] = signal.created_at.isoformat()
+        if signal.updated_at:
+            data["updated_at"] = signal.updated_at.isoformat()
         data["side"] = signal.side.value
         data["direction"] = signal.direction.value
         data["triggered_at"] = signal.triggered_at.isoformat()
+        thresholds = data.get("thresholds")
+        if isinstance(thresholds, dict):
+            if signal.thresholds.created_at:
+                thresholds["created_at"] = signal.thresholds.created_at.isoformat()
+            if signal.thresholds.updated_at:
+                thresholds["updated_at"] = signal.thresholds.updated_at.isoformat()
         return data
 
     def save(self, signal: Signal) -> None:

--- a/bot/data/repositories/trade_repository.py
+++ b/bot/data/repositories/trade_repository.py
@@ -20,12 +20,26 @@ class TradeRepository:
         data["exchange"] = trade.exchange.value
         data["side"] = trade.side.value
         data["status"] = trade.status.value
+        if trade.timeframe:
+            data["timeframe"] = trade.timeframe.value
+        else:
+            data.pop("timeframe", None)
         if trade.opened_at:
             data["opened_at"] = trade.opened_at.isoformat()
         if trade.closed_at:
             data["closed_at"] = trade.closed_at.isoformat()
+        if trade.created_at:
+            data["created_at"] = trade.created_at.isoformat()
+        if trade.updated_at:
+            data["updated_at"] = trade.updated_at.isoformat()
         if data.get("thresholds_snapshot") is None:
             data.pop("thresholds_snapshot", None)
+        elif isinstance(data["thresholds_snapshot"], dict):
+            snapshot = data["thresholds_snapshot"]
+            if trade.thresholds_snapshot and trade.thresholds_snapshot.created_at:
+                snapshot["created_at"] = trade.thresholds_snapshot.created_at.isoformat()
+            if trade.thresholds_snapshot and trade.thresholds_snapshot.updated_at:
+                snapshot["updated_at"] = trade.thresholds_snapshot.updated_at.isoformat()
         return data
 
     def save(self, trade: Trade) -> None:

--- a/bot/domain/models/entities.py
+++ b/bot/domain/models/entities.py
@@ -9,6 +9,7 @@ from ..enums import BreakDirection, Exchange, Side, Timeframe, TradeStatus
 
 @dataclass(slots=True)
 class Candle:
+    id: Optional[str] = None
     symbol: str
     exchange: Exchange
     timeframe: Timeframe
@@ -31,6 +32,7 @@ class ThresholdMetric:
 
 @dataclass(slots=True)
 class Thresholds:
+    id: Optional[str] = None
     s: float = 0.0
     t: float = 0.0
     u: float = 0.0
@@ -42,6 +44,8 @@ class Thresholds:
     allow_short: bool = True
     metrics: List[ThresholdMetric] = field(default_factory=list)
     metadata: Dict[str, Any] = field(default_factory=dict)
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
 @dataclass(slots=True)
@@ -55,11 +59,15 @@ class SignalMetric:
 @dataclass(slots=True)
 class Signal:
     id: str
+    candle_id: Optional[str] = None
     candle: Candle
+    timeframe: Optional[Timeframe] = None
     side: Side
     direction: BreakDirection
     score: float
     triggered_at: datetime
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
     thresholds: Thresholds
     metrics: List[SignalMetric] = field(default_factory=list)
     allow_long: bool = True
@@ -71,8 +79,10 @@ class Signal:
 class Trade:
     id: str
     signal_id: str
+    source_signal_id: Optional[str] = None
     exchange: Exchange
     symbol: str
+    timeframe: Optional[Timeframe] = None
     side: Side
     status: TradeStatus
     entry_price: float
@@ -83,6 +93,9 @@ class Trade:
     opened_at: Optional[datetime] = None
     closed_at: Optional[datetime] = None
     pnl: Optional[float] = None
+    pnl_pct: Optional[float] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
     allow_long: bool = True
     allow_short: bool = True
     thresholds_snapshot: Optional[Thresholds] = None

--- a/bot/domain/services/backtest_runner.py
+++ b/bot/domain/services/backtest_runner.py
@@ -72,16 +72,26 @@ class BacktestRunner:
                 await self.refresh_deposit(provider)
                 snapshot = self._deposit_snapshot()
                 trade_size = self._calculate_trade_size()
+                timestamp = utcnow()
+                source_signal_id = (
+                    signal.metadata.get("source_signal_id")
+                    if isinstance(signal.metadata, dict) and signal.metadata.get("source_signal_id")
+                    else signal.id
+                )
                 trade = Trade(
                     id=signal.id,
                     signal_id=signal.id,
+                    source_signal_id=source_signal_id,
                     exchange=signal.candle.exchange,
                     symbol=signal.candle.symbol,
+                    timeframe=signal.timeframe or signal.candle.timeframe,
                     side=signal.side,
                     status=TradeStatus.OPENED,
                     entry_price=signal.candle.close,
                     size=trade_size,
                     used_margin=trade_size,
+                    created_at=timestamp,
+                    updated_at=timestamp,
                     allow_long=signal.allow_long,
                     allow_short=signal.allow_short,
                     thresholds_snapshot=signal.thresholds,
@@ -156,6 +166,12 @@ class BacktestRunner:
             trade.closed_at = candle.closed_at
             exit_price = trade.tp_price if status == TradeStatus.CLOSED_TP else trade.sl_price
             trade.pnl = self._calculate_pnl(trade, exit_price)
+            trade.pnl_pct = (
+                (trade.pnl / trade.used_margin) * 100.0
+                if trade.pnl is not None and trade.used_margin
+                else None
+            )
+            trade.updated_at = utcnow()
             return
 
     def _check_thresholds(self, trade: Trade, candle: Candle) -> tuple[bool, bool]:

--- a/bot/domain/services/live_runner.py
+++ b/bot/domain/services/live_runner.py
@@ -51,16 +51,26 @@ class LiveTradingRunner:
             return
         snapshot = await self.refresh_deposit()
         trade_size = self._calculate_trade_size()
+        timestamp = utcnow()
+        source_signal_id = (
+            signal.metadata.get("source_signal_id")
+            if isinstance(signal.metadata, dict) and signal.metadata.get("source_signal_id")
+            else signal.id
+        )
         trade = Trade(
             id=signal.id,
             signal_id=signal.id,
+            source_signal_id=source_signal_id,
             exchange=signal.candle.exchange,
             symbol=signal.candle.symbol,
+            timeframe=signal.timeframe or signal.candle.timeframe,
             side=signal.side,
             status=TradeStatus.OPENED,
             entry_price=signal.candle.close,
             size=trade_size,
             used_margin=trade_size,
+            created_at=timestamp,
+            updated_at=timestamp,
             allow_long=signal.allow_long,
             allow_short=signal.allow_short,
             thresholds_snapshot=signal.thresholds,

--- a/bot/domain/services/selector_service.py
+++ b/bot/domain/services/selector_service.py
@@ -8,6 +8,7 @@ from ..enums import BreakDirection, Side
 from ..models.entities import Candle, Signal, Thresholds
 from .metrics_service import Metrics, MetricsService
 from ...utils import ids
+from ...utils.clock import utcnow
 
 
 @dataclass(slots=True)
@@ -116,13 +117,18 @@ class SignalSelectorService:
         if direction is BreakDirection.NONE:
             direction = BreakDirection.HIGH_FIRST if side == Side.LONG else BreakDirection.LOW_FIRST
         candle = candles[-1]
+        timestamp = utcnow()
         signal = Signal(
             id=ids.uuid_str(),
+            candle_id=candle.id,
             candle=candle,
+            timeframe=candle.timeframe,
             side=side,
             direction=direction,
             score=fabs(metrics.pct_move),
             triggered_at=candle.closed_at,
+            created_at=timestamp,
+            updated_at=timestamp,
             thresholds=thresholds,
             metrics=evaluations,
             allow_long=allow_long,


### PR DESCRIPTION
## Summary
- extend core entities with candle identifiers, timeframe, audit timestamps and source signal linkage
- update JSON storage serializers/deserializers and repositories to persist the new fields
- adjust selection, backtest and live services plus OHLCV mapping/config parsing to populate the enriched models

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68cbea6c131c83208e235519d28c020d