### PR TITLE
Align signal thresholds with new ATR and volume rules

### DIFF
--- a/bot/domain/services/metrics_service.py
+++ b/bot/domain/services/metrics_service.py
@@ -63,7 +63,7 @@ class MetricsService:
         body = current.close - current.open
         body_abs = abs(body)
         pct_move = (
-            (current.high - current.open) / current.open * 100 if current.open else 0.0
+            (current.close - current.open) / current.open * 100 if current.open else 0.0
         )
         median_window = min(20, len(candles))
         relative_volume = (

--- a/bot/domain/services/selector_service.py
+++ b/bot/domain/services/selector_service.py
@@ -38,19 +38,19 @@ class SignalSelectorService:
             return False
         if (
             thresholds.max_pct_move != 0
-            and metrics.pct_move >= thresholds.max_pct_move
+            and metrics.pct_move > thresholds.max_pct_move
         ):
             reasons.append("long_pct_move")
             return False
         if (
             thresholds.min_relative_volume > 0
-            and metrics.relative_volume <= thresholds.min_relative_volume
+            and metrics.relative_volume < thresholds.min_relative_volume
         ):
             reasons.append("long_relative_volume")
             return False
         if (
             thresholds.max_relative_volume > 0
-            and metrics.relative_volume >= thresholds.max_relative_volume
+            and metrics.relative_volume > thresholds.max_relative_volume
         ):
             reasons.append("long_relative_volume")
             return False
@@ -62,13 +62,13 @@ class SignalSelectorService:
             return False
         if (
             thresholds.max_upper_wick_pct > 0
-            and metrics.upper_wick_pct >= thresholds.max_upper_wick_pct
+            and metrics.upper_wick_pct > thresholds.max_upper_wick_pct
         ):
             reasons.append("long_upper_wick")
             return False
         if (
             thresholds.max_lower_wick_pct > 0
-            and metrics.lower_wick_pct >= thresholds.max_lower_wick_pct
+            and metrics.lower_wick_pct > thresholds.max_lower_wick_pct
         ):
             reasons.append("long_lower_wick")
             return False
@@ -80,51 +80,43 @@ class SignalSelectorService:
         if not thresholds.allow_short:
             reasons.append("short_disabled")
             return False
-
-        min_rel_vol = thresholds.min_relative_volume
-        max_rel_vol = thresholds.max_relative_volume
-        rel_volume = metrics.relative_volume
-        if min_rel_vol > 0 and max_rel_vol > 0:
-            if min_rel_vol <= rel_volume <= max_rel_vol:
-                reasons.append("short_relative_volume")
-                return False
-        elif min_rel_vol > 0:
-            if rel_volume >= min_rel_vol:
-                reasons.append("short_relative_volume")
-                return False
-        elif max_rel_vol > 0:
-            if rel_volume <= max_rel_vol:
-                reasons.append("short_relative_volume")
-                return False
-
+        if metrics.pct_move >= 0:
+            reasons.append("short_positive_body")
+            return False
+        magnitude = abs(metrics.pct_move)
+        if thresholds.min_pct_move > 0 and magnitude <= thresholds.min_pct_move:
+            reasons.append("short_pct_move")
+            return False
+        if thresholds.max_pct_move > 0 and magnitude > thresholds.max_pct_move:
+            reasons.append("short_pct_move")
+            return False
+        if (
+            thresholds.min_relative_volume > 0
+            and metrics.relative_volume < thresholds.min_relative_volume
+        ):
+            reasons.append("short_relative_volume")
+            return False
+        if (
+            thresholds.max_relative_volume > 0
+            and metrics.relative_volume > thresholds.max_relative_volume
+        ):
+            reasons.append("short_relative_volume")
+            return False
         if (
             thresholds.min_atr_mult > 0
-            and metrics.atr_multiple >= thresholds.min_atr_mult
+            and metrics.atr_multiple <= thresholds.min_atr_mult
         ):
             reasons.append("short_atr_mult")
             return False
-
-        pct_move = metrics.pct_move
-        min_pct_move = thresholds.min_pct_move
-        max_pct_move = thresholds.max_pct_move
-        pct_conditions = []
-        if max_pct_move != 0:
-            pct_conditions.append(pct_move > max_pct_move)
-        if min_pct_move != 0:
-            pct_conditions.append(pct_move < min_pct_move)
-        if pct_conditions and not any(pct_conditions):
-            reasons.append("short_pct_move")
-            return False
-
         if (
             thresholds.max_upper_wick_pct > 0
-            and metrics.upper_wick_pct >= thresholds.max_upper_wick_pct
+            and metrics.upper_wick_pct > thresholds.max_upper_wick_pct
         ):
             reasons.append("short_upper_wick")
             return False
         if (
             thresholds.max_lower_wick_pct > 0
-            and metrics.lower_wick_pct >= thresholds.max_lower_wick_pct
+            and metrics.lower_wick_pct > thresholds.max_lower_wick_pct
         ):
             reasons.append("short_lower_wick")
             return False

--- a/settings.toml
+++ b/settings.toml
@@ -32,51 +32,19 @@ allow = []
 deny = []
 
 [thresholds.default]
-min_relative_volume = 50.0
-max_relative_volume = 100000.0
-min_atr_mult = 100.0
-min_pct_move = 0.0
-max_pct_move = 0.0
-max_upper_wick_pct = 2.0
-max_lower_wick_pct = 1.0
+min_relative_volume = 40.0
+max_relative_volume = 200.0
+min_atr_mult = 5.0
+min_pct_move = 5.0
+max_pct_move = 10.0
+max_upper_wick_pct = 75.0
+max_lower_wick_pct = 50.0
 allow_long = true
 allow_short = true
 
 [[thresholds.default.metrics]]
 name = "atr"
-min_value = 50.0
-
-[[thresholds.default.metrics]]
-name = "average_volume"
-min_value = 100000.0
-
-[[thresholds.default.metrics]]
-name = "momentum"
-min_abs_value = 100.0
-
-[thresholds.symbols.BTCUSDT]
-min_relative_volume = 25.0
-max_relative_volume = 200000.0
-min_atr_mult = 80.0
-min_pct_move = 0.0
-max_pct_move = 0.0
-max_upper_wick_pct = 2.5
-max_lower_wick_pct = 1.0
-allow_long = true
-allow_short = true
-metadata = { timeframe = "15m" }
-
-[[thresholds.symbols.BTCUSDT.metrics]]
-name = "atr"
-min_value = 25.0
-
-[[thresholds.symbols.BTCUSDT.metrics]]
-name = "average_volume"
-min_value = 200000.0
-
-[[thresholds.symbols.BTCUSDT.metrics]]
-name = "momentum"
-min_abs_value = 80.0
+min_value = 5.0
 
 [backtest]
 enabled = true

--- a/tests/test_signal_selector.py
+++ b/tests/test_signal_selector.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from bot.domain.enums import Exchange, Side, Timeframe
+from bot.domain.models.entities import Candle, ThresholdMetric, Thresholds
+from bot.domain.services.metrics_service import MetricsService
+from bot.domain.services.selector_service import SignalSelectorService
+
+
+def _build_candle_sequence(
+    *,
+    count: int,
+    final_open: float,
+    final_close: float,
+    final_high: float,
+    final_low: float,
+    base_volume: float,
+    final_volume: float,
+) -> list[Candle]:
+    base_time = datetime(2024, 1, 1)
+    candles: list[Candle] = []
+    for index in range(count - 1):
+        candles.append(
+            Candle(
+                symbol="TESTUSDT",
+                exchange=Exchange.BINANCE,
+                timeframe=Timeframe.M15,
+                open=100.0,
+                high=102.0,
+                low=98.0,
+                close=100.0,
+                volume=base_volume,
+                started_at=base_time + timedelta(minutes=15 * index),
+                closed_at=base_time + timedelta(minutes=15 * (index + 1)),
+            )
+        )
+    candles.append(
+        Candle(
+            symbol="TESTUSDT",
+            exchange=Exchange.BINANCE,
+            timeframe=Timeframe.M15,
+            open=final_open,
+            high=final_high,
+            low=final_low,
+            close=final_close,
+            volume=final_volume,
+            started_at=base_time + timedelta(minutes=15 * (count - 1)),
+            closed_at=base_time + timedelta(minutes=15 * count),
+        )
+    )
+    return candles
+
+
+def _default_thresholds() -> Thresholds:
+    return Thresholds(
+        min_relative_volume=40.0,
+        max_relative_volume=200.0,
+        min_atr_mult=5.0,
+        min_pct_move=5.0,
+        max_pct_move=10.0,
+        max_upper_wick_pct=75.0,
+        max_lower_wick_pct=50.0,
+        allow_long=True,
+        allow_short=True,
+        metrics=[ThresholdMetric(name="atr", min_value=5.0)],
+    )
+
+
+@pytest.fixture()
+def selector() -> SignalSelectorService:
+    service = MetricsService(atr_period=14, volume_period=20, momentum_period=5)
+    return SignalSelectorService(service)
+
+
+def test_select_allows_long_when_thresholds_met(selector: SignalSelectorService) -> None:
+    candles = _build_candle_sequence(
+        count=20,
+        final_open=100.0,
+        final_close=106.0,
+        final_high=118.0,
+        final_low=88.0,
+        base_volume=2_000_000.0,
+        final_volume=120_000_000.0,
+    )
+    thresholds = _default_thresholds()
+
+    result = selector.select("TESTUSDT", candles, thresholds)
+
+    assert not result.rejected
+    assert len(result.signals) == 1
+    assert result.signals[0].side is Side.LONG
+
+
+def test_select_rejects_when_body_growth_too_small(selector: SignalSelectorService) -> None:
+    candles = _build_candle_sequence(
+        count=20,
+        final_open=100.0,
+        final_close=104.0,
+        final_high=118.0,
+        final_low=88.0,
+        base_volume=2_000_000.0,
+        final_volume=120_000_000.0,
+    )
+    thresholds = _default_thresholds()
+
+    result = selector.select("TESTUSDT", candles, thresholds)
+
+    assert not result.signals
+    assert "long_pct_move" in result.rejected
+
+
+def test_select_allows_short_when_thresholds_met(selector: SignalSelectorService) -> None:
+    candles = _build_candle_sequence(
+        count=20,
+        final_open=100.0,
+        final_close=94.0,
+        final_high=112.0,
+        final_low=82.0,
+        base_volume=2_000_000.0,
+        final_volume=110_000_000.0,
+    )
+    thresholds = _default_thresholds()
+
+    result = selector.select("TESTUSDT", candles, thresholds)
+
+    assert not result.rejected
+    assert len(result.signals) == 1
+    assert result.signals[0].side is Side.SHORT
+
+
+def test_select_rejects_short_with_positive_body(selector: SignalSelectorService) -> None:
+    candles = _build_candle_sequence(
+        count=20,
+        final_open=100.0,
+        final_close=102.0,
+        final_high=112.0,
+        final_low=82.0,
+        base_volume=2_000_000.0,
+        final_volume=120_000_000.0,
+    )
+    thresholds = _default_thresholds()
+
+    result = selector.select("TESTUSDT", candles, thresholds)
+
+    assert not result.signals
+    assert "short_positive_body" in result.rejected


### PR DESCRIPTION
## Summary
- update the default thresholds to enforce the new body-growth, ATR, volume, and wick limits while removing the BTC-specific override
- change the metrics and selector services so pct_move is based on candle body growth and the ATR/volume checks follow the shared thresholds
- add signal selector unit tests that cover both passing and failing scenarios for the revised rule set

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc29f6acfc832099abd72fb5d409ef