### PR TITLE
Support short relative volume ranges

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -144,39 +144,53 @@ def _parse_threshold(raw: Dict[str, object]) -> Thresholds:
                 return False
         return default
 
-    short_pct_move_ranges: list[tuple[float, float | None]] = []
-    if isinstance(raw, dict):
-        ranges_raw = raw.get("short_pct_move_ranges")
-        if isinstance(ranges_raw, list):
-            for entry in ranges_raw:
-                min_value: float | None
-                max_value: float | None
-                if isinstance(entry, dict):
-                    min_raw = (
-                        entry.get("min")
-                        if entry.get("min") is not None
-                        else entry.get("min_value")
-                    )
-                    max_raw = (
-                        entry.get("max")
-                        if entry.get("max") is not None
-                        else entry.get("max_value")
-                    )
-                    if min_raw is None:
-                        continue
+    def _parse_range_list(source: object) -> list[tuple[float | None, float | None]]:
+        parsed: list[tuple[float | None, float | None]] = []
+        if not isinstance(source, list):
+            return parsed
+        for entry in source:
+            min_value: float | None = None
+            max_value: float | None = None
+            if isinstance(entry, dict):
+                min_raw = entry.get("min")
+                if min_raw is None:
+                    min_raw = entry.get("min_value")
+                max_raw = entry.get("max")
+                if max_raw is None:
+                    max_raw = entry.get("max_value")
+                if min_raw is not None:
                     min_value = float(min_raw)
-                    max_value = float(max_raw) if max_raw is not None else None
-                elif isinstance(entry, (list, tuple)) and entry:
+                if max_raw is not None:
+                    max_value = float(max_raw)
+            elif isinstance(entry, (list, tuple)):
+                if len(entry) > 0 and entry[0] is not None:
                     min_value = float(entry[0])
-                    max_value = float(entry[1]) if len(entry) > 1 and entry[1] is not None else None
-                else:
-                    continue
-                short_pct_move_ranges.append((min_value, max_value))
+                if len(entry) > 1 and entry[1] is not None:
+                    max_value = float(entry[1])
+            elif isinstance(entry, (int, float)):
+                min_value = float(entry)
+            if min_value is None and max_value is None:
+                continue
+            parsed.append((min_value, max_value))
+        return parsed
+
+    short_pct_move_ranges: list[tuple[float | None, float | None]] = []
+    if isinstance(raw, dict):
+        short_pct_move_ranges = _parse_range_list(raw.get("short_pct_move_ranges"))
     allow_long = _get_bool("allow_long", True)
     allow_short = _get_bool("allow_short", True)
     metadata = raw.get("metadata", {}) if isinstance(raw, dict) else {}
     if not isinstance(metadata, dict):
         metadata = {}
+    if not short_pct_move_ranges:
+        short_pct_move_ranges = _parse_range_list(metadata.get("short_pct_move_ranges"))
+    short_relative_volume_ranges = _parse_range_list(
+        raw.get("short_relative_volume_ranges") if isinstance(raw, dict) else None
+    )
+    if not short_relative_volume_ranges:
+        short_relative_volume_ranges = _parse_range_list(
+            metadata.get("short_relative_volume_ranges")
+        )
     created_at_raw = raw.get("created_at") if isinstance(raw, dict) else None
     updated_at_raw = raw.get("updated_at") if isinstance(raw, dict) else None
     return Thresholds(
@@ -213,6 +227,7 @@ def _parse_threshold(raw: Dict[str, object]) -> Thresholds:
             ["max_lower_wick_pct", "maxLowerWickPct", "Y", "y"],
         ),
         short_pct_move_ranges=short_pct_move_ranges,
+        short_relative_volume_ranges=short_relative_volume_ranges,
         allow_long=allow_long,
         allow_short=allow_short,
         metrics=metrics,

--- a/bot/domain/models/entities.py
+++ b/bot/domain/models/entities.py
@@ -41,7 +41,12 @@ class Thresholds:
     max_pct_move: float = 0.0
     max_upper_wick_pct: float = 0.0
     max_lower_wick_pct: float = 0.0
-    short_pct_move_ranges: List[tuple[float, Optional[float]]] = field(default_factory=list)
+    short_pct_move_ranges: List[tuple[Optional[float], Optional[float]]] = field(
+        default_factory=list
+    )
+    short_relative_volume_ranges: List[tuple[Optional[float], Optional[float]]] = field(
+        default_factory=list
+    )
     allow_long: bool = True
     allow_short: bool = True
     metrics: List[ThresholdMetric] = field(default_factory=list)

--- a/bot/domain/services/selector_service.py
+++ b/bot/domain/services/selector_service.py
@@ -103,18 +103,31 @@ class SignalSelectorService:
             if thresholds.max_pct_move > 0 and growth > thresholds.max_pct_move:
                 reasons.append("short_pct_move")
                 return False
-        if (
-            thresholds.min_relative_volume > 0
-            and metrics.relative_volume < thresholds.min_relative_volume
-        ):
-            reasons.append("short_relative_volume")
-            return False
-        if (
-            thresholds.max_relative_volume > 0
-            and metrics.relative_volume > thresholds.max_relative_volume
-        ):
-            reasons.append("short_relative_volume")
-            return False
+        if thresholds.short_relative_volume_ranges:
+            in_volume_range = False
+            for min_value, max_value in thresholds.short_relative_volume_ranges:
+                if min_value is not None and metrics.relative_volume < min_value:
+                    continue
+                if max_value is not None and metrics.relative_volume > max_value:
+                    continue
+                in_volume_range = True
+                break
+            if not in_volume_range:
+                reasons.append("short_relative_volume")
+                return False
+        else:
+            if (
+                thresholds.min_relative_volume > 0
+                and metrics.relative_volume < thresholds.min_relative_volume
+            ):
+                reasons.append("short_relative_volume")
+                return False
+            if (
+                thresholds.max_relative_volume > 0
+                and metrics.relative_volume > thresholds.max_relative_volume
+            ):
+                reasons.append("short_relative_volume")
+                return False
         if (
             thresholds.min_atr_mult > 0
             and metrics.atr_multiple <= thresholds.min_atr_mult

--- a/settings.toml
+++ b/settings.toml
@@ -58,6 +58,14 @@ max = 5.0
 [[thresholds.default.short_pct_move_ranges]]
 min = 10.0
 
+[thresholds.default.metadata]
+
+[[thresholds.default.metadata.short_relative_volume_ranges]]
+max = 40.0
+
+[[thresholds.default.metadata.short_relative_volume_ranges]]
+min = 200.0
+
 [backtest]
 enabled = true
 timeframe = "15m"

--- a/tests/test_signal_selector.py
+++ b/tests/test_signal_selector.py
@@ -72,6 +72,7 @@ def _default_thresholds() -> Thresholds:
         max_upper_wick_pct=75.0,
         max_lower_wick_pct=50.0,
         short_pct_move_ranges=[(3.0, 5.0), (10.0, None)],
+        short_relative_volume_ranges=[(None, 40.0), (200.0, None)],
         allow_long=True,
         allow_short=True,
         metrics=[ThresholdMetric(name="atr", min_value=5.0)],
@@ -113,7 +114,7 @@ def test_select_redirects_to_short_when_long_body_growth_too_small(
         final_high=118.0,
         final_low=88.0,
         base_volume=2_000_000.0,
-        final_volume=120_000_000.0,
+        final_volume=440_000_000.0,
     )
     thresholds = _default_thresholds()
 
@@ -131,7 +132,7 @@ def test_select_allows_short_when_thresholds_met(selector: SignalSelectorService
         final_high=140.0,
         final_low=86.0,
         base_volume=2_000_000.0,
-        final_volume=110_000_000.0,
+        final_volume=440_000_000.0,
     )
     thresholds = _default_thresholds()
 
@@ -151,7 +152,7 @@ def test_select_allows_short_when_pct_move_in_high_range(
         final_high=130.0,
         final_low=99.0,
         base_volume=2_000_000.0,
-        final_volume=110_000_000.0,
+        final_volume=440_000_000.0,
     )
     thresholds = _default_thresholds()
 
@@ -193,7 +194,7 @@ def test_select_rejects_short_with_non_positive_body(
         final_high=112.0,
         final_low=82.0,
         base_volume=2_000_000.0,
-        final_volume=110_000_000.0,
+        final_volume=440_000_000.0,
     )
     thresholds = _default_thresholds()
 
@@ -201,6 +202,62 @@ def test_select_rejects_short_with_non_positive_body(
 
     assert not result.signals
     assert "short_non_positive_body" in result.rejected
+
+
+def test_select_short_uses_low_volume_range(selector: SignalSelectorService) -> None:
+    candles = _build_candle_sequence(
+        count=20,
+        final_open=100.0,
+        final_close=112.0,
+        final_high=130.0,
+        final_low=99.0,
+        base_volume=2_000_000.0,
+        final_volume=60_000_000.0,
+    )
+    thresholds = _default_thresholds()
+
+    result = selector.select("TESTUSDT", candles, thresholds)
+
+    assert len(result.signals) == 1
+    assert result.signals[0].side is Side.SHORT
+
+
+def test_select_short_rejects_mid_volume_band(selector: SignalSelectorService) -> None:
+    candles = _build_candle_sequence(
+        count=20,
+        final_open=100.0,
+        final_close=112.0,
+        final_high=130.0,
+        final_low=99.0,
+        base_volume=2_000_000.0,
+        final_volume=200_000_000.0,
+    )
+    thresholds = _default_thresholds()
+    thresholds.allow_long = False
+
+    result = selector.select("TESTUSDT", candles, thresholds)
+
+    assert not result.signals
+    assert "short_relative_volume" in result.rejected
+
+
+def test_select_short_uses_high_volume_range(selector: SignalSelectorService) -> None:
+    candles = _build_candle_sequence(
+        count=20,
+        final_open=100.0,
+        final_close=112.0,
+        final_high=130.0,
+        final_low=99.0,
+        base_volume=2_000_000.0,
+        final_volume=440_000_000.0,
+    )
+    thresholds = _default_thresholds()
+    thresholds.allow_long = False
+
+    result = selector.select("TESTUSDT", candles, thresholds)
+
+    assert len(result.signals) == 1
+    assert result.signals[0].side is Side.SHORT
 
 
 def test_select_includes_timeframe_metadata(selector: SignalSelectorService) -> None:
@@ -211,7 +268,7 @@ def test_select_includes_timeframe_metadata(selector: SignalSelectorService) -> 
         final_high=130.0,
         final_low=95.0,
         base_volume=2_000_000.0,
-        final_volume=110_000_000.0,
+        final_volume=440_000_000.0,
         timeframe=Timeframe.M5,
     )
     thresholds = _default_thresholds()


### PR DESCRIPTION
## Summary
- extend threshold parsing and entities to carry optional range lists for short-specific metrics, including relative volume
- prefer the configured short volume bands when evaluating short entries
- document the default short volume ranges and add selector tests covering the disjoint bands

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccfeff2140832095e3df91a1cb5000