### PR TITLE
Add configurable timezone support

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, Iterable, Mapping, Sequence
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 VALID_MODES = {"backtest", "live"}
 
@@ -28,7 +29,7 @@ from .domain.services.live_runner import LiveTradingRunner
 from .domain.services.metrics_service import MetricsService
 from .domain.services.selector_service import SignalSelectorService
 from .domain.services.tp_sl_service import TpSlService
-from .utils.clock import utcnow
+from .utils.clock import init_clock, utcnow
 from .utils.logging import configure_logging, get_logger
 
 
@@ -646,8 +647,22 @@ def resolve_mode(config: AppConfig, cli_args: Sequence[str] | None = None) -> st
 
 async def main_async(cli_args: Sequence[str] | None = None) -> None:
     config = load_config()
+    timezone_name = config.timezone_name
+    timezone_warning: str | None = None
+    try:
+        app_timezone = ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError:
+        app_timezone = ZoneInfo("UTC")
+        timezone_warning = (
+            f"Invalid timezone '{timezone_name}', defaulting to UTC"
+            if timezone_name.upper() != "UTC"
+            else ""
+        )
+    init_clock(app_timezone)
     configure_logging(config.get("logging.level", "INFO"))
     logger = get_logger("app")
+    if timezone_warning:
+        logger.warning(timezone_warning)
     mode = resolve_mode(config, cli_args)
     storage = init_storage(config)
     providers = init_providers(config)

--- a/bot/data/io/config_loader.py
+++ b/bot/data/io/config_loader.py
@@ -19,6 +19,13 @@ class AppConfig:
             cursor = cursor[part]
         return cursor
 
+    @property
+    def timezone_name(self) -> str:
+        value = self.get("time.zone")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        return "UTC"
+
 
 class ConfigLoader:
     def __init__(self, settings_path: Path, env_path: Path | None = None) -> None:

--- a/bot/data/mappers/ohlcv_mapper.py
+++ b/bot/data/mappers/ohlcv_mapper.py
@@ -5,6 +5,7 @@ from typing import Any, Sequence
 
 from ...domain.enums import Exchange, Timeframe
 from ...domain.models.entities import Candle
+from ...utils.clock import get_timezone
 
 
 def map_ohlcv(
@@ -15,8 +16,10 @@ def map_ohlcv(
 ) -> Candle:
     if len(raw) < 6:
         raise ValueError("raw OHLCV should have at least 6 elements")
-    timestamp = datetime.fromtimestamp(raw[0] / 1000 if raw[0] > 1e12 else raw[0], tz=timezone.utc)
-    candle_id = f"{exchange.value}:{symbol}:{timeframe.value}:{int(timestamp.timestamp())}"
+    base_timestamp = raw[0] / 1000 if raw[0] > 1e12 else raw[0]
+    utc_timestamp = datetime.fromtimestamp(base_timestamp, tz=timezone.utc)
+    timestamp = utc_timestamp.astimezone(get_timezone())
+    candle_id = f"{exchange.value}:{symbol}:{timeframe.value}:{int(utc_timestamp.timestamp())}"
     volume = float(raw[5])
     quote_volume = _extract_quote_volume(raw, exchange)
     return Candle(

--- a/bot/utils/clock.py
+++ b/bot/utils/clock.py
@@ -1,13 +1,25 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timezone, tzinfo
 from time import sleep
 from typing import Iterator
 
 
+_APP_TIMEZONE: tzinfo = timezone.utc
+
+
+def init_clock(tz: tzinfo) -> None:
+    global _APP_TIMEZONE
+    _APP_TIMEZONE = tz
+
+
+def get_timezone() -> tzinfo:
+    return _APP_TIMEZONE
+
+
 def utcnow() -> datetime:
-    return datetime.now(timezone.utc)
+    return datetime.now(_APP_TIMEZONE)
 
 
 def sleep_seconds(seconds: float) -> None:

--- a/settings.toml
+++ b/settings.toml
@@ -1,5 +1,8 @@
 mode = "backtest"
 
+[time]
+zone = "Europe/Belgrade"
+
 [logging]
 level = "INFO"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,19 @@
 import sys
 from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+
+from bot.utils.clock import init_clock
+
+
+@pytest.fixture(autouse=True)
+def _reset_clock_timezone() -> None:
+    init_clock(ZoneInfo("UTC"))
+    yield
+    init_clock(ZoneInfo("UTC"))

--- a/tests/test_excel_storage.py
+++ b/tests/test_excel_storage.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import replace
 from datetime import datetime, timedelta
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import pytest
 from openpyxl import load_workbook
@@ -96,10 +97,13 @@ def _read_sheet_rows(path: Path, sheet_name: str) -> list[dict[str, object]]:
 def test_signal_repository_updates_excel(tmp_path) -> None:
     storage, workbook_path = _create_storage(tmp_path)
     repository = SignalRepository(storage)
-    now = datetime.utcnow().replace(microsecond=0)
+    now = datetime.now(ZoneInfo("UTC")).replace(microsecond=0)
 
     signal = _build_signal("1", 10.0, now)
     repository.save(signal)
+    loaded_signals = {loaded.id: loaded for loaded in storage.load_signals()}
+    assert loaded_signals[signal.id].triggered_at == signal.triggered_at
+    assert loaded_signals[signal.id].triggered_at.tzinfo is not None
 
     rows = _read_sheet_rows(workbook_path, "Signals")
     assert len(rows) == 1
@@ -126,15 +130,23 @@ def test_signal_repository_updates_excel(tmp_path) -> None:
     assert {row["id"] for row in rows} == {signal.id, another_signal.id}
     scores = {row["id"]: row["score"] for row in rows}
     assert scores[signal.id] == updated_signal.score
+    loaded_signals = {loaded.id: loaded for loaded in storage.load_signals()}
+    assert loaded_signals[signal.id].updated_at == updated_signal.updated_at
+    assert loaded_signals[signal.id].updated_at.tzinfo is not None
+    assert loaded_signals[another_signal.id].triggered_at == another_signal.triggered_at
+    assert loaded_signals[another_signal.id].triggered_at.tzinfo is not None
 
 
 def test_trade_repository_updates_excel(tmp_path) -> None:
     storage, workbook_path = _create_storage(tmp_path)
     repository = TradeRepository(storage)
-    now = datetime.utcnow().replace(microsecond=0)
+    now = datetime.now(ZoneInfo("UTC")).replace(microsecond=0)
 
     trade = _build_trade("1", now)
     repository.save(trade)
+    loaded_trades = {loaded.id: loaded for loaded in storage.load_trades()}
+    assert loaded_trades[trade.id].opened_at == trade.opened_at
+    assert loaded_trades[trade.id].opened_at and loaded_trades[trade.id].opened_at.tzinfo is not None
 
     rows = _read_sheet_rows(workbook_path, "Trades")
     assert len(rows) == 1
@@ -171,6 +183,11 @@ def test_trade_repository_updates_excel(tmp_path) -> None:
     assert {row["id"] for row in rows} == {trade.id, second_trade.id}
     status_map = {row["id"]: row["status"] for row in rows}
     assert status_map[trade.id] == updated_trade.status.value
+    loaded_trades = {loaded.id: loaded for loaded in storage.load_trades()}
+    assert loaded_trades[trade.id].updated_at == updated_trade.updated_at
+    assert loaded_trades[trade.id].updated_at and loaded_trades[trade.id].updated_at.tzinfo is not None
+    assert loaded_trades[second_trade.id].opened_at == second_trade.opened_at
+    assert loaded_trades[second_trade.id].opened_at and loaded_trades[second_trade.id].opened_at.tzinfo is not None
 
 
 def test_state_repository_persists_per_provider(tmp_path) -> None:
@@ -179,7 +196,7 @@ def test_state_repository_persists_per_provider(tmp_path) -> None:
     binance_repo = StateRepository(storage, key="binance")
     bybit_repo = StateRepository(storage, key="bybit")
 
-    now = datetime.utcnow().replace(microsecond=0)
+    now = datetime.now(ZoneInfo("UTC")).replace(microsecond=0)
     binance_repo.update_deposit(1_000.0, "USDT", now)
     binance_repo.set_used_amount(250.0)
 
@@ -194,10 +211,12 @@ def test_state_repository_persists_per_provider(tmp_path) -> None:
     assert reloaded_binance.get_deposit() == pytest.approx(1_000.0)
     assert reloaded_binance.get_used_amount() == pytest.approx(250.0)
     assert reloaded_binance.get_last_deposit_update() == now
+    assert reloaded_binance.get_last_deposit_update() and reloaded_binance.get_last_deposit_update().tzinfo is not None
 
     assert reloaded_bybit.get_deposit() == pytest.approx(2_000.0)
     assert reloaded_bybit.get_used_amount() == pytest.approx(125.0)
     assert reloaded_bybit.get_last_deposit_update() == later
+    assert reloaded_bybit.get_last_deposit_update() and reloaded_bybit.get_last_deposit_update().tzinfo is not None
 
     # Default scope remains untouched.
     assert default_repo.get_deposit() == 0.0

--- a/tests/test_live_trading_runner.py
+++ b/tests/test_live_trading_runner.py
@@ -4,6 +4,7 @@ import asyncio
 import types
 from collections import deque
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -96,7 +97,7 @@ def _build_signal(
 
 
 async def _execute_take_profit(tmp_path) -> None:
-    now = datetime.utcnow().replace(microsecond=0)
+    now = datetime.now(ZoneInfo("UTC")).replace(microsecond=0)
     signal = _build_signal(
         identifier="tp",
         side=Side.LONG,
@@ -164,7 +165,7 @@ async def _execute_take_profit(tmp_path) -> None:
 
 
 async def _execute_stop_loss(tmp_path) -> None:
-    now = datetime.utcnow().replace(microsecond=0)
+    now = datetime.now(ZoneInfo("UTC")).replace(microsecond=0)
     signal = _build_signal(
         identifier="sl",
         side=Side.SHORT,

--- a/tests/test_timezones.py
+++ b/tests/test_timezones.py
@@ -1,0 +1,26 @@
+from zoneinfo import ZoneInfo
+
+from bot.data.io.config_loader import AppConfig
+from bot.data.mappers.ohlcv_mapper import map_ohlcv
+from bot.domain.enums import Exchange, Timeframe
+from bot.utils.clock import get_timezone, init_clock
+
+
+def test_app_config_timezone_defaults_to_utc() -> None:
+    config = AppConfig(raw={})
+    assert config.timezone_name == "UTC"
+
+
+def test_map_ohlcv_uses_configured_timezone() -> None:
+    tz = ZoneInfo("Europe/Belgrade")
+    init_clock(tz)
+    base_timestamp = 1_700_000_000
+    raw = [base_timestamp, 1.0, 2.0, 0.5, 1.5, 100.0]
+
+    candle = map_ohlcv(raw, "BTCUSDT", Exchange.BINANCE, Timeframe.M1)
+
+    assert candle.started_at.tzinfo == tz
+    assert candle.closed_at.tzinfo == tz
+    assert int(candle.started_at.timestamp()) == base_timestamp
+    assert candle.id.endswith(str(base_timestamp))
+    assert get_timezone() is tz


### PR DESCRIPTION
## Summary
- add a configurable timezone to the application config and initialize the app clock with the resolved ZoneInfo
- update clock utilities and OHLCV mapping to emit timezone-aware datetimes while keeping candle identifiers stable
- extend fixtures and repository tests to ensure timezone-aware serialization round-trips correctly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc4889cf68832085e9f16dd3eb2b38