### PR TITLE
Increase trade size allocation to 5 percent of deposit

### DIFF
--- a/bot/domain/services/backtest_runner.py
+++ b/bot/domain/services/backtest_runner.py
@@ -156,7 +156,7 @@ class BacktestRunner:
             return None
 
     def _calculate_trade_size(self) -> float:
-        return max(10.0, 0.0005 * self._deposit_usdt) if self._deposit_usdt > 0 else 10.0
+        return max(10.0, 0.05 * self._deposit_usdt) if self._deposit_usdt > 0 else 10.0
 
     def _deposit_snapshot(self) -> Dict[str, Any]:
         return {

--- a/bot/domain/services/live_runner.py
+++ b/bot/domain/services/live_runner.py
@@ -315,7 +315,7 @@ class LiveTradingRunner:
             return None
 
     def _calculate_trade_size(self) -> float:
-        return max(10.0, 0.0005 * self._deposit_usdt) if self._deposit_usdt > 0 else 10.0
+        return max(10.0, 0.05 * self._deposit_usdt) if self._deposit_usdt > 0 else 10.0
 
     def _deposit_snapshot(self) -> Dict[str, Any]:
         return {

--- a/tests/test_live_trading_runner.py
+++ b/tests/test_live_trading_runner.py
@@ -154,6 +154,7 @@ async def _execute_take_profit(tmp_path) -> None:
     assert status == TradeStatus.CLOSED_TP
     trade = trade_repo.get(signal.id)
     assert trade is not None
+    assert trade.size == pytest.approx(500.0)
     assert trade.exit_price == pytest.approx(trade.tp_price)
     assert trade.pnl_pct == pytest.approx(trade.tp_pct)
     assert trade.pnl == pytest.approx(trade.size * (trade.pnl_pct or 0) / 100)
@@ -221,6 +222,7 @@ async def _execute_stop_loss(tmp_path) -> None:
     assert status == TradeStatus.CLOSED_SL
     trade = trade_repo.get(signal.id)
     assert trade is not None
+    assert trade.size == pytest.approx(500.0)
     assert trade.exit_price == pytest.approx(trade.sl_price)
     assert trade.pnl_pct == pytest.approx(trade.sl_pct)
     assert trade.pnl == pytest.approx(trade.size * (trade.pnl_pct or 0) / 100)


### PR DESCRIPTION
## Summary
- update the trade sizing logic in the backtest and live runners to allocate 5% of the current deposit while preserving the minimum size safeguard
- extend live trading runner tests to assert the new position sizing derived from a 10k USDT deposit

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cc3a5dabc48320b0730e9a5c90f151