### PR TITLE
Refine selector thresholds logic

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -71,18 +71,13 @@ def _parse_threshold(raw: Dict[str, object]) -> Thresholds:
                     min_abs_value=float(item["min_abs_value"]) if item.get("min_abs_value") is not None else None,
                 )
             )
-    def _get_float(key: str, fallback: float = 0.0) -> float:
+    def _get_float_from_keys(keys: list[str], fallback: float = 0.0) -> float:
         if not isinstance(raw, dict):
             return fallback
-        value = raw.get(key)
-        if value is None:
-            return fallback
-        return float(value)
-
-    def _get_upper_lower(name: str, fallback: float = 0.0) -> float:
-        upper = name.upper()
-        lower = name.lower()
-        return _get_float(upper, _get_float(lower, fallback))
+        for key in keys:
+            if key in raw and raw[key] is not None:
+                return float(raw[key])
+        return fallback
 
     def _get_bool(key: str, default: bool) -> bool:
         if not isinstance(raw, dict):
@@ -107,13 +102,37 @@ def _parse_threshold(raw: Dict[str, object]) -> Thresholds:
     updated_at_raw = raw.get("updated_at") if isinstance(raw, dict) else None
     return Thresholds(
         id=str(raw.get("id")) if isinstance(raw, dict) and raw.get("id") is not None else None,
-        s=_get_upper_lower("s"),
-        t=_get_upper_lower("t"),
-        u=_get_upper_lower("u"),
-        v=_get_upper_lower("v"),
-        w=_get_upper_lower("w"),
-        x=_get_upper_lower("x"),
-        y=_get_upper_lower("y"),
+        min_relative_volume=_get_float_from_keys(
+            [
+                "min_relative_volume",
+                "minRelativeVolume",
+                "S",
+                "s",
+            ]
+        ),
+        max_relative_volume=_get_float_from_keys(
+            [
+                "max_relative_volume",
+                "maxRelativeVolume",
+                "T",
+                "t",
+            ]
+        ),
+        min_atr_mult=_get_float_from_keys(
+            ["min_atr_mult", "minAtrMult", "U", "u"],
+        ),
+        min_pct_move=_get_float_from_keys(
+            ["min_pct_move", "minPctMove", "V", "v"],
+        ),
+        max_pct_move=_get_float_from_keys(
+            ["max_pct_move", "maxPctMove", "W", "w"],
+        ),
+        max_upper_wick_pct=_get_float_from_keys(
+            ["max_upper_wick_pct", "maxUpperWickPct", "X", "x"],
+        ),
+        max_lower_wick_pct=_get_float_from_keys(
+            ["max_lower_wick_pct", "maxLowerWickPct", "Y", "y"],
+        ),
         allow_long=allow_long,
         allow_short=allow_short,
         metrics=metrics,

--- a/bot/data/io/storage.py
+++ b/bot/data/io/storage.py
@@ -74,15 +74,39 @@ class Storage:
             metadata = {}
         created_at_raw = raw.get("created_at")
         updated_at_raw = raw.get("updated_at")
+        def _get_float_from_keys(keys: list[str]) -> float:
+            for key in keys:
+                if raw.get(key) is not None:
+                    return float(raw[key])
+            return 0.0
+
         return Thresholds(
             id=str(raw["id"]) if raw.get("id") is not None else None,
-            s=float(raw.get("s", 0.0)),
-            t=float(raw.get("t", 0.0)),
-            u=float(raw.get("u", 0.0)),
-            v=float(raw.get("v", 0.0)),
-            w=float(raw.get("w", 0.0)),
-            x=float(raw.get("x", 0.0)),
-            y=float(raw.get("y", 0.0)),
+            min_relative_volume=_get_float_from_keys(
+                [
+                    "min_relative_volume",
+                    "minRelativeVolume",
+                    "S",
+                    "s",
+                ]
+            ),
+            max_relative_volume=_get_float_from_keys(
+                [
+                    "max_relative_volume",
+                    "maxRelativeVolume",
+                    "T",
+                    "t",
+                ]
+            ),
+            min_atr_mult=_get_float_from_keys(["min_atr_mult", "minAtrMult", "U", "u"]),
+            min_pct_move=_get_float_from_keys(["min_pct_move", "minPctMove", "V", "v"]),
+            max_pct_move=_get_float_from_keys(["max_pct_move", "maxPctMove", "W", "w"]),
+            max_upper_wick_pct=_get_float_from_keys(
+                ["max_upper_wick_pct", "maxUpperWickPct", "X", "x"]
+            ),
+            max_lower_wick_pct=_get_float_from_keys(
+                ["max_lower_wick_pct", "maxLowerWickPct", "Y", "y"]
+            ),
             allow_long=self._to_bool(raw.get("allow_long", True)),
             allow_short=self._to_bool(raw.get("allow_short", True)),
             metrics=metrics,

--- a/bot/domain/models/entities.py
+++ b/bot/domain/models/entities.py
@@ -33,13 +33,13 @@ class ThresholdMetric:
 @dataclass(slots=True)
 class Thresholds:
     id: Optional[str] = None
-    s: float = 0.0
-    t: float = 0.0
-    u: float = 0.0
-    v: float = 0.0
-    w: float = 0.0
-    x: float = 0.0
-    y: float = 0.0
+    min_relative_volume: float = 0.0
+    max_relative_volume: float = 0.0
+    min_atr_mult: float = 0.0
+    min_pct_move: float = 0.0
+    max_pct_move: float = 0.0
+    max_upper_wick_pct: float = 0.0
+    max_lower_wick_pct: float = 0.0
     allow_long: bool = True
     allow_short: bool = True
     metrics: List[ThresholdMetric] = field(default_factory=list)

--- a/bot/domain/services/selector_service.py
+++ b/bot/domain/services/selector_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-from math import fabs, isnan
+from math import fabs
 from typing import Iterable, List, Sequence
 
 from ..enums import BreakDirection, Side
@@ -30,26 +30,47 @@ class SignalSelectorService:
         if metrics.pct_move <= 0:
             reasons.append("long_negative_body")
             return False
-        if thresholds.s > 0 and metrics.pct_move < thresholds.s:
+        if (
+            thresholds.min_pct_move != 0
+            and metrics.pct_move <= thresholds.min_pct_move
+        ):
             reasons.append("long_pct_move")
             return False
-        if thresholds.t > 0 and metrics.relative_volume < thresholds.t:
+        if (
+            thresholds.max_pct_move != 0
+            and metrics.pct_move >= thresholds.max_pct_move
+        ):
+            reasons.append("long_pct_move")
+            return False
+        if (
+            thresholds.min_relative_volume > 0
+            and metrics.relative_volume <= thresholds.min_relative_volume
+        ):
             reasons.append("long_relative_volume")
             return False
-        if thresholds.u > 0 and metrics.atr_multiple < thresholds.u:
+        if (
+            thresholds.max_relative_volume > 0
+            and metrics.relative_volume >= thresholds.max_relative_volume
+        ):
+            reasons.append("long_relative_volume")
+            return False
+        if (
+            thresholds.min_atr_mult > 0
+            and metrics.atr_multiple <= thresholds.min_atr_mult
+        ):
             reasons.append("long_atr_mult")
             return False
-        if thresholds.v > 0 and metrics.upper_wick_pct > thresholds.v:
+        if (
+            thresholds.max_upper_wick_pct > 0
+            and metrics.upper_wick_pct >= thresholds.max_upper_wick_pct
+        ):
             reasons.append("long_upper_wick")
             return False
-        if thresholds.w > 0 and metrics.lower_wick_pct > thresholds.w:
+        if (
+            thresholds.max_lower_wick_pct > 0
+            and metrics.lower_wick_pct >= thresholds.max_lower_wick_pct
+        ):
             reasons.append("long_lower_wick")
-            return False
-        if thresholds.x > 0 and not isnan(metrics.pct_to_high) and metrics.pct_to_high < thresholds.x:
-            reasons.append("long_pct_to_high")
-            return False
-        if thresholds.y > 0 and not isnan(metrics.pct_to_low) and fabs(metrics.pct_to_low) > thresholds.y:
-            reasons.append("long_pct_to_low")
             return False
         return True
 
@@ -62,26 +83,52 @@ class SignalSelectorService:
         if metrics.pct_move >= 0:
             reasons.append("short_positive_body")
             return False
-        if thresholds.s > 0 and fabs(metrics.pct_move) < thresholds.s:
-            reasons.append("short_pct_move")
-            return False
-        if thresholds.t > 0 and metrics.relative_volume < thresholds.t:
+        min_rel_vol = thresholds.min_relative_volume
+        max_rel_vol = thresholds.max_relative_volume
+        rel_volume_valid = True
+        if min_rel_vol > 0 and max_rel_vol > 0:
+            rel_volume_valid = (
+                metrics.relative_volume < min_rel_vol
+                or metrics.relative_volume > max_rel_vol
+            )
+        elif min_rel_vol > 0:
+            rel_volume_valid = metrics.relative_volume < min_rel_vol
+        elif max_rel_vol > 0:
+            rel_volume_valid = metrics.relative_volume > max_rel_vol
+        if not rel_volume_valid:
             reasons.append("short_relative_volume")
             return False
-        if thresholds.u > 0 and metrics.atr_multiple < thresholds.u:
+        if (
+            thresholds.min_atr_mult > 0
+            and metrics.atr_multiple >= thresholds.min_atr_mult
+        ):
             reasons.append("short_atr_mult")
             return False
-        if thresholds.v > 0 and metrics.lower_wick_pct > thresholds.v:
-            reasons.append("short_lower_wick")
+        pct_move = metrics.pct_move
+        min_pct_move = thresholds.min_pct_move
+        max_pct_move = thresholds.max_pct_move
+        pct_move_valid = True
+        conditions = []
+        if max_pct_move != 0:
+            conditions.append(pct_move > max_pct_move)
+        if min_pct_move != 0:
+            conditions.append(pct_move < min_pct_move)
+        if conditions:
+            pct_move_valid = any(conditions)
+        if not pct_move_valid:
+            reasons.append("short_pct_move")
             return False
-        if thresholds.w > 0 and metrics.upper_wick_pct > thresholds.w:
+        if (
+            thresholds.max_upper_wick_pct > 0
+            and metrics.upper_wick_pct >= thresholds.max_upper_wick_pct
+        ):
             reasons.append("short_upper_wick")
             return False
-        if thresholds.x > 0 and not isnan(metrics.pct_to_low) and fabs(metrics.pct_to_low) < thresholds.x:
-            reasons.append("short_pct_to_low")
-            return False
-        if thresholds.y > 0 and not isnan(metrics.pct_to_high) and metrics.pct_to_high > thresholds.y:
-            reasons.append("short_pct_to_high")
+        if (
+            thresholds.max_lower_wick_pct > 0
+            and metrics.lower_wick_pct >= thresholds.max_lower_wick_pct
+        ):
+            reasons.append("short_lower_wick")
             return False
         return True
 

--- a/settings.toml
+++ b/settings.toml
@@ -26,13 +26,13 @@ rate_limit_per_minute = 600
 min_quote_volume = 250000.0
 
 [thresholds.default]
-S = 50.0
-T = 100000.0
-U = 100.0
-V = 0.0
-W = 0.0
-X = 2.0
-Y = 1.0
+min_relative_volume = 50.0
+max_relative_volume = 100000.0
+min_atr_mult = 100.0
+min_pct_move = 0.0
+max_pct_move = 0.0
+max_upper_wick_pct = 2.0
+max_lower_wick_pct = 1.0
 allow_long = true
 allow_short = true
 
@@ -49,13 +49,13 @@ name = "momentum"
 min_abs_value = 100.0
 
 [thresholds.symbols.BTCUSDT]
-S = 25.0
-T = 200000.0
-U = 80.0
-V = 0.0
-W = 0.0
-X = 2.5
-Y = 1.0
+min_relative_volume = 25.0
+max_relative_volume = 200000.0
+min_atr_mult = 80.0
+min_pct_move = 0.0
+max_pct_move = 0.0
+max_upper_wick_pct = 2.5
+max_lower_wick_pct = 1.0
 allow_long = true
 allow_short = true
 metadata = { timeframe = "15m" }


### PR DESCRIPTION
## Summary
- replace the Thresholds fields with descriptive names and update storage/config parsing to support the new mapping
- implement the revised long/short selection rules that enforce the new threshold ranges
- refresh the default settings so the TOML uses the renamed threshold keys

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68cbeef3571c832080dae29a1d66af42