### PR TITLE
Add selectable backtest/live mode and tests

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterable, Mapping
+from typing import Dict, Iterable, Mapping, Sequence
+
+VALID_MODES = {"backtest", "live"}
 
 from .data.io.config_loader import AppConfig, ConfigLoader
 from .data.io.storage import Storage
@@ -355,7 +358,7 @@ async def run_backtest(
     logger = get_logger("backtest")
     signal_repo, trade_repo, state_repo, _, selector, tp_sl_service, dedup_policy = services
     backtest_cfg = config.get("backtest", {})
-    if not backtest_cfg.get("enabled", False):
+    if not _is_mode_enabled(backtest_cfg):
         logger.info("Backtest disabled")
         return
     runner = BacktestRunner(
@@ -404,7 +407,7 @@ async def run_live(
     logger = get_logger("live")
     signal_repo, trade_repo, state_repo, _, selector, tp_sl_service, dedup_policy = services
     live_cfg = config.get("live", {})
-    if not live_cfg.get("enabled", False):
+    if not _is_mode_enabled(live_cfg):
         logger.info("Live trading disabled")
         return
     provider_name = live_cfg.get("provider") or next(iter(providers))
@@ -449,10 +452,58 @@ async def run_live(
     await runner.run(symbols, timeframe, thresholds_selection)
 
 
-async def main_async() -> None:
+def _normalize_mode(value: object) -> str | None:
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized:
+            return normalized
+    return None
+
+
+def _is_mode_enabled(config_section: Mapping[str, object] | object, default: bool = True) -> bool:
+    if not isinstance(config_section, Mapping):
+        return default
+    value = config_section.get("enabled")
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+    return bool(value)
+
+
+def resolve_mode(config: AppConfig, cli_args: Sequence[str] | None = None) -> str:
+    cli_args = tuple(cli_args or ())
+    cli_mode: str | None = None
+    for index, arg in enumerate(cli_args):
+        if arg in {"--mode", "-m"}:
+            try:
+                candidate = cli_args[index + 1]
+            except IndexError as exc:  # pragma: no cover - defensive
+                raise ValueError("Missing value for --mode flag") from exc
+            cli_mode = candidate
+            break
+        if arg.startswith("--mode="):
+            cli_mode = arg.split("=", 1)[1]
+            break
+    mode = _normalize_mode(cli_mode) or _normalize_mode(config.get("mode")) or "backtest"
+    if mode not in VALID_MODES:
+        raise ValueError(
+            f"Unsupported mode '{mode}'. Expected one of: {', '.join(sorted(VALID_MODES))}"
+        )
+    return mode
+
+
+async def main_async(cli_args: Sequence[str] | None = None) -> None:
     config = load_config()
     configure_logging(config.get("logging.level", "INFO"))
     logger = get_logger("app")
+    mode = resolve_mode(config, cli_args)
     storage = init_storage(config)
     providers = init_providers(config)
     if not providers:
@@ -461,15 +512,19 @@ async def main_async() -> None:
     services = init_services(config, storage)
     thresholds_map = build_thresholds(config)
     try:
-        await run_backtest(config, providers, thresholds_map, services)
-        await run_live(config, providers, thresholds_map, services)
+        if mode == "backtest":
+            await run_backtest(config, providers, thresholds_map, services)
+        elif mode == "live":
+            await run_live(config, providers, thresholds_map, services)
     finally:
         for provider in providers.values():
             await provider.close()
 
 
-def main() -> None:
-    asyncio.run(main_async())
+def main(argv: Sequence[str] | None = None) -> None:
+    if argv is None:
+        argv = sys.argv[1:]
+    asyncio.run(main_async(argv))
 
 
 if __name__ == "__main__":

--- a/settings.toml
+++ b/settings.toml
@@ -1,3 +1,5 @@
+mode = "backtest"
+
 [logging]
 level = "INFO"
 

--- a/tests/test_app_modes.py
+++ b/tests/test_app_modes.py
@@ -1,0 +1,95 @@
+import asyncio
+
+import pytest
+
+from bot.app import main_async, resolve_mode
+from bot.data.io.config_loader import AppConfig
+
+
+class _DummyProvider:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def close(self) -> None:  # pragma: no cover - trivial
+        self.closed = True
+
+
+def test_main_async_runs_backtest_only(monkeypatch):
+    config = AppConfig(
+        raw={
+            "mode": "backtest",
+            "logging": {"level": "INFO"},
+            "backtest": {"enabled": True},
+            "live": {"enabled": True},
+        }
+    )
+    provider = _DummyProvider()
+    executed: list[str] = []
+
+    async def fake_backtest(*args, **kwargs):
+        executed.append("backtest")
+
+    async def fake_live(*args, **kwargs):
+        executed.append("live")
+
+    monkeypatch.setattr("bot.app.load_config", lambda: config)
+    monkeypatch.setattr("bot.app.configure_logging", lambda level: None)
+    monkeypatch.setattr("bot.app.init_storage", lambda cfg: object())
+    monkeypatch.setattr("bot.app.init_providers", lambda cfg: {"dummy": provider})
+    monkeypatch.setattr("bot.app.init_services", lambda cfg, storage: tuple(object() for _ in range(7)))
+    monkeypatch.setattr("bot.app.build_thresholds", lambda cfg: {})
+    monkeypatch.setattr("bot.app.run_backtest", fake_backtest)
+    monkeypatch.setattr("bot.app.run_live", fake_live)
+
+    asyncio.run(main_async([]))
+
+    assert executed == ["backtest"]
+    assert provider.closed is True
+
+
+def test_main_async_runs_live_only(monkeypatch):
+    config = AppConfig(
+        raw={
+            "mode": "backtest",
+            "logging": {"level": "INFO"},
+            "backtest": {"enabled": True},
+            "live": {"enabled": True},
+        }
+    )
+    provider = _DummyProvider()
+    executed: list[str] = []
+
+    async def fake_backtest(*args, **kwargs):
+        executed.append("backtest")
+
+    async def fake_live(*args, **kwargs):
+        executed.append("live")
+
+    monkeypatch.setattr("bot.app.load_config", lambda: config)
+    monkeypatch.setattr("bot.app.configure_logging", lambda level: None)
+    monkeypatch.setattr("bot.app.init_storage", lambda cfg: object())
+    monkeypatch.setattr("bot.app.init_providers", lambda cfg: {"dummy": provider})
+    monkeypatch.setattr("bot.app.init_services", lambda cfg, storage: tuple(object() for _ in range(7)))
+    monkeypatch.setattr("bot.app.build_thresholds", lambda cfg: {})
+    monkeypatch.setattr("bot.app.run_backtest", fake_backtest)
+    monkeypatch.setattr("bot.app.run_live", fake_live)
+
+    asyncio.run(main_async(["--mode", "live"]))
+
+    assert executed == ["live"]
+    assert provider.closed is True
+
+
+def test_resolve_mode_precedence():
+    config = AppConfig(raw={"mode": "live"})
+    assert resolve_mode(config, ["--mode", "backtest"]) == "backtest"
+    assert resolve_mode(config, []) == "live"
+
+
+def test_resolve_mode_invalid():
+    config = AppConfig(raw={"mode": "demo"})
+    with pytest.raises(ValueError):
+        resolve_mode(config, [])
+
+    with pytest.raises(ValueError):
+        resolve_mode(AppConfig(raw={}), ["--mode", "invalid"])


### PR DESCRIPTION
## Summary
- add CLI/configurable mode resolution that runs only the selected backtest or live runner and normalizes legacy enabled flags
- add a top-level `mode` example in settings to document the new configuration option
- add tests that cover mode resolution precedence and ensure only the chosen runner executes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc3459c1d48320a04a81fe74d6311c