### PR TITLE
Add exit price tracking for trades

### DIFF
--- a/bot/data/io/storage.py
+++ b/bot/data/io/storage.py
@@ -237,6 +237,7 @@ class Storage:
             used_margin=float(
                 raw.get("used_margin", raw.get("used_amount", raw.get("size", 0.0)))
             ),
+            exit_price=float(raw["exit_price"]) if raw.get("exit_price") is not None else None,
             tp_price=float(raw["tp_price"]) if raw.get("tp_price") is not None else None,
             sl_price=float(raw["sl_price"]) if raw.get("sl_price") is not None else None,
             opened_at=datetime.fromisoformat(raw["opened_at"]) if raw.get("opened_at") else None,

--- a/bot/data/repositories/trade_repository.py
+++ b/bot/data/repositories/trade_repository.py
@@ -32,6 +32,10 @@ class TradeRepository:
             data["created_at"] = trade.created_at.isoformat()
         if trade.updated_at:
             data["updated_at"] = trade.updated_at.isoformat()
+        if data.get("exit_price") is None:
+            data.pop("exit_price", None)
+        else:
+            data["exit_price"] = float(data["exit_price"])
         if data.get("thresholds_snapshot") is None:
             data.pop("thresholds_snapshot", None)
         elif isinstance(data["thresholds_snapshot"], dict):

--- a/bot/domain/models/entities.py
+++ b/bot/domain/models/entities.py
@@ -88,6 +88,7 @@ class Trade:
     entry_price: float
     size: float
     used_margin: float = 0.0
+    exit_price: Optional[float] = None
     tp_price: Optional[float] = None
     sl_price: Optional[float] = None
     opened_at: Optional[datetime] = None

--- a/bot/domain/services/backtest_runner.py
+++ b/bot/domain/services/backtest_runner.py
@@ -165,6 +165,7 @@ class BacktestRunner:
             trade.status = status
             trade.closed_at = candle.closed_at
             exit_price = trade.tp_price if status == TradeStatus.CLOSED_TP else trade.sl_price
+            trade.exit_price = exit_price
             trade.pnl = self._calculate_pnl(trade, exit_price)
             trade.pnl_pct = (
                 (trade.pnl / trade.used_margin) * 100.0


### PR DESCRIPTION
## Summary
- add an optional `exit_price` field to the `Trade` entity and propagate it through storage serialization
- ensure trades persist their exit price in the repository payload
- populate the exit price when backtests close trades so that PnL calculations and storage include it

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbf6d97b88832097f9981f441f8dfd