### PR TITLE
Add provider kind enum and typed provider factories

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -7,7 +7,7 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterable, Sequence
+from typing import Dict, Iterable, Protocol, Sequence, TypeVar, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 VALID_MODES = {"backtest", "live"}
@@ -17,6 +17,7 @@ from .data.io.config_models import (
     BinanceProviderConfig,
     BybitProviderConfig,
     ExchangeProviderConfig,
+    ProviderKind,
 )
 from .data.io.storage import Storage
 from .data.providers.base import BaseExchangeProvider
@@ -35,6 +36,59 @@ from .domain.services.selector_service import SignalSelectorService
 from .domain.services.tp_sl_service import TpSlService
 from .utils.clock import init_clock, utcnow
 from .utils.logging import configure_logging, get_logger
+
+
+ProviderConfigT = TypeVar("ProviderConfigT", bound=ExchangeProviderConfig)
+ProviderT = TypeVar("ProviderT", bound=BaseExchangeProvider)
+
+
+class ProviderFactory(Protocol[ProviderConfigT, ProviderT]):
+    def __call__(
+        self,
+        config: ProviderConfigT,
+        api_key: str | None,
+        api_secret: str | None,
+    ) -> ProviderT:
+        ...
+
+
+ProviderFactoryType = ProviderFactory[ExchangeProviderConfig, BaseExchangeProvider]
+
+
+def _create_binance_provider(
+    config: BinanceProviderConfig,
+    api_key: str | None,
+    api_secret: str | None,
+) -> BinanceFuturesProvider:
+    return BinanceFuturesProvider(
+        config.api_base,
+        config.ws_base,
+        config.rate_limit_per_minute,
+        config.min_quote_volume,
+        api_key=api_key,
+        api_secret=api_secret,
+    )
+
+
+def _create_bybit_provider(
+    config: BybitProviderConfig,
+    api_key: str | None,
+    api_secret: str | None,
+) -> BybitPerpetualProvider:
+    return BybitPerpetualProvider(
+        config.api_base,
+        config.ws_base,
+        config.rate_limit_per_minute,
+        config.min_quote_volume,
+        api_key=api_key,
+        api_secret=api_secret,
+    )
+
+
+PROVIDER_FACTORIES: dict[ProviderKind, ProviderFactoryType] = {
+    ProviderKind.BINANCE: cast(ProviderFactoryType, _create_binance_provider),
+    ProviderKind.BYBIT: cast(ProviderFactoryType, _create_bybit_provider),
+}
 
 
 @dataclass(frozen=True)
@@ -74,37 +128,22 @@ def init_providers(config: AppConfig) -> Dict[str, BaseExchangeProvider]:
     for name, provider_cfg in config.providers.items():
         api_key = provider_cfg.get_api_key(env_values)
         api_secret = provider_cfg.get_api_secret(env_values)
-        provider = _build_provider(name, provider_cfg, api_key, api_secret)
+        provider = _build_provider(provider_cfg.kind, provider_cfg, api_key, api_secret)
         if provider is not None:
             providers[name] = provider
     return providers
 
 
 def _build_provider(
-    name: str,
+    kind: ProviderKind,
     provider_cfg: ExchangeProviderConfig,
     api_key: str | None,
     api_secret: str | None,
 ) -> BaseExchangeProvider | None:
-    if isinstance(provider_cfg, BinanceProviderConfig) or name == "binance":
-        return BinanceFuturesProvider(
-            provider_cfg.api_base,
-            provider_cfg.ws_base,
-            provider_cfg.rate_limit_per_minute,
-            provider_cfg.min_quote_volume,
-            api_key=api_key,
-            api_secret=api_secret,
-        )
-    if isinstance(provider_cfg, BybitProviderConfig) or name == "bybit":
-        return BybitPerpetualProvider(
-            provider_cfg.api_base,
-            provider_cfg.ws_base,
-            provider_cfg.rate_limit_per_minute,
-            provider_cfg.min_quote_volume,
-            api_key=api_key,
-            api_secret=api_secret,
-        )
-    return None
+    factory = PROVIDER_FACTORIES.get(kind)
+    if factory is None:
+        return None
+    return factory(provider_cfg, api_key, api_secret)
 
 
 def build_thresholds(config: AppConfig) -> Dict[str, Thresholds]:
@@ -513,3 +552,5 @@ def main(argv: Sequence[str] | None = None) -> None:
 
 if __name__ == "__main__":
     main()
+
+

--- a/bot/data/io/config_models.py
+++ b/bot/data/io/config_models.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Iterable, Mapping, Sequence, TypeVar
+from enum import Enum
+from typing import Any, Iterable, Mapping, Sequence, Tuple, TypeVar
 
 from ...domain.enums import Timeframe
 from ...domain.models.entities import ThresholdMetric as DomainThresholdMetric
@@ -182,12 +183,19 @@ class ProviderCredential:
         return None
 
 
+class ProviderKind(str, Enum):
+    GENERIC = "generic"
+    BINANCE = "binance"
+    BYBIT = "bybit"
+
+
 ProviderConfigT = TypeVar("ProviderConfigT", bound="ExchangeProviderConfig")
 
 
 @dataclass(slots=True)
 class ExchangeProviderConfig:
     name: str
+    kind: ProviderKind = field(init=False, default=ProviderKind.GENERIC)
     api_base: str
     ws_base: str
     rate_limit_per_minute: int
@@ -214,7 +222,7 @@ class ExchangeProviderConfig:
         api_secret = ProviderCredential.from_mapping(
             raw, "api_secret", f"{prefix}_API_SECRET"
         )
-        return cls(
+        instance = cls(
             name=name,
             api_base=api_base,
             ws_base=ws_base,
@@ -223,6 +231,7 @@ class ExchangeProviderConfig:
             api_key=api_key,
             api_secret=api_secret,
         )
+        return instance
 
     def get_api_key(self, env: Mapping[str, str] | None = None) -> str | None:
         return self.api_key.resolve(env)
@@ -241,17 +250,16 @@ class ExchangeProviderConfig:
 
 @dataclass(slots=True)
 class BinanceProviderConfig(ExchangeProviderConfig):
-    pass
+    kind: ProviderKind = field(init=False, default=ProviderKind.BINANCE)
 
 
 @dataclass(slots=True)
 class BybitProviderConfig(ExchangeProviderConfig):
-    pass
+    kind: ProviderKind = field(init=False, default=ProviderKind.BYBIT)
 
-
-_PROVIDER_CONFIG_TYPES: dict[str, type[ExchangeProviderConfig]] = {
-    "binance": BinanceProviderConfig,
-    "bybit": BybitProviderConfig,
+_PROVIDER_CONFIG_TYPES: dict[str, tuple[ProviderKind, type[ExchangeProviderConfig]]] = {
+    "binance": (ProviderKind.BINANCE, BinanceProviderConfig),
+    "bybit": (ProviderKind.BYBIT, BybitProviderConfig),
 }
 
 
@@ -264,9 +272,13 @@ def parse_exchange_provider_configs(
     for name, value in raw.items():
         if not isinstance(name, str):
             continue
-        config_cls = _PROVIDER_CONFIG_TYPES.get(name.lower(), ExchangeProviderConfig)
+        kind, config_cls = _PROVIDER_CONFIG_TYPES.get(
+            name.lower(), (ProviderKind.GENERIC, ExchangeProviderConfig)
+        )
         mapping = value if isinstance(value, Mapping) else {}
-        providers[name] = config_cls.from_mapping(name, mapping)
+        config = config_cls.from_mapping(name, mapping)
+        config.kind = kind
+        providers[name] = config
     return providers
 
 

--- a/tests/test_config_parsing.py
+++ b/tests/test_config_parsing.py
@@ -1,6 +1,10 @@
 from bot.app import build_thresholds
 from bot.data.io.config_loader import AppConfig
-from bot.data.io.config_models import BinanceProviderConfig, BybitProviderConfig
+from bot.data.io.config_models import (
+    BinanceProviderConfig,
+    BybitProviderConfig,
+    ProviderKind,
+)
 from bot.domain.enums import Timeframe
 
 
@@ -146,6 +150,7 @@ def test_provider_configs_are_typed_and_resolve_credentials(monkeypatch) -> None
 
     binance_cfg = providers["binance"]
     assert isinstance(binance_cfg, BinanceProviderConfig)
+    assert binance_cfg.kind is ProviderKind.BINANCE
     assert binance_cfg.api_base == "https://fapi.binance.com"
     assert binance_cfg.ws_base == "wss://fstream.binance.com/ws"
     assert binance_cfg.rate_limit_per_minute == 1200
@@ -157,6 +162,7 @@ def test_provider_configs_are_typed_and_resolve_credentials(monkeypatch) -> None
 
     bybit_cfg = providers["bybit"]
     assert isinstance(bybit_cfg, BybitProviderConfig)
+    assert bybit_cfg.kind is ProviderKind.BYBIT
     assert bybit_cfg.api_key_env == "BYBIT_API_KEY"
     assert bybit_cfg.api_secret_env == "BYBIT_API_SECRET"
     assert bybit_cfg.get_api_key(config.env) == "from-env"


### PR DESCRIPTION
## Summary
- introduce a ProviderKind enum on exchange provider configs and populate it during parsing
- replace runtime isinstance checks with a ProviderKind keyed factory dispatch for provider creation
- extend config parsing tests to verify the provider kind annotations

## Testing
- pytest *(fails: missing optional dependency `openpyxl` in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd218e27808320a0c3cd32237e431a