### PR TITLE
Add dynamic symbol discovery using 24h stats

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -4,7 +4,7 @@ import asyncio
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Iterable, Mapping
 
 from .data.io.config_loader import AppConfig, ConfigLoader
 from .data.io.storage import Storage
@@ -216,14 +216,123 @@ def init_services(config: AppConfig, storage: Storage) -> tuple[
     )
 
 
+def _normalize_symbol_set(raw: object) -> set[str]:
+    symbols: set[str] = set()
+    if isinstance(raw, str):
+        raw = [raw]
+    if isinstance(raw, (list, tuple, set, frozenset)):
+        for item in raw:
+            if isinstance(item, str) and item:
+                symbols.add(item.upper())
+    return symbols
+
+
+def _resolve_provider_name(
+    symbol: str,
+    config: AppConfig,
+    providers: Dict[str, BaseExchangeProvider],
+    default: str | None = None,
+) -> str:
+    mapping = config.get("symbols.providers", {})
+    provider_name: str | None = None
+    if isinstance(mapping, Mapping):
+        provider_name = mapping.get(symbol) or mapping.get("default")
+    if not provider_name and default:
+        provider_name = default
+    if not provider_name:
+        provider_name = next(iter(providers))
+    if provider_name not in providers:
+        provider_name = next(iter(providers))
+    return provider_name
+
+
+async def discover_symbol_universe(
+    config: AppConfig,
+    providers: Dict[str, BaseExchangeProvider],
+    mode: str,
+    provider_scope: Iterable[str] | None = None,
+) -> Dict[str, str]:
+    logger = get_logger("symbol-discovery")
+    selection_cfg = config.get("symbols.selection", {})
+    suffix = "USDT"
+    min_quote_volume = 5_000_000.0
+    allow: set[str] = set()
+    deny: set[str] = set()
+    if isinstance(selection_cfg, Mapping):
+        suffix = str(selection_cfg.get("quote_suffix", suffix)).upper() or suffix
+        min_quote_volume = float(selection_cfg.get("min_quote_volume", min_quote_volume))
+        allow |= _normalize_symbol_set(selection_cfg.get("allow"))
+        deny |= _normalize_symbol_set(selection_cfg.get("deny"))
+    mode_cfg = config.get(mode, {})
+    if isinstance(mode_cfg, Mapping):
+        allow |= _normalize_symbol_set(mode_cfg.get("allow"))
+        allow |= _normalize_symbol_set(mode_cfg.get("symbols"))
+        deny |= _normalize_symbol_set(mode_cfg.get("deny"))
+
+    provider_names = list(provider_scope or providers.keys())
+    discovered: Dict[str, str] = {}
+    volumes: Dict[str, float] = {}
+
+    for provider_name in provider_names:
+        provider = providers.get(provider_name)
+        if not provider:
+            continue
+        try:
+            stats = await provider.get_24h_quote_volume()
+        except NotImplementedError:
+            logger.debug("Provider %s does not expose 24h statistics", provider_name)
+            continue
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.warning("Failed to fetch 24h statistics from %s: %s", provider_name, exc)
+            continue
+        if not isinstance(stats, Mapping):
+            continue
+        for symbol, volume in stats.items():
+            if not isinstance(symbol, str):
+                continue
+            normalized = symbol.upper()
+            if suffix and not normalized.endswith(suffix):
+                continue
+            if normalized in deny:
+                continue
+            try:
+                volume_value = float(volume)
+            except (TypeError, ValueError):
+                continue
+            if volume_value < min_quote_volume:
+                continue
+            existing_volume = volumes.get(normalized)
+            if existing_volume is None or volume_value > existing_volume:
+                volumes[normalized] = volume_value
+                discovered[normalized] = provider_name
+
+    default_provider = provider_names[0] if len(provider_names) == 1 else None
+    for symbol in allow:
+        if symbol in deny:
+            continue
+        if symbol not in discovered:
+            provider_name = _resolve_provider_name(symbol, config, providers, default_provider)
+            if provider_name in providers:
+                discovered[symbol] = provider_name
+
+    for symbol in list(discovered):
+        if symbol in deny:
+            discovered.pop(symbol, None)
+
+    return dict(sorted(discovered.items()))
+
+
 def select_provider_for_symbol(
     providers: Dict[str, BaseExchangeProvider],
     symbol: str,
     config: AppConfig,
+    discovered: Dict[str, str] | None = None,
 ) -> BaseExchangeProvider:
-    mapping = config.get("symbols.providers", {})
-    name = mapping.get(symbol) or mapping.get("default") or next(iter(providers))
-    return providers[name]
+    if discovered and symbol in discovered:
+        provider_name = discovered[symbol]
+    else:
+        provider_name = _resolve_provider_name(symbol, config, providers)
+    return providers[provider_name]
 
 
 async def run_backtest(
@@ -257,8 +366,12 @@ async def run_backtest(
     )
     timeframe = Timeframe(backtest_cfg.get("timeframe", Timeframe.M15.value))
     limit = int(backtest_cfg.get("limit", 500))
-    for symbol in backtest_cfg.get("symbols", []):
-        provider = select_provider_for_symbol(providers, symbol, config)
+    discovered = await discover_symbol_universe(config, providers, "backtest")
+    if not discovered:
+        logger.warning("No symbols available for backtest after applying liquidity filters")
+        return
+    for symbol in discovered:
+        provider = select_provider_for_symbol(providers, symbol, config, discovered)
         try:
             candles = await provider.fetch_ohlcv(symbol, timeframe, limit)
         except Exception as exc:  # pragma: no cover - network errors
@@ -305,7 +418,16 @@ async def run_live(
         window=window,
         poll_interval=poll_interval,
     )
-    symbols = live_cfg.get("symbols", [])
+    discovered = await discover_symbol_universe(
+        config,
+        providers,
+        "live",
+        provider_scope=[provider_name],
+    )
+    symbols = [symbol for symbol, name in discovered.items() if name == provider_name]
+    if not symbols:
+        logger.warning("No symbols available for live trading after applying liquidity filters")
+        return
 
     await runner.refresh_deposit(force=True)
 

--- a/bot/data/providers/base.py
+++ b/bot/data/providers/base.py
@@ -60,6 +60,10 @@ class BaseExchangeProvider:
     async def get_symbols(self) -> Iterable[str]:
         raise NotImplementedError
 
+    async def get_24h_quote_volume(self) -> Dict[str, float]:
+        """Return a mapping of symbol to 24 hour quote volume."""
+        raise NotImplementedError
+
     async def update_deposit(self) -> Dict[str, Any]:
         raise NotImplementedError
 

--- a/bot/data/providers/binance.py
+++ b/bot/data/providers/binance.py
@@ -4,7 +4,7 @@ import asyncio
 import hmac
 import time
 from hashlib import sha256
-from typing import Any, AsyncIterator, Iterable, List
+from typing import Any, AsyncIterator, Dict, Iterable, List
 from urllib.parse import urlencode
 
 try:
@@ -88,6 +88,30 @@ class BinanceFuturesProvider(BaseExchangeProvider):
         info = response.json()
         symbols = [item["symbol"] for item in info.get("symbols", []) if item.get("status") == "TRADING"]
         return [symbol for symbol in symbols if not symbol.endswith("_PERP")]  # filter illiquid synthetics
+
+    async def get_24h_quote_volume(self) -> Dict[str, float]:
+        await self.ensure_rate_limit()
+        if not self._session:
+            raise RuntimeError("httpx is required to fetch statistics from Binance")
+        endpoint = f"{self._api_base}/fapi/v1/ticker/24hr"
+        response = await self._session.get(endpoint)
+        response.raise_for_status()
+        data = response.json()
+        volumes: Dict[str, float] = {}
+        if isinstance(data, list):
+            for item in data:
+                if not isinstance(item, dict):
+                    continue
+                symbol = item.get("symbol")
+                if not isinstance(symbol, str):
+                    continue
+                volume_raw = item.get("quoteVolume")
+                try:
+                    volume = float(volume_raw)
+                except (TypeError, ValueError):
+                    continue
+                volumes[symbol.upper()] = volume
+        return volumes
 
     async def update_deposit(self) -> dict[str, Any]:
         await self.ensure_rate_limit()

--- a/bot/data/providers/bybit.py
+++ b/bot/data/providers/bybit.py
@@ -4,7 +4,7 @@ import asyncio
 import hmac
 import time
 from hashlib import sha256
-from typing import Any, AsyncIterator, Iterable, List
+from typing import Any, AsyncIterator, Dict, Iterable, List
 from urllib.parse import urlencode
 
 try:
@@ -98,6 +98,32 @@ class BybitPerpetualProvider(BaseExchangeProvider):
         raw = data.get("result", {}).get("list", [])
         symbols = [item.get("symbol") for item in raw if item.get("status") == "Trading"]
         return [symbol for symbol in symbols if symbol]
+
+    async def get_24h_quote_volume(self) -> Dict[str, float]:
+        await self.ensure_rate_limit()
+        if not self._session:
+            raise RuntimeError("httpx is required to fetch statistics from Bybit")
+        endpoint = f"{self._api_base}/derivatives/v3/public/tickers"
+        params = {"category": "linear"}
+        response = await self._session.get(endpoint, params=params)
+        response.raise_for_status()
+        data = response.json()
+        items = data.get("result", {}).get("list", [])
+        volumes: Dict[str, float] = {}
+        if isinstance(items, list):
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                symbol = item.get("symbol")
+                if not isinstance(symbol, str):
+                    continue
+                volume_raw = item.get("turnover24h") or item.get("turnover")
+                try:
+                    volume = float(volume_raw)
+                except (TypeError, ValueError):
+                    continue
+                volumes[symbol.upper()] = volume
+        return volumes
 
     async def update_deposit(self) -> dict[str, Any]:
         await self.ensure_rate_limit()

--- a/settings.toml
+++ b/settings.toml
@@ -25,6 +25,12 @@ ws_base = "wss://stream.bybit.com/v5/public/linear"
 rate_limit_per_minute = 600
 min_quote_volume = 250000.0
 
+[symbols.selection]
+min_quote_volume = 5000000.0
+quote_suffix = "USDT"
+allow = []
+deny = []
+
 [thresholds.default]
 min_relative_volume = 50.0
 max_relative_volume = 100000.0
@@ -74,14 +80,12 @@ min_abs_value = 80.0
 
 [backtest]
 enabled = true
-symbols = ["BTCUSDT"]
 timeframe = "15m"
 limit = 200
 window = 50
 
 [live]
 enabled = false
-symbols = ["BTCUSDT"]
 provider = "binance"
 timeframe = "5m"
 window = 50


### PR DESCRIPTION
## Summary
- expose a 24 hour quote volume helper on the Binance and Bybit providers
- discover tradable symbols dynamically in the app using exchange statistics with allow/deny overrides
- add configuration knobs for automated symbol selection defaults

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68cc260b84248320a40047a190ac6398