### PR TITLE
Add typed OHLCV models and integrate with providers

### DIFF
--- a/bot/data/mappers/ohlcv_mapper.py
+++ b/bot/data/mappers/ohlcv_mapper.py
@@ -1,67 +1,40 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Sequence
+from datetime import timezone
 
 from ...domain.enums import Exchange, Timeframe
 from ...domain.models.entities import Candle
 from ...utils.clock import get_timezone
+from ..models import OhlcvSnapshot
 
 
 def map_ohlcv(
-    raw: Sequence[Any],
+    snapshot: OhlcvSnapshot,
     symbol: str,
     exchange: Exchange,
     timeframe: Timeframe,
 ) -> Candle:
-    if len(raw) < 6:
-        raise ValueError("raw OHLCV should have at least 6 elements")
-    raw_timestamp = raw[0]
-    if isinstance(raw_timestamp, datetime):
-        if raw_timestamp.tzinfo is None:
-            raise ValueError("raw OHLCV timestamp must include timezone information")
-        utc_timestamp = raw_timestamp.astimezone(timezone.utc)
-    else:
-        try:
-            base_timestamp = float(raw_timestamp)
-        except (TypeError, ValueError) as exc:
-            raise TypeError("raw OHLCV timestamp must be numeric or datetime") from exc
-        if base_timestamp > 1e12:
-            base_timestamp /= 1000
-        utc_timestamp = datetime.fromtimestamp(base_timestamp, tz=timezone.utc)
-    timestamp = utc_timestamp.astimezone(get_timezone())
-    if not isinstance(timestamp, datetime):  # pragma: no cover - defensive
-        raise TypeError("Candle timestamp must be a datetime instance")
-    candle_id = f"{exchange.value}:{symbol}:{timeframe.value}:{int(utc_timestamp.timestamp())}"
-    volume = float(raw[5])
-    quote_volume = _extract_quote_volume(raw, exchange)
+    opened_at = snapshot.opened_at.astimezone(timezone.utc)
+    closed_at = snapshot.closed_at.astimezone(timezone.utc)
+    timestamp = opened_at.astimezone(get_timezone())
+    candle_id = f"{exchange.value}:{symbol}:{timeframe.value}:{int(opened_at.timestamp())}"
     return Candle(
         id=candle_id,
         symbol=symbol,
         exchange=exchange,
         timeframe=timeframe,
-        open=float(raw[1]),
-        high=float(raw[2]),
-        low=float(raw[3]),
-        close=float(raw[4]),
-        volume=volume,
-        quote_volume=quote_volume,
+        open=snapshot.open_price,
+        high=snapshot.high_price,
+        low=snapshot.low_price,
+        close=snapshot.close_price,
+        volume=snapshot.volume,
+        quote_volume=_extract_quote_volume(snapshot),
         started_at=timestamp,
-        closed_at=timestamp,
+        closed_at=closed_at.astimezone(get_timezone()),
     )
 
 
-def _extract_quote_volume(raw: Sequence[Any], exchange: Exchange) -> float | None:
-    if exchange == Exchange.BINANCE and len(raw) > 7:
-        return _safe_float(raw[7])
-    if exchange == Exchange.BYBIT and len(raw) > 6:
-        # Bybit provides turnover (quote volume) at index 6 in the kline array
-        return _safe_float(raw[6])
+def _extract_quote_volume(snapshot: OhlcvSnapshot) -> float | None:
+    if snapshot.quote_volume is not None:
+        return snapshot.quote_volume
     return None
-
-
-def _safe_float(value: Any) -> float | None:
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None

--- a/bot/data/models/__init__.py
+++ b/bot/data/models/__init__.py
@@ -5,6 +5,7 @@ from .exchange import (
     BybitInstrument,
     BybitTicker,
 )
+from .ohlcv import BinanceKline, BybitKline, OhlcvSnapshot
 
 __all__ = [
     "DepositSnapshot",
@@ -12,4 +13,7 @@ __all__ = [
     "BinanceTicker24h",
     "BybitInstrument",
     "BybitTicker",
+    "BinanceKline",
+    "BybitKline",
+    "OhlcvSnapshot",
 ]

--- a/bot/data/models/ohlcv.py
+++ b/bot/data/models/ohlcv.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Protocol, Sequence
+
+
+class OhlcvSnapshot(Protocol):
+    """Protocol representing a validated OHLCV snapshot."""
+
+    opened_at: datetime
+    closed_at: datetime
+    open_price: float
+    high_price: float
+    low_price: float
+    close_price: float
+    volume: float
+    quote_volume: float | None
+
+
+def _ensure_datetime(value: Any, field: str) -> datetime:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            raise ValueError(f"{field} must include timezone information")
+        return value.astimezone(timezone.utc)
+    try:
+        timestamp = float(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+        raise TypeError(f"{field} must be a datetime or numeric timestamp") from exc
+    if timestamp > 1e12:
+        timestamp /= 1000.0
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc)
+
+
+def _ensure_float(value: Any, field: str) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+        raise TypeError(f"{field} must be numeric") from exc
+
+
+def _ensure_optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return None
+
+
+@dataclass(slots=True)
+class BinanceKline:
+    opened_at: datetime
+    closed_at: datetime
+    open_price: float
+    high_price: float
+    low_price: float
+    close_price: float
+    volume: float
+    quote_volume: float | None
+    raw: Sequence[Any]
+
+    @classmethod
+    def from_raw(cls, raw: Any) -> "BinanceKline":
+        if not isinstance(raw, Sequence):
+            raise TypeError("Binance kline payload must be a sequence")
+        if len(raw) < 6:
+            raise ValueError("Binance kline payload must include at least 6 entries")
+        opened_at = _ensure_datetime(raw[0], "open time")
+        close_source = raw[6] if len(raw) > 6 else raw[0]
+        closed_at = _ensure_datetime(close_source, "close time")
+        open_price = _ensure_float(raw[1], "open price")
+        high_price = _ensure_float(raw[2], "high price")
+        low_price = _ensure_float(raw[3], "low price")
+        close_price = _ensure_float(raw[4], "close price")
+        volume = _ensure_float(raw[5], "volume")
+        quote_volume = _ensure_optional_float(raw[7] if len(raw) > 7 else None)
+        return cls(
+            opened_at=opened_at,
+            closed_at=closed_at,
+            open_price=open_price,
+            high_price=high_price,
+            low_price=low_price,
+            close_price=close_price,
+            volume=volume,
+            quote_volume=quote_volume,
+            raw=raw,
+        )
+
+
+def _extract_first(raw: Mapping[str, Any], keys: Sequence[str], field: str) -> Any:
+    for key in keys:
+        if key in raw:
+            return raw[key]
+    raise KeyError(f"{field} not found in Bybit kline payload")
+
+
+@dataclass(slots=True)
+class BybitKline:
+    opened_at: datetime
+    closed_at: datetime
+    open_price: float
+    high_price: float
+    low_price: float
+    close_price: float
+    volume: float
+    quote_volume: float | None
+    raw: Mapping[str, Any]
+
+    @classmethod
+    def from_raw(cls, raw: Any) -> "BybitKline":
+        if not isinstance(raw, Mapping):
+            raise TypeError("Bybit kline payload must be a mapping")
+        opened_value = _extract_first(
+            raw,
+            ("startTime", "start", "openTime", "open_time", "timestamp"),
+            "open time",
+        )
+        closed_value = raw.get("endTime") or raw.get("end") or opened_value
+        opened_at = _ensure_datetime(opened_value, "open time")
+        closed_at = _ensure_datetime(closed_value, "close time")
+        open_price = _ensure_float(
+            _extract_first(raw, ("openPrice", "open"), "open price"), "open price"
+        )
+        high_price = _ensure_float(
+            _extract_first(raw, ("highPrice", "high"), "high price"), "high price"
+        )
+        low_price = _ensure_float(
+            _extract_first(raw, ("lowPrice", "low"), "low price"), "low price"
+        )
+        close_price = _ensure_float(
+            _extract_first(raw, ("closePrice", "close"), "close price"), "close price"
+        )
+        volume = _ensure_float(
+            _extract_first(raw, ("volume", "vol", "turnover"), "volume"), "volume"
+        )
+        quote_volume = _ensure_optional_float(
+            raw.get("turnover") or raw.get("quoteVolume") or raw.get("quote_volume")
+        )
+        return cls(
+            opened_at=opened_at,
+            closed_at=closed_at,
+            open_price=open_price,
+            high_price=high_price,
+            low_price=low_price,
+            close_price=close_price,
+            volume=volume,
+            quote_volume=quote_volume,
+            raw=raw,
+        )
+

--- a/bot/data/providers/base.py
+++ b/bot/data/providers/base.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import time
-from datetime import datetime
 from typing import Any, AsyncIterator, Dict, Iterable, List, Sequence
 
 from ...domain.enums import Exchange, Timeframe
 from ...domain.models.entities import Candle
-from ..models import DepositSnapshot
+from ..models import DepositSnapshot, OhlcvSnapshot
 from ..mappers.ohlcv_mapper import map_ohlcv
 from ...utils.logging import get_logger
 
@@ -88,9 +87,9 @@ class BaseExchangeProvider:
         """Release provider resources."""
 
     def map_candles(
-        self, raw: Iterable[Sequence[Any]], symbol: str, timeframe: Timeframe
+        self, entries: Iterable[OhlcvSnapshot], symbol: str, timeframe: Timeframe
     ) -> List[Candle]:
-        return [map_ohlcv(item, symbol, self.exchange, timeframe) for item in raw]
+        return [map_ohlcv(item, symbol, self.exchange, timeframe) for item in entries]
 
     async def ensure_rate_limit(self) -> None:
         await self._rate_limiter.throttle()

--- a/bot/data/providers/binance.py
+++ b/bot/data/providers/binance.py
@@ -16,7 +16,12 @@ except ImportError:  # pragma: no cover
 from ...domain.enums import Exchange, Timeframe
 from ...domain.models.entities import Candle
 from ...utils.logging import get_logger
-from ..models import BinanceSymbolInfo, BinanceTicker24h, DepositSnapshot
+from ..models import (
+    BinanceKline,
+    BinanceSymbolInfo,
+    BinanceTicker24h,
+    DepositSnapshot,
+)
 from .base import BaseExchangeProvider
 
 
@@ -110,8 +115,11 @@ class BinanceFuturesProvider(BaseExchangeProvider):
             params["startTime"] = since
         response = await self._session.get(endpoint, params=params)
         response.raise_for_status()
-        raw: Iterable[Any] = response.json()
-        candles = self.map_candles(raw, symbol, timeframe)
+        payload = response.json()
+        if not isinstance(payload, Sequence):
+            raise TypeError("Binance klines payload must be a sequence")
+        entries = [BinanceKline.from_raw(item) for item in payload]
+        candles = self.map_candles(entries, symbol, timeframe)
         filtered = await self._filter_liquidity(candles)
         return self._sort_and_deduplicate(filtered)
 

--- a/bot/data/providers/bybit.py
+++ b/bot/data/providers/bybit.py
@@ -15,7 +15,7 @@ except ImportError:  # pragma: no cover
 
 from ...domain.enums import Exchange, Timeframe
 from ...domain.models.entities import Candle
-from ..models import BybitInstrument, BybitTicker, DepositSnapshot
+from ..models import BybitInstrument, BybitKline, BybitTicker, DepositSnapshot
 from .base import BaseExchangeProvider
 
 
@@ -131,8 +131,11 @@ class BybitPerpetualProvider(BaseExchangeProvider):
         response = await self._session.get(endpoint, params=params)
         response.raise_for_status()
         data = response.json()
-        raw: Iterable[Any] = data.get("result", {}).get("list", [])
-        candles = self.map_candles(raw, symbol, timeframe)
+        raw_entries = data.get("result", {}).get("list", [])
+        if not isinstance(raw_entries, Sequence):
+            raise TypeError("Bybit klines payload must be a sequence")
+        entries = [BybitKline.from_raw(item) for item in raw_entries]
+        candles = self.map_candles(entries, symbol, timeframe)
         filtered = await self._filter_liquidity(candles)
         return self._sort_and_deduplicate(filtered)
 

--- a/tests/test_candle_datetime.py
+++ b/tests/test_candle_datetime.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 import pytest
 
 from bot.data.mappers.ohlcv_mapper import map_ohlcv
+from bot.data.models import BinanceKline
 from bot.data.providers.base import BaseExchangeProvider
 from bot.domain.enums import Exchange, Timeframe
 from bot.domain.models.entities import Candle
@@ -35,7 +36,9 @@ def _build_candle(started_at: datetime) -> Candle:
 
 def test_map_ohlcv_started_at_is_datetime() -> None:
     raw = [1_697_049_600_000, 1, 2, 3, 4, 5, 6, 7]
-    candle = map_ohlcv(raw, "BTC/USDT", Exchange.BINANCE, Timeframe.M1)
+    candle = map_ohlcv(
+        BinanceKline.from_raw(raw), "BTC/USDT", Exchange.BINANCE, Timeframe.M1
+    )
 
     assert isinstance(candle.started_at, datetime)
     assert candle.started_at.tzinfo is not None
@@ -45,14 +48,16 @@ def test_map_ohlcv_rejects_naive_datetime() -> None:
     raw = [datetime(2023, 1, 1), 1, 2, 3, 4, 5]
 
     with pytest.raises(ValueError):
-        map_ohlcv(raw, "BTC/USDT", Exchange.BINANCE, Timeframe.M1)
+        BinanceKline.from_raw(raw)
 
 
 def test_map_ohlcv_accepts_aware_datetime() -> None:
     aware_datetime = datetime(2023, 1, 1, tzinfo=timezone.utc)
     raw = [aware_datetime, 1, 2, 3, 4, 5]
 
-    candle = map_ohlcv(raw, "BTC/USDT", Exchange.BINANCE, Timeframe.M1)
+    candle = map_ohlcv(
+        BinanceKline.from_raw(raw), "BTC/USDT", Exchange.BINANCE, Timeframe.M1
+    )
 
     assert candle.started_at.tzinfo is not None
     assert candle.started_at.tzinfo.utcoffset(candle.started_at) == timezone.utc.utcoffset(aware_datetime)

--- a/tests/test_timezones.py
+++ b/tests/test_timezones.py
@@ -2,6 +2,7 @@ from zoneinfo import ZoneInfo
 
 from bot.data.io.config_loader import AppConfig
 from bot.data.mappers.ohlcv_mapper import map_ohlcv
+from bot.data.models import BinanceKline
 from bot.domain.enums import Exchange, Timeframe
 from bot.utils.clock import get_timezone, init_clock
 
@@ -17,7 +18,9 @@ def test_map_ohlcv_uses_configured_timezone() -> None:
     base_timestamp = 1_700_000_000
     raw = [base_timestamp, 1.0, 2.0, 0.5, 1.5, 100.0]
 
-    candle = map_ohlcv(raw, "BTCUSDT", Exchange.BINANCE, Timeframe.M1)
+    candle = map_ohlcv(
+        BinanceKline.from_raw(raw), "BTCUSDT", Exchange.BINANCE, Timeframe.M1
+    )
 
     assert candle.started_at.tzinfo == tz
     assert candle.closed_at.tzinfo == tz


### PR DESCRIPTION
## Summary
- add BinanceKline and BybitKline dataclasses to normalise OHLCV payloads
- parse Binance and Bybit OHLCV responses into typed snapshots before mapping
- update candle mapper and tests to rely on validated OHLCV snapshots

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'openpyxl')*
- pytest tests/test_candle_datetime.py tests/test_timezones.py


------
https://chatgpt.com/codex/tasks/task_e_68cd1b5b29f883208c4a2853f9964011