### PR TITLE
Add authenticated balance updates for Binance and Bybit

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from datetime import datetime
 from pathlib import Path
 from typing import Dict
@@ -46,10 +47,35 @@ def init_providers(config: AppConfig) -> Dict[str, BaseExchangeProvider]:
         min_volume = float(cfg.get("min_quote_volume", 0))
         api_base = cfg.get("api_base")
         ws_base = cfg.get("ws_base")
+        env_prefix = name.upper()
+
+        def _resolve_secret(key: str, env_suffix: str) -> str | None:
+            value = cfg.get(key)
+            if value:
+                return str(value)
+            env_key = cfg.get(f"{key}_env") or f"{env_prefix}_{env_suffix}"
+            return config.get(f"env.{env_key}") or os.getenv(env_key)
+
+        api_key = _resolve_secret("api_key", "API_KEY")
+        api_secret = _resolve_secret("api_secret", "API_SECRET")
         if name == "binance":
-            providers[name] = BinanceFuturesProvider(api_base, ws_base, rate, min_volume)
+            providers[name] = BinanceFuturesProvider(
+                api_base,
+                ws_base,
+                rate,
+                min_volume,
+                api_key=api_key,
+                api_secret=api_secret,
+            )
         elif name == "bybit":
-            providers[name] = BybitPerpetualProvider(api_base, ws_base, rate, min_volume)
+            providers[name] = BybitPerpetualProvider(
+                api_base,
+                ws_base,
+                rate,
+                min_volume,
+                api_key=api_key,
+                api_secret=api_secret,
+            )
     return providers
 
 

--- a/bot/data/providers/binance.py
+++ b/bot/data/providers/binance.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-import json
+import hmac
+import time
+from hashlib import sha256
 from typing import Any, AsyncIterator, Iterable, List
+from urllib.parse import urlencode
 
 try:
     import httpx
@@ -25,10 +28,31 @@ class BinanceFuturesProvider(BaseExchangeProvider):
         rate_limit_per_minute: int,
         min_quote_volume: float,
         session: httpx.AsyncClient | None = None,
+        api_key: str | None = None,
+        api_secret: str | None = None,
     ) -> None:
         super().__init__(api_base, ws_base, rate_limit_per_minute, min_quote_volume)
         self._session = session or (httpx.AsyncClient(timeout=10.0) if httpx else None)
         self._logger = get_logger(self.__class__.__name__)
+        self._api_key = api_key
+        self._api_secret = api_secret
+
+    def _require_credentials(self) -> tuple[str, str]:
+        if not self._api_key or not self._api_secret:
+            raise RuntimeError("Binance API credentials are required for private requests")
+        return self._api_key, self._api_secret
+
+    async def _authenticated_get(self, endpoint: str, params: dict[str, Any] | None = None) -> httpx.Response:
+        if not self._session:
+            raise RuntimeError("httpx is required to perform authenticated requests to Binance")
+        api_key, api_secret = self._require_credentials()
+        query_params = params.copy() if params else {}
+        query_params.setdefault("timestamp", int(time.time() * 1000))
+        query_string = urlencode(query_params)
+        signature = hmac.new(api_secret.encode("utf-8"), query_string.encode("utf-8"), sha256).hexdigest()
+        query_params["signature"] = signature
+        headers = {"X-MBX-APIKEY": api_key}
+        return await self._session.get(endpoint, params=query_params, headers=headers)
 
     async def fetch_ohlcv(self, symbol: str, timeframe: Timeframe, limit: int) -> List[Candle]:
         await self.ensure_rate_limit()
@@ -67,13 +91,24 @@ class BinanceFuturesProvider(BaseExchangeProvider):
 
     async def update_deposit(self) -> dict[str, Any]:
         await self.ensure_rate_limit()
-        if not self._session:
-            raise RuntimeError("httpx is required to fetch account balance from Binance")
         endpoint = f"{self._api_base}/fapi/v2/balance"
-        response = await self._session.get(endpoint)
+        response = await self._authenticated_get(endpoint)
         response.raise_for_status()
         balances = response.json()
-        usdt_balance = next((float(item.get("balance", 0.0)) for item in balances if item.get("asset") == "USDT"), 0.0)
+        usdt_balance = 0.0
+        for item in balances:
+            if item.get("asset") != "USDT":
+                continue
+            for key in ("availableBalance", "balance", "crossWalletBalance", "equity"):
+                value = item.get(key)
+                if value is not None:
+                    try:
+                        usdt_balance = float(value)
+                        break
+                    except (TypeError, ValueError):
+                        continue
+            if usdt_balance:
+                break
         return {"asset": "USDT", "balance": usdt_balance}
 
     async def close(self) -> None:

--- a/bot/data/providers/bybit.py
+++ b/bot/data/providers/bybit.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import hmac
+import time
+from hashlib import sha256
 from typing import Any, AsyncIterator, Iterable, List
+from urllib.parse import urlencode
 
 try:
     import httpx
@@ -23,9 +27,40 @@ class BybitPerpetualProvider(BaseExchangeProvider):
         rate_limit_per_minute: int,
         min_quote_volume: float,
         session: httpx.AsyncClient | None = None,
+        api_key: str | None = None,
+        api_secret: str | None = None,
     ) -> None:
         super().__init__(api_base, ws_base, rate_limit_per_minute, min_quote_volume)
         self._session = session or (httpx.AsyncClient(timeout=10.0) if httpx else None)
+        self._api_key = api_key
+        self._api_secret = api_secret
+
+    def _require_credentials(self) -> tuple[str, str]:
+        if not self._api_key or not self._api_secret:
+            raise RuntimeError("Bybit API credentials are required for private requests")
+        return self._api_key, self._api_secret
+
+    async def _authenticated_get(
+        self, endpoint: str, params: dict[str, Any] | None = None
+    ) -> httpx.Response:
+        if not self._session:
+            raise RuntimeError("httpx is required to perform authenticated requests to Bybit")
+        api_key, api_secret = self._require_credentials()
+        query_params = params.copy() if params else {}
+        recv_window = str(query_params.pop("recvWindow", query_params.pop("recv_window", "5000")))
+        query_string = urlencode(sorted(query_params.items())) if query_params else ""
+        timestamp = str(int(time.time() * 1000))
+        query_params["recvWindow"] = recv_window
+        prehash = f"{timestamp}{api_key}{recv_window}{query_string}"
+        signature = hmac.new(api_secret.encode("utf-8"), prehash.encode("utf-8"), sha256).hexdigest()
+        headers = {
+            "X-BAPI-API-KEY": api_key,
+            "X-BAPI-TIMESTAMP": timestamp,
+            "X-BAPI-RECV-WINDOW": recv_window,
+            "X-BAPI-SIGN": signature,
+            "X-BAPI-SIGN-TYPE": "2",
+        }
+        return await self._session.get(endpoint, params=query_params, headers=headers)
 
     async def fetch_ohlcv(self, symbol: str, timeframe: Timeframe, limit: int) -> List[Candle]:
         await self.ensure_rate_limit()
@@ -66,16 +101,37 @@ class BybitPerpetualProvider(BaseExchangeProvider):
 
     async def update_deposit(self) -> dict[str, Any]:
         await self.ensure_rate_limit()
-        if not self._session:
-            raise RuntimeError("httpx is required to fetch balances from Bybit")
         endpoint = f"{self._api_base}/v5/account/wallet-balance"
         params = {"accountType": "UNIFIED"}
-        response = await self._session.get(endpoint, params=params)
+        response = await self._authenticated_get(endpoint, params=params)
         response.raise_for_status()
         data = response.json()
-        balances = data.get("result", {}).get("list", [])
-        usdt = next((float(item.get("totalWalletBalance", 0.0)) for item in balances if item.get("coin") == "USDT"), 0.0)
-        return {"asset": "USDT", "balance": usdt}
+        result = data.get("result", {})
+        entries = result.get("list", [])
+        usdt_balance = 0.0
+        for entry in entries:
+            coins = entry.get("coin")
+            if isinstance(coins, list):
+                for coin in coins:
+                    if coin.get("coin") == "USDT":
+                        for key in (
+                            "walletBalance",
+                            "availableToWithdraw",
+                            "equity",
+                            "availableBalance",
+                        ):
+                            value = coin.get(key)
+                            if value is not None:
+                                try:
+                                    usdt_balance = float(value)
+                                    break
+                                except (TypeError, ValueError):
+                                    continue
+                        if usdt_balance:
+                            break
+            if usdt_balance:
+                break
+        return {"asset": "USDT", "balance": usdt_balance}
 
     async def close(self) -> None:
         if self._session:


### PR DESCRIPTION
## Summary
- load API credentials for exchange providers from settings or environment
- store API keys in Binance and Bybit providers and sign private REST requests
- fetch wallet balances with authenticated calls and parse USDT balances for deposit updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc06ef1c5c83208e55b8528d1e7b32