### PR TITLE
Ensure candle timestamps are datetimes

### DIFF
--- a/bot/data/mappers/ohlcv_mapper.py
+++ b/bot/data/mappers/ohlcv_mapper.py
@@ -16,9 +16,22 @@ def map_ohlcv(
 ) -> Candle:
     if len(raw) < 6:
         raise ValueError("raw OHLCV should have at least 6 elements")
-    base_timestamp = raw[0] / 1000 if raw[0] > 1e12 else raw[0]
-    utc_timestamp = datetime.fromtimestamp(base_timestamp, tz=timezone.utc)
+    raw_timestamp = raw[0]
+    if isinstance(raw_timestamp, datetime):
+        if raw_timestamp.tzinfo is None:
+            raise ValueError("raw OHLCV timestamp must include timezone information")
+        utc_timestamp = raw_timestamp.astimezone(timezone.utc)
+    else:
+        try:
+            base_timestamp = float(raw_timestamp)
+        except (TypeError, ValueError) as exc:
+            raise TypeError("raw OHLCV timestamp must be numeric or datetime") from exc
+        if base_timestamp > 1e12:
+            base_timestamp /= 1000
+        utc_timestamp = datetime.fromtimestamp(base_timestamp, tz=timezone.utc)
     timestamp = utc_timestamp.astimezone(get_timezone())
+    if not isinstance(timestamp, datetime):  # pragma: no cover - defensive
+        raise TypeError("Candle timestamp must be a datetime instance")
     candle_id = f"{exchange.value}:{symbol}:{timeframe.value}:{int(utc_timestamp.timestamp())}"
     volume = float(raw[5])
     quote_volume = _extract_quote_volume(raw, exchange)

--- a/bot/data/providers/base.py
+++ b/bot/data/providers/base.py
@@ -102,11 +102,7 @@ class BaseExchangeProvider:
         deduplicated: List[Candle] = []
         seen: set[tuple[str | None, int]] = set()
         for candle in sorted_candles:
-            started_at = candle.started_at
-            if isinstance(started_at, datetime):
-                timestamp_ms = int(started_at.timestamp() * 1000)
-            else:  # pragma: no cover - defensive, Candle.started_at is datetime
-                timestamp_ms = int(started_at)
+            timestamp_ms = int(candle.started_at.timestamp() * 1000)
             key = (candle.id, timestamp_ms)
             if key in seen:
                 continue

--- a/tests/test_candle_datetime.py
+++ b/tests/test_candle_datetime.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from bot.data.mappers.ohlcv_mapper import map_ohlcv
+from bot.data.providers.base import BaseExchangeProvider
+from bot.domain.enums import Exchange, Timeframe
+from bot.domain.models.entities import Candle
+
+
+class _DummyProvider(BaseExchangeProvider):
+    exchange = Exchange.BINANCE
+
+    async def fetch_ohlcv(self, *args, **kwargs):  # pragma: no cover - unused
+        raise NotImplementedError
+
+
+def _build_candle(started_at: datetime) -> Candle:
+    return Candle(
+        id="c1",
+        symbol="BTC/USDT",
+        exchange=Exchange.BINANCE,
+        timeframe=Timeframe.M1,
+        open=1.0,
+        high=1.0,
+        low=1.0,
+        close=1.0,
+        volume=1.0,
+        started_at=started_at,
+        closed_at=started_at,
+    )
+
+
+def test_map_ohlcv_started_at_is_datetime() -> None:
+    raw = [1_697_049_600_000, 1, 2, 3, 4, 5, 6, 7]
+    candle = map_ohlcv(raw, "BTC/USDT", Exchange.BINANCE, Timeframe.M1)
+
+    assert isinstance(candle.started_at, datetime)
+    assert candle.started_at.tzinfo is not None
+
+
+def test_map_ohlcv_rejects_naive_datetime() -> None:
+    raw = [datetime(2023, 1, 1), 1, 2, 3, 4, 5]
+
+    with pytest.raises(ValueError):
+        map_ohlcv(raw, "BTC/USDT", Exchange.BINANCE, Timeframe.M1)
+
+
+def test_map_ohlcv_accepts_aware_datetime() -> None:
+    aware_datetime = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    raw = [aware_datetime, 1, 2, 3, 4, 5]
+
+    candle = map_ohlcv(raw, "BTC/USDT", Exchange.BINANCE, Timeframe.M1)
+
+    assert candle.started_at.tzinfo is not None
+    assert candle.started_at.tzinfo.utcoffset(candle.started_at) == timezone.utc.utcoffset(aware_datetime)
+
+
+def test_sort_and_deduplicate_requires_datetime_started_at() -> None:
+    provider = _DummyProvider("api", "ws", rate_limit_per_minute=10, min_quote_volume=0.0)
+    valid_started_at = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    valid_candle = _build_candle(valid_started_at)
+    invalid_candle = Candle(
+        id="c2",
+        symbol="BTC/USDT",
+        exchange=Exchange.BINANCE,
+        timeframe=Timeframe.M1,
+        open=1.0,
+        high=1.0,
+        low=1.0,
+        close=1.0,
+        volume=1.0,
+        started_at=0,  # type: ignore[arg-type]
+        closed_at=valid_started_at,
+    )
+
+    with pytest.raises(TypeError):
+        provider._sort_and_deduplicate([valid_candle, invalid_candle])


### PR DESCRIPTION
## Summary
- require OHLCV mapping inputs to provide timezone-aware datetimes and always emit Candle.started_at as datetime instances
- simplify provider candle deduplication to operate on datetime timestamps only
- add unit tests covering candle timestamp validation and provider deduplication failures for non-datetime inputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd1624847c8320adecaef243a3a3ad