### PR TITLE
Support multiple live providers and scoped state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# MTF Trend Bot
+
+This project provides tools for multi-timeframe signal discovery, backtesting, and live execution across multiple crypto derivatives exchanges.
+
+## Configuration
+
+All runtime configuration is stored in `settings.toml`. The most relevant options include:
+
+- `providers` – API credentials and rate limits for each supported exchange.
+- `symbols` – filters and manual overrides for the trading universe.
+- `thresholds` – strategy thresholds used during backtests and live execution.
+- `backtest` – options controlling historical analysis.
+- `live` – configuration for the live trading runners.
+
+## Running live trading with multiple providers
+
+Live mode now supports concurrent execution on several exchanges. To enable it:
+
+1. Enable live mode by setting `live.enabled = true`.
+2. Configure the `live.providers` list with all providers you want to trade on, for example:
+   ```toml
+   [live]
+   enabled = true
+   providers = ["binance", "bybit"]
+   timeframe = "5m"
+   window = 50
+   ```
+3. Ensure API credentials are configured for each provider in the `[providers.<name>]` sections or via environment variables.
+4. Optionally adjust symbol assignments in `[symbols.providers]` to pin specific tickers to their preferred exchange.
+
+Each provider receives an independent processing pipeline and maintains a separate state/deposit snapshot in the Excel storage (see `storage.path`). This isolation allows the bot to track balances and open position usage for every exchange independently.
+
+## Backtesting
+
+Backtests use the same symbol discovery process as live trading, including per-provider assignments. Review the `[backtest]` section to adjust window length, candle limits, and timeframes.
+
+## Storage
+
+Trading signals, executed trades, and per-provider capital state are persisted in the Excel file configured via `storage.path`. The state sheet now records a `key` column identifying the provider/exchange associated with each capital snapshot.

--- a/bot/app.py
+++ b/bot/app.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import asyncio
+import contextlib
 import os
 import sys
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, Iterable, Mapping, Sequence
@@ -27,6 +30,21 @@ from .domain.services.selector_service import SignalSelectorService
 from .domain.services.tp_sl_service import TpSlService
 from .utils.clock import utcnow
 from .utils.logging import configure_logging, get_logger
+
+
+@dataclass(frozen=True)
+class SymbolUniverse:
+    assignments: Dict[str, str]
+    pipelines: Dict[str, tuple[str, ...]]
+
+    def provider_for(self, symbol: str) -> str | None:
+        return self.assignments.get(symbol)
+
+    def symbols(self) -> tuple[str, ...]:
+        return tuple(self.assignments.keys())
+
+    def symbols_for_provider(self, provider: str) -> tuple[str, ...]:
+        return self.pipelines.get(provider, tuple())
 
 
 def load_config() -> AppConfig:
@@ -257,7 +275,7 @@ async def discover_symbol_universe(
     providers: Dict[str, BaseExchangeProvider],
     mode: str,
     provider_scope: Iterable[str] | None = None,
-) -> Dict[str, str]:
+) -> SymbolUniverse:
     logger = get_logger("symbol-discovery")
     selection_cfg = config.get("symbols.selection", {})
     suffix = "USDT"
@@ -325,14 +343,21 @@ async def discover_symbol_universe(
         if symbol in deny:
             discovered.pop(symbol, None)
 
-    return dict(sorted(discovered.items()))
+    assignments = dict(sorted(discovered.items()))
+    pipelines: Dict[str, tuple[str, ...]] = {}
+    for symbol, provider_name in assignments.items():
+        existing = set(pipelines.get(provider_name, ()))
+        existing.add(symbol)
+        pipelines[provider_name] = tuple(sorted(existing))
+
+    return SymbolUniverse(assignments=assignments, pipelines=pipelines)
 
 
 def select_provider_for_symbol(
     providers: Dict[str, BaseExchangeProvider],
     symbol: str,
     config: AppConfig,
-    discovered: Dict[str, str] | None = None,
+    discovered: Mapping[str, str] | None = None,
 ) -> BaseExchangeProvider:
     if discovered and symbol in discovered:
         provider_name = discovered[symbol]
@@ -400,12 +425,14 @@ async def run_backtest(
         )
     configured_limit = backtest_cfg.get("limit")
     requested_limit = int(configured_limit) if configured_limit is not None else None
-    discovered = await discover_symbol_universe(config, providers, "backtest")
-    if not discovered:
+    universe = await discover_symbol_universe(config, providers, "backtest")
+    if not universe.assignments:
         logger.warning("No symbols available for backtest after applying liquidity filters")
         return
-    for symbol in discovered:
-        provider = select_provider_for_symbol(providers, symbol, config, discovered)
+    for symbol in universe.assignments:
+        provider = select_provider_for_symbol(
+            providers, symbol, config, universe.assignments
+        )
         for timeframe in timeframes:
             try:
                 limit = provider.resolve_ohlcv_limit(requested_limit)
@@ -448,46 +475,90 @@ async def run_live(
     if not _is_mode_enabled(live_cfg):
         logger.info("Live trading disabled")
         return
-    provider_name = live_cfg.get("provider") or next(iter(providers))
-    provider = providers[provider_name]
+    provider_values = live_cfg.get("providers")
+    provider_names: list[str] = []
+    if isinstance(provider_values, str):
+        provider_names = [provider_values]
+    elif isinstance(provider_values, Iterable):
+        provider_names = [str(value) for value in provider_values if isinstance(value, str)]
+
+    if not provider_names:
+        single = live_cfg.get("provider")
+        if isinstance(single, str):
+            provider_names = [single]
+
+    if not provider_names:
+        provider_names = list(providers.keys())
+
+    invalid = [name for name in provider_names if name not in providers]
+    if invalid:
+        logger.warning("Unknown providers configured for live mode: %s", ", ".join(invalid))
+    provider_names = [name for name in provider_names if name in providers]
+    if not provider_names:
+        logger.warning("No valid providers configured for live trading")
+        return
+
     timeframe = Timeframe(live_cfg.get("timeframe", Timeframe.M5.value))
     window = int(live_cfg.get("window", 50))
-    runner = LiveTradingRunner(
-        provider,
-        selector,
-        tp_sl_service,
-        signal_repo,
-        state_repo,
-        trade_repo,
-        dedup_policy,
-        window=window,
-    )
-    discovered = await discover_symbol_universe(
+    universe = await discover_symbol_universe(
         config,
         providers,
         "live",
-        provider_scope=[provider_name],
+        provider_scope=provider_names,
     )
-    symbols = [symbol for symbol, name in discovered.items() if name == provider_name]
-    if not symbols:
+    pipelines = {
+        name: list(sorted(universe.symbols_for_provider(name)))
+        for name in provider_names
+        if universe.symbols_for_provider(name)
+    }
+    if not pipelines:
         logger.warning("No symbols available for live trading after applying liquidity filters")
         return
 
-    await runner.refresh_deposit(force=True)
+    async def run_pipeline(provider_name: str, symbols: list[str]) -> None:
+        provider = providers[provider_name]
+        scoped_state = state_repo.derive(provider_name) if hasattr(state_repo, "derive") else state_repo
+        runner = LiveTradingRunner(
+            provider,
+            selector,
+            tp_sl_service,
+            signal_repo,
+            scoped_state,
+            trade_repo,
+            dedup_policy,
+            window=window,
+        )
 
-    async def deposit_monitor() -> None:
-        while True:
-            try:
-                snapshot = await runner.refresh_deposit(force=True)
-                logger.info("Deposit update at %s: %s", utcnow().isoformat(), snapshot)
-            except Exception as exc:  # pragma: no cover - network errors
-                logger.warning("Failed to update deposit: %s", exc)
-            await asyncio.sleep(3600.0)
+        await runner.refresh_deposit(force=True)
 
-    asyncio.create_task(deposit_monitor())
+        async def deposit_monitor() -> None:
+            while True:
+                try:
+                    snapshot = await runner.refresh_deposit(force=True)
+                    logger.info(
+                        "[%s] Deposit update at %s: %s",
+                        provider_name,
+                        utcnow().isoformat(),
+                        snapshot,
+                    )
+                except Exception as exc:  # pragma: no cover - network errors
+                    logger.warning("[%s] Failed to update deposit: %s", provider_name, exc)
+                await asyncio.sleep(3600.0)
 
-    thresholds_selection = {symbol: thresholds_map.get(symbol, thresholds_map["default"]) for symbol in symbols}
-    await runner.run(symbols, timeframe, thresholds_selection)
+        monitor_task = asyncio.create_task(deposit_monitor())
+        thresholds_selection = {
+            symbol: thresholds_map.get(symbol, thresholds_map["default"])
+            for symbol in symbols
+        }
+        try:
+            await runner.run(symbols, timeframe, thresholds_selection)
+        finally:
+            monitor_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await monitor_task
+
+    tasks = [asyncio.create_task(run_pipeline(name, symbols)) for name, symbols in pipelines.items()]
+    await asyncio.gather(*tasks)
 
 
 def _normalize_mode(value: object) -> str | None:

--- a/bot/data/io/excel_writer.py
+++ b/bot/data/io/excel_writer.py
@@ -82,7 +82,7 @@ class ExcelWriter:
 
     STATE_SHEET = SheetConfig(
         name="State",
-        headers=["asset", "deposit_amount", "deposit_updated_at", "used_amount"],
+        headers=["key", "asset", "deposit_amount", "deposit_updated_at", "used_amount"],
     )
 
     def __init__(self, path: Path) -> None:
@@ -119,20 +119,29 @@ class ExcelWriter:
             ws = self._get_sheet(wb, self.TRADE_SHEET)
             return list(self._iter_rows(ws, self.TRADE_SHEET.headers))
 
-    def write_state(self, row: Dict[str, object]) -> None:
+    def write_state(self, row: Dict[str, object], key: Optional[str] = None) -> None:
         with self._lock:
             wb = self._load()
             ws = self._get_sheet(wb, self.STATE_SHEET)
-            # State sheet only keeps a single row; replace the contents.
-            self._replace_all_rows(ws, self.STATE_SHEET.headers, [row])
+            row = dict(row)
+            row["key"] = key if key is not None else "default"
+            if key is None:
+                self._replace_all_rows(ws, self.STATE_SHEET.headers, [row])
+            else:
+                self._upsert_row(ws, self.STATE_SHEET.headers, "key", row)
             wb.save(self._path)
 
-    def read_state(self) -> Optional[Dict[str, object]]:
+    def read_state(self, key: Optional[str] = None) -> Optional[Dict[str, object]]:
         with self._lock:
             wb = self._load()
             ws = self._get_sheet(wb, self.STATE_SHEET)
-            for row in self._iter_rows(ws, self.STATE_SHEET.headers):
-                return row
+            if key is None:
+                for row in self._iter_rows(ws, self.STATE_SHEET.headers):
+                    return row
+            else:
+                for row in self._iter_rows(ws, self.STATE_SHEET.headers):
+                    if row.get("key") == key:
+                        return row
             return None
 
     # ------------------------------------------------------------------
@@ -164,7 +173,40 @@ class ExcelWriter:
         ws = workbook[config.name]
         if ws.max_row == 0:
             self._write_headers(ws, config.headers)
+        if config is self.STATE_SHEET:
+            self._ensure_state_sheet_schema(ws)
         return ws
+
+    def _ensure_state_sheet_schema(self, sheet: Worksheet) -> None:
+        expected = self.STATE_SHEET.headers
+        existing_headers = [cell.value for cell in sheet[1]] if sheet.max_row else []
+        if existing_headers[: len(expected)] == expected:
+            return
+        legacy_headers = ["asset", "deposit_amount", "deposit_updated_at", "used_amount"]
+        if existing_headers[: len(legacy_headers)] == legacy_headers:
+            rows: List[Dict[str, object]] = []
+            for row in sheet.iter_rows(min_row=2, values_only=True):
+                if all(value is None for value in row):
+                    continue
+                rows.append(
+                    {
+                        header: row[idx] if idx < len(row) else None
+                        for idx, header in enumerate(legacy_headers)
+                    }
+                )
+            self._write_headers(sheet, expected)
+            for row in rows:
+                sheet.append(
+                    [
+                        "default",
+                        row.get("asset"),
+                        row.get("deposit_amount"),
+                        row.get("deposit_updated_at"),
+                        row.get("used_amount"),
+                    ]
+                )
+        else:
+            self._write_headers(sheet, expected)
 
     def _write_headers(self, sheet: Worksheet, headers: Iterable[str]) -> None:
         sheet.delete_rows(1, sheet.max_row)

--- a/bot/data/io/storage.py
+++ b/bot/data/io/storage.py
@@ -62,7 +62,13 @@ class Storage:
     # State API
     # ------------------------------------------------------------------
     def save_state(
-        self, asset: str, deposit_amount: float, updated_at: Optional[datetime], used: float
+        self,
+        asset: str,
+        deposit_amount: float,
+        updated_at: Optional[datetime],
+        used: float,
+        *,
+        key: Optional[str] = None,
     ) -> None:
         row = {
             "asset": asset,
@@ -70,10 +76,13 @@ class Storage:
             "deposit_updated_at": updated_at.isoformat() if updated_at else None,
             "used_amount": float(used),
         }
-        self._writer.write_state(row)
+        self._writer.write_state(row, key=key)
 
-    def load_state(self) -> tuple[str, float, Optional[str], float]:
-        row = self._writer.read_state()
+    def load_state(self, key: Optional[str] = None) -> tuple[str, float, Optional[str], float]:
+        key_value = key if key is not None else "default"
+        row = self._writer.read_state(key_value)
+        if row is None and key_value == "default":
+            row = self._writer.read_state(None)
         if row is None:
             return ("USDT", 0.0, None, 0.0)
         asset = str(row.get("asset") or "USDT")

--- a/bot/data/repositories/state_repository.py
+++ b/bot/data/repositories/state_repository.py
@@ -15,16 +15,17 @@ from ..io.storage import Storage
 class StateRepository:
     """Persisted state of the trading capital."""
 
-    def __init__(self, storage: Storage) -> None:
+    def __init__(self, storage: Storage, key: str | None = None) -> None:
         self._storage = storage
         self._lock = RLock()
+        self._key = key or "default"
         self._asset = "USDT"
         self._deposit_updated_at: datetime | None = None
         self.load()
 
     def load(self) -> None:
         with self._lock:
-            asset, amount, updated_at_raw, used_amount = self._storage.load_state()
+            asset, amount, updated_at_raw, used_amount = self._storage.load_state(self._key)
             self._asset = asset
             updated_at = (
                 datetime.fromisoformat(updated_at_raw)
@@ -32,15 +33,16 @@ class StateRepository:
                 else None
             )
             self._deposit_updated_at = updated_at
-            set_deposit(amount, self._asset, updated_at)
-            set_used_amount(float(used_amount))
+            set_deposit(amount, self._asset, updated_at, key=self._key)
+            set_used_amount(float(used_amount), key=self._key)
 
     def _persist(self) -> None:
         self._storage.save_state(
             asset=self._asset,
-            deposit_amount=get_deposit_amount(),
+            deposit_amount=get_deposit_amount(self._key),
             updated_at=self._deposit_updated_at,
-            used=get_used_amount(),
+            used=get_used_amount(self._key),
+            key=self._key,
         )
 
     def update_deposit(
@@ -49,11 +51,11 @@ class StateRepository:
         with self._lock:
             self._asset = asset
             self._deposit_updated_at = updated_at or utcnow()
-            set_deposit(amount, self._asset, self._deposit_updated_at)
+            set_deposit(amount, self._asset, self._deposit_updated_at, key=self._key)
             self._persist()
 
     def get_deposit(self) -> float:
-        return get_deposit_amount()
+        return get_deposit_amount(self._key)
 
     def get_deposit_asset(self) -> str:
         return self._asset
@@ -63,8 +65,11 @@ class StateRepository:
 
     def set_used_amount(self, amount: float) -> None:
         with self._lock:
-            set_used_amount(amount)
+            set_used_amount(amount, key=self._key)
             self._persist()
 
     def get_used_amount(self) -> float:
-        return get_used_amount()
+        return get_used_amount(self._key)
+
+    def derive(self, key: str) -> "StateRepository":
+        return StateRepository(self._storage, key)

--- a/bot/domain/models/state.py
+++ b/bot/domain/models/state.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Dict
+
+DEFAULT_SCOPE = "default"
 
 
 @dataclass(slots=True)
@@ -20,25 +23,51 @@ class UsedCapitalState:
     amount: float = 0.0
 
 
-DEPOSIT_USDT = DepositState()
-USED_CAPITAL = UsedCapitalState()
+_DEPOSIT_STATES: Dict[str, DepositState] = {}
+_USED_STATES: Dict[str, UsedCapitalState] = {}
 
 
-def set_deposit(amount: float, asset: str, updated_at: datetime | None) -> None:
-    """Update the in-memory deposit snapshot."""
-
-    DEPOSIT_USDT.asset = asset
-    DEPOSIT_USDT.amount = amount
-    DEPOSIT_USDT.updated_at = updated_at
+def _normalize_scope(key: str | None) -> str:
+    return key or DEFAULT_SCOPE
 
 
-def get_deposit_amount() -> float:
-    return DEPOSIT_USDT.amount
+def _get_deposit_state(scope: str) -> DepositState:
+    state = _DEPOSIT_STATES.get(scope)
+    if state is None:
+        state = DepositState()
+        _DEPOSIT_STATES[scope] = state
+    return state
 
 
-def set_used_amount(amount: float) -> None:
-    USED_CAPITAL.amount = amount
+def _get_used_state(scope: str) -> UsedCapitalState:
+    state = _USED_STATES.get(scope)
+    if state is None:
+        state = UsedCapitalState()
+        _USED_STATES[scope] = state
+    return state
 
 
-def get_used_amount() -> float:
-    return USED_CAPITAL.amount
+def set_deposit(amount: float, asset: str, updated_at: datetime | None, *, key: str | None = None) -> None:
+    """Update the in-memory deposit snapshot for the given key."""
+
+    scope = _normalize_scope(key)
+    state = _get_deposit_state(scope)
+    state.asset = asset
+    state.amount = amount
+    state.updated_at = updated_at
+
+
+def get_deposit_amount(key: str | None = None) -> float:
+    scope = _normalize_scope(key)
+    return _get_deposit_state(scope).amount
+
+
+def set_used_amount(amount: float, *, key: str | None = None) -> None:
+    scope = _normalize_scope(key)
+    state = _get_used_state(scope)
+    state.amount = amount
+
+
+def get_used_amount(key: str | None = None) -> float:
+    scope = _normalize_scope(key)
+    return _get_used_state(scope).amount

--- a/settings.toml
+++ b/settings.toml
@@ -56,7 +56,7 @@ window = 50
 
 [live]
 enabled = false
-provider = "binance"
+providers = ["binance", "bybit"]
 timeframe = "5m"
 window = 50
 poll_interval = 10.0

--- a/tests/test_backtest_timeframes.py
+++ b/tests/test_backtest_timeframes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 
-from bot.app import run_backtest
+from bot.app import SymbolUniverse, run_backtest
 from bot.data.io.config_loader import AppConfig
 from bot.domain.enums import Timeframe
 from bot.domain.models.entities import Thresholds
@@ -38,7 +38,7 @@ def test_run_backtest_iterates_over_timeframes(monkeypatch):
             return SimpleNamespace(timeframe=timeframe, trades=[], signals=[])
 
     async def fake_discover(*args, **kwargs):
-        return {"BTCUSDT": "dummy"}
+        return SymbolUniverse(assignments={"BTCUSDT": "dummy"}, pipelines={"dummy": ("BTCUSDT",)})
 
     async def _exercise() -> None:
         monkeypatch.setattr("bot.app.BacktestRunner", _StubRunner)

--- a/tests/test_excel_storage.py
+++ b/tests/test_excel_storage.py
@@ -4,10 +4,12 @@ from dataclasses import replace
 from datetime import datetime, timedelta
 from pathlib import Path
 
+import pytest
 from openpyxl import load_workbook
 
 from bot.data.io.storage import Storage
 from bot.data.repositories.signal_repository import SignalRepository
+from bot.data.repositories.state_repository import StateRepository
 from bot.data.repositories.trade_repository import TradeRepository
 from bot.domain.enums import BreakDirection, Exchange, Side, Timeframe, TradeStatus
 from bot.domain.models.entities import Candle, Signal, Thresholds, Trade
@@ -169,3 +171,38 @@ def test_trade_repository_updates_excel(tmp_path) -> None:
     assert {row["id"] for row in rows} == {trade.id, second_trade.id}
     status_map = {row["id"]: row["status"] for row in rows}
     assert status_map[trade.id] == updated_trade.status.value
+
+
+def test_state_repository_persists_per_provider(tmp_path) -> None:
+    storage, workbook_path = _create_storage(tmp_path)
+    default_repo = StateRepository(storage)
+    binance_repo = StateRepository(storage, key="binance")
+    bybit_repo = StateRepository(storage, key="bybit")
+
+    now = datetime.utcnow().replace(microsecond=0)
+    binance_repo.update_deposit(1_000.0, "USDT", now)
+    binance_repo.set_used_amount(250.0)
+
+    later = now + timedelta(minutes=5)
+    bybit_repo.update_deposit(2_000.0, "USDT", later)
+    bybit_repo.set_used_amount(125.0)
+
+    # Reload repositories to ensure persisted values are scoped.
+    reloaded_binance = StateRepository(storage, key="binance")
+    reloaded_bybit = StateRepository(storage, key="bybit")
+
+    assert reloaded_binance.get_deposit() == pytest.approx(1_000.0)
+    assert reloaded_binance.get_used_amount() == pytest.approx(250.0)
+    assert reloaded_binance.get_last_deposit_update() == now
+
+    assert reloaded_bybit.get_deposit() == pytest.approx(2_000.0)
+    assert reloaded_bybit.get_used_amount() == pytest.approx(125.0)
+    assert reloaded_bybit.get_last_deposit_update() == later
+
+    # Default scope remains untouched.
+    assert default_repo.get_deposit() == 0.0
+    assert default_repo.get_used_amount() == 0.0
+
+    rows = _read_sheet_rows(workbook_path, "State")
+    keys = {row.get("key") for row in rows}
+    assert {"binance", "bybit"}.issubset(keys)


### PR DESCRIPTION
## Summary
- add a SymbolUniverse helper and update live/backtest flows to understand provider assignments
- run live trading pipelines per provider with independent state repositories and deposit monitors
- store capital state per exchange in the Excel workbook and document the new configuration options

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc3c08c5108320bd1d67d1c21cea42