### PR TITLE
Introduce AppMode enum and update mode handling

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -10,8 +10,7 @@ from pathlib import Path
 from typing import Dict, Iterable, Protocol, Sequence, TypeVar, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-VALID_MODES = {"backtest", "live"}
-
+from .app_modes import AppMode
 from .data.io.config_loader import AppConfig, ConfigLoader
 from .data.io.config_models import (
     BinanceProviderConfig,
@@ -215,7 +214,7 @@ def _resolve_provider_name(
 async def discover_symbol_universe(
     config: AppConfig,
     providers: Dict[str, BaseExchangeProvider],
-    mode: str,
+    mode: AppMode,
     provider_scope: Iterable[str] | None = None,
 ) -> SymbolUniverse:
     logger = get_logger("symbol-discovery")
@@ -326,7 +325,7 @@ async def run_backtest(
     )
     timeframes = backtest_cfg.timeframes
     requested_limit = backtest_cfg.limit
-    universe = await discover_symbol_universe(config, providers, "backtest")
+    universe = await discover_symbol_universe(config, providers, AppMode.BACKTEST)
     if not universe.assignments:
         logger.warning("No symbols available for backtest after applying liquidity filters")
         return
@@ -420,7 +419,7 @@ async def run_live(
     universe = await discover_symbol_universe(
         config,
         providers,
-        "live",
+        AppMode.LIVE,
         provider_scope=provider_names,
     )
     pipelines = {
@@ -478,34 +477,30 @@ async def run_live(
     await asyncio.gather(*tasks)
 
 
-def _normalize_mode(value: object) -> str | None:
-    if isinstance(value, str):
-        normalized = value.strip().lower()
-        if normalized:
-            return normalized
-    return None
-
-
-def resolve_mode(config: AppConfig, cli_args: Sequence[str] | None = None) -> str:
+def resolve_mode(config: AppConfig, cli_args: Sequence[str] | None = None) -> AppMode:
     cli_args = tuple(cli_args or ())
-    cli_mode: str | None = None
+    cli_mode: AppMode | None = None
     for index, arg in enumerate(cli_args):
         if arg in {"--mode", "-m"}:
             try:
                 candidate = cli_args[index + 1]
             except IndexError as exc:  # pragma: no cover - defensive
                 raise ValueError("Missing value for --mode flag") from exc
-            cli_mode = candidate
+            cli_mode = AppMode.parse(candidate)
             break
         if arg.startswith("--mode="):
-            cli_mode = arg.split("=", 1)[1]
+            cli_mode = AppMode.parse(arg.split("=", 1)[1])
             break
-    mode = _normalize_mode(cli_mode) or _normalize_mode(config.get("mode")) or "backtest"
-    if mode not in VALID_MODES:
-        raise ValueError(
-            f"Unsupported mode '{mode}'. Expected one of: {', '.join(sorted(VALID_MODES))}"
-        )
-    return mode
+    if cli_mode is not None:
+        return cli_mode
+
+    config_mode_raw = config.get("mode")
+    if isinstance(config_mode_raw, str) and not config_mode_raw.strip():
+        config_mode_raw = None
+    if config_mode_raw is not None:
+        return AppMode.parse(config_mode_raw)
+
+    return AppMode.BACKTEST
 
 
 async def main_async(cli_args: Sequence[str] | None = None) -> None:
@@ -535,9 +530,9 @@ async def main_async(cli_args: Sequence[str] | None = None) -> None:
     services = init_services(config, storage)
     thresholds_map = build_thresholds(config)
     try:
-        if mode == "backtest":
+        if mode is AppMode.BACKTEST:
             await run_backtest(config, providers, thresholds_map, services)
-        elif mode == "live":
+        elif mode is AppMode.LIVE:
             await run_live(config, providers, thresholds_map, services)
     finally:
         for provider in providers.values():

--- a/bot/app_modes.py
+++ b/bot/app_modes.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class AppMode(str, Enum):
+    BACKTEST = "backtest"
+    LIVE = "live"
+
+    @classmethod
+    def parse(cls, raw: object) -> "AppMode":
+        if isinstance(raw, cls):
+            return raw
+        if isinstance(raw, str):
+            candidate = raw.strip().lower()
+            if candidate:
+                for mode in cls:
+                    if mode.value == candidate:
+                        return mode
+        expected = ", ".join(mode.value for mode in cls)
+        raise ValueError(f"Unsupported mode '{raw}'. Expected one of: {expected}")

--- a/bot/data/io/config_loader.py
+++ b/bot/data/io/config_loader.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Mapping
 
+from bot.app_modes import AppMode
+
 from .config_models import (
     BacktestConfig,
     DedupConfig,
@@ -72,10 +74,14 @@ class AppConfig:
             return value.strip()
         return "UTC"
 
-    def selection_overrides_for(self, mode: str) -> ModeSelectionOverrides:
-        if mode == "backtest":
+    def selection_overrides_for(self, mode: AppMode | str) -> ModeSelectionOverrides:
+        if isinstance(mode, AppMode):
+            key = mode.value
+        else:
+            key = mode
+        if key == "backtest":
             return self.backtest.selection
-        if mode == "live":
+        if key == "live":
             return self.live.selection
         return ModeSelectionOverrides()
 

--- a/tests/test_app_modes.py
+++ b/tests/test_app_modes.py
@@ -3,6 +3,7 @@ import asyncio
 import pytest
 
 from bot.app import main_async, resolve_mode
+from bot.app_modes import AppMode
 from bot.data.io.config_loader import AppConfig
 
 
@@ -82,8 +83,8 @@ def test_main_async_runs_live_only(monkeypatch):
 
 def test_resolve_mode_precedence():
     config = AppConfig(raw={"mode": "live"})
-    assert resolve_mode(config, ["--mode", "backtest"]) == "backtest"
-    assert resolve_mode(config, []) == "live"
+    assert resolve_mode(config, ["--mode", "backtest"]) == AppMode.BACKTEST
+    assert resolve_mode(config, []) == AppMode.LIVE
 
 
 def test_resolve_mode_invalid():

--- a/tests/test_config_parsing.py
+++ b/tests/test_config_parsing.py
@@ -1,4 +1,5 @@
 from bot.app import build_thresholds
+from bot.app_modes import AppMode
 from bot.data.io.config_loader import AppConfig
 from bot.data.io.config_models import (
     BinanceProviderConfig,
@@ -36,7 +37,7 @@ def test_symbol_selection_and_overrides_are_typed() -> None:
     assert selection.allow == frozenset({"BTCUSDT", "ETHUSDT"})
     assert selection.deny == frozenset({"DOGEUSDT"})
 
-    overrides = config.selection_overrides_for("live")
+    overrides = config.selection_overrides_for(AppMode.LIVE)
     assert overrides.allow == frozenset({"BTCUSDT"})
     assert overrides.symbols == frozenset()
     assert overrides.deny == frozenset()


### PR DESCRIPTION
## Summary
- add a dedicated AppMode enum with parsing logic for CLI/config inputs
- make resolve_mode and downstream orchestration use AppMode objects instead of raw strings
- teach symbol discovery and config helpers to accept AppMode values and adjust tests accordingly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd22d49c588320b67ef93f9303d8e4