### PR TITLE
Add typed config parsing and update app helpers

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -8,7 +8,7 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterable, Mapping, Sequence
+from typing import Dict, Iterable, Sequence
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 VALID_MODES = {"backtest", "live"}
@@ -22,7 +22,7 @@ from .data.repositories.signal_repository import SignalRepository
 from .data.repositories.state_repository import StateRepository
 from .data.repositories.trade_repository import TradeRepository
 from .domain.enums import Timeframe
-from .domain.models.entities import Candle, ThresholdMetric, Thresholds
+from .domain.models.entities import Candle, Thresholds
 from .domain.services.backtest_runner import BacktestRunner
 from .domain.services.dedup_policy import DeduplicationPolicy
 from .domain.services.live_runner import LiveTradingRunner
@@ -104,148 +104,11 @@ def init_providers(config: AppConfig) -> Dict[str, BaseExchangeProvider]:
     return providers
 
 
-def _parse_threshold(raw: Dict[str, object]) -> Thresholds:
-    metrics_raw = raw.get("metrics", []) if isinstance(raw, dict) else []
-    metrics: list[ThresholdMetric] = []
-    if isinstance(metrics_raw, list):
-        for item in metrics_raw:
-            if not isinstance(item, dict):
-                continue
-            name = item.get("name")
-            if not name:
-                continue
-            metrics.append(
-                ThresholdMetric(
-                    name=str(name),
-                    min_value=float(item["min_value"]) if item.get("min_value") is not None else None,
-                    max_value=float(item["max_value"]) if item.get("max_value") is not None else None,
-                    min_abs_value=float(item["min_abs_value"]) if item.get("min_abs_value") is not None else None,
-                )
-            )
-    def _get_float_from_keys(keys: list[str], fallback: float = 0.0) -> float:
-        if not isinstance(raw, dict):
-            return fallback
-        for key in keys:
-            if key in raw and raw[key] is not None:
-                return float(raw[key])
-        return fallback
-
-    def _get_bool(key: str, default: bool) -> bool:
-        if not isinstance(raw, dict):
-            return default
-        value = raw.get(key)
-        if isinstance(value, bool):
-            return value
-        if isinstance(value, str):
-            lowered = value.strip().lower()
-            if lowered in {"true", "1", "yes"}:
-                return True
-            if lowered in {"false", "0", "no"}:
-                return False
-        return default
-
-    def _parse_range_list(source: object) -> list[tuple[float | None, float | None]]:
-        parsed: list[tuple[float | None, float | None]] = []
-        if not isinstance(source, list):
-            return parsed
-        for entry in source:
-            min_value: float | None = None
-            max_value: float | None = None
-            if isinstance(entry, dict):
-                min_raw = entry.get("min")
-                if min_raw is None:
-                    min_raw = entry.get("min_value")
-                max_raw = entry.get("max")
-                if max_raw is None:
-                    max_raw = entry.get("max_value")
-                if min_raw is not None:
-                    min_value = float(min_raw)
-                if max_raw is not None:
-                    max_value = float(max_raw)
-            elif isinstance(entry, (list, tuple)):
-                if len(entry) > 0 and entry[0] is not None:
-                    min_value = float(entry[0])
-                if len(entry) > 1 and entry[1] is not None:
-                    max_value = float(entry[1])
-            elif isinstance(entry, (int, float)):
-                min_value = float(entry)
-            if min_value is None and max_value is None:
-                continue
-            parsed.append((min_value, max_value))
-        return parsed
-
-    short_pct_move_ranges: list[tuple[float | None, float | None]] = []
-    if isinstance(raw, dict):
-        short_pct_move_ranges = _parse_range_list(raw.get("short_pct_move_ranges"))
-    allow_long = _get_bool("allow_long", True)
-    allow_short = _get_bool("allow_short", True)
-    metadata = raw.get("metadata", {}) if isinstance(raw, dict) else {}
-    if not isinstance(metadata, dict):
-        metadata = {}
-    if not short_pct_move_ranges:
-        short_pct_move_ranges = _parse_range_list(metadata.get("short_pct_move_ranges"))
-    short_relative_volume_ranges = _parse_range_list(
-        raw.get("short_relative_volume_ranges") if isinstance(raw, dict) else None
-    )
-    if not short_relative_volume_ranges:
-        short_relative_volume_ranges = _parse_range_list(
-            metadata.get("short_relative_volume_ranges")
-        )
-    created_at_raw = raw.get("created_at") if isinstance(raw, dict) else None
-    updated_at_raw = raw.get("updated_at") if isinstance(raw, dict) else None
-    return Thresholds(
-        id=str(raw.get("id")) if isinstance(raw, dict) and raw.get("id") is not None else None,
-        min_relative_volume=_get_float_from_keys(
-            [
-                "min_relative_volume",
-                "minRelativeVolume",
-                "S",
-                "s",
-            ]
-        ),
-        max_relative_volume=_get_float_from_keys(
-            [
-                "max_relative_volume",
-                "maxRelativeVolume",
-                "T",
-                "t",
-            ]
-        ),
-        min_atr_mult=_get_float_from_keys(
-            ["min_atr_mult", "minAtrMult", "U", "u"],
-        ),
-        min_pct_move=_get_float_from_keys(
-            ["min_pct_move", "minPctMove", "V", "v"],
-        ),
-        max_pct_move=_get_float_from_keys(
-            ["max_pct_move", "maxPctMove", "W", "w"],
-        ),
-        max_upper_wick_pct=_get_float_from_keys(
-            ["max_upper_wick_pct", "maxUpperWickPct", "X", "x"],
-        ),
-        max_lower_wick_pct=_get_float_from_keys(
-            ["max_lower_wick_pct", "maxLowerWickPct", "Y", "y"],
-        ),
-        short_pct_move_ranges=short_pct_move_ranges,
-        short_relative_volume_ranges=short_relative_volume_ranges,
-        allow_long=allow_long,
-        allow_short=allow_short,
-        metrics=metrics,
-        metadata=metadata if isinstance(metadata, dict) else {},
-        created_at=datetime.fromisoformat(created_at_raw) if isinstance(created_at_raw, str) else None,
-        updated_at=datetime.fromisoformat(updated_at_raw) if isinstance(updated_at_raw, str) else None,
-    )
-
-
 def build_thresholds(config: AppConfig) -> Dict[str, Thresholds]:
-    raw = config.get("thresholds", {})
-    if not isinstance(raw, dict):
-        return {"default": Thresholds()}
-    thresholds: Dict[str, Thresholds] = {}
-    default_raw = raw.get("default", {})
-    thresholds["default"] = _parse_threshold(default_raw)
-    for symbol, data in raw.get("symbols", {}).items():
-        thresholds[symbol] = _parse_threshold(data)
+    thresholds_cfg = config.thresholds
+    thresholds: Dict[str, Thresholds] = {"default": thresholds_cfg.default.to_domain()}
+    for symbol, cfg in thresholds_cfg.symbols.items():
+        thresholds[symbol] = cfg.to_domain()
     return thresholds
 
 
@@ -285,27 +148,19 @@ def init_services(config: AppConfig, storage: Storage) -> tuple[
     )
 
 
-def _normalize_symbol_set(raw: object) -> set[str]:
-    symbols: set[str] = set()
-    if isinstance(raw, str):
-        raw = [raw]
-    if isinstance(raw, (list, tuple, set, frozenset)):
-        for item in raw:
-            if isinstance(item, str) and item:
-                symbols.add(item.upper())
-    return symbols
-
-
 def _resolve_provider_name(
     symbol: str,
     config: AppConfig,
     providers: Dict[str, BaseExchangeProvider],
     default: str | None = None,
 ) -> str:
-    mapping = config.get("symbols.providers", {})
-    provider_name: str | None = None
-    if isinstance(mapping, Mapping):
-        provider_name = mapping.get(symbol) or mapping.get("default")
+    mapping = config.symbol_provider_mapping
+    symbol_key = symbol.upper()
+    provider_name = (
+        mapping.get(symbol_key)
+        or mapping.get(symbol)
+        or mapping.get("default")
+    )
     if not provider_name and default:
         provider_name = default
     if not provider_name:
@@ -322,21 +177,15 @@ async def discover_symbol_universe(
     provider_scope: Iterable[str] | None = None,
 ) -> SymbolUniverse:
     logger = get_logger("symbol-discovery")
-    selection_cfg = config.get("symbols.selection", {})
-    suffix = "USDT"
-    min_quote_volume = 5_000_000.0
-    allow: set[str] = set()
-    deny: set[str] = set()
-    if isinstance(selection_cfg, Mapping):
-        suffix = str(selection_cfg.get("quote_suffix", suffix)).upper() or suffix
-        min_quote_volume = float(selection_cfg.get("min_quote_volume", min_quote_volume))
-        allow |= _normalize_symbol_set(selection_cfg.get("allow"))
-        deny |= _normalize_symbol_set(selection_cfg.get("deny"))
-    mode_cfg = config.get(mode, {})
-    if isinstance(mode_cfg, Mapping):
-        allow |= _normalize_symbol_set(mode_cfg.get("allow"))
-        allow |= _normalize_symbol_set(mode_cfg.get("symbols"))
-        deny |= _normalize_symbol_set(mode_cfg.get("deny"))
+    selection_cfg = config.symbol_selection
+    suffix = selection_cfg.quote_suffix
+    min_quote_volume = selection_cfg.min_quote_volume
+    allow: set[str] = set(selection_cfg.allow)
+    deny: set[str] = set(selection_cfg.deny)
+    overrides = config.selection_overrides_for(mode)
+    allow.update(overrides.allow)
+    allow.update(overrides.symbols)
+    deny.update(overrides.deny)
 
     provider_names = list(provider_scope or providers.keys())
     discovered: Dict[str, str] = {}
@@ -420,8 +269,8 @@ async def run_backtest(
 ) -> None:
     logger = get_logger("backtest")
     signal_repo, trade_repo, state_repo, _, selector, tp_sl_service, dedup_policy = services
-    backtest_cfg = config.get("backtest", {})
-    if not _is_mode_enabled(backtest_cfg):
+    backtest_cfg = config.backtest
+    if not backtest_cfg.enabled:
         logger.info("Backtest disabled")
         return
     runner = BacktestRunner(
@@ -431,38 +280,10 @@ async def run_backtest(
         state_repo,
         trade_repo,
         dedup_policy,
-        window=int(backtest_cfg.get("window", 50)),
+        window=backtest_cfg.window,
     )
-    configured_timeframes = backtest_cfg.get("timeframes")
-    timeframes: tuple[Timeframe, ...]
-    if isinstance(configured_timeframes, (list, tuple, set, frozenset)):
-        parsed: list[Timeframe] = []
-        for raw in configured_timeframes:
-            try:
-                parsed.append(Timeframe(raw))
-            except Exception:
-                continue
-        timeframes = tuple(parsed)
-    else:
-        timeframe_value = backtest_cfg.get("timeframe")
-        if timeframe_value is not None:
-            timeframes = (Timeframe(timeframe_value),)
-        else:
-            timeframes = (
-                Timeframe.M1,
-                Timeframe.M3,
-                Timeframe.M5,
-                Timeframe.M15,
-            )
-    if not timeframes:
-        timeframes = (
-            Timeframe.M1,
-            Timeframe.M3,
-            Timeframe.M5,
-            Timeframe.M15,
-        )
-    configured_limit = backtest_cfg.get("limit")
-    requested_limit = int(configured_limit) if configured_limit is not None else None
+    timeframes = backtest_cfg.timeframes
+    requested_limit = backtest_cfg.limit
     universe = await discover_symbol_universe(config, providers, "backtest")
     if not universe.assignments:
         logger.warning("No symbols available for backtest after applying liquidity filters")
@@ -474,14 +295,7 @@ async def run_backtest(
         for timeframe in timeframes:
             try:
                 limit = provider.resolve_ohlcv_limit(requested_limit)
-                history_batches_raw = backtest_cfg.get("history_batches", 10)
-                history_batches = (
-                    int(history_batches_raw)
-                    if isinstance(history_batches_raw, (int, float, str))
-                    and str(history_batches_raw).strip()
-                    else 10
-                )
-                history_batches = max(history_batches, 1)
+                history_batches = backtest_cfg.history_batches
                 timeframe_delta = timeframe.to_timedelta()
                 timeframe_ms = int(timeframe_delta.total_seconds() * 1000)
                 total_candles = limit * history_batches
@@ -545,24 +359,11 @@ async def run_live(
 ) -> None:
     logger = get_logger("live")
     signal_repo, trade_repo, state_repo, _, selector, tp_sl_service, dedup_policy = services
-    live_cfg = config.get("live", {})
-    if not _is_mode_enabled(live_cfg):
+    live_cfg = config.live
+    if not live_cfg.enabled:
         logger.info("Live trading disabled")
         return
-    provider_values = live_cfg.get("providers")
-    provider_names: list[str] = []
-    if isinstance(provider_values, str):
-        provider_names = [provider_values]
-    elif isinstance(provider_values, Iterable):
-        provider_names = [str(value) for value in provider_values if isinstance(value, str)]
-
-    if not provider_names:
-        single = live_cfg.get("provider")
-        if isinstance(single, str):
-            provider_names = [single]
-
-    if not provider_names:
-        provider_names = list(providers.keys())
+    provider_names: list[str] = list(live_cfg.providers) or list(providers.keys())
 
     invalid = [name for name in provider_names if name not in providers]
     if invalid:
@@ -572,8 +373,8 @@ async def run_live(
         logger.warning("No valid providers configured for live trading")
         return
 
-    timeframe = Timeframe(live_cfg.get("timeframe", Timeframe.M5.value))
-    window = int(live_cfg.get("window", 50))
+    timeframe = live_cfg.timeframe
+    window = live_cfg.window
     universe = await discover_symbol_universe(
         config,
         providers,
@@ -641,23 +442,6 @@ def _normalize_mode(value: object) -> str | None:
         if normalized:
             return normalized
     return None
-
-
-def _is_mode_enabled(config_section: Mapping[str, object] | object, default: bool = True) -> bool:
-    if not isinstance(config_section, Mapping):
-        return default
-    value = config_section.get("enabled")
-    if value is None:
-        return default
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        lowered = value.strip().lower()
-        if lowered in {"true", "1", "yes", "on"}:
-            return True
-        if lowered in {"false", "0", "no", "off"}:
-            return False
-    return bool(value)
 
 
 def resolve_mode(config: AppConfig, cli_args: Sequence[str] | None = None) -> str:

--- a/bot/data/io/config_loader.py
+++ b/bot/data/io/config_loader.py
@@ -2,14 +2,39 @@ from __future__ import annotations
 
 import os
 import tomllib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Mapping
+
+from .config_models import (
+    BacktestConfig,
+    LiveConfig,
+    ModeSelectionOverrides,
+    SymbolSelectionConfig,
+    ThresholdsConfig,
+    parse_symbol_provider_mapping,
+)
 
 
 @dataclass(slots=True)
 class AppConfig:
     raw: Dict[str, Any]
+    thresholds: ThresholdsConfig = field(init=False)
+    symbol_selection: SymbolSelectionConfig = field(init=False)
+    symbol_provider_mapping: dict[str, str] = field(init=False)
+    backtest: BacktestConfig = field(init=False)
+    live: LiveConfig = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.thresholds = ThresholdsConfig.from_raw(self.get("thresholds", {}))
+        self.symbol_selection = SymbolSelectionConfig.from_raw(
+            self.get("symbols.selection", {})
+        )
+        self.symbol_provider_mapping = parse_symbol_provider_mapping(
+            self.get("symbols.providers", {})
+        )
+        self.backtest = BacktestConfig.from_raw(self.get("backtest", {}))
+        self.live = LiveConfig.from_raw(self.get("live", {}))
 
     def get(self, path: str, default: Any = None) -> Any:
         cursor: Any = self.raw
@@ -25,6 +50,13 @@ class AppConfig:
         if isinstance(value, str) and value.strip():
             return value.strip()
         return "UTC"
+
+    def selection_overrides_for(self, mode: str) -> ModeSelectionOverrides:
+        if mode == "backtest":
+            return self.backtest.selection
+        if mode == "live":
+            return self.live.selection
+        return ModeSelectionOverrides()
 
 
 class ConfigLoader:

--- a/bot/data/io/config_models.py
+++ b/bot/data/io/config_models.py
@@ -1,0 +1,468 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Iterable, Mapping, Sequence
+
+from ...domain.enums import Timeframe
+from ...domain.models.entities import ThresholdMetric as DomainThresholdMetric
+from ...domain.models.entities import Thresholds as DomainThresholds
+
+
+_DEFAULT_BACKTEST_TIMEFRAMES: tuple[Timeframe, ...] = (
+    Timeframe.M1,
+    Timeframe.M3,
+    Timeframe.M5,
+    Timeframe.M15,
+)
+
+
+def _to_optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _to_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+    if value is None:
+        return default
+    return bool(value)
+
+
+def _to_int(value: Any, default: int, minimum: int | None = None) -> int:
+    if isinstance(value, bool):
+        candidate: int | None = 1 if value else 0
+    elif isinstance(value, (int, float)):
+        candidate = int(value)
+    elif isinstance(value, str) and value.strip():
+        try:
+            candidate = int(float(value))
+        except ValueError:
+            candidate = None
+    else:
+        candidate = None
+    if candidate is None:
+        candidate = default
+    if minimum is not None and candidate < minimum:
+        return minimum
+    return candidate
+
+
+def _to_optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return 1 if value else 0
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(float(value))
+        except ValueError:
+            return None
+    return None
+
+
+def _normalize_symbol_set(value: Any) -> frozenset[str]:
+    symbols: set[str] = set()
+    if isinstance(value, str):
+        value = [value]
+    if isinstance(value, Iterable):
+        for item in value:
+            if isinstance(item, str) and item.strip():
+                symbols.add(item.strip().upper())
+    return frozenset(symbols)
+
+
+def _parse_range_entry(entry: Any) -> tuple[float | None, float | None] | None:
+    min_value: float | None = None
+    max_value: float | None = None
+    if isinstance(entry, Mapping):
+        min_raw = entry.get("min")
+        if min_raw is None:
+            min_raw = entry.get("min_value")
+        max_raw = entry.get("max")
+        if max_raw is None:
+            max_raw = entry.get("max_value")
+        min_value = _to_optional_float(min_raw)
+        max_value = _to_optional_float(max_raw)
+    elif isinstance(entry, Sequence) and not isinstance(entry, (str, bytes, bytearray)):
+        if len(entry) > 0:
+            min_value = _to_optional_float(entry[0])
+        if len(entry) > 1:
+            max_value = _to_optional_float(entry[1])
+    elif isinstance(entry, (int, float)):
+        min_value = float(entry)
+    if min_value is None and max_value is None:
+        return None
+    return (min_value, max_value)
+
+
+def _parse_range_list(source: Any) -> tuple[tuple[float | None, float | None], ...]:
+    if not isinstance(source, Iterable) or isinstance(source, (str, bytes, bytearray)):
+        return tuple()
+    parsed: list[tuple[float | None, float | None]] = []
+    for entry in source:
+        parsed_entry = _parse_range_entry(entry)
+        if parsed_entry is not None:
+            parsed.append(parsed_entry)
+    return tuple(parsed)
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _float_or_default(value: float | None) -> float:
+    return value if value is not None else 0.0
+
+
+@dataclass(slots=True)
+class ThresholdMetricConfig:
+    name: str
+    min_value: float | None = None
+    max_value: float | None = None
+    min_abs_value: float | None = None
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any]) -> "ThresholdMetricConfig" | None:
+        name = raw.get("name")
+        if not isinstance(name, str) or not name.strip():
+            return None
+        return cls(
+            name=name.strip(),
+            min_value=_to_optional_float(raw.get("min_value")),
+            max_value=_to_optional_float(raw.get("max_value")),
+            min_abs_value=_to_optional_float(raw.get("min_abs_value")),
+        )
+
+    def to_domain(self) -> DomainThresholdMetric:
+        return DomainThresholdMetric(
+            name=self.name,
+            min_value=self.min_value,
+            max_value=self.max_value,
+            min_abs_value=self.min_abs_value,
+        )
+
+
+@dataclass(slots=True)
+class ThresholdConfig:
+    id: str | None = None
+    min_relative_volume: float | None = None
+    max_relative_volume: float | None = None
+    min_atr_mult: float | None = None
+    min_pct_move: float | None = None
+    max_pct_move: float | None = None
+    max_upper_wick_pct: float | None = None
+    max_lower_wick_pct: float | None = None
+    allow_long: bool = True
+    allow_short: bool = True
+    metrics: tuple[ThresholdMetricConfig, ...] = field(default_factory=tuple)
+    short_pct_move_ranges: tuple[tuple[float | None, float | None], ...] = field(
+        default_factory=tuple
+    )
+    short_relative_volume_ranges: tuple[tuple[float | None, float | None], ...] = field(
+        default_factory=tuple
+    )
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any] | None) -> "ThresholdConfig":
+        if raw is None or not isinstance(raw, Mapping):
+            raw = {}
+        metadata_raw = raw.get("metadata")
+        metadata = metadata_raw if isinstance(metadata_raw, Mapping) else {}
+        metrics_raw = raw.get("metrics")
+        metrics: list[ThresholdMetricConfig] = []
+        if isinstance(metrics_raw, Iterable) and not isinstance(
+            metrics_raw, (str, bytes, bytearray)
+        ):
+            for item in metrics_raw:
+                if isinstance(item, Mapping):
+                    metric = ThresholdMetricConfig.from_mapping(item)
+                    if metric is not None:
+                        metrics.append(metric)
+        short_pct_move_ranges = _parse_range_list(raw.get("short_pct_move_ranges"))
+        if not short_pct_move_ranges and metadata:
+            short_pct_move_ranges = _parse_range_list(
+                metadata.get("short_pct_move_ranges")
+            )
+        short_relative_volume_ranges = _parse_range_list(
+            raw.get("short_relative_volume_ranges")
+        )
+        if not short_relative_volume_ranges and metadata:
+            short_relative_volume_ranges = _parse_range_list(
+                metadata.get("short_relative_volume_ranges")
+            )
+        return cls(
+            id=str(raw.get("id")) if raw.get("id") is not None else None,
+            min_relative_volume=_coerce_from_keys(
+                raw,
+                [
+                    "min_relative_volume",
+                    "minRelativeVolume",
+                    "S",
+                    "s",
+                ],
+            ),
+            max_relative_volume=_coerce_from_keys(
+                raw,
+                [
+                    "max_relative_volume",
+                    "maxRelativeVolume",
+                    "T",
+                    "t",
+                ],
+            ),
+            min_atr_mult=_coerce_from_keys(raw, ["min_atr_mult", "minAtrMult", "U", "u"]),
+            min_pct_move=_coerce_from_keys(raw, ["min_pct_move", "minPctMove", "V", "v"]),
+            max_pct_move=_coerce_from_keys(raw, ["max_pct_move", "maxPctMove", "W", "w"]),
+            max_upper_wick_pct=_coerce_from_keys(
+                raw, ["max_upper_wick_pct", "maxUpperWickPct", "X", "x"]
+            ),
+            max_lower_wick_pct=_coerce_from_keys(
+                raw, ["max_lower_wick_pct", "maxLowerWickPct", "Y", "y"]
+            ),
+            allow_long=_to_bool(raw.get("allow_long"), True),
+            allow_short=_to_bool(raw.get("allow_short"), True),
+            metrics=tuple(metrics),
+            short_pct_move_ranges=short_pct_move_ranges,
+            short_relative_volume_ranges=short_relative_volume_ranges,
+            metadata=metadata,
+            created_at=_parse_datetime(raw.get("created_at")),
+            updated_at=_parse_datetime(raw.get("updated_at")),
+        )
+
+    def to_domain(self) -> DomainThresholds:
+        return DomainThresholds(
+            id=self.id,
+            min_relative_volume=_float_or_default(self.min_relative_volume),
+            max_relative_volume=_float_or_default(self.max_relative_volume),
+            min_atr_mult=_float_or_default(self.min_atr_mult),
+            min_pct_move=_float_or_default(self.min_pct_move),
+            max_pct_move=_float_or_default(self.max_pct_move),
+            max_upper_wick_pct=_float_or_default(self.max_upper_wick_pct),
+            max_lower_wick_pct=_float_or_default(self.max_lower_wick_pct),
+            short_pct_move_ranges=[*self.short_pct_move_ranges],
+            short_relative_volume_ranges=[*self.short_relative_volume_ranges],
+            allow_long=self.allow_long,
+            allow_short=self.allow_short,
+            metrics=[metric.to_domain() for metric in self.metrics],
+            metadata=dict(self.metadata),
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+        )
+
+
+def _coerce_from_keys(
+    raw: Mapping[str, Any], keys: Sequence[str], fallback: float | None = None
+) -> float | None:
+    for key in keys:
+        if key in raw:
+            value = _to_optional_float(raw.get(key))
+            if value is not None:
+                return value
+    return fallback
+
+
+@dataclass(slots=True)
+class ThresholdsConfig:
+    default: ThresholdConfig
+    symbols: dict[str, ThresholdConfig]
+
+    @classmethod
+    def from_raw(cls, raw: Any) -> "ThresholdsConfig":
+        if not isinstance(raw, Mapping):
+            raw = {}
+        default_raw = raw.get("default") if isinstance(raw, Mapping) else None
+        default_cfg = ThresholdConfig.from_mapping(default_raw)
+        symbols_cfg: dict[str, ThresholdConfig] = {}
+        symbols_raw = raw.get("symbols") if isinstance(raw, Mapping) else None
+        if isinstance(symbols_raw, Mapping):
+            for key, value in symbols_raw.items():
+                if isinstance(key, str):
+                    symbols_cfg[key] = ThresholdConfig.from_mapping(value)
+        return cls(default=default_cfg, symbols=symbols_cfg)
+
+
+@dataclass(slots=True)
+class SymbolSelectionConfig:
+    quote_suffix: str = "USDT"
+    min_quote_volume: float = 5_000_000.0
+    allow: frozenset[str] = field(default_factory=frozenset)
+    deny: frozenset[str] = field(default_factory=frozenset)
+
+    @classmethod
+    def from_raw(cls, raw: Any) -> "SymbolSelectionConfig":
+        if not isinstance(raw, Mapping):
+            raw = {}
+        quote_suffix_raw = raw.get("quote_suffix", "USDT")
+        quote_suffix = str(quote_suffix_raw).upper() if quote_suffix_raw is not None else "USDT"
+        if not quote_suffix:
+            quote_suffix = "USDT"
+        min_quote_volume = _to_optional_float(raw.get("min_quote_volume")) or 5_000_000.0
+        return cls(
+            quote_suffix=quote_suffix,
+            min_quote_volume=min_quote_volume,
+            allow=_normalize_symbol_set(raw.get("allow")),
+            deny=_normalize_symbol_set(raw.get("deny")),
+        )
+
+
+@dataclass(slots=True)
+class ModeSelectionOverrides:
+    allow: frozenset[str] = field(default_factory=frozenset)
+    deny: frozenset[str] = field(default_factory=frozenset)
+    symbols: frozenset[str] = field(default_factory=frozenset)
+
+    @classmethod
+    def from_raw(cls, raw: Any) -> "ModeSelectionOverrides":
+        if not isinstance(raw, Mapping):
+            raw = {}
+        return cls(
+            allow=_normalize_symbol_set(raw.get("allow")),
+            deny=_normalize_symbol_set(raw.get("deny")),
+            symbols=_normalize_symbol_set(raw.get("symbols")),
+        )
+
+
+@dataclass(slots=True)
+class BacktestConfig:
+    enabled: bool
+    window: int
+    timeframes: tuple[Timeframe, ...]
+    limit: int | None
+    history_batches: int
+    selection: ModeSelectionOverrides
+
+    @classmethod
+    def from_raw(cls, raw: Any) -> "BacktestConfig":
+        if not isinstance(raw, Mapping):
+            raw = {}
+        enabled = _to_bool(raw.get("enabled"), True)
+        window = _to_int(raw.get("window"), 50, minimum=1)
+        timeframes = _parse_timeframes(raw.get("timeframes"))
+        if not timeframes:
+            single_timeframe = raw.get("timeframe")
+            timeframe_value = _parse_timeframe(single_timeframe)
+            if timeframe_value is not None:
+                timeframes = (timeframe_value,)
+        if not timeframes:
+            timeframes = _DEFAULT_BACKTEST_TIMEFRAMES
+        limit = _to_optional_int(raw.get("limit"))
+        history_batches = _to_int(raw.get("history_batches"), 10, minimum=1)
+        selection = ModeSelectionOverrides.from_raw(raw)
+        return cls(
+            enabled=enabled,
+            window=window,
+            timeframes=timeframes,
+            limit=limit,
+            history_batches=history_batches,
+            selection=selection,
+        )
+
+
+def _parse_timeframes(value: Any) -> tuple[Timeframe, ...]:
+    if isinstance(value, (str, Timeframe)):
+        value = [value]
+    if not isinstance(value, Iterable) or isinstance(value, (bytes, bytearray)):
+        return tuple()
+    parsed: list[Timeframe] = []
+    for item in value:
+        timeframe = _parse_timeframe(item)
+        if timeframe is not None:
+            parsed.append(timeframe)
+    return tuple(parsed)
+
+
+def _parse_timeframe(value: Any) -> Timeframe | None:
+    if isinstance(value, Timeframe):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            return Timeframe(value)
+        except ValueError:
+            return None
+    return None
+
+
+@dataclass(slots=True)
+class LiveConfig:
+    enabled: bool
+    providers: tuple[str, ...]
+    timeframe: Timeframe
+    window: int
+    selection: ModeSelectionOverrides
+
+    @classmethod
+    def from_raw(cls, raw: Any) -> "LiveConfig":
+        if not isinstance(raw, Mapping):
+            raw = {}
+        enabled = _to_bool(raw.get("enabled"), True)
+        providers = _parse_providers(raw)
+        timeframe = _parse_timeframe(raw.get("timeframe")) or Timeframe.M5
+        window = _to_int(raw.get("window"), 50, minimum=1)
+        selection = ModeSelectionOverrides.from_raw(raw)
+        return cls(
+            enabled=enabled,
+            providers=providers,
+            timeframe=timeframe,
+            window=window,
+            selection=selection,
+        )
+
+
+def _parse_providers(raw: Mapping[str, Any]) -> tuple[str, ...]:
+    providers_value = raw.get("providers")
+    if isinstance(providers_value, str):
+        providers = [providers_value]
+    elif isinstance(providers_value, Iterable) and not isinstance(
+        providers_value, (bytes, bytearray)
+    ):
+        providers = [
+            str(value)
+            for value in providers_value
+            if isinstance(value, str) and value.strip()
+        ]
+    else:
+        providers = []
+    if not providers:
+        single = raw.get("provider")
+        if isinstance(single, str) and single.strip():
+            providers = [single.strip()]
+    return tuple(providers)
+
+
+def parse_symbol_provider_mapping(raw: Any) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    if isinstance(raw, Mapping):
+        for key, value in raw.items():
+            if not isinstance(key, str) or not isinstance(value, str):
+                continue
+            normalized = "default" if key.lower() == "default" else key.upper()
+            mapping[normalized] = value
+    return mapping

--- a/tests/test_backtest_timeframes.py
+++ b/tests/test_backtest_timeframes.py
@@ -26,6 +26,14 @@ class _StubProvider:
 
 def test_run_backtest_iterates_over_timeframes(monkeypatch):
     config = AppConfig(raw={"backtest": {"enabled": True, "history_batches": 1}})
+    assert config.backtest.enabled is True
+    assert config.backtest.history_batches == 1
+    assert config.backtest.timeframes == (
+        Timeframe.M1,
+        Timeframe.M3,
+        Timeframe.M5,
+        Timeframe.M15,
+    )
     provider = _StubProvider()
     providers = {"dummy": provider}
     thresholds_map = {"default": Thresholds()}
@@ -120,6 +128,9 @@ def test_run_backtest_fetches_batched_history(monkeypatch):
             }
         }
     )
+    assert config.backtest.limit == limit
+    assert config.backtest.history_batches == history_batches
+    assert config.backtest.timeframes == (timeframe,)
     thresholds_map = {"default": Thresholds()}
     providers = {"dummy": provider}
     services = tuple(object() for _ in range(7))

--- a/tests/test_config_parsing.py
+++ b/tests/test_config_parsing.py
@@ -1,0 +1,84 @@
+from bot.app import build_thresholds
+from bot.data.io.config_loader import AppConfig
+from bot.domain.enums import Timeframe
+
+
+def test_symbol_selection_and_overrides_are_typed() -> None:
+    config = AppConfig(
+        raw={
+            "symbols": {
+                "selection": {
+                    "quote_suffix": "usdc",
+                    "min_quote_volume": "2000000",
+                    "allow": ["btcusdt", "ethusdt"],
+                    "deny": "dogeusdt",
+                },
+                "providers": {"BTCUSDT": "binance", "default": "bybit"},
+            },
+            "live": {
+                "enabled": "false",
+                "provider": "binance",
+                "timeframe": "5m",
+                "window": "25",
+                "allow": ["btcusdt"],
+            },
+        }
+    )
+
+    selection = config.symbol_selection
+    assert selection.quote_suffix == "USDC"
+    assert selection.min_quote_volume == 2_000_000.0
+    assert selection.allow == frozenset({"BTCUSDT", "ETHUSDT"})
+    assert selection.deny == frozenset({"DOGEUSDT"})
+
+    overrides = config.selection_overrides_for("live")
+    assert overrides.allow == frozenset({"BTCUSDT"})
+    assert overrides.symbols == frozenset()
+    assert overrides.deny == frozenset()
+
+    live_cfg = config.live
+    assert live_cfg.enabled is False
+    assert live_cfg.providers == ("binance",)
+    assert live_cfg.timeframe == Timeframe.M5
+    assert live_cfg.window == 25
+    assert config.symbol_provider_mapping["BTCUSDT"] == "binance"
+    assert config.symbol_provider_mapping["default"] == "bybit"
+
+
+def test_build_thresholds_uses_typed_models() -> None:
+    config = AppConfig(
+        raw={
+            "thresholds": {
+                "default": {
+                    "min_relative_volume": "1.5",
+                    "allow_long": False,
+                    "short_pct_move_ranges": [
+                        {"min": 0.5, "max": 1.0},
+                    ],
+                    "metrics": [
+                        {"name": "rsi", "min_value": "5", "max_value": 60},
+                    ],
+                },
+                "symbols": {
+                    "ETHUSDT": {
+                        "min_pct_move": "0.25",
+                        "allow_short": False,
+                    }
+                },
+            }
+        }
+    )
+
+    thresholds = build_thresholds(config)
+
+    default_cfg = thresholds["default"]
+    assert default_cfg.min_relative_volume == 1.5
+    assert default_cfg.allow_long is False
+    assert default_cfg.short_pct_move_ranges == [(0.5, 1.0)]
+    assert default_cfg.metrics[0].name == "rsi"
+    assert default_cfg.metrics[0].min_value == 5.0
+    assert default_cfg.metrics[0].max_value == 60.0
+
+    eth_cfg = thresholds["ETHUSDT"]
+    assert eth_cfg.min_pct_move == 0.25
+    assert eth_cfg.allow_short is False


### PR DESCRIPTION
## Summary
- introduce dataclasses for structured config sections and parse them inside AppConfig
- refactor application helpers to consume typed config models rather than raw dictionaries
- cover the new typed behaviour with additional tests and adjustments to existing ones

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd079e9a8483209d6ed90023aed246