### PR TITLE
Support multi-timeframe backtests

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -370,7 +370,34 @@ async def run_backtest(
         dedup_policy,
         window=int(backtest_cfg.get("window", 50)),
     )
-    timeframe = Timeframe(backtest_cfg.get("timeframe", Timeframe.M15.value))
+    configured_timeframes = backtest_cfg.get("timeframes")
+    timeframes: tuple[Timeframe, ...]
+    if isinstance(configured_timeframes, (list, tuple, set, frozenset)):
+        parsed: list[Timeframe] = []
+        for raw in configured_timeframes:
+            try:
+                parsed.append(Timeframe(raw))
+            except Exception:
+                continue
+        timeframes = tuple(parsed)
+    else:
+        timeframe_value = backtest_cfg.get("timeframe")
+        if timeframe_value is not None:
+            timeframes = (Timeframe(timeframe_value),)
+        else:
+            timeframes = (
+                Timeframe.M1,
+                Timeframe.M3,
+                Timeframe.M5,
+                Timeframe.M15,
+            )
+    if not timeframes:
+        timeframes = (
+            Timeframe.M1,
+            Timeframe.M3,
+            Timeframe.M5,
+            Timeframe.M15,
+        )
     configured_limit = backtest_cfg.get("limit")
     requested_limit = int(configured_limit) if configured_limit is not None else None
     discovered = await discover_symbol_universe(config, providers, "backtest")
@@ -379,15 +406,26 @@ async def run_backtest(
         return
     for symbol in discovered:
         provider = select_provider_for_symbol(providers, symbol, config, discovered)
-        try:
-            limit = provider.resolve_ohlcv_limit(requested_limit)
-            candles = await provider.fetch_ohlcv(symbol, timeframe, limit)
-        except Exception as exc:  # pragma: no cover - network errors
-            logger.error("Failed to fetch backtest data for %s: %s", symbol, exc)
-            continue
-        thresholds = thresholds_map.get(symbol) or thresholds_map["default"]
-        result = await runner.run(symbol, candles, thresholds, provider)
-        logger.info("Backtest for %s produced %d trades", symbol, len(result.trades))
+        for timeframe in timeframes:
+            try:
+                limit = provider.resolve_ohlcv_limit(requested_limit)
+                candles = await provider.fetch_ohlcv(symbol, timeframe, limit)
+            except Exception as exc:  # pragma: no cover - network errors
+                logger.error(
+                    "Failed to fetch backtest data for %s (%s): %s",
+                    symbol,
+                    timeframe.value,
+                    exc,
+                )
+                continue
+            thresholds = thresholds_map.get(symbol) or thresholds_map["default"]
+            result = await runner.run(symbol, candles, thresholds, provider, timeframe=timeframe)
+            logger.info(
+                "Backtest for %s (%s) produced %d trades",
+                symbol,
+                result.timeframe.value if result.timeframe else timeframe.value,
+                len(result.trades),
+            )
 
 
 async def run_live(

--- a/bot/domain/services/backtest_runner.py
+++ b/bot/domain/services/backtest_runner.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Dict, Sequence
 
-from ..enums import Side, TradeStatus
+from ..enums import Side, Timeframe, TradeStatus
 from ..models.entities import Candle, Signal, Thresholds, Trade
 from ...data.providers.base import BaseExchangeProvider
 from ...data.repositories.signal_repository import SignalRepository
@@ -19,6 +19,7 @@ from .tp_sl_service import TpSlService
 
 @dataclass(slots=True)
 class BacktestResult:
+    timeframe: Timeframe | None
     trades: Sequence[Trade]
     signals: Sequence[Signal]
 
@@ -52,10 +53,14 @@ class BacktestRunner:
         candles: Sequence[Candle],
         thresholds: Thresholds,
         provider: BaseExchangeProvider,
+        timeframe: Timeframe | None = None,
     ) -> BacktestResult:
         generated_signals: list[Signal] = []
         generated_trades: list[Trade] = []
         await self.refresh_deposit(provider, force=True)
+        effective_timeframe: Timeframe | None = timeframe
+        if effective_timeframe is None and candles:
+            effective_timeframe = candles[-1].timeframe
         for index in range(self._window, len(candles)):
             window_candles = candles[index - self._window : index]
             future_candles = candles[index :]
@@ -66,6 +71,13 @@ class BacktestRunner:
                 future_candles=future_candles,
             )
             for signal in result.signals:
+                resolved_timeframe = (
+                    effective_timeframe or signal.timeframe or signal.candle.timeframe
+                )
+                if resolved_timeframe:
+                    signal.timeframe = resolved_timeframe
+                    signal.candle.timeframe = resolved_timeframe
+                    signal.metadata.setdefault("timeframe", resolved_timeframe.value)
                 accepted, key = self._dedup.should_accept(signal)
                 if not accepted:
                     self._logger.debug("Skipping duplicate signal %s", key)
@@ -81,7 +93,7 @@ class BacktestRunner:
                     source_signal_id=source_signal_id,
                     exchange=signal.candle.exchange,
                     symbol=signal.candle.symbol,
-                    timeframe=signal.timeframe or signal.candle.timeframe,
+                    timeframe=resolved_timeframe,
                     side=signal.side,
                     status=TradeStatus.OPENED,
                     entry_price=signal.candle.close,
@@ -102,7 +114,11 @@ class BacktestRunner:
                 self._update_used_amount()
                 generated_signals.append(signal)
                 generated_trades.append(trade)
-        return BacktestResult(trades=generated_trades, signals=generated_signals)
+        return BacktestResult(
+            timeframe=effective_timeframe,
+            trades=generated_trades,
+            signals=generated_signals,
+        )
 
     async def refresh_deposit(
         self, provider: BaseExchangeProvider, force: bool = False

--- a/bot/domain/services/selector_service.py
+++ b/bot/domain/services/selector_service.py
@@ -174,6 +174,7 @@ class SignalSelectorService:
                 "metrics": metrics.as_dict(),
                 "evaluations": [asdict(evaluation) for evaluation in evaluations],
                 "symbol": symbol,
+                "timeframe": candle.timeframe.value,
             },
         )
         return SelectionResult(signals=[signal], rejected=[])

--- a/tests/test_backtest_timeframes.py
+++ b/tests/test_backtest_timeframes.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from bot.app import run_backtest
+from bot.data.io.config_loader import AppConfig
+from bot.domain.enums import Timeframe
+from bot.domain.models.entities import Thresholds
+
+
+class _StubProvider:
+    def __init__(self) -> None:
+        self.fetch_calls: list[tuple[str, Timeframe, int | None]] = []
+
+    def resolve_ohlcv_limit(self, limit: int | None) -> int | None:  # pragma: no cover - trivial
+        return limit
+
+    async def fetch_ohlcv(self, symbol: str, timeframe: Timeframe, limit: int | None):
+        self.fetch_calls.append((symbol, timeframe, limit))
+        return []
+
+
+def test_run_backtest_iterates_over_timeframes(monkeypatch):
+    config = AppConfig(raw={"backtest": {"enabled": True}})
+    provider = _StubProvider()
+    providers = {"dummy": provider}
+    thresholds_map = {"default": Thresholds()}
+    services = tuple(object() for _ in range(7))
+    run_calls: list[tuple[str, Timeframe | None]] = []
+
+    class _StubRunner:
+        def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - simple wiring
+            pass
+
+        async def run(self, symbol, candles, thresholds, provider, timeframe=None):
+            run_calls.append((symbol, timeframe))
+            return SimpleNamespace(timeframe=timeframe, trades=[], signals=[])
+
+    async def fake_discover(*args, **kwargs):
+        return {"BTCUSDT": "dummy"}
+
+    async def _exercise() -> None:
+        monkeypatch.setattr("bot.app.BacktestRunner", _StubRunner)
+        monkeypatch.setattr("bot.app.discover_symbol_universe", fake_discover)
+        monkeypatch.setattr(
+            "bot.app.select_provider_for_symbol", lambda *args, **kwargs: provider
+        )
+        await run_backtest(config, providers, thresholds_map, services)
+
+    asyncio.run(_exercise())
+
+    expected_timeframes = (Timeframe.M1, Timeframe.M3, Timeframe.M5, Timeframe.M15)
+    assert run_calls == [("BTCUSDT", timeframe) for timeframe in expected_timeframes]
+    assert [tf for _, tf, _ in provider.fetch_calls] == list(expected_timeframes)

--- a/tests/test_signal_selector.py
+++ b/tests/test_signal_selector.py
@@ -19,36 +19,44 @@ def _build_candle_sequence(
     final_low: float,
     base_volume: float,
     final_volume: float,
+    timeframe: Timeframe = Timeframe.M15,
 ) -> list[Candle]:
     base_time = datetime(2024, 1, 1)
+    minutes_map = {
+        Timeframe.M1: 1,
+        Timeframe.M3: 3,
+        Timeframe.M5: 5,
+        Timeframe.M15: 15,
+    }
+    step_minutes = minutes_map[timeframe]
     candles: list[Candle] = []
     for index in range(count - 1):
         candles.append(
             Candle(
                 symbol="TESTUSDT",
                 exchange=Exchange.BINANCE,
-                timeframe=Timeframe.M15,
+                timeframe=timeframe,
                 open=100.0,
                 high=102.0,
                 low=98.0,
                 close=100.0,
                 volume=base_volume,
-                started_at=base_time + timedelta(minutes=15 * index),
-                closed_at=base_time + timedelta(minutes=15 * (index + 1)),
+                started_at=base_time + timedelta(minutes=step_minutes * index),
+                closed_at=base_time + timedelta(minutes=step_minutes * (index + 1)),
             )
         )
     candles.append(
         Candle(
             symbol="TESTUSDT",
             exchange=Exchange.BINANCE,
-            timeframe=Timeframe.M15,
+            timeframe=timeframe,
             open=final_open,
             high=final_high,
             low=final_low,
             close=final_close,
             volume=final_volume,
-            started_at=base_time + timedelta(minutes=15 * (count - 1)),
-            closed_at=base_time + timedelta(minutes=15 * count),
+            started_at=base_time + timedelta(minutes=step_minutes * (count - 1)),
+            closed_at=base_time + timedelta(minutes=step_minutes * count),
         )
     )
     return candles
@@ -147,3 +155,24 @@ def test_select_rejects_short_with_positive_body(selector: SignalSelectorService
 
     assert not result.signals
     assert "short_positive_body" in result.rejected
+
+
+def test_select_includes_timeframe_metadata(selector: SignalSelectorService) -> None:
+    candles = _build_candle_sequence(
+        count=20,
+        final_open=100.0,
+        final_close=94.0,
+        final_high=112.0,
+        final_low=82.0,
+        base_volume=2_000_000.0,
+        final_volume=110_000_000.0,
+        timeframe=Timeframe.M5,
+    )
+    thresholds = _default_thresholds()
+
+    result = selector.select("TESTUSDT", candles, thresholds)
+
+    assert len(result.signals) == 1
+    signal = result.signals[0]
+    assert signal.timeframe is Timeframe.M5
+    assert signal.metadata["timeframe"] == Timeframe.M5.value


### PR DESCRIPTION
## Summary
- allow backtests to iterate across a configurable set of timeframes with sensible multi-timeframe defaults
- propagate timeframe context through `BacktestRunner` so stored signals/trades and metadata remain aligned
- extend selector metadata and add regression tests covering multi-timeframe handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cc3923bdd483209fa8b1f5394e669b