### PR TITLE
Adjust short selection to use pump ranges

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -144,6 +144,34 @@ def _parse_threshold(raw: Dict[str, object]) -> Thresholds:
                 return False
         return default
 
+    short_pct_move_ranges: list[tuple[float, float | None]] = []
+    if isinstance(raw, dict):
+        ranges_raw = raw.get("short_pct_move_ranges")
+        if isinstance(ranges_raw, list):
+            for entry in ranges_raw:
+                min_value: float | None
+                max_value: float | None
+                if isinstance(entry, dict):
+                    min_raw = (
+                        entry.get("min")
+                        if entry.get("min") is not None
+                        else entry.get("min_value")
+                    )
+                    max_raw = (
+                        entry.get("max")
+                        if entry.get("max") is not None
+                        else entry.get("max_value")
+                    )
+                    if min_raw is None:
+                        continue
+                    min_value = float(min_raw)
+                    max_value = float(max_raw) if max_raw is not None else None
+                elif isinstance(entry, (list, tuple)) and entry:
+                    min_value = float(entry[0])
+                    max_value = float(entry[1]) if len(entry) > 1 and entry[1] is not None else None
+                else:
+                    continue
+                short_pct_move_ranges.append((min_value, max_value))
     allow_long = _get_bool("allow_long", True)
     allow_short = _get_bool("allow_short", True)
     metadata = raw.get("metadata", {}) if isinstance(raw, dict) else {}
@@ -184,6 +212,7 @@ def _parse_threshold(raw: Dict[str, object]) -> Thresholds:
         max_lower_wick_pct=_get_float_from_keys(
             ["max_lower_wick_pct", "maxLowerWickPct", "Y", "y"],
         ),
+        short_pct_move_ranges=short_pct_move_ranges,
         allow_long=allow_long,
         allow_short=allow_short,
         metrics=metrics,

--- a/bot/data/io/storage.py
+++ b/bot/data/io/storage.py
@@ -126,6 +126,29 @@ class Storage:
             metadata = {}
         created_at_raw = raw.get("created_at")
         updated_at_raw = raw.get("updated_at")
+        short_pct_move_ranges: List[tuple[float, Optional[float]]] = []
+        ranges_raw = raw.get("short_pct_move_ranges")
+        if isinstance(ranges_raw, list):
+            for entry in ranges_raw:
+                min_value: float | None
+                max_value: float | None
+                if isinstance(entry, dict):
+                    min_raw = entry.get("min")
+                    if min_raw is None:
+                        min_raw = entry.get("min_value")
+                    max_raw = entry.get("max")
+                    if max_raw is None:
+                        max_raw = entry.get("max_value")
+                    if min_raw is None:
+                        continue
+                    min_value = float(min_raw)
+                    max_value = float(max_raw) if max_raw is not None else None
+                elif isinstance(entry, (list, tuple)) and entry:
+                    min_value = float(entry[0])
+                    max_value = float(entry[1]) if len(entry) > 1 and entry[1] is not None else None
+                else:
+                    continue
+                short_pct_move_ranges.append((min_value, max_value))
         def _get_float_from_keys(keys: list[str]) -> float:
             for key in keys:
                 if raw.get(key) is not None:
@@ -159,6 +182,7 @@ class Storage:
             max_lower_wick_pct=_get_float_from_keys(
                 ["max_lower_wick_pct", "maxLowerWickPct", "Y", "y"]
             ),
+            short_pct_move_ranges=short_pct_move_ranges,
             allow_long=self._to_bool(raw.get("allow_long", True)),
             allow_short=self._to_bool(raw.get("allow_short", True)),
             metrics=metrics,

--- a/bot/domain/models/entities.py
+++ b/bot/domain/models/entities.py
@@ -41,6 +41,7 @@ class Thresholds:
     max_pct_move: float = 0.0
     max_upper_wick_pct: float = 0.0
     max_lower_wick_pct: float = 0.0
+    short_pct_move_ranges: List[tuple[float, Optional[float]]] = field(default_factory=list)
     allow_long: bool = True
     allow_short: bool = True
     metrics: List[ThresholdMetric] = field(default_factory=list)

--- a/bot/domain/services/selector_service.py
+++ b/bot/domain/services/selector_service.py
@@ -80,16 +80,29 @@ class SignalSelectorService:
         if not thresholds.allow_short:
             reasons.append("short_disabled")
             return False
-        if metrics.pct_move >= 0:
-            reasons.append("short_positive_body")
+        if metrics.pct_move <= 0:
+            reasons.append("short_non_positive_body")
             return False
-        magnitude = abs(metrics.pct_move)
-        if thresholds.min_pct_move > 0 and magnitude <= thresholds.min_pct_move:
-            reasons.append("short_pct_move")
-            return False
-        if thresholds.max_pct_move > 0 and magnitude > thresholds.max_pct_move:
-            reasons.append("short_pct_move")
-            return False
+        growth = metrics.pct_move
+        if thresholds.short_pct_move_ranges:
+            in_range = False
+            for min_value, max_value in thresholds.short_pct_move_ranges:
+                if growth < min_value:
+                    continue
+                if max_value is not None and growth > max_value:
+                    continue
+                in_range = True
+                break
+            if not in_range:
+                reasons.append("short_pct_move")
+                return False
+        else:
+            if thresholds.min_pct_move > 0 and growth <= thresholds.min_pct_move:
+                reasons.append("short_pct_move")
+                return False
+            if thresholds.max_pct_move > 0 and growth > thresholds.max_pct_move:
+                reasons.append("short_pct_move")
+                return False
         if (
             thresholds.min_relative_volume > 0
             and metrics.relative_volume < thresholds.min_relative_volume

--- a/settings.toml
+++ b/settings.toml
@@ -51,6 +51,13 @@ allow_short = true
 name = "atr"
 min_value = 5.0
 
+[[thresholds.default.short_pct_move_ranges]]
+min = 3.0
+max = 5.0
+
+[[thresholds.default.short_pct_move_ranges]]
+min = 10.0
+
 [backtest]
 enabled = true
 timeframe = "15m"

--- a/tests/test_signal_selector.py
+++ b/tests/test_signal_selector.py
@@ -71,6 +71,7 @@ def _default_thresholds() -> Thresholds:
         max_pct_move=10.0,
         max_upper_wick_pct=75.0,
         max_lower_wick_pct=50.0,
+        short_pct_move_ranges=[(3.0, 5.0), (10.0, None)],
         allow_long=True,
         allow_short=True,
         metrics=[ThresholdMetric(name="atr", min_value=5.0)],
@@ -102,7 +103,9 @@ def test_select_allows_long_when_thresholds_met(selector: SignalSelectorService)
     assert result.signals[0].side is Side.LONG
 
 
-def test_select_rejects_when_body_growth_too_small(selector: SignalSelectorService) -> None:
+def test_select_redirects_to_short_when_long_body_growth_too_small(
+    selector: SignalSelectorService,
+) -> None:
     candles = _build_candle_sequence(
         count=20,
         final_open=100.0,
@@ -116,11 +119,73 @@ def test_select_rejects_when_body_growth_too_small(selector: SignalSelectorServi
 
     result = selector.select("TESTUSDT", candles, thresholds)
 
-    assert not result.signals
-    assert "long_pct_move" in result.rejected
+    assert len(result.signals) == 1
+    assert result.signals[0].side is Side.SHORT
 
 
 def test_select_allows_short_when_thresholds_met(selector: SignalSelectorService) -> None:
+    candles = _build_candle_sequence(
+        count=20,
+        final_open=100.0,
+        final_close=104.0,
+        final_high=140.0,
+        final_low=86.0,
+        base_volume=2_000_000.0,
+        final_volume=110_000_000.0,
+    )
+    thresholds = _default_thresholds()
+
+    result = selector.select("TESTUSDT", candles, thresholds)
+
+    assert len(result.signals) == 1
+    assert result.signals[0].side is Side.SHORT
+
+
+def test_select_allows_short_when_pct_move_in_high_range(
+    selector: SignalSelectorService,
+) -> None:
+    candles = _build_candle_sequence(
+        count=20,
+        final_open=100.0,
+        final_close=112.0,
+        final_high=130.0,
+        final_low=99.0,
+        base_volume=2_000_000.0,
+        final_volume=110_000_000.0,
+    )
+    thresholds = _default_thresholds()
+
+    result = selector.select("TESTUSDT", candles, thresholds)
+
+    assert not result.rejected
+    assert len(result.signals) == 1
+    assert result.signals[0].side is Side.SHORT
+
+
+def test_select_rejects_short_outside_pct_move_ranges(
+    selector: SignalSelectorService,
+) -> None:
+    candles = _build_candle_sequence(
+        count=20,
+        final_open=100.0,
+        final_close=106.0,
+        final_high=112.0,
+        final_low=82.0,
+        base_volume=2_000_000.0,
+        final_volume=120_000_000.0,
+    )
+    thresholds = _default_thresholds()
+    thresholds.allow_long = False
+
+    result = selector.select("TESTUSDT", candles, thresholds)
+
+    assert not result.signals
+    assert "short_pct_move" in result.rejected
+
+
+def test_select_rejects_short_with_non_positive_body(
+    selector: SignalSelectorService,
+) -> None:
     candles = _build_candle_sequence(
         count=20,
         final_open=100.0,
@@ -134,36 +199,17 @@ def test_select_allows_short_when_thresholds_met(selector: SignalSelectorService
 
     result = selector.select("TESTUSDT", candles, thresholds)
 
-    assert not result.rejected
-    assert len(result.signals) == 1
-    assert result.signals[0].side is Side.SHORT
-
-
-def test_select_rejects_short_with_positive_body(selector: SignalSelectorService) -> None:
-    candles = _build_candle_sequence(
-        count=20,
-        final_open=100.0,
-        final_close=102.0,
-        final_high=112.0,
-        final_low=82.0,
-        base_volume=2_000_000.0,
-        final_volume=120_000_000.0,
-    )
-    thresholds = _default_thresholds()
-
-    result = selector.select("TESTUSDT", candles, thresholds)
-
     assert not result.signals
-    assert "short_positive_body" in result.rejected
+    assert "short_non_positive_body" in result.rejected
 
 
 def test_select_includes_timeframe_metadata(selector: SignalSelectorService) -> None:
     candles = _build_candle_sequence(
         count=20,
         final_open=100.0,
-        final_close=94.0,
-        final_high=112.0,
-        final_low=82.0,
+        final_close=112.0,
+        final_high=130.0,
+        final_low=95.0,
         base_volume=2_000_000.0,
         final_volume=110_000_000.0,
         timeframe=Timeframe.M5,


### PR DESCRIPTION
## Summary
- allow short entries only on positive bodies and evaluate them against configured pump ranges
- extend thresholds parsing and storage to accept reusable short-specific percentage ranges
- declare default short pump ranges in settings and update selector tests for green-candle scenarios

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ccfba640648320baeeec1d5076d1e8