### PR TITLE
Add typed metrics snapshot handling

### DIFF
--- a/bot/data/io/excel_rows.py
+++ b/bot/data/io/excel_rows.py
@@ -83,6 +83,7 @@ class StoredSignalRow:
     candle_closed_at: str
     thresholds_json: str
     metrics_json: str
+    metrics_snapshot_json: str | None
     metadata_json: str
 
     def __post_init__(self) -> None:
@@ -110,6 +111,7 @@ class StoredSignalRow:
         object.__setattr__(self, "candle_closed_at", _require_str(self.candle_closed_at, "candle_closed_at"))
         object.__setattr__(self, "thresholds_json", _require_str(self.thresholds_json, "thresholds_json"))
         object.__setattr__(self, "metrics_json", _require_str(self.metrics_json, "metrics_json"))
+        object.__setattr__(self, "metrics_snapshot_json", _optional_str(self.metrics_snapshot_json))
         object.__setattr__(self, "metadata_json", _require_str(self.metadata_json, "metadata_json"))
 
     def to_excel_row(self) -> dict[str, object]:
@@ -138,6 +140,7 @@ class StoredSignalRow:
             "candle_closed_at": self.candle_closed_at,
             "thresholds_json": self.thresholds_json,
             "metrics_json": self.metrics_json,
+            "metrics_snapshot_json": self.metrics_snapshot_json,
             "metadata_json": self.metadata_json,
         }
 
@@ -168,6 +171,7 @@ class StoredSignalRow:
             candle_closed_at=row.get("candle_closed_at"),
             thresholds_json=row.get("thresholds_json"),
             metrics_json=row.get("metrics_json"),
+            metrics_snapshot_json=row.get("metrics_snapshot_json"),
             metadata_json=row.get("metadata_json"),
         )
 

--- a/bot/data/io/excel_writer.py
+++ b/bot/data/io/excel_writer.py
@@ -46,6 +46,7 @@ class ExcelWriter:
             "candle_closed_at",
             "thresholds_json",
             "metrics_json",
+            "metrics_snapshot_json",
             "metadata_json",
         ],
     )

--- a/bot/data/io/storage.py
+++ b/bot/data/io/storage.py
@@ -4,7 +4,7 @@ import json
 from dataclasses import asdict
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 from ...domain.enums import BreakDirection, Exchange, Side, Timeframe, TradeStatus
 from ...domain.models.entities import (
@@ -15,6 +15,7 @@ from ...domain.models.entities import (
     Thresholds,
     Trade,
 )
+from ...domain.services.metrics_service import SelectionMetricsSnapshot
 from .excel_rows import StoredSignalRow, StoredStateRow, StoredTradeRow
 from .excel_writer import ExcelWriter
 
@@ -240,6 +241,15 @@ class Storage:
         metadata = raw.get("metadata", {})
         if not isinstance(metadata, dict):
             metadata = {}
+        snapshot_raw = raw.get("metrics_snapshot")
+        metrics_snapshot = self._deserialize_metrics_snapshot(snapshot_raw)
+        if metrics_snapshot is None:
+            legacy_snapshot = metadata.get("metrics")
+            if isinstance(legacy_snapshot, Mapping):
+                metrics_snapshot = self._deserialize_metrics_snapshot(legacy_snapshot)
+                if metrics_snapshot is not None:
+                    metadata = dict(metadata)
+                    metadata.pop("metrics", None)
         created_at_raw = raw.get("created_at")
         updated_at_raw = raw.get("updated_at")
         timeframe_raw = raw.get("timeframe")
@@ -265,6 +275,7 @@ class Storage:
             metrics=metrics,
             allow_long=self._to_bool(raw.get("allow_long", thresholds.allow_long), thresholds.allow_long),
             allow_short=self._to_bool(raw.get("allow_short", thresholds.allow_short), thresholds.allow_short),
+            metrics_snapshot=metrics_snapshot,
             metadata=metadata,
         )
 
@@ -346,6 +357,11 @@ class Storage:
                 metric_dict["threshold"] = threshold
             metrics.append(metric_dict)
         metadata = json.dumps(signal.metadata or {}, sort_keys=True)
+        snapshot_json = None
+        if signal.metrics_snapshot is not None:
+            snapshot_json = json.dumps(
+                signal.metrics_snapshot.to_mapping(), sort_keys=True
+            )
         candle = signal.candle
         return StoredSignalRow(
             id=signal.id,
@@ -372,6 +388,7 @@ class Storage:
             candle_closed_at=candle.closed_at.isoformat(),
             thresholds_json=json.dumps(thresholds, sort_keys=True),
             metrics_json=json.dumps(metrics, sort_keys=True),
+            metrics_snapshot_json=snapshot_json,
             metadata_json=metadata,
         )
 
@@ -419,9 +436,11 @@ class Storage:
         thresholds_json = row.thresholds_json
         metrics_json = row.metrics_json
         metadata_json = row.metadata_json
+        snapshot_json = row.metrics_snapshot_json
         thresholds = self._safe_json_load(thresholds_json, {})
         metrics = self._safe_json_load(metrics_json, [])
         metadata = self._safe_json_load(metadata_json, {})
+        snapshot = self._safe_json_load(snapshot_json, None)
         candle: Dict[str, Any] = {
             "id": row.candle_id,
             "symbol": row.symbol,
@@ -453,9 +472,20 @@ class Storage:
             "allow_short": row.allow_short,
             "thresholds": thresholds,
             "metrics": metrics,
+            "metrics_snapshot": snapshot,
             "metadata": metadata,
         }
         return payload
+
+    def _deserialize_metrics_snapshot(
+        self, raw: Any
+    ) -> SelectionMetricsSnapshot | None:
+        if not isinstance(raw, Mapping):
+            return None
+        try:
+            return SelectionMetricsSnapshot.from_mapping(raw)
+        except (KeyError, TypeError, ValueError):
+            return None
 
     def _row_to_trade_payload(self, row: StoredTradeRow) -> Dict[str, Any]:
         thresholds_json = row.thresholds_snapshot_json

--- a/bot/domain/models/entities.py
+++ b/bot/domain/models/entities.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from ..enums import BreakDirection, Exchange, Side, Timeframe, TradeStatus
+
+
+if TYPE_CHECKING:
+    from ..services.metrics_service import SelectionMetricsSnapshot
 
 
 @dataclass(slots=True)
@@ -79,6 +83,7 @@ class Signal:
     metrics: List[SignalMetric] = field(default_factory=list)
     allow_long: bool = True
     allow_short: bool = True
+    metrics_snapshot: SelectionMetricsSnapshot | None = None
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 

--- a/bot/domain/services/backtest_runner.py
+++ b/bot/domain/services/backtest_runner.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Dict, Sequence
 
@@ -159,18 +158,13 @@ class BacktestRunner:
     def _apply_backtest_outcome(
         self, signal: Signal, trade: Trade, future_candles: Sequence[Candle]
     ) -> None:
-        raw_metrics = signal.metadata.get("metrics")
-        metrics: Dict[str, Any] = dict(raw_metrics) if isinstance(raw_metrics, Mapping) else {}
+        snapshot = signal.metrics_snapshot
+        if snapshot is None:
+            self._logger.debug("Signal %s missing metrics snapshot", signal.id)
+            return
 
-        def _extract_pct(key: str) -> float:
-            value = metrics.get(key)
-            try:
-                return float(value)
-            except (TypeError, ValueError):
-                return 0.0
-
-        pct_to_high_break = _extract_pct("pct_to_high_break")
-        pct_to_low_break = _extract_pct("pct_to_low_break")
+        pct_to_high_break = snapshot.pct_to_high_break
+        pct_to_low_break = snapshot.pct_to_low_break
 
         for candle in future_candles:
             hit_tp, hit_sl = self._tp_sl_service.check_levels(trade, candle)

--- a/bot/domain/services/metrics_service.py
+++ b/bot/domain/services/metrics_service.py
@@ -1,11 +1,109 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Sequence
+from typing import Dict, List, Mapping, Sequence
 
 from ..enums import BreakDirection
 from ..models.entities import Candle, SignalMetric, Thresholds
 from ...utils import math_ops
+
+
+SNAPSHOT_FIELDS = (
+    "atr",
+    "average_volume",
+    "momentum",
+    "pct_move",
+    "relative_volume",
+    "atr_multiple",
+    "upper_wick_pct",
+    "body_pct",
+    "lower_wick_pct",
+    "pct_to_high",
+    "pct_to_low",
+    "pct_to_high_break",
+    "pct_to_low_break",
+    "break_direction",
+)
+
+
+@dataclass(slots=True)
+class SelectionMetricsSnapshot:
+    atr: float
+    average_volume: float
+    momentum: float
+    pct_move: float
+    relative_volume: float
+    atr_multiple: float
+    upper_wick_pct: float
+    body_pct: float
+    lower_wick_pct: float
+    pct_to_high: float
+    pct_to_low: float
+    pct_to_high_break: float
+    pct_to_low_break: float
+    break_direction: float
+
+    def to_mapping(self) -> Dict[str, float]:
+        return {
+            "atr": self.atr,
+            "average_volume": self.average_volume,
+            "momentum": self.momentum,
+            "pct_move": self.pct_move,
+            "relative_volume": self.relative_volume,
+            "atr_multiple": self.atr_multiple,
+            "upper_wick_pct": self.upper_wick_pct,
+            "body_pct": self.body_pct,
+            "lower_wick_pct": self.lower_wick_pct,
+            "pct_to_high": self.pct_to_high,
+            "pct_to_low": self.pct_to_low,
+            "pct_to_high_break": self.pct_to_high_break,
+            "pct_to_low_break": self.pct_to_low_break,
+            "break_direction": self.break_direction,
+        }
+
+    @classmethod
+    def from_metrics(cls, metrics: "Metrics") -> "SelectionMetricsSnapshot":
+        return cls(
+            atr=metrics.atr,
+            average_volume=metrics.average_volume,
+            momentum=metrics.momentum,
+            pct_move=metrics.pct_move,
+            relative_volume=metrics.relative_volume,
+            atr_multiple=metrics.atr_multiple,
+            upper_wick_pct=metrics.upper_wick_pct,
+            body_pct=metrics.body_pct,
+            lower_wick_pct=metrics.lower_wick_pct,
+            pct_to_high=metrics.pct_to_high,
+            pct_to_low=metrics.pct_to_low,
+            pct_to_high_break=metrics.pct_to_high_break,
+            pct_to_low_break=metrics.pct_to_low_break,
+            break_direction=float(metrics.break_direction.value),
+        )
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, object]) -> "SelectionMetricsSnapshot":
+        values: Dict[str, float] = {}
+        for key in SNAPSHOT_FIELDS:
+            raw_value = data.get(key)
+            if raw_value is None:
+                raise KeyError(f"missing '{key}' in metrics snapshot")
+            values[key] = float(raw_value)
+        return cls(
+            atr=values["atr"],
+            average_volume=values["average_volume"],
+            momentum=values["momentum"],
+            pct_move=values["pct_move"],
+            relative_volume=values["relative_volume"],
+            atr_multiple=values["atr_multiple"],
+            upper_wick_pct=values["upper_wick_pct"],
+            body_pct=values["body_pct"],
+            lower_wick_pct=values["lower_wick_pct"],
+            pct_to_high=values["pct_to_high"],
+            pct_to_low=values["pct_to_low"],
+            pct_to_high_break=values["pct_to_high_break"],
+            pct_to_low_break=values["pct_to_low_break"],
+            break_direction=values["break_direction"],
+        )
 
 
 @dataclass(slots=True)
@@ -26,22 +124,8 @@ class Metrics:
     break_direction: BreakDirection
 
     def as_dict(self) -> Dict[str, float]:
-        return {
-            "atr": self.atr,
-            "average_volume": self.average_volume,
-            "momentum": self.momentum,
-            "pct_move": self.pct_move,
-            "relative_volume": self.relative_volume,
-            "atr_multiple": self.atr_multiple,
-            "upper_wick_pct": self.upper_wick_pct,
-            "body_pct": self.body_pct,
-            "lower_wick_pct": self.lower_wick_pct,
-            "pct_to_high": self.pct_to_high,
-            "pct_to_low": self.pct_to_low,
-            "pct_to_high_break": self.pct_to_high_break,
-            "pct_to_low_break": self.pct_to_low_break,
-            "break_direction": float(self.break_direction.value),
-        }
+        snapshot = SelectionMetricsSnapshot.from_metrics(self)
+        return snapshot.to_mapping()
 
 
 class MetricsService:

--- a/bot/domain/services/selector_service.py
+++ b/bot/domain/services/selector_service.py
@@ -6,7 +6,7 @@ from typing import Iterable, List, Sequence
 
 from ..enums import BreakDirection, Side
 from ..models.entities import Candle, Signal, Thresholds
-from .metrics_service import Metrics, MetricsService
+from .metrics_service import Metrics, MetricsService, SelectionMetricsSnapshot
 from ...utils import ids
 from ...utils.clock import utcnow
 
@@ -157,6 +157,7 @@ class SignalSelectorService:
     ) -> SelectionResult:
         metrics = self._metrics_service.calculate(candles, future_candles)
         evaluations = self._metrics_service.evaluate_thresholds(metrics, thresholds)
+        metrics_snapshot = SelectionMetricsSnapshot.from_metrics(metrics)
         failed = [evaluation.name for evaluation in evaluations if not evaluation.passed]
         if failed:
             return SelectionResult(signals=[], rejected=failed)
@@ -196,8 +197,8 @@ class SignalSelectorService:
             metrics=evaluations,
             allow_long=allow_long,
             allow_short=allow_short,
+            metrics_snapshot=metrics_snapshot,
             metadata={
-                "metrics": metrics.as_dict(),
                 "evaluations": [asdict(evaluation) for evaluation in evaluations],
                 "symbol": symbol,
                 "timeframe": candle.timeframe.value,

--- a/tests/test_excel_storage.py
+++ b/tests/test_excel_storage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import replace
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -15,6 +16,7 @@ from bot.data.repositories.state_repository import StateRepository
 from bot.data.repositories.trade_repository import TradeRepository
 from bot.domain.enums import BreakDirection, Exchange, Side, Timeframe, TradeStatus
 from bot.domain.models.entities import Candle, Signal, Thresholds, Trade
+from bot.domain.services.metrics_service import SelectionMetricsSnapshot
 
 
 def _create_storage(tmp_path: Path) -> tuple[Storage, Path]:
@@ -44,6 +46,23 @@ def _build_signal(identifier: str, score: float, triggered_at: datetime) -> Sign
         max_relative_volume=5.0,
         metadata={"timeframe": Timeframe.M15.value},
     )
+    base = score / 10.0
+    snapshot = SelectionMetricsSnapshot(
+        atr=1.0 + base,
+        average_volume=2.0 + base,
+        momentum=3.0 + base,
+        pct_move=4.0 + base,
+        relative_volume=5.0 + base,
+        atr_multiple=6.0 + base,
+        upper_wick_pct=7.0 + base,
+        body_pct=8.0 + base,
+        lower_wick_pct=9.0 + base,
+        pct_to_high=10.0 + base,
+        pct_to_low=-(11.0 + base),
+        pct_to_high_break=12.0 + base,
+        pct_to_low_break=13.0 + base,
+        break_direction=0.0,
+    )
     return Signal(
         id=f"sig-{identifier}",
         candle=candle,
@@ -58,6 +77,7 @@ def _build_signal(identifier: str, score: float, triggered_at: datetime) -> Sign
         updated_at=triggered_at,
         allow_long=True,
         allow_short=True,
+        metrics_snapshot=snapshot,
         metadata={"note": "initial"},
     )
 
@@ -105,11 +125,16 @@ def test_signal_repository_updates_excel(tmp_path) -> None:
     loaded_signals = {loaded.id: loaded for loaded in storage.load_signals()}
     assert loaded_signals[signal.id].triggered_at == signal.triggered_at
     assert loaded_signals[signal.id].triggered_at.tzinfo is not None
+    assert loaded_signals[signal.id].metrics_snapshot == signal.metrics_snapshot
+    assert "metrics" not in loaded_signals[signal.id].metadata
 
     stored_rows = storage._writer.read_signals()
     assert stored_rows and isinstance(stored_rows[0], StoredSignalRow)
     assert stored_rows[0].score == pytest.approx(signal.score)
     assert stored_rows[0].allow_long is True
+    assert stored_rows[0].metrics_snapshot_json is not None
+    stored_snapshot = json.loads(stored_rows[0].metrics_snapshot_json)
+    assert stored_snapshot["pct_move"] == pytest.approx(signal.metrics_snapshot.pct_move)
 
     rows = _read_sheet_rows(workbook_path, "Signals")
     assert len(rows) == 1
@@ -141,6 +166,7 @@ def test_signal_repository_updates_excel(tmp_path) -> None:
     assert loaded_signals[signal.id].updated_at.tzinfo is not None
     assert loaded_signals[another_signal.id].triggered_at == another_signal.triggered_at
     assert loaded_signals[another_signal.id].triggered_at.tzinfo is not None
+    assert loaded_signals[another_signal.id].metrics_snapshot == another_signal.metrics_snapshot
 
 
 def test_trade_repository_updates_excel(tmp_path) -> None:

--- a/tests/test_live_trading_runner.py
+++ b/tests/test_live_trading_runner.py
@@ -15,6 +15,7 @@ from bot.data.repositories.state_repository import StateRepository
 from bot.data.repositories.trade_repository import TradeRepository
 from bot.domain.enums import BreakDirection, Exchange, Side, Timeframe, TradeStatus
 from bot.domain.models.entities import Candle, Signal, Thresholds
+from bot.domain.services.metrics_service import SelectionMetricsSnapshot
 from bot.domain.services.dedup_policy import DeduplicationPolicy
 from bot.domain.services.live_runner import LiveTradingRunner
 from bot.domain.services.tp_sl_service import TpSlService
@@ -82,6 +83,22 @@ def _build_signal(
         max_relative_volume=5.0,
         metadata={"timeframe": timeframe.value},
     )
+    snapshot = SelectionMetricsSnapshot(
+        atr=1.0,
+        average_volume=2.0,
+        momentum=3.0,
+        pct_move=4.0,
+        relative_volume=5.0,
+        atr_multiple=6.0,
+        upper_wick_pct=7.0,
+        body_pct=8.0,
+        lower_wick_pct=9.0,
+        pct_to_high=10.0,
+        pct_to_low=-11.0,
+        pct_to_high_break=12.0,
+        pct_to_low_break=13.0,
+        break_direction=0.0,
+    )
     return Signal(
         id=f"sig-{identifier}",
         candle=candle,
@@ -94,6 +111,7 @@ def _build_signal(
         timeframe=timeframe,
         created_at=candle_close,
         updated_at=candle_close,
+        metrics_snapshot=snapshot,
     )
 
 

--- a/tests/test_signal_selector.py
+++ b/tests/test_signal_selector.py
@@ -101,7 +101,11 @@ def test_select_allows_long_when_thresholds_met(selector: SignalSelectorService)
 
     assert not result.rejected
     assert len(result.signals) == 1
-    assert result.signals[0].side is Side.LONG
+    signal = result.signals[0]
+    assert signal.side is Side.LONG
+    assert signal.metrics_snapshot is not None
+    assert signal.metrics_snapshot.pct_move == pytest.approx(6.0)
+    assert "metrics" not in signal.metadata
 
 
 def test_select_redirects_to_short_when_long_body_growth_too_small(


### PR DESCRIPTION
## Summary
- introduce a dedicated SelectionMetricsSnapshot data class and carry it through Signal creation
- persist and restore the metrics snapshot in Excel storage and use it in backtesting
- adjust tests to validate the snapshot round trip and updated metadata behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd17f2be148320a9a497929819b8aa