### PR TITLE
Clamp backtest candle limits to exchange maximums

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -365,7 +365,8 @@ async def run_backtest(
         window=int(backtest_cfg.get("window", 50)),
     )
     timeframe = Timeframe(backtest_cfg.get("timeframe", Timeframe.M15.value))
-    limit = int(backtest_cfg.get("limit", 500))
+    configured_limit = backtest_cfg.get("limit")
+    requested_limit = int(configured_limit) if configured_limit is not None else None
     discovered = await discover_symbol_universe(config, providers, "backtest")
     if not discovered:
         logger.warning("No symbols available for backtest after applying liquidity filters")
@@ -373,6 +374,7 @@ async def run_backtest(
     for symbol in discovered:
         provider = select_provider_for_symbol(providers, symbol, config, discovered)
         try:
+            limit = provider.resolve_ohlcv_limit(requested_limit)
             candles = await provider.fetch_ohlcv(symbol, timeframe, limit)
         except Exception as exc:  # pragma: no cover - network errors
             logger.error("Failed to fetch backtest data for %s: %s", symbol, exc)

--- a/bot/data/providers/base.py
+++ b/bot/data/providers/base.py
@@ -27,6 +27,8 @@ class RateLimiter:
 
 class BaseExchangeProvider:
     exchange: Exchange
+    max_ohlcv_limit: int | None = None
+    _ohlcv_limit_fallback: int = 500
 
     def __init__(
         self,
@@ -51,6 +53,13 @@ class BaseExchangeProvider:
 
     async def fetch_ohlcv(self, symbol: str, timeframe: Timeframe, limit: int) -> List[Candle]:
         raise NotImplementedError
+
+    def resolve_ohlcv_limit(self, requested_limit: int | None) -> int:
+        """Return a safe OHLCV limit supported by the provider."""
+        max_limit = self.max_ohlcv_limit or self._ohlcv_limit_fallback
+        if requested_limit is None or requested_limit <= 0:
+            return max_limit
+        return min(requested_limit, max_limit)
 
     async def stream_candles(
         self, symbol: str, timeframe: Timeframe

--- a/bot/data/providers/binance.py
+++ b/bot/data/providers/binance.py
@@ -20,6 +20,8 @@ from .base import BaseExchangeProvider
 
 class BinanceFuturesProvider(BaseExchangeProvider):
     exchange = Exchange.BINANCE
+    max_ohlcv_limit = 1500
+    _ohlcv_limit_fallback = 1500
 
     def __init__(
         self,
@@ -58,6 +60,7 @@ class BinanceFuturesProvider(BaseExchangeProvider):
         await self.ensure_rate_limit()
         if not self._session:
             raise RuntimeError("httpx is required to fetch candles from Binance")
+        limit = self.resolve_ohlcv_limit(limit)
         endpoint = f"{self._api_base}/fapi/v1/klines"
         params = {"symbol": symbol.upper(), "interval": timeframe.value, "limit": limit}
         response = await self._session.get(endpoint, params=params)

--- a/bot/data/providers/bybit.py
+++ b/bot/data/providers/bybit.py
@@ -19,6 +19,8 @@ from .base import BaseExchangeProvider
 
 class BybitPerpetualProvider(BaseExchangeProvider):
     exchange = Exchange.BYBIT
+    max_ohlcv_limit = 1000
+    _ohlcv_limit_fallback = 1000
 
     def __init__(
         self,
@@ -66,6 +68,7 @@ class BybitPerpetualProvider(BaseExchangeProvider):
         await self.ensure_rate_limit()
         if not self._session:
             raise RuntimeError("httpx is required to fetch candles from Bybit")
+        limit = self.resolve_ohlcv_limit(limit)
         endpoint = f"{self._api_base}/derivatives/v3/public/kline"
         params = {"symbol": symbol.upper(), "interval": timeframe.value, "limit": limit, "category": "linear"}
         response = await self._session.get(endpoint, params=params)

--- a/bot/domain/models/entities.py
+++ b/bot/domain/models/entities.py
@@ -9,7 +9,6 @@ from ..enums import BreakDirection, Exchange, Side, Timeframe, TradeStatus
 
 @dataclass(slots=True)
 class Candle:
-    id: Optional[str] = None
     symbol: str
     exchange: Exchange
     timeframe: Timeframe
@@ -18,9 +17,10 @@ class Candle:
     low: float
     close: float
     volume: float
-    quote_volume: Optional[float] = None
     started_at: datetime
     closed_at: datetime
+    id: Optional[str] = None
+    quote_volume: Optional[float] = None
 
 
 @dataclass(slots=True)
@@ -60,16 +60,16 @@ class SignalMetric:
 @dataclass(slots=True)
 class Signal:
     id: str
-    candle_id: Optional[str] = None
     candle: Candle
-    timeframe: Optional[Timeframe] = None
     side: Side
     direction: BreakDirection
     score: float
     triggered_at: datetime
+    thresholds: Thresholds
+    candle_id: Optional[str] = None
+    timeframe: Optional[Timeframe] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
-    thresholds: Thresholds
     metrics: List[SignalMetric] = field(default_factory=list)
     allow_long: bool = True
     allow_short: bool = True
@@ -80,14 +80,14 @@ class Signal:
 class Trade:
     id: str
     signal_id: str
-    source_signal_id: Optional[str] = None
     exchange: Exchange
     symbol: str
-    timeframe: Optional[Timeframe] = None
     side: Side
     status: TradeStatus
     entry_price: float
     size: float
+    source_signal_id: Optional[str] = None
+    timeframe: Optional[Timeframe] = None
     used_margin: float = 0.0
     exit_price: Optional[float] = None
     tp_price: Optional[float] = None

--- a/settings.toml
+++ b/settings.toml
@@ -81,7 +81,7 @@ min_abs_value = 80.0
 [backtest]
 enabled = true
 timeframe = "15m"
-limit = 200
+limit = 1500
 window = 50
 
 [live]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_provider_limits.py
+++ b/tests/test_provider_limits.py
@@ -1,0 +1,52 @@
+import pytest
+
+from bot.data.providers.base import BaseExchangeProvider
+from bot.domain.enums import Exchange, Timeframe
+
+
+class _StubProvider(BaseExchangeProvider):
+    exchange = Exchange.BINANCE
+    max_ohlcv_limit = 1500
+    _ohlcv_limit_fallback = 1500
+
+    async def fetch_ohlcv(self, symbol: str, timeframe: Timeframe, limit: int):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def stream_candles(self, symbol: str, timeframe: Timeframe):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def get_symbols(self):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def get_24h_quote_volume(self):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def update_deposit(self):  # pragma: no cover - unused
+        raise NotImplementedError
+
+
+class _StubBybitProvider(_StubProvider):
+    exchange = Exchange.BYBIT
+    max_ohlcv_limit = 1000
+    _ohlcv_limit_fallback = 1000
+
+
+@pytest.mark.parametrize(
+    "provider_cls,expected_limit,requested_limit",
+    [
+        (_StubProvider, 1500, None),
+        (_StubProvider, 1500, 2000),
+        (_StubProvider, 1000, 1000),
+        (_StubBybitProvider, 1000, None),
+        (_StubBybitProvider, 1000, 1500),
+        (_StubBybitProvider, 500, 500),
+    ],
+)
+def test_resolve_ohlcv_limit(provider_cls, expected_limit, requested_limit):
+    provider = provider_cls(
+        api_base="https://example.com",
+        ws_base="wss://example.com/ws",
+        rate_limit_per_minute=1200,
+        min_quote_volume=1.0,
+    )
+    assert provider.resolve_ohlcv_limit(requested_limit) == expected_limit


### PR DESCRIPTION
## Summary
- resolve backtest OHLCV depth per provider and request at most the exchange-supported limit
- clamp Binance and Bybit candle requests to their documented maximums and expose provider-specific defaults
- reorder domain entities to keep required dataclass fields positional-safe and bump the sample backtest limit to 1 500
- add tests covering the limit resolution helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc276b9b2c83209d03e5f3e46357ca