### PR TITLE
Ensure live pipelines use derived state repositories

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -392,7 +392,7 @@ async def run_live(
 
     async def run_pipeline(provider_name: str, symbols: list[str]) -> None:
         provider = providers[provider_name]
-        scoped_state = state_repo.derive(provider_name) if hasattr(state_repo, "derive") else state_repo
+        scoped_state = state_repo.derive(provider_name)
         runner = LiveTradingRunner(
             provider,
             selector,


### PR DESCRIPTION
## Summary
- always derive a provider-specific state repository when constructing live pipelines

## Testing
- pytest
- python -m mypy bot

------
https://chatgpt.com/codex/tasks/task_e_68cd0e29335c8320ab7949bc50234832