### PR TITLE
Update break metrics to use breakout candle values

### DIFF
--- a/bot/domain/services/metrics_service.py
+++ b/bot/domain/services/metrics_service.py
@@ -113,14 +113,14 @@ class MetricsService:
                 if broke_high and high_break_index is None:
                     high_break_index = idx
                     pct_to_high_break = (
-                        max(current.high - current.close, 0.0) / current.close * 100
+                        max(candle.high - current.close, 0.0) / current.close * 100
                         if current.close
                         else 0.0
                     )
                 if broke_low and low_break_index is None:
                     low_break_index = idx
                     pct_to_low_break = (
-                        min(current.low - current.close, 0.0) / current.close * 100
+                        max(current.close - candle.low, 0.0) / current.close * 100
                         if current.close
                         else 0.0
                     )


### PR DESCRIPTION
## Summary
- adjust breakout percentage calculations to use the candle that first breaches the range
- ensure percent-to-break metrics remain positive and reflect the actual breakout move

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbf4e8f00483209d2f453ab57740ff