### PR TITLE
Add typed exchange provider configs and update provider initialization

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import asyncio
 import contextlib
-import os
 import sys
 from dataclasses import dataclass
 from datetime import datetime
@@ -14,6 +13,11 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 VALID_MODES = {"backtest", "live"}
 
 from .data.io.config_loader import AppConfig, ConfigLoader
+from .data.io.config_models import (
+    BinanceProviderConfig,
+    BybitProviderConfig,
+    ExchangeProviderConfig,
+)
 from .data.io.storage import Storage
 from .data.providers.base import BaseExchangeProvider
 from .data.providers.binance import BinanceFuturesProvider
@@ -66,42 +70,41 @@ def init_storage(config: AppConfig) -> Storage:
 
 def init_providers(config: AppConfig) -> Dict[str, BaseExchangeProvider]:
     providers: Dict[str, BaseExchangeProvider] = {}
-    providers_cfg = config.get("providers", {})
-    for name, cfg in providers_cfg.items():
-        rate = int(cfg.get("rate_limit_per_minute", 60))
-        min_volume = float(cfg.get("min_quote_volume", 0))
-        api_base = cfg.get("api_base")
-        ws_base = cfg.get("ws_base")
-        env_prefix = name.upper()
-
-        def _resolve_secret(key: str, env_suffix: str) -> str | None:
-            value = cfg.get(key)
-            if value:
-                return str(value)
-            env_key = cfg.get(f"{key}_env") or f"{env_prefix}_{env_suffix}"
-            return config.get(f"env.{env_key}") or os.getenv(env_key)
-
-        api_key = _resolve_secret("api_key", "API_KEY")
-        api_secret = _resolve_secret("api_secret", "API_SECRET")
-        if name == "binance":
-            providers[name] = BinanceFuturesProvider(
-                api_base,
-                ws_base,
-                rate,
-                min_volume,
-                api_key=api_key,
-                api_secret=api_secret,
-            )
-        elif name == "bybit":
-            providers[name] = BybitPerpetualProvider(
-                api_base,
-                ws_base,
-                rate,
-                min_volume,
-                api_key=api_key,
-                api_secret=api_secret,
-            )
+    env_values = config.env
+    for name, provider_cfg in config.providers.items():
+        api_key = provider_cfg.get_api_key(env_values)
+        api_secret = provider_cfg.get_api_secret(env_values)
+        provider = _build_provider(name, provider_cfg, api_key, api_secret)
+        if provider is not None:
+            providers[name] = provider
     return providers
+
+
+def _build_provider(
+    name: str,
+    provider_cfg: ExchangeProviderConfig,
+    api_key: str | None,
+    api_secret: str | None,
+) -> BaseExchangeProvider | None:
+    if isinstance(provider_cfg, BinanceProviderConfig) or name == "binance":
+        return BinanceFuturesProvider(
+            provider_cfg.api_base,
+            provider_cfg.ws_base,
+            provider_cfg.rate_limit_per_minute,
+            provider_cfg.min_quote_volume,
+            api_key=api_key,
+            api_secret=api_secret,
+        )
+    if isinstance(provider_cfg, BybitProviderConfig) or name == "bybit":
+        return BybitPerpetualProvider(
+            provider_cfg.api_base,
+            provider_cfg.ws_base,
+            provider_cfg.rate_limit_per_minute,
+            provider_cfg.min_quote_volume,
+            api_key=api_key,
+            api_secret=api_secret,
+        )
+    return None
 
 
 def build_thresholds(config: AppConfig) -> Dict[str, Thresholds]:

--- a/bot/data/io/config_loader.py
+++ b/bot/data/io/config_loader.py
@@ -8,10 +8,12 @@ from typing import Any, Dict, Mapping
 
 from .config_models import (
     BacktestConfig,
+    ExchangeProviderConfig,
     LiveConfig,
     ModeSelectionOverrides,
     SymbolSelectionConfig,
     ThresholdsConfig,
+    parse_exchange_provider_configs,
     parse_symbol_provider_mapping,
 )
 
@@ -19,11 +21,13 @@ from .config_models import (
 @dataclass(slots=True)
 class AppConfig:
     raw: Dict[str, Any]
+    env: dict[str, str] = field(init=False)
     thresholds: ThresholdsConfig = field(init=False)
     symbol_selection: SymbolSelectionConfig = field(init=False)
     symbol_provider_mapping: dict[str, str] = field(init=False)
     backtest: BacktestConfig = field(init=False)
     live: LiveConfig = field(init=False)
+    providers: dict[str, ExchangeProviderConfig] = field(init=False)
 
     def __post_init__(self) -> None:
         self.thresholds = ThresholdsConfig.from_raw(self.get("thresholds", {}))
@@ -35,6 +39,17 @@ class AppConfig:
         )
         self.backtest = BacktestConfig.from_raw(self.get("backtest", {}))
         self.live = LiveConfig.from_raw(self.get("live", {}))
+        env_values: dict[str, str] = {}
+        env_raw = self.get("env", {})
+        if isinstance(env_raw, Mapping):
+            for key, value in env_raw.items():
+                if not isinstance(key, str):
+                    continue
+                if value is None:
+                    continue
+                env_values[key] = str(value)
+        self.env = env_values
+        self.providers = parse_exchange_provider_configs(self.get("providers", {}))
 
     def get(self, path: str, default: Any = None) -> Any:
         cursor: Any = self.raw

--- a/bot/data/io/config_models.py
+++ b/bot/data/io/config_models.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Iterable, Mapping, Sequence, TypeVar
 
 from ...domain.enums import Timeframe
 from ...domain.models.entities import ThresholdMetric as DomainThresholdMetric
@@ -137,6 +138,136 @@ def _parse_datetime(value: Any) -> datetime | None:
 
 def _float_or_default(value: float | None) -> float:
     return value if value is not None else 0.0
+
+
+def _normalize_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        candidate = value.strip()
+        return candidate or None
+    return str(value)
+
+
+@dataclass(slots=True)
+class ProviderCredential:
+    value: str | None = None
+    env_key: str | None = None
+
+    @classmethod
+    def from_mapping(
+        cls, raw: Mapping[str, Any], key: str, default_env: str | None = None
+    ) -> "ProviderCredential":
+        value = _normalize_str(raw.get(key))
+        env_key = _normalize_str(raw.get(f"{key}_env"))
+        if env_key is None:
+            env_key = default_env
+        return cls(value=value, env_key=env_key)
+
+    def resolve(self, env: Mapping[str, str] | None = None) -> str | None:
+        if self.value is not None:
+            return self.value
+        if not self.env_key:
+            return None
+        env_mapping = env or {}
+        candidate = env_mapping.get(self.env_key)
+        normalized = _normalize_str(candidate)
+        if normalized is not None:
+            return normalized
+        fallback = os.getenv(self.env_key)
+        if isinstance(fallback, str):
+            fallback = fallback.strip()
+            if fallback:
+                return fallback
+        return None
+
+
+ProviderConfigT = TypeVar("ProviderConfigT", bound="ExchangeProviderConfig")
+
+
+@dataclass(slots=True)
+class ExchangeProviderConfig:
+    name: str
+    api_base: str
+    ws_base: str
+    rate_limit_per_minute: int
+    min_quote_volume: float
+    api_key: ProviderCredential = field(default_factory=ProviderCredential)
+    api_secret: ProviderCredential = field(default_factory=ProviderCredential)
+
+    @classmethod
+    def from_mapping(
+        cls: type[ProviderConfigT],
+        name: str,
+        raw: Mapping[str, Any] | None,
+    ) -> ProviderConfigT:
+        if raw is None or not isinstance(raw, Mapping):
+            raw = {}
+        prefix = name.upper()
+        api_base = _normalize_str(raw.get("api_base")) or ""
+        ws_base = _normalize_str(raw.get("ws_base")) or ""
+        rate_limit = _to_int(raw.get("rate_limit_per_minute"), 60, minimum=1)
+        min_volume = _to_optional_float(raw.get("min_quote_volume")) or 0.0
+        api_key = ProviderCredential.from_mapping(
+            raw, "api_key", f"{prefix}_API_KEY"
+        )
+        api_secret = ProviderCredential.from_mapping(
+            raw, "api_secret", f"{prefix}_API_SECRET"
+        )
+        return cls(
+            name=name,
+            api_base=api_base,
+            ws_base=ws_base,
+            rate_limit_per_minute=rate_limit,
+            min_quote_volume=min_volume,
+            api_key=api_key,
+            api_secret=api_secret,
+        )
+
+    def get_api_key(self, env: Mapping[str, str] | None = None) -> str | None:
+        return self.api_key.resolve(env)
+
+    def get_api_secret(self, env: Mapping[str, str] | None = None) -> str | None:
+        return self.api_secret.resolve(env)
+
+    @property
+    def api_key_env(self) -> str | None:
+        return self.api_key.env_key
+
+    @property
+    def api_secret_env(self) -> str | None:
+        return self.api_secret.env_key
+
+
+@dataclass(slots=True)
+class BinanceProviderConfig(ExchangeProviderConfig):
+    pass
+
+
+@dataclass(slots=True)
+class BybitProviderConfig(ExchangeProviderConfig):
+    pass
+
+
+_PROVIDER_CONFIG_TYPES: dict[str, type[ExchangeProviderConfig]] = {
+    "binance": BinanceProviderConfig,
+    "bybit": BybitProviderConfig,
+}
+
+
+def parse_exchange_provider_configs(
+    raw: Any,
+) -> dict[str, ExchangeProviderConfig]:
+    if not isinstance(raw, Mapping):
+        return {}
+    providers: dict[str, ExchangeProviderConfig] = {}
+    for name, value in raw.items():
+        if not isinstance(name, str):
+            continue
+        config_cls = _PROVIDER_CONFIG_TYPES.get(name.lower(), ExchangeProviderConfig)
+        mapping = value if isinstance(value, Mapping) else {}
+        providers[name] = config_cls.from_mapping(name, mapping)
+    return providers
 
 
 @dataclass(slots=True)

--- a/bot/data/providers/bybit.py
+++ b/bot/data/providers/bybit.py
@@ -61,6 +61,28 @@ class _BybitAccountBalance:
         return cls(coins=tuple(coins), raw=raw)
 
 
+def _normalize_kline_entry(entry: Any) -> Mapping[str, Any] | None:
+    if isinstance(entry, Mapping):
+        return entry
+    if isinstance(entry, Sequence) and not isinstance(entry, (str, bytes, bytearray)):
+        keys = (
+            "start",
+            "open",
+            "high",
+            "low",
+            "close",
+            "volume",
+            "turnover",
+        )
+        normalized: dict[str, Any] = {}
+        for index, key in enumerate(keys):
+            if index < len(entry):
+                normalized[key] = entry[index]
+        if normalized:
+            return normalized
+    return None
+
+
 class BybitPerpetualProvider(BaseExchangeProvider):
     exchange = Exchange.BYBIT
     max_ohlcv_limit = 1000
@@ -134,7 +156,14 @@ class BybitPerpetualProvider(BaseExchangeProvider):
         raw_entries = data.get("result", {}).get("list", [])
         if not isinstance(raw_entries, Sequence):
             raise TypeError("Bybit klines payload must be a sequence")
-        entries = [BybitKline.from_raw(item) for item in raw_entries]
+        normalized_entries = [
+            _normalize_kline_entry(item) for item in raw_entries
+        ]
+        entries = [
+            BybitKline.from_raw(item)
+            for item in normalized_entries
+            if item is not None
+        ]
         candles = self.map_candles(entries, symbol, timeframe)
         filtered = await self._filter_liquidity(candles)
         return self._sort_and_deduplicate(filtered)

--- a/tests/test_config_parsing.py
+++ b/tests/test_config_parsing.py
@@ -1,5 +1,6 @@
 from bot.app import build_thresholds
 from bot.data.io.config_loader import AppConfig
+from bot.data.io.config_models import BinanceProviderConfig, BybitProviderConfig
 from bot.domain.enums import Timeframe
 
 
@@ -82,3 +83,49 @@ def test_build_thresholds_uses_typed_models() -> None:
     eth_cfg = thresholds["ETHUSDT"]
     assert eth_cfg.min_pct_move == 0.25
     assert eth_cfg.allow_short is False
+
+
+def test_provider_configs_are_typed_and_resolve_credentials(monkeypatch) -> None:
+    monkeypatch.setenv("BYBIT_API_KEY", "from-env")
+    config = AppConfig(
+        raw={
+            "providers": {
+                "binance": {
+                    "api_base": "https://fapi.binance.com",
+                    "ws_base": "wss://fstream.binance.com/ws",
+                    "rate_limit_per_minute": "1200",
+                    "min_quote_volume": "500000",
+                    "api_key_env": "BINANCE_KEY",
+                },
+                "bybit": {
+                    "api_base": "https://api.bybit.com",
+                    "ws_base": "wss://stream.bybit.com/v5/public/linear",
+                    "rate_limit_per_minute": 600,
+                    "min_quote_volume": 250000,
+                    "api_secret": "super-secret",
+                },
+            },
+            "env": {"BINANCE_KEY": "binance-from-env"},
+        }
+    )
+
+    providers = config.providers
+    assert set(providers) == {"binance", "bybit"}
+
+    binance_cfg = providers["binance"]
+    assert isinstance(binance_cfg, BinanceProviderConfig)
+    assert binance_cfg.api_base == "https://fapi.binance.com"
+    assert binance_cfg.ws_base == "wss://fstream.binance.com/ws"
+    assert binance_cfg.rate_limit_per_minute == 1200
+    assert binance_cfg.min_quote_volume == 500000.0
+    assert binance_cfg.api_key_env == "BINANCE_KEY"
+    assert binance_cfg.api_secret_env == "BINANCE_API_SECRET"
+    assert binance_cfg.get_api_key(config.env) == "binance-from-env"
+    assert binance_cfg.get_api_secret(config.env) is None
+
+    bybit_cfg = providers["bybit"]
+    assert isinstance(bybit_cfg, BybitProviderConfig)
+    assert bybit_cfg.api_key_env == "BYBIT_API_KEY"
+    assert bybit_cfg.api_secret_env == "BYBIT_API_SECRET"
+    assert bybit_cfg.get_api_key(config.env) == "from-env"
+    assert bybit_cfg.get_api_secret(config.env) == "super-secret"


### PR DESCRIPTION
## Summary
- add typed exchange provider config models with credential resolution helpers
- extend AppConfig to expose typed provider definitions and refactor provider initialization to use them
- normalize Bybit kline payloads and add tests covering provider config parsing

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cd1dacc9ec832088d3e3b71d772251