### PR TITLE
Support batched backtest history fetching

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -21,7 +21,7 @@ from .data.repositories.signal_repository import SignalRepository
 from .data.repositories.state_repository import StateRepository
 from .data.repositories.trade_repository import TradeRepository
 from .domain.enums import Timeframe
-from .domain.models.entities import ThresholdMetric, Thresholds
+from .domain.models.entities import Candle, ThresholdMetric, Thresholds
 from .domain.services.backtest_runner import BacktestRunner
 from .domain.services.dedup_policy import DeduplicationPolicy
 from .domain.services.live_runner import LiveTradingRunner
@@ -436,7 +436,43 @@ async def run_backtest(
         for timeframe in timeframes:
             try:
                 limit = provider.resolve_ohlcv_limit(requested_limit)
-                candles = await provider.fetch_ohlcv(symbol, timeframe, limit)
+                history_batches_raw = backtest_cfg.get("history_batches", 10)
+                history_batches = (
+                    int(history_batches_raw)
+                    if isinstance(history_batches_raw, (int, float, str))
+                    and str(history_batches_raw).strip()
+                    else 10
+                )
+                history_batches = max(history_batches, 1)
+                timeframe_delta = timeframe.to_timedelta()
+                timeframe_ms = int(timeframe_delta.total_seconds() * 1000)
+                total_candles = limit * history_batches
+                start_dt = utcnow() - timeframe_delta * total_candles
+                since_ms = int(start_dt.timestamp() * 1000)
+                candles: list[Candle] = []
+                seen: set[tuple[str | None, int]] = set()
+                for _ in range(history_batches):
+                    batch = await provider.fetch_ohlcv(
+                        symbol, timeframe, limit, since=since_ms
+                    )
+                    if batch:
+                        for candle in batch:
+                            key = (
+                                candle.id,
+                                int(candle.started_at.timestamp() * 1000),
+                            )
+                            if key in seen:
+                                continue
+                            seen.add(key)
+                            candles.append(candle)
+                        last_candle = max(batch, key=lambda c: c.started_at)
+                        since_ms = int(
+                            (last_candle.started_at + timeframe_delta).timestamp()
+                            * 1000
+                        )
+                    else:
+                        since_ms += timeframe_ms * limit
+                candles.sort(key=lambda candle: candle.started_at)
             except Exception as exc:  # pragma: no cover - network errors
                 logger.error(
                     "Failed to fetch backtest data for %s (%s): %s",

--- a/bot/data/providers/base.py
+++ b/bot/data/providers/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from datetime import datetime
 from typing import Any, AsyncIterator, Dict, Iterable, List, Sequence
 
 from ...domain.enums import Exchange, Timeframe
@@ -51,7 +52,13 @@ class BaseExchangeProvider:
                 filtered.append(candle)
         return filtered
 
-    async def fetch_ohlcv(self, symbol: str, timeframe: Timeframe, limit: int) -> List[Candle]:
+    async def fetch_ohlcv(
+        self,
+        symbol: str,
+        timeframe: Timeframe,
+        limit: int,
+        since: int | None = None,
+    ) -> List[Candle]:
         raise NotImplementedError
 
     def resolve_ohlcv_limit(self, requested_limit: int | None) -> int:
@@ -86,3 +93,22 @@ class BaseExchangeProvider:
 
     async def ensure_rate_limit(self) -> None:
         await self._rate_limiter.throttle()
+
+    def _sort_and_deduplicate(self, candles: Iterable[Candle]) -> List[Candle]:
+        """Return candles ordered by start time without duplicates."""
+
+        sorted_candles = sorted(candles, key=lambda candle: candle.started_at)
+        deduplicated: List[Candle] = []
+        seen: set[tuple[str | None, int]] = set()
+        for candle in sorted_candles:
+            started_at = candle.started_at
+            if isinstance(started_at, datetime):
+                timestamp_ms = int(started_at.timestamp() * 1000)
+            else:  # pragma: no cover - defensive, Candle.started_at is datetime
+                timestamp_ms = int(started_at)
+            key = (candle.id, timestamp_ms)
+            if key in seen:
+                continue
+            seen.add(key)
+            deduplicated.append(candle)
+        return deduplicated

--- a/bot/data/providers/binance.py
+++ b/bot/data/providers/binance.py
@@ -56,18 +56,27 @@ class BinanceFuturesProvider(BaseExchangeProvider):
         headers = {"X-MBX-APIKEY": api_key}
         return await self._session.get(endpoint, params=query_params, headers=headers)
 
-    async def fetch_ohlcv(self, symbol: str, timeframe: Timeframe, limit: int) -> List[Candle]:
+    async def fetch_ohlcv(
+        self,
+        symbol: str,
+        timeframe: Timeframe,
+        limit: int,
+        since: int | None = None,
+    ) -> List[Candle]:
         await self.ensure_rate_limit()
         if not self._session:
             raise RuntimeError("httpx is required to fetch candles from Binance")
         limit = self.resolve_ohlcv_limit(limit)
         endpoint = f"{self._api_base}/fapi/v1/klines"
         params = {"symbol": symbol.upper(), "interval": timeframe.value, "limit": limit}
+        if since is not None:
+            params["startTime"] = since
         response = await self._session.get(endpoint, params=params)
         response.raise_for_status()
         raw: Iterable[Any] = response.json()
         candles = self.map_candles(raw, symbol, timeframe)
-        return await self._filter_liquidity(candles)
+        filtered = await self._filter_liquidity(candles)
+        return self._sort_and_deduplicate(filtered)
 
     async def stream_candles(
         self, symbol: str, timeframe: Timeframe

--- a/bot/data/providers/bybit.py
+++ b/bot/data/providers/bybit.py
@@ -64,19 +64,33 @@ class BybitPerpetualProvider(BaseExchangeProvider):
         }
         return await self._session.get(endpoint, params=query_params, headers=headers)
 
-    async def fetch_ohlcv(self, symbol: str, timeframe: Timeframe, limit: int) -> List[Candle]:
+    async def fetch_ohlcv(
+        self,
+        symbol: str,
+        timeframe: Timeframe,
+        limit: int,
+        since: int | None = None,
+    ) -> List[Candle]:
         await self.ensure_rate_limit()
         if not self._session:
             raise RuntimeError("httpx is required to fetch candles from Bybit")
         limit = self.resolve_ohlcv_limit(limit)
         endpoint = f"{self._api_base}/derivatives/v3/public/kline"
-        params = {"symbol": symbol.upper(), "interval": timeframe.value, "limit": limit, "category": "linear"}
+        params = {
+            "symbol": symbol.upper(),
+            "interval": timeframe.value,
+            "limit": limit,
+            "category": "linear",
+        }
+        if since is not None:
+            params["start"] = since
         response = await self._session.get(endpoint, params=params)
         response.raise_for_status()
         data = response.json()
         raw: Iterable[Any] = data.get("result", {}).get("list", [])
         candles = self.map_candles(raw, symbol, timeframe)
-        return await self._filter_liquidity(candles)
+        filtered = await self._filter_liquidity(candles)
+        return self._sort_and_deduplicate(filtered)
 
     async def stream_candles(
         self, symbol: str, timeframe: Timeframe

--- a/bot/domain/enums.py
+++ b/bot/domain/enums.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from enum import Enum, IntEnum
 
 
@@ -13,6 +14,15 @@ class Timeframe(str, Enum):
     M3 = "3m"
     M5 = "5m"
     M15 = "15m"
+
+    def to_timedelta(self) -> timedelta:
+        mapping = {
+            Timeframe.M1: timedelta(minutes=1),
+            Timeframe.M3: timedelta(minutes=3),
+            Timeframe.M5: timedelta(minutes=5),
+            Timeframe.M15: timedelta(minutes=15),
+        }
+        return mapping[self]
 
 
 class Side(str, Enum):

--- a/tests/test_backtest_timeframes.py
+++ b/tests/test_backtest_timeframes.py
@@ -1,28 +1,31 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 from bot.app import SymbolUniverse, run_backtest
 from bot.data.io.config_loader import AppConfig
-from bot.domain.enums import Timeframe
-from bot.domain.models.entities import Thresholds
+from bot.domain.enums import Exchange, Timeframe
+from bot.domain.models.entities import Candle, Thresholds
 
 
 class _StubProvider:
     def __init__(self) -> None:
-        self.fetch_calls: list[tuple[str, Timeframe, int | None]] = []
+        self.fetch_calls: list[tuple[str, Timeframe, int, int | None]] = []
 
-    def resolve_ohlcv_limit(self, limit: int | None) -> int | None:  # pragma: no cover - trivial
-        return limit
+    def resolve_ohlcv_limit(self, limit: int | None) -> int:  # pragma: no cover - trivial
+        return limit or 5
 
-    async def fetch_ohlcv(self, symbol: str, timeframe: Timeframe, limit: int | None):
-        self.fetch_calls.append((symbol, timeframe, limit))
+    async def fetch_ohlcv(
+        self, symbol: str, timeframe: Timeframe, limit: int, since: int | None = None
+    ):
+        self.fetch_calls.append((symbol, timeframe, limit, since))
         return []
 
 
 def test_run_backtest_iterates_over_timeframes(monkeypatch):
-    config = AppConfig(raw={"backtest": {"enabled": True}})
+    config = AppConfig(raw={"backtest": {"enabled": True, "history_batches": 1}})
     provider = _StubProvider()
     providers = {"dummy": provider}
     thresholds_map = {"default": Thresholds()}
@@ -52,4 +55,102 @@ def test_run_backtest_iterates_over_timeframes(monkeypatch):
 
     expected_timeframes = (Timeframe.M1, Timeframe.M3, Timeframe.M5, Timeframe.M15)
     assert run_calls == [("BTCUSDT", timeframe) for timeframe in expected_timeframes]
-    assert [tf for _, tf, _ in provider.fetch_calls] == list(expected_timeframes)
+    assert [tf for _, tf, _, _ in provider.fetch_calls] == list(expected_timeframes)
+
+
+def test_run_backtest_fetches_batched_history(monkeypatch):
+    limit = 2
+    history_batches = 3
+    timeframe = Timeframe.M1
+    timeframe_delta = timeframe.to_timedelta()
+    now = datetime(2023, 1, 1, 0, 10, tzinfo=timezone.utc)
+    start_dt = now - timeframe_delta * limit * history_batches
+
+    def _make_candle(index: int) -> Candle:
+        started = start_dt + timeframe_delta * index
+        return Candle(
+            id=f"candle-{index}",
+            symbol="BTCUSDT",
+            exchange=Exchange.BINANCE,
+            timeframe=timeframe,
+            open=100.0 + index,
+            high=101.0 + index,
+            low=99.0 + index,
+            close=100.5 + index,
+            volume=1000.0,
+            started_at=started,
+            closed_at=started + timeframe_delta,
+        )
+
+    base_candles = [_make_candle(i) for i in range(4)]
+    batches = [
+        [base_candles[0], base_candles[1]],
+        [base_candles[1], base_candles[2]],
+        [base_candles[2], base_candles[3]],
+    ]
+    data_by_since: dict[int, list[Candle]] = {}
+    since_dt = start_dt
+    for batch in batches:
+        since_value = int(since_dt.timestamp() * 1000)
+        data_by_since[since_value] = batch
+        since_dt = batch[-1].started_at + timeframe_delta
+
+    class _BatchProvider:
+        def __init__(self, mapping: dict[int, list[Candle]]) -> None:
+            self._mapping = mapping
+            self.fetch_calls: list[tuple[str, Timeframe, int, int | None]] = []
+
+        def resolve_ohlcv_limit(self, requested: int | None) -> int:
+            return requested or limit
+
+        async def fetch_ohlcv(
+            self, symbol: str, timeframe: Timeframe, limit: int, since: int | None = None
+        ) -> list[Candle]:
+            self.fetch_calls.append((symbol, timeframe, limit, since))
+            return list(self._mapping.get(since or 0, []))
+
+    provider = _BatchProvider(data_by_since)
+    config = AppConfig(
+        raw={
+            "backtest": {
+                "enabled": True,
+                "limit": limit,
+                "history_batches": history_batches,
+                "timeframes": [timeframe.value],
+            }
+        }
+    )
+    thresholds_map = {"default": Thresholds()}
+    providers = {"dummy": provider}
+    services = tuple(object() for _ in range(7))
+    captured: list[list[Candle]] = []
+
+    class _RecordingRunner:
+        def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - wiring
+            pass
+
+        async def run(self, symbol, candles, thresholds, provider, timeframe=None):
+            captured.append(candles)
+            return SimpleNamespace(timeframe=timeframe, trades=[], signals=[])
+
+    async def fake_discover(*args, **kwargs):
+        return SymbolUniverse(assignments={"BTCUSDT": "dummy"}, pipelines={"dummy": ("BTCUSDT",)})
+
+    async def _exercise() -> None:
+        monkeypatch.setattr("bot.app.utcnow", lambda: now)
+        monkeypatch.setattr("bot.app.BacktestRunner", _RecordingRunner)
+        monkeypatch.setattr("bot.app.discover_symbol_universe", fake_discover)
+        monkeypatch.setattr(
+            "bot.app.select_provider_for_symbol", lambda *args, **kwargs: provider
+        )
+        await run_backtest(config, providers, thresholds_map, services)
+
+    asyncio.run(_exercise())
+
+    assert len(provider.fetch_calls) == history_batches
+    since_values = [call[3] for call in provider.fetch_calls]
+    expected_since = list(data_by_since.keys())
+    assert since_values == expected_since
+    assert captured
+    recorded = captured[0]
+    assert [c.id for c in recorded] == [c.id for c in base_candles]

--- a/tests/test_live_trading_runner.py
+++ b/tests/test_live_trading_runner.py
@@ -27,7 +27,9 @@ class FakeProvider:
             key: deque(sequence) for key, sequence in candles_by_key.items()
         }
 
-    async def fetch_ohlcv(self, symbol: str, timeframe: Timeframe, limit: int) -> list[Candle]:
+    async def fetch_ohlcv(
+        self, symbol: str, timeframe: Timeframe, limit: int, since: int | None = None
+    ) -> list[Candle]:
         queue = self._candles_by_key.setdefault((symbol, timeframe), deque())
         if queue:
             return queue.popleft()
@@ -264,7 +266,11 @@ async def _assert_timeframe_cadence(tmp_path, monkeypatch) -> None:
             }
 
         async def fetch_ohlcv(
-            self, symbol: str, timeframe: Timeframe, limit: int
+            self,
+            symbol: str,
+            timeframe: Timeframe,
+            limit: int,
+            since: int | None = None,
         ) -> list[Candle]:
             self.calls[timeframe].append(self._clock.now())
             seconds = _seconds_for_timeframe(timeframe)

--- a/tests/test_provider_history.py
+++ b/tests/test_provider_history.py
@@ -1,0 +1,94 @@
+import asyncio
+
+from bot.data.providers.binance import BinanceFuturesProvider
+from bot.data.providers.bybit import BybitPerpetualProvider
+from bot.domain.enums import Timeframe
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:  # pragma: no cover - no errors simulated
+        return None
+
+    def json(self):  # pragma: no cover - simple passthrough
+        return self._payload
+
+
+class _FakeSession:
+    def __init__(self, payload):
+        self._payload = payload
+        self.calls: list[tuple[str, dict[str, object] | None]] = []
+
+    async def get(self, endpoint: str, params: dict[str, object] | None = None):
+        self.calls.append((endpoint, params))
+        return _FakeResponse(self._payload)
+
+
+def test_binance_fetch_ohlcv_forwards_since_and_sorts() -> None:
+    base_ts = 1_700_000_000_000
+    payload = [
+        [base_ts + 60_000, "1", "2", "0", "1.5", "100", base_ts + 120_000, "200"],
+        [base_ts, "1", "2", "0", "1.5", "100", base_ts + 60_000, "150"],
+        [base_ts, "1.1", "2.1", "0.1", "1.6", "120", base_ts + 60_000, "160"],
+    ]
+    session = _FakeSession(payload)
+    provider = BinanceFuturesProvider(
+        api_base="https://example.com",
+        ws_base="wss://example.com/ws",
+        rate_limit_per_minute=60,
+        min_quote_volume=0.0,
+        session=session,
+    )
+
+    candles = asyncio.run(
+        provider.fetch_ohlcv("BTCUSDT", Timeframe.M1, limit=3, since=1234567890)
+    )
+
+    assert session.calls
+    _, params = session.calls[0]
+    assert params is not None
+    assert params.get("startTime") == 1234567890
+    assert len(candles) == 2
+    assert [c.started_at for c in candles] == sorted(c.started_at for c in candles)
+
+
+def test_bybit_fetch_ohlcv_forwards_since_and_sorts() -> None:
+    base_ts = 1_700_000_000_000
+    payload = {
+        "result": {
+            "list": [
+                [
+                    base_ts + 60_000,
+                    "1",
+                    "2",
+                    "0",
+                    "1.5",
+                    "100",
+                    "200",
+                ],
+                [base_ts, "1", "2", "0", "1.5", "100", "150"],
+                [base_ts, "1.1", "2.1", "0.1", "1.6", "120", "160"],
+            ]
+        }
+    }
+    session = _FakeSession(payload)
+    provider = BybitPerpetualProvider(
+        api_base="https://example.com",
+        ws_base="wss://example.com/ws",
+        rate_limit_per_minute=60,
+        min_quote_volume=0.0,
+        session=session,
+    )
+
+    candles = asyncio.run(
+        provider.fetch_ohlcv("BTCUSDT", Timeframe.M1, limit=3, since=987654321)
+    )
+
+    assert session.calls
+    _, params = session.calls[0]
+    assert params is not None
+    assert params.get("start") == 987654321
+    assert len(candles) == 2
+    assert [c.started_at for c in candles] == sorted(c.started_at for c in candles)

--- a/tests/test_provider_limits.py
+++ b/tests/test_provider_limits.py
@@ -9,7 +9,9 @@ class _StubProvider(BaseExchangeProvider):
     max_ohlcv_limit = 1500
     _ohlcv_limit_fallback = 1500
 
-    async def fetch_ohlcv(self, symbol: str, timeframe: Timeframe, limit: int):  # pragma: no cover - unused
+    async def fetch_ohlcv(
+        self, symbol: str, timeframe: Timeframe, limit: int, since: int | None = None
+    ):  # pragma: no cover - unused
         raise NotImplementedError
 
     async def stream_candles(self, symbol: str, timeframe: Timeframe):  # pragma: no cover - unused


### PR DESCRIPTION
## Summary
- allow exchange providers to accept optional `since` timestamps, forward them to HTTP params, and normalize candle order
- expose a `Timeframe.to_timedelta()` helper and use it in backtest batching logic
- update backtest to fetch multiple history batches with deduplication and extend tests to cover the new flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cc4609339483209eef259fd7da184e