### PR TITLE
Refine live runner polling cadence

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -411,7 +411,6 @@ async def run_live(
     provider = providers[provider_name]
     timeframe = Timeframe(live_cfg.get("timeframe", Timeframe.M5.value))
     window = int(live_cfg.get("window", 50))
-    poll_interval = float(live_cfg.get("poll_interval", 10.0))
     runner = LiveTradingRunner(
         provider,
         selector,
@@ -421,7 +420,6 @@ async def run_live(
         trade_repo,
         dedup_policy,
         window=window,
-        poll_interval=poll_interval,
     )
     discovered = await discover_symbol_universe(
         config,

--- a/bot/domain/services/live_runner.py
+++ b/bot/domain/services/live_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections import deque
 from collections.abc import Mapping
+from datetime import datetime, timedelta
 from typing import Any, Deque, Dict, Iterable, Optional
 
 from ...data.providers.base import BaseExchangeProvider
@@ -29,7 +30,6 @@ class LiveTradingRunner:
         trade_repository: TradeRepository,
         dedup_policy: DeduplicationPolicy,
         window: int,
-        poll_interval: float = 5.0,
     ) -> None:
         self._provider = provider
         self._selector = selector
@@ -39,12 +39,17 @@ class LiveTradingRunner:
         self._trades = trade_repository
         self._dedup = dedup_policy
         self._window = window
-        self._poll_interval = poll_interval
         self._logger = get_logger(self.__class__.__name__)
         self._deposit_usdt = state_repository.get_deposit()
         self._deposit_asset = state_repository.get_deposit_asset()
         self._last_deposit_update = state_repository.get_last_deposit_update()
         self._trade_watchers: Dict[str, asyncio.Task[None]] = {}
+        self._timeframes: tuple[Timeframe, ...] = (
+            Timeframe.M1,
+            Timeframe.M3,
+            Timeframe.M5,
+            Timeframe.M15,
+        )
 
     async def _handle_signal(self, signal: Signal) -> None:
         accepted, key = self._dedup.should_accept(signal)
@@ -107,7 +112,7 @@ class LiveTradingRunner:
             try:
                 candles = await self._provider.fetch_ohlcv(trade.symbol, timeframe, 3)
                 if not candles:
-                    await asyncio.sleep(self._poll_interval)
+                    await asyncio.sleep(self._get_poll_delay(timeframe))
                     continue
                 for candle in candles:
                     if last_closed_at and candle.closed_at <= last_closed_at:
@@ -142,33 +147,76 @@ class LiveTradingRunner:
                     self._trades.save(trade)
                     self._update_used_amount()
                     return
-                await asyncio.sleep(self._poll_interval)
+                await asyncio.sleep(self._get_poll_delay(timeframe))
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
                 self._logger.error(
                     "Error watching trade %s: %s", trade.id, exc, exc_info=True
                 )
-                await asyncio.sleep(self._poll_interval)
+                await asyncio.sleep(self._get_poll_delay(timeframe))
 
-    async def _process_symbol(self, symbol: str, timeframe: Timeframe, thresholds: Thresholds) -> None:
-        window: Deque[Candle] = deque(maxlen=self._window)
+    async def _process_symbol(self, symbol: str, thresholds: Thresholds) -> None:
+        if self._selector is None:
+            self._logger.warning("Selector is not configured; skipping symbol %s", symbol)
+            return
+        windows: Dict[Timeframe, Deque[Candle]] = {
+            timeframe: deque(maxlen=self._window) for timeframe in self._timeframes
+        }
+        last_closed: Dict[Timeframe, Optional[datetime]] = {
+            timeframe: None for timeframe in self._timeframes
+        }
+        next_poll: Dict[Timeframe, datetime] = {
+            timeframe: utcnow() for timeframe in self._timeframes
+        }
         last_error: Optional[str] = None
         repeat_count = 0
         while True:
             try:
-                tf_value = thresholds.metadata.get("timeframe")
-                tf = Timeframe(tf_value) if tf_value else timeframe
-                candles = await self._provider.fetch_ohlcv(symbol, tf, self._window)
-                if candles:
+                processed = False
+                now = utcnow()
+                for timeframe in self._timeframes:
+                    if now < next_poll[timeframe]:
+                        continue
+                    processed = True
+                    delay = self._get_poll_delay(timeframe)
+                    try:
+                        candles = await self._provider.fetch_ohlcv(
+                            symbol, timeframe, self._window
+                        )
+                    finally:
+                        next_poll[timeframe] = utcnow() + timedelta(seconds=delay)
+                    if not candles:
+                        continue
+                    window = windows[timeframe]
+                    latest_closed = last_closed[timeframe]
+                    new_candles = [
+                        candle
+                        for candle in candles
+                        if candle.closed_at
+                        and (latest_closed is None or candle.closed_at > latest_closed)
+                    ]
+                    if not new_candles:
+                        continue
                     window.extend(candles[-self._window :])
-                if len(window) >= self._window:
+                    last_closed[timeframe] = max(
+                        (candle.closed_at for candle in new_candles if candle.closed_at),
+                        default=latest_closed,
+                    )
+                    if len(window) < self._window:
+                        continue
                     result = self._selector.select(symbol, list(window), thresholds)
                     for signal in result.signals:
                         await self._handle_signal(signal)
                 last_error = None
                 repeat_count = 0
-                await asyncio.sleep(self._poll_interval)
+                now = utcnow()
+                wait_until = min(next_poll.values())
+                wait_seconds = max(0.0, (wait_until - now).total_seconds())
+                if wait_seconds > 0:
+                    await asyncio.sleep(wait_seconds)
+                elif not processed:
+                    await asyncio.sleep(0.0)
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
@@ -191,7 +239,8 @@ class LiveTradingRunner:
                         error_signature,
                         exc_info=True,
                     )
-                await asyncio.sleep(self._poll_interval)
+                min_delay = min(self._get_poll_delay(tf) for tf in self._timeframes)
+                await asyncio.sleep(min_delay)
 
     async def run(
         self,
@@ -206,7 +255,7 @@ class LiveTradingRunner:
             if not thresholds:
                 self._logger.warning("No thresholds configured for %s", symbol)
                 continue
-            tasks.append(asyncio.create_task(self._process_symbol(symbol, timeframe, thresholds)))
+            tasks.append(asyncio.create_task(self._process_symbol(symbol, thresholds)))
         results = await asyncio.gather(*tasks, return_exceptions=True)
         for result in results:
             if isinstance(result, Exception):
@@ -215,6 +264,21 @@ class LiveTradingRunner:
                     result,
                     exc_info=(type(result), result, result.__traceback__),
                 )
+
+    def _get_poll_delay(self, timeframe: Timeframe) -> float:
+        seconds = self._timeframe_to_seconds(timeframe)
+        return max(seconds / 4.0, 0.25)
+
+    @staticmethod
+    def _timeframe_to_seconds(timeframe: Timeframe) -> float:
+        value = timeframe.value
+        if value.endswith("m"):
+            try:
+                minutes = int(value[:-1])
+            except ValueError:
+                return 60.0
+            return float(minutes * 60)
+        return 60.0
 
     async def refresh_deposit(self, force: bool = False) -> Dict[str, Any]:
         if not force and self._last_deposit_update:

--- a/tests/test_live_trading_runner.py
+++ b/tests/test_live_trading_runner.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import types
 from collections import deque
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -15,6 +16,7 @@ from bot.domain.models.entities import Candle, Signal, Thresholds
 from bot.domain.services.dedup_policy import DeduplicationPolicy
 from bot.domain.services.live_runner import LiveTradingRunner
 from bot.domain.services.tp_sl_service import TpSlService
+from bot.domain.services.selector_service import SelectionResult
 
 
 class FakeProvider:
@@ -33,6 +35,17 @@ class FakeProvider:
 
     async def update_deposit(self) -> dict[str, float | str]:
         return {"asset": "USDT", "balance": 10_000.0}
+
+
+class FakeClock:
+    def __init__(self, start: datetime) -> None:
+        self._now = start
+
+    def now(self) -> datetime:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += timedelta(seconds=seconds)
 
 
 def _build_signal(
@@ -124,8 +137,9 @@ async def _execute_take_profit(tmp_path) -> None:
         trade_repository=trade_repo,
         dedup_policy=DeduplicationPolicy(),
         window=1,
-        poll_interval=0.01,
     )
+
+    runner._get_poll_delay = types.MethodType(lambda self, timeframe: 0.01, runner)
 
     await runner._handle_signal(signal)
 
@@ -190,8 +204,9 @@ async def _execute_stop_loss(tmp_path) -> None:
         trade_repository=trade_repo,
         dedup_policy=DeduplicationPolicy(),
         window=1,
-        poll_interval=0.01,
     )
+
+    runner._get_poll_delay = types.MethodType(lambda self, timeframe: 0.01, runner)
 
     await runner._handle_signal(signal)
 
@@ -218,3 +233,111 @@ def test_trade_watcher_closes_on_take_profit(tmp_path) -> None:
 
 def test_trade_watcher_closes_on_stop_loss(tmp_path) -> None:
     asyncio.run(_execute_stop_loss(tmp_path))
+
+
+async def _assert_timeframe_cadence(tmp_path, monkeypatch) -> None:
+    base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    clock = FakeClock(base_time)
+    monkeypatch.setattr("bot.domain.services.live_runner.utcnow", clock.now)
+
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay: float) -> None:
+        clock.advance(delay)
+        await real_sleep(0)
+
+    monkeypatch.setattr("bot.domain.services.live_runner.asyncio.sleep", fake_sleep)
+
+    class CadenceProvider:
+        exchange = Exchange.BINANCE
+
+        def __init__(self, clock: FakeClock) -> None:
+            self._clock = clock
+            self.calls: dict[Timeframe, list[datetime]] = {
+                tf: [] for tf in (Timeframe.M1, Timeframe.M3, Timeframe.M5, Timeframe.M15)
+            }
+            self._last_close: dict[Timeframe, datetime] = {
+                tf: clock.now() - timedelta(seconds=_seconds_for_timeframe(tf))
+                for tf in self.calls
+            }
+
+        async def fetch_ohlcv(
+            self, symbol: str, timeframe: Timeframe, limit: int
+        ) -> list[Candle]:
+            self.calls[timeframe].append(self._clock.now())
+            seconds = _seconds_for_timeframe(timeframe)
+            next_close = self._last_close[timeframe] + timedelta(seconds=seconds)
+            self._last_close[timeframe] = next_close
+            candle = Candle(
+                id=f"{symbol}-{timeframe.value}-{len(self.calls[timeframe])}",
+                symbol=symbol,
+                exchange=Exchange.BINANCE,
+                timeframe=timeframe,
+                open=100.0,
+                high=101.0,
+                low=99.0,
+                close=100.5,
+                volume=1000.0,
+                started_at=next_close - timedelta(seconds=seconds),
+                closed_at=next_close,
+            )
+            return [candle]
+
+        async def update_deposit(self) -> dict[str, float | str]:
+            return {"asset": "USDT", "balance": 10_000.0}
+
+    def _seconds_for_timeframe(timeframe: Timeframe) -> int:
+        return {
+            Timeframe.M1: 60,
+            Timeframe.M3: 180,
+            Timeframe.M5: 300,
+            Timeframe.M15: 900,
+        }[timeframe]
+
+    provider = CadenceProvider(clock)
+    storage = Storage(tmp_path / "cadence.xlsx")
+    runner = LiveTradingRunner(
+        provider=provider,
+        selector=_NoopSelector(),
+        tp_sl_service=TpSlService(),
+        signal_repository=SignalRepository(storage),
+        state_repository=StateRepository(storage),
+        trade_repository=TradeRepository(storage),
+        dedup_policy=DeduplicationPolicy(),
+        window=1,
+    )
+
+    thresholds = Thresholds(id="thr-cadence")
+    task = asyncio.create_task(runner._process_symbol("BTCUSDT", thresholds))
+
+    async def _wait_for_samples() -> None:
+        while min(len(samples) for samples in provider.calls.values()) < 3:
+            await real_sleep(0)
+
+    await asyncio.wait_for(_wait_for_samples(), timeout=1.0)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    for timeframe, timestamps in provider.calls.items():
+        assert len(timestamps) >= 3
+        expected = runner._get_poll_delay(timeframe)
+        for earlier, later in zip(timestamps, timestamps[1:]):
+            delta = (later - earlier).total_seconds()
+            assert delta >= expected - 1e-6
+
+
+class _NoopSelector:
+    def select(
+        self,
+        symbol: str,
+        candles: list[Candle],
+        thresholds: Thresholds,
+        future_candles: list[Candle] | None = None,
+    ) -> SelectionResult:
+        return SelectionResult(signals=[], rejected=[])
+
+
+def test_timeframe_cadence_respects_limits(tmp_path, monkeypatch) -> None:
+    asyncio.run(_assert_timeframe_cadence(tmp_path, monkeypatch))


### PR DESCRIPTION
## Summary
- refactor the live trading runner to cycle through M1/M3/M5/M15 timeframes per symbol, track closed candles, and derive poll delays from the timeframe
- adjust the live app bootstrap to the new runner signature
- update live runner tests with poll delay overrides and a cadence regression to enforce timeframe-specific fetch limits

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc30f566b48320a636eb117bb2f39f