### PR TITLE
Add typed exchange response models and parsing

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -354,20 +354,13 @@ async def discover_symbol_universe(
         except Exception as exc:  # pragma: no cover - network errors
             logger.warning("Failed to fetch 24h statistics from %s: %s", provider_name, exc)
             continue
-        if not isinstance(stats, Mapping):
-            continue
         for symbol, volume in stats.items():
-            if not isinstance(symbol, str):
-                continue
             normalized = symbol.upper()
             if suffix and not normalized.endswith(suffix):
                 continue
             if normalized in deny:
                 continue
-            try:
-                volume_value = float(volume)
-            except (TypeError, ValueError):
-                continue
+            volume_value = float(volume)
             if volume_value < min_quote_volume:
                 continue
             existing_volume = volumes.get(normalized)

--- a/bot/data/models/__init__.py
+++ b/bot/data/models/__init__.py
@@ -1,3 +1,15 @@
 from .deposit import DepositSnapshot
+from .exchange import (
+    BinanceSymbolInfo,
+    BinanceTicker24h,
+    BybitInstrument,
+    BybitTicker,
+)
 
-__all__ = ["DepositSnapshot"]
+__all__ = [
+    "DepositSnapshot",
+    "BinanceSymbolInfo",
+    "BinanceTicker24h",
+    "BybitInstrument",
+    "BybitTicker",
+]

--- a/bot/data/models/exchange.py
+++ b/bot/data/models/exchange.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+def _ensure_str(value: Any, field: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"Expected {field} to be str, got {type(value)!r}")
+    return value
+
+
+def _ensure_float(value: Any, field: str) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Invalid float value for {field}: {value!r}") from exc
+    raise TypeError(f"Expected numeric value for {field}, got {type(value)!r}")
+
+
+@dataclass(slots=True)
+class BinanceSymbolInfo:
+    symbol: str
+    status: str
+
+    @classmethod
+    def from_raw(cls, raw: Mapping[str, Any]) -> "BinanceSymbolInfo":
+        symbol = _ensure_str(raw["symbol"], "symbol").upper()
+        status = _ensure_str(raw["status"], "status")
+        return cls(symbol=symbol, status=status)
+
+
+@dataclass(slots=True)
+class BinanceTicker24h:
+    symbol: str
+    quote_volume: float
+
+    @classmethod
+    def from_raw(cls, raw: Mapping[str, Any]) -> "BinanceTicker24h":
+        symbol = _ensure_str(raw["symbol"], "symbol").upper()
+        quote_volume = _ensure_float(raw["quoteVolume"], "quoteVolume")
+        return cls(symbol=symbol, quote_volume=quote_volume)
+
+
+@dataclass(slots=True)
+class BybitInstrument:
+    symbol: str
+    status: str
+
+    @classmethod
+    def from_raw(cls, raw: Mapping[str, Any]) -> "BybitInstrument":
+        symbol = _ensure_str(raw["symbol"], "symbol").upper()
+        status = _ensure_str(raw["status"], "status")
+        return cls(symbol=symbol, status=status)
+
+
+@dataclass(slots=True)
+class BybitTicker:
+    symbol: str
+    turnover24h: float | None
+    turnover: float | None
+
+    @classmethod
+    def from_raw(cls, raw: Mapping[str, Any]) -> "BybitTicker":
+        symbol = _ensure_str(raw["symbol"], "symbol").upper()
+        turnover24h = raw["turnover24h"] if "turnover24h" in raw else None
+        turnover = raw["turnover"] if "turnover" in raw else None
+        parsed_turnover24h = None
+        parsed_turnover = None
+        if turnover24h is not None:
+            parsed_turnover24h = _ensure_float(turnover24h, "turnover24h")
+        if turnover is not None:
+            parsed_turnover = _ensure_float(turnover, "turnover")
+        return cls(symbol=symbol, turnover24h=parsed_turnover24h, turnover=parsed_turnover)
+
+    def quote_volume(self) -> float | None:
+        if self.turnover24h is not None:
+            return self.turnover24h
+        return self.turnover

--- a/bot/data/providers/binance.py
+++ b/bot/data/providers/binance.py
@@ -16,7 +16,7 @@ except ImportError:  # pragma: no cover
 from ...domain.enums import Exchange, Timeframe
 from ...domain.models.entities import Candle
 from ...utils.logging import get_logger
-from ..models import DepositSnapshot
+from ..models import BinanceSymbolInfo, BinanceTicker24h, DepositSnapshot
 from .base import BaseExchangeProvider
 
 
@@ -127,7 +127,7 @@ class BinanceFuturesProvider(BaseExchangeProvider):
                 yield candles[-1]
             await asyncio.sleep(1)
 
-    async def get_symbols(self) -> Iterable[str]:
+    async def get_symbols(self) -> list[str]:
         await self.ensure_rate_limit()
         if not self._session:
             raise RuntimeError("httpx is required to fetch symbols from Binance")
@@ -135,8 +135,9 @@ class BinanceFuturesProvider(BaseExchangeProvider):
         response = await self._session.get(endpoint)
         response.raise_for_status()
         info = response.json()
-        symbols = [item["symbol"] for item in info.get("symbols", []) if item.get("status") == "TRADING"]
-        return [symbol for symbol in symbols if not symbol.endswith("_PERP")]  # filter illiquid synthetics
+        symbols = _parse_binance_symbols(info)
+        trading = [item.symbol for item in symbols if item.status.upper() == "TRADING"]
+        return [symbol for symbol in trading if not symbol.endswith("_PERP")]  # filter illiquid synthetics
 
     async def get_24h_quote_volume(self) -> Dict[str, float]:
         await self.ensure_rate_limit()
@@ -146,21 +147,8 @@ class BinanceFuturesProvider(BaseExchangeProvider):
         response = await self._session.get(endpoint)
         response.raise_for_status()
         data = response.json()
-        volumes: Dict[str, float] = {}
-        if isinstance(data, list):
-            for item in data:
-                if not isinstance(item, dict):
-                    continue
-                symbol = item.get("symbol")
-                if not isinstance(symbol, str):
-                    continue
-                volume_raw = item.get("quoteVolume")
-                try:
-                    volume = float(volume_raw)
-                except (TypeError, ValueError):
-                    continue
-                volumes[symbol.upper()] = volume
-        return volumes
+        tickers = _parse_binance_tickers(data)
+        return {ticker.symbol: ticker.quote_volume for ticker in tickers}
 
     async def update_deposit(self) -> DepositSnapshot:
         await self.ensure_rate_limit()
@@ -199,3 +187,37 @@ def _select_amount(balance: _BinanceBalance | None) -> float:
         if value is not None:
             return value
     return 0.0
+
+
+def _parse_binance_symbols(payload: Any) -> list[BinanceSymbolInfo]:
+    if not isinstance(payload, Mapping):
+        return []
+    try:
+        symbols_raw = payload["symbols"]
+    except KeyError:
+        return []
+    if not isinstance(symbols_raw, Sequence):
+        return []
+    parsed: list[BinanceSymbolInfo] = []
+    for item in symbols_raw:
+        if not isinstance(item, Mapping):
+            continue
+        try:
+            parsed.append(BinanceSymbolInfo.from_raw(item))
+        except (KeyError, TypeError, ValueError):  # pragma: no cover - defensive
+            continue
+    return parsed
+
+
+def _parse_binance_tickers(payload: Any) -> list[BinanceTicker24h]:
+    if not isinstance(payload, Sequence):
+        return []
+    parsed: list[BinanceTicker24h] = []
+    for item in payload:
+        if not isinstance(item, Mapping):
+            continue
+        try:
+            parsed.append(BinanceTicker24h.from_raw(item))
+        except (KeyError, TypeError, ValueError):  # pragma: no cover - defensive
+            continue
+    return parsed

--- a/bot/data/providers/bybit.py
+++ b/bot/data/providers/bybit.py
@@ -15,7 +15,7 @@ except ImportError:  # pragma: no cover
 
 from ...domain.enums import Exchange, Timeframe
 from ...domain.models.entities import Candle
-from ..models import DepositSnapshot
+from ..models import BybitInstrument, BybitTicker, DepositSnapshot
 from .base import BaseExchangeProvider
 
 
@@ -147,7 +147,7 @@ class BybitPerpetualProvider(BaseExchangeProvider):
                 yield candles[-1]
             await asyncio.sleep(1)
 
-    async def get_symbols(self) -> Iterable[str]:
+    async def get_symbols(self) -> list[str]:
         await self.ensure_rate_limit()
         if not self._session:
             raise RuntimeError("httpx is required to fetch symbols from Bybit")
@@ -156,9 +156,9 @@ class BybitPerpetualProvider(BaseExchangeProvider):
         response = await self._session.get(endpoint, params=params)
         response.raise_for_status()
         data = response.json()
-        raw = data.get("result", {}).get("list", [])
-        symbols = [item.get("symbol") for item in raw if item.get("status") == "Trading"]
-        return [symbol for symbol in symbols if symbol]
+        instruments = _parse_bybit_instruments(data)
+        trading = [item.symbol for item in instruments if item.status == "Trading"]
+        return trading
 
     async def get_24h_quote_volume(self) -> Dict[str, float]:
         await self.ensure_rate_limit()
@@ -169,21 +169,13 @@ class BybitPerpetualProvider(BaseExchangeProvider):
         response = await self._session.get(endpoint, params=params)
         response.raise_for_status()
         data = response.json()
-        items = data.get("result", {}).get("list", [])
+        tickers = _parse_bybit_tickers(data)
         volumes: Dict[str, float] = {}
-        if isinstance(items, list):
-            for item in items:
-                if not isinstance(item, dict):
-                    continue
-                symbol = item.get("symbol")
-                if not isinstance(symbol, str):
-                    continue
-                volume_raw = item.get("turnover24h") or item.get("turnover")
-                try:
-                    volume = float(volume_raw)
-                except (TypeError, ValueError):
-                    continue
-                volumes[symbol.upper()] = volume
+        for ticker in tickers:
+            volume = ticker.quote_volume()
+            if volume is None:
+                continue
+            volumes[ticker.symbol] = volume
         return volumes
 
     async def update_deposit(self) -> DepositSnapshot:
@@ -241,3 +233,55 @@ def _select_bybit_amount(balance: _BybitCoinBalance | None) -> float:
         if value is not None:
             return value
     return 0.0
+
+
+def _parse_bybit_instruments(payload: Any) -> list[BybitInstrument]:
+    if not isinstance(payload, Mapping):
+        return []
+    try:
+        result = payload["result"]
+    except KeyError:
+        return []
+    if not isinstance(result, Mapping):
+        return []
+    try:
+        instruments_raw = result["list"]
+    except KeyError:
+        return []
+    if not isinstance(instruments_raw, Sequence):
+        return []
+    parsed: list[BybitInstrument] = []
+    for item in instruments_raw:
+        if not isinstance(item, Mapping):
+            continue
+        try:
+            parsed.append(BybitInstrument.from_raw(item))
+        except (KeyError, TypeError, ValueError):  # pragma: no cover - defensive
+            continue
+    return parsed
+
+
+def _parse_bybit_tickers(payload: Any) -> list[BybitTicker]:
+    if not isinstance(payload, Mapping):
+        return []
+    try:
+        result = payload["result"]
+    except KeyError:
+        return []
+    if not isinstance(result, Mapping):
+        return []
+    try:
+        tickers_raw = result["list"]
+    except KeyError:
+        return []
+    if not isinstance(tickers_raw, Sequence):
+        return []
+    parsed: list[BybitTicker] = []
+    for item in tickers_raw:
+        if not isinstance(item, Mapping):
+            continue
+        try:
+            parsed.append(BybitTicker.from_raw(item))
+        except (KeyError, TypeError, ValueError):  # pragma: no cover - defensive
+            continue
+    return parsed


### PR DESCRIPTION
## Summary
- add dataclasses for Binance and Bybit REST payloads to ensure strongly typed models
- update exchange providers to parse API responses into these models and return typed collections
- simplify symbol discovery to rely on typed provider outputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd056efab483208a06fcb6c358400d