### PR TITLE
Add typed metrics and dedup configuration models

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -127,18 +127,18 @@ def init_services(config: AppConfig, storage: Storage) -> tuple[
     signal_repo = SignalRepository(storage)
     trade_repo = TradeRepository(storage)
     state_repo = StateRepository(storage)
-    metrics_cfg = config.get("metrics", {})
+    metrics_cfg = config.metrics
     metrics_service = MetricsService(
-        atr_period=int(metrics_cfg.get("atr_period", 14)),
-        volume_period=int(metrics_cfg.get("volume_period", 20)),
-        momentum_period=int(metrics_cfg.get("momentum_period", 5)),
+        atr_period=metrics_cfg.atr_period,
+        volume_period=metrics_cfg.volume_period,
+        momentum_period=metrics_cfg.momentum_period,
     )
     selector = SignalSelectorService(metrics_service)
     tp_sl_service = TpSlService()
-    dedup_cfg = config.get("dedup", {})
+    dedup_cfg = config.dedup
     dedup_policy = DeduplicationPolicy(
-        ttl_seconds=int(dedup_cfg.get("ttl_seconds", 14400)),
-        max_records=int(dedup_cfg.get("max_records", 1000)),
+        ttl_seconds=dedup_cfg.ttl_seconds,
+        max_records=dedup_cfg.max_records,
     )
     return (
         signal_repo,

--- a/bot/data/io/config_loader.py
+++ b/bot/data/io/config_loader.py
@@ -8,8 +8,10 @@ from typing import Any, Dict, Mapping
 
 from .config_models import (
     BacktestConfig,
+    DedupConfig,
     ExchangeProviderConfig,
     LiveConfig,
+    MetricsConfig,
     ModeSelectionOverrides,
     SymbolSelectionConfig,
     ThresholdsConfig,
@@ -28,6 +30,8 @@ class AppConfig:
     backtest: BacktestConfig = field(init=False)
     live: LiveConfig = field(init=False)
     providers: dict[str, ExchangeProviderConfig] = field(init=False)
+    metrics: MetricsConfig = field(init=False)
+    dedup: DedupConfig = field(init=False)
 
     def __post_init__(self) -> None:
         self.thresholds = ThresholdsConfig.from_raw(self.get("thresholds", {}))
@@ -39,6 +43,8 @@ class AppConfig:
         )
         self.backtest = BacktestConfig.from_raw(self.get("backtest", {}))
         self.live = LiveConfig.from_raw(self.get("live", {}))
+        self.metrics = MetricsConfig.from_raw(self.get("metrics", {}))
+        self.dedup = DedupConfig.from_raw(self.get("dedup", {}))
         env_values: dict[str, str] = {}
         env_raw = self.get("env", {})
         if isinstance(env_raw, Mapping):

--- a/bot/data/io/config_models.py
+++ b/bot/data/io/config_models.py
@@ -271,6 +271,38 @@ def parse_exchange_provider_configs(
 
 
 @dataclass(slots=True)
+class MetricsConfig:
+    atr_period: int = 14
+    volume_period: int = 20
+    momentum_period: int = 5
+
+    @classmethod
+    def from_raw(cls, raw: Any) -> "MetricsConfig":
+        if not isinstance(raw, Mapping):
+            raw = {}
+        return cls(
+            atr_period=_to_int(raw.get("atr_period"), 14, minimum=1),
+            volume_period=_to_int(raw.get("volume_period"), 20, minimum=1),
+            momentum_period=_to_int(raw.get("momentum_period"), 5, minimum=1),
+        )
+
+
+@dataclass(slots=True)
+class DedupConfig:
+    ttl_seconds: int = 14_400
+    max_records: int = 1_000
+
+    @classmethod
+    def from_raw(cls, raw: Any) -> "DedupConfig":
+        if not isinstance(raw, Mapping):
+            raw = {}
+        return cls(
+            ttl_seconds=_to_int(raw.get("ttl_seconds"), 14_400, minimum=1),
+            max_records=_to_int(raw.get("max_records"), 1_000, minimum=1),
+        )
+
+
+@dataclass(slots=True)
 class ThresholdMetricConfig:
     name: str
     min_value: float | None = None

--- a/tests/test_config_parsing.py
+++ b/tests/test_config_parsing.py
@@ -46,6 +46,38 @@ def test_symbol_selection_and_overrides_are_typed() -> None:
     assert config.symbol_provider_mapping["default"] == "bybit"
 
 
+def test_metrics_and_dedup_configs_are_typed() -> None:
+    config = AppConfig(
+        raw={
+            "metrics": {
+                "atr_period": "21",
+                "volume_period": 30.9,
+                "momentum_period": 0,
+            },
+            "dedup": {
+                "ttl_seconds": "3600",
+                "max_records": "0",
+            },
+        }
+    )
+
+    metrics = config.metrics
+    assert metrics.atr_period == 21
+    assert metrics.volume_period == 30
+    assert metrics.momentum_period == 1
+
+    dedup = config.dedup
+    assert dedup.ttl_seconds == 3600
+    assert dedup.max_records == 1
+
+    defaults = AppConfig(raw={})
+    assert defaults.metrics.atr_period == 14
+    assert defaults.metrics.volume_period == 20
+    assert defaults.metrics.momentum_period == 5
+    assert defaults.dedup.ttl_seconds == 14_400
+    assert defaults.dedup.max_records == 1_000
+
+
 def test_build_thresholds_uses_typed_models() -> None:
     config = AppConfig(
         raw={


### PR DESCRIPTION
## Summary
- add MetricsConfig and DedupConfig dataclasses to centralize config parsing and validation
- instantiate the new typed configs in AppConfig and expose them via properties
- update service initialization and configuration tests to use the typed accessors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd1fcf5d848320a16860f1114aa49c