### PR TITLE
Refactor deposit handling to use snapshots

### DIFF
--- a/bot/data/models/__init__.py
+++ b/bot/data/models/__init__.py
@@ -1,0 +1,3 @@
+from .deposit import DepositSnapshot
+
+__all__ = ["DepositSnapshot"]

--- a/bot/data/models/deposit.py
+++ b/bot/data/models/deposit.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(slots=True)
+class DepositSnapshot:
+    asset: str
+    balance: float
+    raw: Mapping[str, Any] | None = None

--- a/bot/data/providers/base.py
+++ b/bot/data/providers/base.py
@@ -7,6 +7,7 @@ from typing import Any, AsyncIterator, Dict, Iterable, List, Sequence
 
 from ...domain.enums import Exchange, Timeframe
 from ...domain.models.entities import Candle
+from ..models import DepositSnapshot
 from ..mappers.ohlcv_mapper import map_ohlcv
 from ...utils.logging import get_logger
 
@@ -80,7 +81,7 @@ class BaseExchangeProvider:
         """Return a mapping of symbol to 24 hour quote volume."""
         raise NotImplementedError
 
-    async def update_deposit(self) -> Dict[str, Any]:
+    async def update_deposit(self) -> DepositSnapshot:
         raise NotImplementedError
 
     async def close(self) -> None:

--- a/bot/data/providers/binance.py
+++ b/bot/data/providers/binance.py
@@ -4,7 +4,8 @@ import asyncio
 import hmac
 import time
 from hashlib import sha256
-from typing import Any, AsyncIterator, Dict, Iterable, List
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Dict, Iterable, List, Mapping, Sequence
 from urllib.parse import urlencode
 
 try:
@@ -15,7 +16,43 @@ except ImportError:  # pragma: no cover
 from ...domain.enums import Exchange, Timeframe
 from ...domain.models.entities import Candle
 from ...utils.logging import get_logger
+from ..models import DepositSnapshot
 from .base import BaseExchangeProvider
+
+
+@dataclass(slots=True)
+class _BinanceBalance:
+    asset: str
+    balance: float | None
+    available_balance: float | None
+    cross_wallet_balance: float | None
+    equity: float | None
+    raw: Mapping[str, Any] | None
+
+    @classmethod
+    def from_raw(cls, raw: Mapping[str, Any]) -> "_BinanceBalance":
+        asset = str(raw.get("asset") or "").upper()
+        balance = cls._to_float(raw.get("balance"))
+        available_balance = cls._to_float(raw.get("availableBalance"))
+        cross_wallet_balance = cls._to_float(raw.get("crossWalletBalance"))
+        equity = cls._to_float(raw.get("equity"))
+        return cls(
+            asset=asset,
+            balance=balance,
+            available_balance=available_balance,
+            cross_wallet_balance=cross_wallet_balance,
+            equity=equity,
+            raw=raw,
+        )
+
+    @staticmethod
+    def _to_float(value: Any) -> float | None:
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
 
 
 class BinanceFuturesProvider(BaseExchangeProvider):
@@ -125,28 +162,40 @@ class BinanceFuturesProvider(BaseExchangeProvider):
                 volumes[symbol.upper()] = volume
         return volumes
 
-    async def update_deposit(self) -> dict[str, Any]:
+    async def update_deposit(self) -> DepositSnapshot:
         await self.ensure_rate_limit()
         endpoint = f"{self._api_base}/fapi/v2/balance"
         response = await self._authenticated_get(endpoint)
         response.raise_for_status()
-        balances = response.json()
-        usdt_balance = 0.0
-        for item in balances:
-            if item.get("asset") != "USDT":
-                continue
-            for key in ("availableBalance", "balance", "crossWalletBalance", "equity"):
-                value = item.get(key)
-                if value is not None:
-                    try:
-                        usdt_balance = float(value)
-                        break
-                    except (TypeError, ValueError):
-                        continue
-            if usdt_balance:
-                break
-        return {"asset": "USDT", "balance": usdt_balance}
+        raw_balances = response.json()
+        balances: Sequence[_BinanceBalance] = []
+        if isinstance(raw_balances, Sequence):
+            parsed: list[_BinanceBalance] = []
+            for item in raw_balances:
+                if isinstance(item, Mapping):
+                    parsed.append(_BinanceBalance.from_raw(item))
+            balances = tuple(parsed)
+
+        target_asset = "USDT"
+        selected = next((balance for balance in balances if balance.asset == target_asset), None)
+        amount = _select_amount(selected)
+        raw = selected.raw if selected else None
+        return DepositSnapshot(asset=target_asset, balance=amount, raw=raw)
 
     async def close(self) -> None:
         if self._session:
             await self._session.aclose()
+
+
+def _select_amount(balance: _BinanceBalance | None) -> float:
+    if balance is None:
+        return 0.0
+    for value in (
+        balance.available_balance,
+        balance.balance,
+        balance.cross_wallet_balance,
+        balance.equity,
+    ):
+        if value is not None:
+            return value
+    return 0.0

--- a/bot/data/providers/bybit.py
+++ b/bot/data/providers/bybit.py
@@ -4,7 +4,8 @@ import asyncio
 import hmac
 import time
 from hashlib import sha256
-from typing import Any, AsyncIterator, Dict, Iterable, List
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Dict, Iterable, List, Mapping, Sequence
 from urllib.parse import urlencode
 
 try:
@@ -14,7 +15,50 @@ except ImportError:  # pragma: no cover
 
 from ...domain.enums import Exchange, Timeframe
 from ...domain.models.entities import Candle
+from ..models import DepositSnapshot
 from .base import BaseExchangeProvider
+
+
+@dataclass(slots=True)
+class _BybitCoinBalance:
+    asset: str
+    wallet_balance: float | None
+    available_to_withdraw: float | None
+    equity: float | None
+    available_balance: float | None
+    raw: Mapping[str, Any] | None
+
+    @classmethod
+    def from_raw(cls, raw: Mapping[str, Any]) -> "_BybitCoinBalance":
+        asset = str(raw.get("coin") or "").upper()
+        wallet_balance = _to_float(raw.get("walletBalance"))
+        available_to_withdraw = _to_float(raw.get("availableToWithdraw"))
+        equity = _to_float(raw.get("equity"))
+        available_balance = _to_float(raw.get("availableBalance"))
+        return cls(
+            asset=asset,
+            wallet_balance=wallet_balance,
+            available_to_withdraw=available_to_withdraw,
+            equity=equity,
+            available_balance=available_balance,
+            raw=raw,
+        )
+
+
+@dataclass(slots=True)
+class _BybitAccountBalance:
+    coins: Sequence[_BybitCoinBalance]
+    raw: Mapping[str, Any] | None
+
+    @classmethod
+    def from_raw(cls, raw: Mapping[str, Any]) -> "_BybitAccountBalance":
+        coins_raw = raw.get("coin")
+        coins: list[_BybitCoinBalance] = []
+        if isinstance(coins_raw, Sequence):
+            for item in coins_raw:
+                if isinstance(item, Mapping):
+                    coins.append(_BybitCoinBalance.from_raw(item))
+        return cls(coins=tuple(coins), raw=raw)
 
 
 class BybitPerpetualProvider(BaseExchangeProvider):
@@ -142,40 +186,58 @@ class BybitPerpetualProvider(BaseExchangeProvider):
                 volumes[symbol.upper()] = volume
         return volumes
 
-    async def update_deposit(self) -> dict[str, Any]:
+    async def update_deposit(self) -> DepositSnapshot:
         await self.ensure_rate_limit()
         endpoint = f"{self._api_base}/v5/account/wallet-balance"
         params = {"accountType": "UNIFIED"}
         response = await self._authenticated_get(endpoint, params=params)
         response.raise_for_status()
         data = response.json()
-        result = data.get("result", {})
-        entries = result.get("list", [])
-        usdt_balance = 0.0
+        result_raw = data.get("result")
+        entries_raw = result_raw.get("list") if isinstance(result_raw, Mapping) else None
+        entries: Sequence[_BybitAccountBalance] = []
+        if isinstance(entries_raw, Sequence):
+            parsed: list[_BybitAccountBalance] = []
+            for entry in entries_raw:
+                if isinstance(entry, Mapping):
+                    parsed.append(_BybitAccountBalance.from_raw(entry))
+            entries = tuple(parsed)
+
+        target_asset = "USDT"
+        selected_coin: _BybitCoinBalance | None = None
+        raw_coin: Mapping[str, Any] | None = None
         for entry in entries:
-            coins = entry.get("coin")
-            if isinstance(coins, list):
-                for coin in coins:
-                    if coin.get("coin") == "USDT":
-                        for key in (
-                            "walletBalance",
-                            "availableToWithdraw",
-                            "equity",
-                            "availableBalance",
-                        ):
-                            value = coin.get(key)
-                            if value is not None:
-                                try:
-                                    usdt_balance = float(value)
-                                    break
-                                except (TypeError, ValueError):
-                                    continue
-                        if usdt_balance:
-                            break
-            if usdt_balance:
+            selected_coin = next((coin for coin in entry.coins if coin.asset == target_asset), None)
+            if selected_coin:
+                raw_coin = selected_coin.raw
                 break
-        return {"asset": "USDT", "balance": usdt_balance}
+
+        amount = _select_bybit_amount(selected_coin)
+        return DepositSnapshot(asset=target_asset, balance=amount, raw=raw_coin)
 
     async def close(self) -> None:
         if self._session:
             await self._session.aclose()
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _select_bybit_amount(balance: _BybitCoinBalance | None) -> float:
+    if balance is None:
+        return 0.0
+    for value in (
+        balance.available_to_withdraw,
+        balance.available_balance,
+        balance.wallet_balance,
+        balance.equity,
+    ):
+        if value is not None:
+            return value
+    return 0.0

--- a/bot/domain/services/backtest_runner.py
+++ b/bot/domain/services/backtest_runner.py
@@ -10,6 +10,7 @@ from ...data.providers.base import BaseExchangeProvider
 from ...data.repositories.signal_repository import SignalRepository
 from ...data.repositories.state_repository import StateRepository
 from ...data.repositories.trade_repository import TradeRepository
+from ...data.models import DepositSnapshot
 from ...utils.logging import get_logger
 from ...utils.clock import utcnow
 from .dedup_policy import DeduplicationPolicy
@@ -43,8 +44,9 @@ class BacktestRunner:
         self._dedup = dedup_policy
         self._window = window
         self._logger = get_logger(self.__class__.__name__)
-        self._deposit_usdt = state_repository.get_deposit()
-        self._deposit_asset = state_repository.get_deposit_asset()
+        initial_asset = state_repository.get_deposit_asset()
+        initial_balance = state_repository.get_deposit()
+        self._deposit = DepositSnapshot(asset=initial_asset, balance=initial_balance)
         self._last_deposit_update = state_repository.get_last_deposit_update()
 
     async def run(
@@ -122,46 +124,29 @@ class BacktestRunner:
 
     async def refresh_deposit(
         self, provider: BaseExchangeProvider, force: bool = False
-    ) -> None:
+    ) -> DepositSnapshot:
         if not force and self._last_deposit_update:
             delta = (utcnow() - self._last_deposit_update).total_seconds()
             if delta < 3600:
-                return
-        balance = await provider.update_deposit()
-        asset, amount = self._extract_deposit(balance)
+                return self._deposit
+        snapshot = await provider.update_deposit()
+        asset = snapshot.asset or self._deposit.asset
+        amount = snapshot.balance
+        normalized = DepositSnapshot(asset=asset, balance=amount, raw=snapshot.raw)
         timestamp = utcnow()
-        self._deposit_usdt = amount
-        self._deposit_asset = asset
+        self._deposit = normalized
         self._last_deposit_update = timestamp
         self._state.update_deposit(amount, asset, timestamp)
-
-    def _extract_deposit(self, balance: Mapping[str, Any]) -> tuple[str, float]:
-        asset = str(balance.get("asset") or self._deposit_asset or "USDT")
-        for key in ("balance", "availableBalance", "available", "amount", "equity"):
-            value = self._to_float(balance.get(key))
-            if value is not None:
-                return asset, value
-        fallback = self._to_float(balance.get(asset))
-        if fallback is not None:
-            return asset, fallback
-        return self._deposit_asset or "USDT", self._deposit_usdt
-
-    @staticmethod
-    def _to_float(value: Any) -> float | None:
-        if value is None:
-            return None
-        try:
-            return float(value)
-        except (TypeError, ValueError):
-            return None
+        return self._deposit
 
     def _calculate_trade_size(self) -> float:
-        return max(10.0, 0.05 * self._deposit_usdt) if self._deposit_usdt > 0 else 10.0
+        balance = self._deposit.balance
+        return max(10.0, 0.05 * balance) if balance > 0 else 10.0
 
     def _deposit_snapshot(self) -> Dict[str, Any]:
         return {
-            "asset": self._deposit_asset,
-            "balance": self._deposit_usdt,
+            "asset": self._deposit.asset,
+            "balance": self._deposit.balance,
             "updated_at": self._last_deposit_update.isoformat() if self._last_deposit_update else None,
         }
 

--- a/bot/domain/services/live_runner.py
+++ b/bot/domain/services/live_runner.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import asyncio
 from collections import deque
-from collections.abc import Mapping
 from datetime import datetime, timedelta
-from typing import Any, Deque, Dict, Iterable, Optional
+from typing import Deque, Dict, Iterable, Optional
 
 from ...data.providers.base import BaseExchangeProvider
 from ...data.repositories.signal_repository import SignalRepository
 from ...data.repositories.state_repository import StateRepository
 from ...data.repositories.trade_repository import TradeRepository
+from ...data.models import DepositSnapshot
 from ...utils.logging import get_logger
 from ...utils.clock import utcnow
 from ..enums import Timeframe, TradeStatus
@@ -40,8 +40,9 @@ class LiveTradingRunner:
         self._dedup = dedup_policy
         self._window = window
         self._logger = get_logger(self.__class__.__name__)
-        self._deposit_usdt = state_repository.get_deposit()
-        self._deposit_asset = state_repository.get_deposit_asset()
+        initial_asset = state_repository.get_deposit_asset()
+        initial_balance = state_repository.get_deposit()
+        self._deposit = DepositSnapshot(asset=initial_asset, balance=initial_balance)
         self._last_deposit_update = state_repository.get_last_deposit_update()
         self._trade_watchers: Dict[str, asyncio.Task[None]] = {}
         self._timeframes: tuple[Timeframe, ...] = (
@@ -77,7 +78,16 @@ class LiveTradingRunner:
             allow_long=signal.allow_long,
             allow_short=signal.allow_short,
             thresholds_snapshot=signal.thresholds,
-            metadata={"mode": "live", "deposit_snapshot": snapshot},
+            metadata={
+                "mode": "live",
+                "deposit_snapshot": {
+                    "asset": snapshot.asset,
+                    "balance": snapshot.balance,
+                    "updated_at": self._last_deposit_update.isoformat()
+                    if self._last_deposit_update
+                    else None,
+                },
+            },
         )
         self._tp_sl_service.assign(signal, trade)
         self._signals.save(signal)
@@ -280,49 +290,24 @@ class LiveTradingRunner:
             return float(minutes * 60)
         return 60.0
 
-    async def refresh_deposit(self, force: bool = False) -> Dict[str, Any]:
+    async def refresh_deposit(self, force: bool = False) -> DepositSnapshot:
         if not force and self._last_deposit_update:
             delta = (utcnow() - self._last_deposit_update).total_seconds()
             if delta < 3600:
-                return self._deposit_snapshot()
-        balance = await self._provider.update_deposit()
-        asset, amount = self._extract_deposit(balance)
+                return self._deposit
+        snapshot = await self._provider.update_deposit()
+        asset = snapshot.asset or self._deposit.asset
+        amount = snapshot.balance
+        normalized = DepositSnapshot(asset=asset, balance=amount, raw=snapshot.raw)
         timestamp = utcnow()
-        self._deposit_usdt = amount
-        self._deposit_asset = asset
+        self._deposit = normalized
         self._last_deposit_update = timestamp
         self._state.update_deposit(amount, asset, timestamp)
-        return self._deposit_snapshot()
-
-    def _extract_deposit(self, balance: Mapping[str, Any]) -> tuple[str, float]:
-        asset = str(balance.get("asset") or self._deposit_asset or "USDT")
-        for key in ("balance", "availableBalance", "available", "amount", "equity"):
-            value = self._to_float(balance.get(key))
-            if value is not None:
-                return asset, value
-        fallback = self._to_float(balance.get(asset))
-        if fallback is not None:
-            return asset, fallback
-        return self._deposit_asset or "USDT", self._deposit_usdt
-
-    @staticmethod
-    def _to_float(value: Any) -> float | None:
-        if value is None:
-            return None
-        try:
-            return float(value)
-        except (TypeError, ValueError):
-            return None
+        return self._deposit
 
     def _calculate_trade_size(self) -> float:
-        return max(10.0, 0.05 * self._deposit_usdt) if self._deposit_usdt > 0 else 10.0
-
-    def _deposit_snapshot(self) -> Dict[str, Any]:
-        return {
-            "asset": self._deposit_asset,
-            "balance": self._deposit_usdt,
-            "updated_at": self._last_deposit_update.isoformat() if self._last_deposit_update else None,
-        }
+        balance = self._deposit.balance
+        return max(10.0, 0.05 * balance) if balance > 0 else 10.0
 
     def _update_used_amount(self) -> None:
         open_amount = sum(

--- a/tests/test_live_trading_runner.py
+++ b/tests/test_live_trading_runner.py
@@ -9,6 +9,7 @@ from zoneinfo import ZoneInfo
 import pytest
 
 from bot.data.io.storage import Storage
+from bot.data.models import DepositSnapshot
 from bot.data.repositories.signal_repository import SignalRepository
 from bot.data.repositories.state_repository import StateRepository
 from bot.data.repositories.trade_repository import TradeRepository
@@ -36,8 +37,8 @@ class FakeProvider:
             return queue.popleft()
         return []
 
-    async def update_deposit(self) -> dict[str, float | str]:
-        return {"asset": "USDT", "balance": 10_000.0}
+    async def update_deposit(self) -> DepositSnapshot:
+        return DepositSnapshot(asset="USDT", balance=10_000.0)
 
 
 class FakeClock:
@@ -292,8 +293,8 @@ async def _assert_timeframe_cadence(tmp_path, monkeypatch) -> None:
             )
             return [candle]
 
-        async def update_deposit(self) -> dict[str, float | str]:
-            return {"asset": "USDT", "balance": 10_000.0}
+        async def update_deposit(self) -> DepositSnapshot:
+            return DepositSnapshot(asset="USDT", balance=10_000.0)
 
     def _seconds_for_timeframe(timeframe: Timeframe) -> int:
         return {

--- a/tests/test_provider_limits.py
+++ b/tests/test_provider_limits.py
@@ -1,5 +1,6 @@
 import pytest
 
+from bot.data.models import DepositSnapshot
 from bot.data.providers.base import BaseExchangeProvider
 from bot.domain.enums import Exchange, Timeframe
 
@@ -23,7 +24,7 @@ class _StubProvider(BaseExchangeProvider):
     async def get_24h_quote_volume(self):  # pragma: no cover - unused
         raise NotImplementedError
 
-    async def update_deposit(self):  # pragma: no cover - unused
+    async def update_deposit(self) -> DepositSnapshot:  # pragma: no cover - unused
         raise NotImplementedError
 
 


### PR DESCRIPTION
## Summary
- add a dedicated DepositSnapshot dataclass for normalized balance information
- refactor exchange providers to parse balance responses into typed models and return DepositSnapshot
- update live and backtest runners plus tests to use DepositSnapshot instead of raw dicts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cd033990408320a9df5503e592b096