### PR TITLE
Refine runtime type usage and resource cleanup

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -340,9 +340,7 @@ async def main_async() -> None:
         await run_live(config, providers, thresholds_map, services)
     finally:
         for provider in providers.values():
-            close = getattr(provider, "close", None)
-            if close:
-                await close()
+            await provider.close()
 
 
 def main() -> None:

--- a/bot/data/providers/base.py
+++ b/bot/data/providers/base.py
@@ -63,6 +63,9 @@ class BaseExchangeProvider:
     async def update_deposit(self) -> Dict[str, Any]:
         raise NotImplementedError
 
+    async def close(self) -> None:
+        """Release provider resources."""
+
     def map_candles(
         self, raw: Iterable[Sequence[Any]], symbol: str, timeframe: Timeframe
     ) -> List[Candle]:

--- a/bot/domain/services/backtest_runner.py
+++ b/bot/domain/services/backtest_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Dict, Sequence
 
@@ -118,21 +119,25 @@ class BacktestRunner:
         self._last_deposit_update = timestamp
         self._state.update_deposit(amount, asset, timestamp)
 
-    def _extract_deposit(self, balance: Any) -> tuple[str, float]:
-        if isinstance(balance, dict):
-            asset = str(balance.get("asset") or self._deposit_asset or "USDT")
-            for key in ("balance", "availableBalance", "available", "amount", "equity"):
-                value = balance.get(key)
-                if value is not None:
-                    try:
-                        return asset, float(value)
-                    except (TypeError, ValueError):
-                        continue
-            try:
-                return asset, float(balance.get(asset, 0.0))
-            except (TypeError, ValueError):
-                pass
+    def _extract_deposit(self, balance: Mapping[str, Any]) -> tuple[str, float]:
+        asset = str(balance.get("asset") or self._deposit_asset or "USDT")
+        for key in ("balance", "availableBalance", "available", "amount", "equity"):
+            value = self._to_float(balance.get(key))
+            if value is not None:
+                return asset, value
+        fallback = self._to_float(balance.get(asset))
+        if fallback is not None:
+            return asset, fallback
         return self._deposit_asset or "USDT", self._deposit_usdt
+
+    @staticmethod
+    def _to_float(value: Any) -> float | None:
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
 
     def _calculate_trade_size(self) -> float:
         return max(10.0, 0.0005 * self._deposit_usdt) if self._deposit_usdt > 0 else 10.0
@@ -154,8 +159,7 @@ class BacktestRunner:
         self, signal: Signal, trade: Trade, future_candles: Sequence[Candle]
     ) -> None:
         raw_metrics = signal.metadata.get("metrics")
-        metrics_getter = getattr(raw_metrics, "get", None)
-        metrics: Dict[str, Any] = raw_metrics if callable(metrics_getter) else {}
+        metrics: Dict[str, Any] = dict(raw_metrics) if isinstance(raw_metrics, Mapping) else {}
 
         def _extract_pct(key: str) -> float:
             value = metrics.get(key)

--- a/bot/domain/services/live_runner.py
+++ b/bot/domain/services/live_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import deque
+from collections.abc import Mapping
 from typing import Any, Deque, Dict, Iterable, Optional
 
 from ...data.providers.base import BaseExchangeProvider
@@ -52,11 +53,7 @@ class LiveTradingRunner:
         snapshot = await self.refresh_deposit()
         trade_size = self._calculate_trade_size()
         timestamp = utcnow()
-        source_signal_id = (
-            signal.metadata.get("source_signal_id")
-            if isinstance(signal.metadata, dict) and signal.metadata.get("source_signal_id")
-            else signal.id
-        )
+        source_signal_id = signal.metadata.get("source_signal_id") or signal.id
         trade = Trade(
             id=signal.id,
             signal_id=signal.id,
@@ -161,21 +158,25 @@ class LiveTradingRunner:
         self._state.update_deposit(amount, asset, timestamp)
         return self._deposit_snapshot()
 
-    def _extract_deposit(self, balance: Any) -> tuple[str, float]:
-        if isinstance(balance, dict):
-            asset = str(balance.get("asset") or self._deposit_asset or "USDT")
-            for key in ("balance", "availableBalance", "available", "amount", "equity"):
-                value = balance.get(key)
-                if value is not None:
-                    try:
-                        return asset, float(value)
-                    except (TypeError, ValueError):
-                        continue
-            try:
-                return asset, float(balance.get(asset, 0.0))
-            except (TypeError, ValueError):
-                pass
+    def _extract_deposit(self, balance: Mapping[str, Any]) -> tuple[str, float]:
+        asset = str(balance.get("asset") or self._deposit_asset or "USDT")
+        for key in ("balance", "availableBalance", "available", "amount", "equity"):
+            value = self._to_float(balance.get(key))
+            if value is not None:
+                return asset, value
+        fallback = self._to_float(balance.get(asset))
+        if fallback is not None:
+            return asset, fallback
         return self._deposit_asset or "USDT", self._deposit_usdt
+
+    @staticmethod
+    def _to_float(value: Any) -> float | None:
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
 
     def _calculate_trade_size(self) -> float:
         return max(10.0, 0.0005 * self._deposit_usdt) if self._deposit_usdt > 0 else 10.0

--- a/bot/utils/logging.py
+++ b/bot/utils/logging.py
@@ -5,12 +5,26 @@ from logging import Logger
 from typing import Optional
 
 
+_LEVEL_BY_NAME: dict[str, int] = {
+    "CRITICAL": logging.CRITICAL,
+    "ERROR": logging.ERROR,
+    "WARNING": logging.WARNING,
+    "INFO": logging.INFO,
+    "DEBUG": logging.DEBUG,
+    "NOTSET": logging.NOTSET,
+}
+
+
 _LOGGER_CACHE: dict[str, Logger] = {}
+
+
+def _resolve_level(level: str) -> int:
+    return _LEVEL_BY_NAME.get(level.upper(), logging.INFO)
 
 
 def configure_logging(level: str = "INFO") -> None:
     logging.basicConfig(
-        level=getattr(logging, level.upper(), logging.INFO),
+        level=_resolve_level(level),
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
 
@@ -20,6 +34,6 @@ def get_logger(name: str, level: Optional[str] = None) -> Logger:
         return _LOGGER_CACHE[name]
     logger = logging.getLogger(name)
     if level:
-        logger.setLevel(getattr(logging, level.upper(), logging.INFO))
+        logger.setLevel(_resolve_level(level))
     _LOGGER_CACHE[name] = logger
     return logger


### PR DESCRIPTION
## Summary
- eliminate dynamic attribute checks when handling signal metadata
- centralize deposit parsing for live and backtest runners with explicit float conversion helpers
- provide deterministic logging level resolution and ensure providers expose a standard close coroutine

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68cc1a0f0ffc832092438e98ecc30441