### PR TITLE
Add typed Excel DTOs and update storage

### DIFF
--- a/bot/data/io/excel_rows.py
+++ b/bot/data/io/excel_rows.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Mapping, Optional
+
+
+def _require_str(value: Any, field: str) -> str:
+    if value is None:
+        raise ValueError(f"Missing required value for '{field}'")
+    if isinstance(value, str):
+        return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _require_float(value: Any, field: str) -> float:
+    if value is None:
+        raise ValueError(f"Missing required value for '{field}'")
+    return float(value)
+
+
+def _optional_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    return float(value)
+
+
+def _require_int(value: Any, field: str) -> int:
+    if value is None:
+        raise ValueError(f"Missing required value for '{field}'")
+    return int(value)
+
+
+def _ensure_bool(value: Any, *, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes"}:
+            return True
+        if lowered in {"false", "0", "no"}:
+            return False
+    if value is None:
+        return default
+    return bool(value)
+
+
+@dataclass(frozen=True)
+class StoredSignalRow:
+    id: str
+    candle_id: str | None
+    symbol: str
+    exchange: str
+    timeframe: str | None
+    candle_timeframe: str | None
+    side: str
+    direction: int
+    score: float
+    triggered_at: str
+    created_at: str | None
+    updated_at: str | None
+    allow_long: bool
+    allow_short: bool
+    candle_open: float
+    candle_high: float
+    candle_low: float
+    candle_close: float
+    candle_volume: float
+    candle_quote_volume: float | None
+    candle_started_at: str
+    candle_closed_at: str
+    thresholds_json: str
+    metrics_json: str
+    metadata_json: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "id", _require_str(self.id, "id"))
+        object.__setattr__(self, "candle_id", _optional_str(self.candle_id))
+        object.__setattr__(self, "symbol", _require_str(self.symbol, "symbol"))
+        object.__setattr__(self, "exchange", _require_str(self.exchange, "exchange"))
+        object.__setattr__(self, "timeframe", _optional_str(self.timeframe))
+        object.__setattr__(self, "candle_timeframe", _optional_str(self.candle_timeframe))
+        object.__setattr__(self, "side", _require_str(self.side, "side"))
+        object.__setattr__(self, "direction", _require_int(self.direction, "direction"))
+        object.__setattr__(self, "score", _require_float(self.score, "score"))
+        object.__setattr__(self, "triggered_at", _require_str(self.triggered_at, "triggered_at"))
+        object.__setattr__(self, "created_at", _optional_str(self.created_at))
+        object.__setattr__(self, "updated_at", _optional_str(self.updated_at))
+        object.__setattr__(self, "allow_long", _ensure_bool(self.allow_long, default=True))
+        object.__setattr__(self, "allow_short", _ensure_bool(self.allow_short, default=True))
+        object.__setattr__(self, "candle_open", _require_float(self.candle_open, "candle_open"))
+        object.__setattr__(self, "candle_high", _require_float(self.candle_high, "candle_high"))
+        object.__setattr__(self, "candle_low", _require_float(self.candle_low, "candle_low"))
+        object.__setattr__(self, "candle_close", _require_float(self.candle_close, "candle_close"))
+        object.__setattr__(self, "candle_volume", _require_float(self.candle_volume, "candle_volume"))
+        object.__setattr__(self, "candle_quote_volume", _optional_float(self.candle_quote_volume))
+        object.__setattr__(self, "candle_started_at", _require_str(self.candle_started_at, "candle_started_at"))
+        object.__setattr__(self, "candle_closed_at", _require_str(self.candle_closed_at, "candle_closed_at"))
+        object.__setattr__(self, "thresholds_json", _require_str(self.thresholds_json, "thresholds_json"))
+        object.__setattr__(self, "metrics_json", _require_str(self.metrics_json, "metrics_json"))
+        object.__setattr__(self, "metadata_json", _require_str(self.metadata_json, "metadata_json"))
+
+    def to_excel_row(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "candle_id": self.candle_id,
+            "symbol": self.symbol,
+            "exchange": self.exchange,
+            "timeframe": self.timeframe,
+            "candle_timeframe": self.candle_timeframe,
+            "side": self.side,
+            "direction": self.direction,
+            "score": self.score,
+            "triggered_at": self.triggered_at,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "allow_long": self.allow_long,
+            "allow_short": self.allow_short,
+            "candle_open": self.candle_open,
+            "candle_high": self.candle_high,
+            "candle_low": self.candle_low,
+            "candle_close": self.candle_close,
+            "candle_volume": self.candle_volume,
+            "candle_quote_volume": self.candle_quote_volume,
+            "candle_started_at": self.candle_started_at,
+            "candle_closed_at": self.candle_closed_at,
+            "thresholds_json": self.thresholds_json,
+            "metrics_json": self.metrics_json,
+            "metadata_json": self.metadata_json,
+        }
+
+    @classmethod
+    def from_excel_row(cls, row: Mapping[str, object]) -> "StoredSignalRow":
+        return cls(
+            id=row.get("id"),
+            candle_id=row.get("candle_id"),
+            symbol=row.get("symbol"),
+            exchange=row.get("exchange"),
+            timeframe=row.get("timeframe"),
+            candle_timeframe=row.get("candle_timeframe"),
+            side=row.get("side"),
+            direction=row.get("direction"),
+            score=row.get("score"),
+            triggered_at=row.get("triggered_at"),
+            created_at=row.get("created_at"),
+            updated_at=row.get("updated_at"),
+            allow_long=row.get("allow_long", True),
+            allow_short=row.get("allow_short", True),
+            candle_open=row.get("candle_open"),
+            candle_high=row.get("candle_high"),
+            candle_low=row.get("candle_low"),
+            candle_close=row.get("candle_close"),
+            candle_volume=row.get("candle_volume"),
+            candle_quote_volume=row.get("candle_quote_volume"),
+            candle_started_at=row.get("candle_started_at"),
+            candle_closed_at=row.get("candle_closed_at"),
+            thresholds_json=row.get("thresholds_json"),
+            metrics_json=row.get("metrics_json"),
+            metadata_json=row.get("metadata_json"),
+        )
+
+
+@dataclass(frozen=True)
+class StoredTradeRow:
+    id: str
+    signal_id: str
+    source_signal_id: str | None
+    exchange: str
+    symbol: str
+    timeframe: str | None
+    side: str
+    status: str
+    entry_price: float
+    size: float
+    used_margin: float
+    exit_price: float | None
+    tp_price: float | None
+    sl_price: float | None
+    tp_pct: float | None
+    sl_pct: float | None
+    opened_at: str | None
+    closed_at: str | None
+    pnl: float | None
+    pnl_pct: float | None
+    created_at: str | None
+    updated_at: str | None
+    allow_long: bool
+    allow_short: bool
+    thresholds_snapshot_json: str | None
+    metadata_json: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "id", _require_str(self.id, "id"))
+        object.__setattr__(self, "signal_id", _require_str(self.signal_id, "signal_id"))
+        object.__setattr__(self, "source_signal_id", _optional_str(self.source_signal_id))
+        object.__setattr__(self, "exchange", _require_str(self.exchange, "exchange"))
+        object.__setattr__(self, "symbol", _require_str(self.symbol, "symbol"))
+        object.__setattr__(self, "timeframe", _optional_str(self.timeframe))
+        object.__setattr__(self, "side", _require_str(self.side, "side"))
+        object.__setattr__(self, "status", _require_str(self.status, "status"))
+        object.__setattr__(self, "entry_price", _require_float(self.entry_price, "entry_price"))
+        object.__setattr__(self, "size", _require_float(self.size, "size"))
+        object.__setattr__(self, "used_margin", _require_float(self.used_margin, "used_margin"))
+        object.__setattr__(self, "exit_price", _optional_float(self.exit_price))
+        object.__setattr__(self, "tp_price", _optional_float(self.tp_price))
+        object.__setattr__(self, "sl_price", _optional_float(self.sl_price))
+        object.__setattr__(self, "tp_pct", _optional_float(self.tp_pct))
+        object.__setattr__(self, "sl_pct", _optional_float(self.sl_pct))
+        object.__setattr__(self, "opened_at", _optional_str(self.opened_at))
+        object.__setattr__(self, "closed_at", _optional_str(self.closed_at))
+        object.__setattr__(self, "pnl", _optional_float(self.pnl))
+        object.__setattr__(self, "pnl_pct", _optional_float(self.pnl_pct))
+        object.__setattr__(self, "created_at", _optional_str(self.created_at))
+        object.__setattr__(self, "updated_at", _optional_str(self.updated_at))
+        object.__setattr__(self, "allow_long", _ensure_bool(self.allow_long, default=True))
+        object.__setattr__(self, "allow_short", _ensure_bool(self.allow_short, default=True))
+        object.__setattr__(self, "thresholds_snapshot_json", _optional_str(self.thresholds_snapshot_json))
+        object.__setattr__(self, "metadata_json", _require_str(self.metadata_json, "metadata_json"))
+
+    def to_excel_row(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "signal_id": self.signal_id,
+            "source_signal_id": self.source_signal_id,
+            "exchange": self.exchange,
+            "symbol": self.symbol,
+            "timeframe": self.timeframe,
+            "side": self.side,
+            "status": self.status,
+            "entry_price": self.entry_price,
+            "size": self.size,
+            "used_margin": self.used_margin,
+            "exit_price": self.exit_price,
+            "tp_price": self.tp_price,
+            "sl_price": self.sl_price,
+            "tp_pct": self.tp_pct,
+            "sl_pct": self.sl_pct,
+            "opened_at": self.opened_at,
+            "closed_at": self.closed_at,
+            "pnl": self.pnl,
+            "pnl_pct": self.pnl_pct,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "allow_long": self.allow_long,
+            "allow_short": self.allow_short,
+            "thresholds_snapshot_json": self.thresholds_snapshot_json,
+            "metadata_json": self.metadata_json,
+        }
+
+    @classmethod
+    def from_excel_row(cls, row: Mapping[str, object]) -> "StoredTradeRow":
+        return cls(
+            id=row.get("id"),
+            signal_id=row.get("signal_id"),
+            source_signal_id=row.get("source_signal_id"),
+            exchange=row.get("exchange"),
+            symbol=row.get("symbol"),
+            timeframe=row.get("timeframe"),
+            side=row.get("side"),
+            status=row.get("status"),
+            entry_price=row.get("entry_price"),
+            size=row.get("size"),
+            used_margin=row.get("used_margin"),
+            exit_price=row.get("exit_price"),
+            tp_price=row.get("tp_price"),
+            sl_price=row.get("sl_price"),
+            tp_pct=row.get("tp_pct"),
+            sl_pct=row.get("sl_pct"),
+            opened_at=row.get("opened_at"),
+            closed_at=row.get("closed_at"),
+            pnl=row.get("pnl"),
+            pnl_pct=row.get("pnl_pct"),
+            created_at=row.get("created_at"),
+            updated_at=row.get("updated_at"),
+            allow_long=row.get("allow_long", True),
+            allow_short=row.get("allow_short", True),
+            thresholds_snapshot_json=row.get("thresholds_snapshot_json"),
+            metadata_json=row.get("metadata_json"),
+        )
+
+
+@dataclass(frozen=True)
+class StoredStateRow:
+    key: str
+    asset: str
+    deposit_amount: float
+    deposit_updated_at: str | None
+    used_amount: float
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "key", _require_str(self.key, "key"))
+        object.__setattr__(self, "asset", _require_str(self.asset, "asset"))
+        object.__setattr__(self, "deposit_amount", _require_float(self.deposit_amount, "deposit_amount"))
+        object.__setattr__(self, "deposit_updated_at", _optional_str(self.deposit_updated_at))
+        object.__setattr__(self, "used_amount", _require_float(self.used_amount, "used_amount"))
+
+    def to_excel_row(self) -> dict[str, object]:
+        return {
+            "key": self.key,
+            "asset": self.asset,
+            "deposit_amount": self.deposit_amount,
+            "deposit_updated_at": self.deposit_updated_at,
+            "used_amount": self.used_amount,
+        }
+
+    @classmethod
+    def from_excel_row(cls, row: Mapping[str, object]) -> "StoredStateRow":
+        return cls(
+            key=row.get("key", "default"),
+            asset=row.get("asset", "USDT"),
+            deposit_amount=row.get("deposit_amount", 0.0),
+            deposit_updated_at=row.get("deposit_updated_at"),
+            used_amount=row.get("used_amount", 0.0),
+        )

--- a/bot/data/io/excel_writer.py
+++ b/bot/data/io/excel_writer.py
@@ -7,6 +7,8 @@ from typing import Dict, Iterable, List, Optional
 from openpyxl import Workbook, load_workbook
 from openpyxl.worksheet.worksheet import Worksheet
 
+from .excel_rows import StoredSignalRow, StoredStateRow, StoredTradeRow
+
 
 @dataclass(frozen=True)
 class SheetConfig:
@@ -93,55 +95,56 @@ class ExcelWriter:
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
-    def write_signal(self, row: Dict[str, object]) -> None:
+    def write_signal(self, row: StoredSignalRow) -> None:
         with self._lock:
             wb = self._load()
             ws = self._get_sheet(wb, self.SIGNAL_SHEET)
-            self._upsert_row(ws, self.SIGNAL_SHEET.headers, "id", row)
+            self._upsert_row(ws, self.SIGNAL_SHEET.headers, "id", row.to_excel_row())
             wb.save(self._path)
 
-    def read_signals(self) -> List[Dict[str, object]]:
+    def read_signals(self) -> List[StoredSignalRow]:
         with self._lock:
             wb = self._load()
             ws = self._get_sheet(wb, self.SIGNAL_SHEET)
-            return list(self._iter_rows(ws, self.SIGNAL_SHEET.headers))
+            return [
+                StoredSignalRow.from_excel_row(row)
+                for row in self._iter_rows(ws, self.SIGNAL_SHEET.headers)
+            ]
 
-    def write_trade(self, row: Dict[str, object]) -> None:
+    def write_trade(self, row: StoredTradeRow) -> None:
         with self._lock:
             wb = self._load()
             ws = self._get_sheet(wb, self.TRADE_SHEET)
-            self._upsert_row(ws, self.TRADE_SHEET.headers, "id", row)
+            self._upsert_row(ws, self.TRADE_SHEET.headers, "id", row.to_excel_row())
             wb.save(self._path)
 
-    def read_trades(self) -> List[Dict[str, object]]:
+    def read_trades(self) -> List[StoredTradeRow]:
         with self._lock:
             wb = self._load()
             ws = self._get_sheet(wb, self.TRADE_SHEET)
-            return list(self._iter_rows(ws, self.TRADE_SHEET.headers))
+            return [
+                StoredTradeRow.from_excel_row(row)
+                for row in self._iter_rows(ws, self.TRADE_SHEET.headers)
+            ]
 
-    def write_state(self, row: Dict[str, object], key: Optional[str] = None) -> None:
+    def write_state(self, row: StoredStateRow) -> None:
         with self._lock:
             wb = self._load()
             ws = self._get_sheet(wb, self.STATE_SHEET)
-            row = dict(row)
-            row["key"] = key if key is not None else "default"
-            if key is None:
-                self._replace_all_rows(ws, self.STATE_SHEET.headers, [row])
-            else:
-                self._upsert_row(ws, self.STATE_SHEET.headers, "key", row)
+            self._upsert_row(ws, self.STATE_SHEET.headers, "key", row.to_excel_row())
             wb.save(self._path)
 
-    def read_state(self, key: Optional[str] = None) -> Optional[Dict[str, object]]:
+    def read_state(self, key: Optional[str] = None) -> Optional[StoredStateRow]:
         with self._lock:
             wb = self._load()
             ws = self._get_sheet(wb, self.STATE_SHEET)
             if key is None:
                 for row in self._iter_rows(ws, self.STATE_SHEET.headers):
-                    return row
+                    return StoredStateRow.from_excel_row(row)
             else:
                 for row in self._iter_rows(ws, self.STATE_SHEET.headers):
                     if row.get("key") == key:
-                        return row
+                        return StoredStateRow.from_excel_row(row)
             return None
 
     # ------------------------------------------------------------------

--- a/bot/data/io/storage.py
+++ b/bot/data/io/storage.py
@@ -15,6 +15,7 @@ from ...domain.models.entities import (
     Thresholds,
     Trade,
 )
+from .excel_rows import StoredSignalRow, StoredStateRow, StoredTradeRow
 from .excel_writer import ExcelWriter
 
 
@@ -70,13 +71,14 @@ class Storage:
         *,
         key: Optional[str] = None,
     ) -> None:
-        row = {
-            "asset": asset,
-            "deposit_amount": float(deposit_amount),
-            "deposit_updated_at": updated_at.isoformat() if updated_at else None,
-            "used_amount": float(used),
-        }
-        self._writer.write_state(row, key=key)
+        stored_row = StoredStateRow(
+            key=key or "default",
+            asset=asset,
+            deposit_amount=deposit_amount,
+            deposit_updated_at=updated_at.isoformat() if updated_at else None,
+            used_amount=used,
+        )
+        self._writer.write_state(stored_row)
 
     def load_state(self, key: Optional[str] = None) -> tuple[str, float, Optional[str], float]:
         key_value = key if key is not None else "default"
@@ -85,13 +87,10 @@ class Storage:
             row = self._writer.read_state(None)
         if row is None:
             return ("USDT", 0.0, None, 0.0)
-        asset = str(row.get("asset") or "USDT")
-        amount_raw = row.get("deposit_amount")
-        updated_raw = row.get("deposit_updated_at")
-        used_raw = row.get("used_amount")
-        amount = float(amount_raw) if amount_raw is not None else 0.0
-        used = float(used_raw) if used_raw is not None else 0.0
-        updated_at = str(updated_raw) if updated_raw else None
+        asset = row.asset or "USDT"
+        amount = row.deposit_amount
+        used = row.used_amount
+        updated_at = row.deposit_updated_at
         return (asset, amount, updated_at, used)
 
     @staticmethod
@@ -223,11 +222,11 @@ class Storage:
             symbol=candle_raw["symbol"],
             exchange=Exchange(candle_raw["exchange"]),
             timeframe=Timeframe(candle_raw["timeframe"]),
-            open=float(candle_raw["open"]),
-            high=float(candle_raw["high"]),
-            low=float(candle_raw["low"]),
-            close=float(candle_raw["close"]),
-            volume=float(candle_raw["volume"]),
+            open=candle_raw["open"],
+            high=candle_raw["high"],
+            low=candle_raw["low"],
+            close=candle_raw["close"],
+            volume=candle_raw["volume"],
             started_at=datetime.fromisoformat(candle_raw["started_at"]),
             closed_at=datetime.fromisoformat(candle_raw["closed_at"]),
         )
@@ -258,7 +257,7 @@ class Storage:
             timeframe=timeframe,
             side=Side(raw["side"]),
             direction=BreakDirection(raw["direction"]),
-            score=float(raw["score"]),
+            score=raw["score"],
             triggered_at=datetime.fromisoformat(raw["triggered_at"]),
             created_at=datetime.fromisoformat(created_at_raw) if isinstance(created_at_raw, str) else None,
             updated_at=datetime.fromisoformat(updated_at_raw) if isinstance(updated_at_raw, str) else None,
@@ -308,20 +307,18 @@ class Storage:
             timeframe=timeframe,
             side=Side(raw["side"]),
             status=TradeStatus(raw["status"]),
-            entry_price=float(raw["entry_price"]),
-            size=float(raw.get("size", 0.0)),
-            used_margin=float(
-                raw.get("used_margin", raw.get("used_amount", raw.get("size", 0.0)))
-            ),
-            exit_price=float(raw["exit_price"]) if raw.get("exit_price") is not None else None,
-            tp_price=float(raw["tp_price"]) if raw.get("tp_price") is not None else None,
-            sl_price=float(raw["sl_price"]) if raw.get("sl_price") is not None else None,
-            tp_pct=float(raw["tp_pct"]) if raw.get("tp_pct") is not None else None,
-            sl_pct=float(raw["sl_pct"]) if raw.get("sl_pct") is not None else None,
+            entry_price=raw["entry_price"],
+            size=raw.get("size", 0.0),
+            used_margin=raw.get("used_margin", raw.get("used_amount", raw.get("size", 0.0))),
+            exit_price=raw.get("exit_price"),
+            tp_price=raw.get("tp_price"),
+            sl_price=raw.get("sl_price"),
+            tp_pct=raw.get("tp_pct"),
+            sl_pct=raw.get("sl_pct"),
             opened_at=datetime.fromisoformat(raw["opened_at"]) if raw.get("opened_at") else None,
             closed_at=datetime.fromisoformat(raw["closed_at"]) if raw.get("closed_at") else None,
-            pnl=float(raw["pnl"]) if raw.get("pnl") is not None else None,
-            pnl_pct=float(raw["pnl_pct"]) if raw.get("pnl_pct") is not None else None,
+            pnl=raw.get("pnl"),
+            pnl_pct=raw.get("pnl_pct"),
             created_at=datetime.fromisoformat(created_at_raw) if isinstance(created_at_raw, str) else None,
             updated_at=datetime.fromisoformat(updated_at_raw) if isinstance(updated_at_raw, str) else None,
             allow_long=self._to_bool(raw.get("allow_long", True)),
@@ -334,7 +331,7 @@ class Storage:
     # ------------------------------------------------------------------
     # Serialization helpers
     # ------------------------------------------------------------------
-    def _serialize_signal(self, signal: Signal) -> Dict[str, object]:
+    def _serialize_signal(self, signal: Signal) -> StoredSignalRow:
         thresholds = asdict(signal.thresholds)
         if signal.thresholds.created_at:
             thresholds["created_at"] = signal.thresholds.created_at.isoformat()
@@ -350,37 +347,35 @@ class Storage:
             metrics.append(metric_dict)
         metadata = json.dumps(signal.metadata or {}, sort_keys=True)
         candle = signal.candle
-        return {
-            "id": signal.id,
-            "candle_id": signal.candle_id or candle.id,
-            "symbol": candle.symbol,
-            "exchange": candle.exchange.value,
-            "timeframe": signal.timeframe.value if signal.timeframe else None,
-            "candle_timeframe": candle.timeframe.value,
-            "side": signal.side.value,
-            "direction": signal.direction.value,
-            "score": float(signal.score),
-            "triggered_at": signal.triggered_at.isoformat(),
-            "created_at": signal.created_at.isoformat() if signal.created_at else None,
-            "updated_at": signal.updated_at.isoformat() if signal.updated_at else None,
-            "allow_long": bool(signal.allow_long),
-            "allow_short": bool(signal.allow_short),
-            "candle_open": float(candle.open),
-            "candle_high": float(candle.high),
-            "candle_low": float(candle.low),
-            "candle_close": float(candle.close),
-            "candle_volume": float(candle.volume),
-            "candle_quote_volume": float(candle.quote_volume)
-            if candle.quote_volume is not None
-            else None,
-            "candle_started_at": candle.started_at.isoformat(),
-            "candle_closed_at": candle.closed_at.isoformat(),
-            "thresholds_json": json.dumps(thresholds, sort_keys=True),
-            "metrics_json": json.dumps(metrics, sort_keys=True),
-            "metadata_json": metadata,
-        }
+        return StoredSignalRow(
+            id=signal.id,
+            candle_id=signal.candle_id or candle.id,
+            symbol=candle.symbol,
+            exchange=candle.exchange.value,
+            timeframe=signal.timeframe.value if signal.timeframe else None,
+            candle_timeframe=candle.timeframe.value,
+            side=signal.side.value,
+            direction=signal.direction.value,
+            score=signal.score,
+            triggered_at=signal.triggered_at.isoformat(),
+            created_at=signal.created_at.isoformat() if signal.created_at else None,
+            updated_at=signal.updated_at.isoformat() if signal.updated_at else None,
+            allow_long=bool(signal.allow_long),
+            allow_short=bool(signal.allow_short),
+            candle_open=candle.open,
+            candle_high=candle.high,
+            candle_low=candle.low,
+            candle_close=candle.close,
+            candle_volume=candle.volume,
+            candle_quote_volume=candle.quote_volume,
+            candle_started_at=candle.started_at.isoformat(),
+            candle_closed_at=candle.closed_at.isoformat(),
+            thresholds_json=json.dumps(thresholds, sort_keys=True),
+            metrics_json=json.dumps(metrics, sort_keys=True),
+            metadata_json=metadata,
+        )
 
-    def _serialize_trade(self, trade: Trade) -> Dict[str, object]:
+    def _serialize_trade(self, trade: Trade) -> StoredTradeRow:
         thresholds_snapshot = None
         if trade.thresholds_snapshot:
             snapshot = asdict(trade.thresholds_snapshot)
@@ -391,107 +386,107 @@ class Storage:
             snapshot["metadata"] = dict(trade.thresholds_snapshot.metadata or {})
             thresholds_snapshot = json.dumps(snapshot, sort_keys=True)
         metadata_json = json.dumps(trade.metadata or {}, sort_keys=True)
-        return {
-            "id": trade.id,
-            "signal_id": trade.signal_id,
-            "source_signal_id": trade.source_signal_id,
-            "exchange": trade.exchange.value,
-            "symbol": trade.symbol,
-            "timeframe": trade.timeframe.value if trade.timeframe else None,
-            "side": trade.side.value,
-            "status": trade.status.value,
-            "entry_price": float(trade.entry_price),
-            "size": float(trade.size),
-            "used_margin": float(trade.used_margin),
-            "exit_price": float(trade.exit_price) if trade.exit_price is not None else None,
-            "tp_price": float(trade.tp_price) if trade.tp_price is not None else None,
-            "sl_price": float(trade.sl_price) if trade.sl_price is not None else None,
-            "tp_pct": float(trade.tp_pct) if trade.tp_pct is not None else None,
-            "sl_pct": float(trade.sl_pct) if trade.sl_pct is not None else None,
-            "opened_at": trade.opened_at.isoformat() if trade.opened_at else None,
-            "closed_at": trade.closed_at.isoformat() if trade.closed_at else None,
-            "pnl": float(trade.pnl) if trade.pnl is not None else None,
-            "pnl_pct": float(trade.pnl_pct) if trade.pnl_pct is not None else None,
-            "created_at": trade.created_at.isoformat() if trade.created_at else None,
-            "updated_at": trade.updated_at.isoformat() if trade.updated_at else None,
-            "allow_long": bool(trade.allow_long),
-            "allow_short": bool(trade.allow_short),
-            "thresholds_snapshot_json": thresholds_snapshot,
-            "metadata_json": metadata_json,
-        }
+        return StoredTradeRow(
+            id=trade.id,
+            signal_id=trade.signal_id,
+            source_signal_id=trade.source_signal_id,
+            exchange=trade.exchange.value,
+            symbol=trade.symbol,
+            timeframe=trade.timeframe.value if trade.timeframe else None,
+            side=trade.side.value,
+            status=trade.status.value,
+            entry_price=trade.entry_price,
+            size=trade.size,
+            used_margin=trade.used_margin,
+            exit_price=trade.exit_price,
+            tp_price=trade.tp_price,
+            sl_price=trade.sl_price,
+            tp_pct=trade.tp_pct,
+            sl_pct=trade.sl_pct,
+            opened_at=trade.opened_at.isoformat() if trade.opened_at else None,
+            closed_at=trade.closed_at.isoformat() if trade.closed_at else None,
+            pnl=trade.pnl,
+            pnl_pct=trade.pnl_pct,
+            created_at=trade.created_at.isoformat() if trade.created_at else None,
+            updated_at=trade.updated_at.isoformat() if trade.updated_at else None,
+            allow_long=bool(trade.allow_long),
+            allow_short=bool(trade.allow_short),
+            thresholds_snapshot_json=thresholds_snapshot,
+            metadata_json=metadata_json,
+        )
 
-    def _row_to_signal_payload(self, row: Dict[str, object]) -> Dict[str, Any]:
-        thresholds_json = row.get("thresholds_json")
-        metrics_json = row.get("metrics_json")
-        metadata_json = row.get("metadata_json")
+    def _row_to_signal_payload(self, row: StoredSignalRow) -> Dict[str, Any]:
+        thresholds_json = row.thresholds_json
+        metrics_json = row.metrics_json
+        metadata_json = row.metadata_json
         thresholds = self._safe_json_load(thresholds_json, {})
         metrics = self._safe_json_load(metrics_json, [])
         metadata = self._safe_json_load(metadata_json, {})
         candle: Dict[str, Any] = {
-            "id": row.get("candle_id"),
-            "symbol": row.get("symbol"),
-            "exchange": row.get("exchange"),
-            "timeframe": row.get("candle_timeframe") or row.get("timeframe"),
-            "open": row.get("candle_open") or 0.0,
-            "high": row.get("candle_high") or 0.0,
-            "low": row.get("candle_low") or 0.0,
-            "close": row.get("candle_close") or 0.0,
-            "volume": row.get("candle_volume") or 0.0,
-            "started_at": row.get("candle_started_at"),
-            "closed_at": row.get("candle_closed_at"),
+            "id": row.candle_id,
+            "symbol": row.symbol,
+            "exchange": row.exchange,
+            "timeframe": row.candle_timeframe or row.timeframe,
+            "open": row.candle_open,
+            "high": row.candle_high,
+            "low": row.candle_low,
+            "close": row.candle_close,
+            "volume": row.candle_volume,
+            "started_at": row.candle_started_at,
+            "closed_at": row.candle_closed_at,
         }
-        quote_volume = row.get("candle_quote_volume")
+        quote_volume = row.candle_quote_volume
         if quote_volume is not None:
             candle["quote_volume"] = quote_volume
         payload: Dict[str, Any] = {
-            "id": row.get("id"),
-            "candle_id": row.get("candle_id"),
+            "id": row.id,
+            "candle_id": row.candle_id,
             "candle": candle,
-            "side": row.get("side"),
-            "direction": row.get("direction"),
-            "score": row.get("score") or 0.0,
-            "triggered_at": row.get("triggered_at"),
-            "created_at": row.get("created_at"),
-            "updated_at": row.get("updated_at"),
-            "timeframe": row.get("timeframe"),
-            "allow_long": row.get("allow_long", True),
-            "allow_short": row.get("allow_short", True),
+            "side": row.side,
+            "direction": row.direction,
+            "score": row.score,
+            "triggered_at": row.triggered_at,
+            "created_at": row.created_at,
+            "updated_at": row.updated_at,
+            "timeframe": row.timeframe,
+            "allow_long": row.allow_long,
+            "allow_short": row.allow_short,
             "thresholds": thresholds,
             "metrics": metrics,
             "metadata": metadata,
         }
         return payload
 
-    def _row_to_trade_payload(self, row: Dict[str, object]) -> Dict[str, Any]:
-        thresholds_json = row.get("thresholds_snapshot_json")
-        metadata_json = row.get("metadata_json")
+    def _row_to_trade_payload(self, row: StoredTradeRow) -> Dict[str, Any]:
+        thresholds_json = row.thresholds_snapshot_json
+        metadata_json = row.metadata_json
         thresholds = self._safe_json_load(thresholds_json, None)
         metadata = self._safe_json_load(metadata_json, {})
         payload: Dict[str, Any] = {
-            "id": row.get("id"),
-            "signal_id": row.get("signal_id"),
-            "source_signal_id": row.get("source_signal_id"),
-            "exchange": row.get("exchange"),
-            "symbol": row.get("symbol"),
-            "timeframe": row.get("timeframe"),
-            "side": row.get("side"),
-            "status": row.get("status"),
-            "entry_price": row.get("entry_price"),
-            "size": row.get("size"),
-            "used_margin": row.get("used_margin"),
-            "exit_price": row.get("exit_price"),
-            "tp_price": row.get("tp_price"),
-            "sl_price": row.get("sl_price"),
-            "tp_pct": row.get("tp_pct"),
-            "sl_pct": row.get("sl_pct"),
-            "opened_at": row.get("opened_at"),
-            "closed_at": row.get("closed_at"),
-            "pnl": row.get("pnl"),
-            "pnl_pct": row.get("pnl_pct"),
-            "created_at": row.get("created_at"),
-            "updated_at": row.get("updated_at"),
-            "allow_long": row.get("allow_long", True),
-            "allow_short": row.get("allow_short", True),
+            "id": row.id,
+            "signal_id": row.signal_id,
+            "source_signal_id": row.source_signal_id,
+            "exchange": row.exchange,
+            "symbol": row.symbol,
+            "timeframe": row.timeframe,
+            "side": row.side,
+            "status": row.status,
+            "entry_price": row.entry_price,
+            "size": row.size,
+            "used_margin": row.used_margin,
+            "exit_price": row.exit_price,
+            "tp_price": row.tp_price,
+            "sl_price": row.sl_price,
+            "tp_pct": row.tp_pct,
+            "sl_pct": row.sl_pct,
+            "opened_at": row.opened_at,
+            "closed_at": row.closed_at,
+            "pnl": row.pnl,
+            "pnl_pct": row.pnl_pct,
+            "created_at": row.created_at,
+            "updated_at": row.updated_at,
+            "allow_long": row.allow_long,
+            "allow_short": row.allow_short,
             "thresholds_snapshot": thresholds,
             "metadata": metadata,
         }

--- a/tests/test_excel_storage.py
+++ b/tests/test_excel_storage.py
@@ -8,6 +8,7 @@ from zoneinfo import ZoneInfo
 import pytest
 from openpyxl import load_workbook
 
+from bot.data.io.excel_rows import StoredSignalRow, StoredStateRow, StoredTradeRow
 from bot.data.io.storage import Storage
 from bot.data.repositories.signal_repository import SignalRepository
 from bot.data.repositories.state_repository import StateRepository
@@ -105,6 +106,11 @@ def test_signal_repository_updates_excel(tmp_path) -> None:
     assert loaded_signals[signal.id].triggered_at == signal.triggered_at
     assert loaded_signals[signal.id].triggered_at.tzinfo is not None
 
+    stored_rows = storage._writer.read_signals()
+    assert stored_rows and isinstance(stored_rows[0], StoredSignalRow)
+    assert stored_rows[0].score == pytest.approx(signal.score)
+    assert stored_rows[0].allow_long is True
+
     rows = _read_sheet_rows(workbook_path, "Signals")
     assert len(rows) == 1
     assert rows[0]["id"] == signal.id
@@ -189,6 +195,10 @@ def test_trade_repository_updates_excel(tmp_path) -> None:
     assert loaded_trades[second_trade.id].opened_at == second_trade.opened_at
     assert loaded_trades[second_trade.id].opened_at and loaded_trades[second_trade.id].opened_at.tzinfo is not None
 
+    stored_trades = storage._writer.read_trades()
+    assert stored_trades and isinstance(stored_trades[0], StoredTradeRow)
+    assert stored_trades[0].entry_price == pytest.approx(trade.entry_price)
+
 
 def test_state_repository_persists_per_provider(tmp_path) -> None:
     storage, workbook_path = _create_storage(tmp_path)
@@ -225,3 +235,7 @@ def test_state_repository_persists_per_provider(tmp_path) -> None:
     rows = _read_sheet_rows(workbook_path, "State")
     keys = {row.get("key") for row in rows}
     assert {"binance", "bybit"}.issubset(keys)
+
+    stored_state = storage._writer.read_state("binance")
+    assert stored_state and isinstance(stored_state, StoredStateRow)
+    assert stored_state.deposit_amount == pytest.approx(1_000.0)


### PR DESCRIPTION
## Summary
- add typed dataclasses that mirror the Excel workbook schema and validate stored data
- switch the Excel writer and storage layers to use the new DTOs while simplifying deserialisation
- refresh the Excel storage tests to assert the typed rows are produced and consumed correctly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cd0add72988320a5aafdf28695f50d