### PR TITLE
Add quote volume support for liquidity filtering

### DIFF
--- a/bot/data/mappers/ohlcv_mapper.py
+++ b/bot/data/mappers/ohlcv_mapper.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Sequence
+from typing import Any, Sequence
 
 from ...domain.enums import Exchange, Timeframe
 from ...domain.models.entities import Candle
 
 
 def map_ohlcv(
-    raw: Sequence[float],
+    raw: Sequence[Any],
     symbol: str,
     exchange: Exchange,
     timeframe: Timeframe,
@@ -17,6 +17,8 @@ def map_ohlcv(
         raise ValueError("raw OHLCV should have at least 6 elements")
     timestamp = datetime.fromtimestamp(raw[0] / 1000 if raw[0] > 1e12 else raw[0], tz=timezone.utc)
     candle_id = f"{exchange.value}:{symbol}:{timeframe.value}:{int(timestamp.timestamp())}"
+    volume = float(raw[5])
+    quote_volume = _extract_quote_volume(raw, exchange)
     return Candle(
         id=candle_id,
         symbol=symbol,
@@ -26,7 +28,24 @@ def map_ohlcv(
         high=float(raw[2]),
         low=float(raw[3]),
         close=float(raw[4]),
-        volume=float(raw[5]),
+        volume=volume,
+        quote_volume=quote_volume,
         started_at=timestamp,
         closed_at=timestamp,
     )
+
+
+def _extract_quote_volume(raw: Sequence[Any], exchange: Exchange) -> float | None:
+    if exchange == Exchange.BINANCE and len(raw) > 7:
+        return _safe_float(raw[7])
+    if exchange == Exchange.BYBIT and len(raw) > 6:
+        # Bybit provides turnover (quote volume) at index 6 in the kline array
+        return _safe_float(raw[6])
+    return None
+
+
+def _safe_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/bot/data/providers/base.py
+++ b/bot/data/providers/base.py
@@ -42,7 +42,12 @@ class BaseExchangeProvider:
         self._logger = get_logger(self.__class__.__name__)
 
     async def _filter_liquidity(self, candles: Sequence[Candle]) -> List[Candle]:
-        return [c for c in candles if c.volume >= self._min_quote_volume]
+        filtered: List[Candle] = []
+        for candle in candles:
+            quote_volume = candle.quote_volume if candle.quote_volume is not None else candle.volume
+            if quote_volume >= self._min_quote_volume:
+                filtered.append(candle)
+        return filtered
 
     async def fetch_ohlcv(self, symbol: str, timeframe: Timeframe, limit: int) -> List[Candle]:
         raise NotImplementedError

--- a/bot/domain/models/entities.py
+++ b/bot/domain/models/entities.py
@@ -18,6 +18,7 @@ class Candle:
     low: float
     close: float
     volume: float
+    quote_volume: Optional[float] = None
     started_at: datetime
     closed_at: datetime
 


### PR DESCRIPTION
## Summary
- add quote volume field to Candle entity and populate it via the OHLCV mapper
- extract quote volumes from Binance and Bybit klines to match liquidity filters
- update base provider liquidity filter to rely on quote volume while retaining a base-volume fallback

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68cbfff4cdc083209398ed02057a27d4