### PR TITLE
Use BreakDirection in metrics snapshots

### DIFF
--- a/bot/domain/services/metrics_service.py
+++ b/bot/domain/services/metrics_service.py
@@ -41,9 +41,9 @@ class SelectionMetricsSnapshot:
     pct_to_low: float
     pct_to_high_break: float
     pct_to_low_break: float
-    break_direction: float
+    break_direction: BreakDirection
 
-    def to_mapping(self) -> Dict[str, float]:
+    def to_mapping(self) -> Dict[str, float | int]:
         return {
             "atr": self.atr,
             "average_volume": self.average_volume,
@@ -58,7 +58,7 @@ class SelectionMetricsSnapshot:
             "pct_to_low": self.pct_to_low,
             "pct_to_high_break": self.pct_to_high_break,
             "pct_to_low_break": self.pct_to_low_break,
-            "break_direction": self.break_direction,
+            "break_direction": int(self.break_direction.value),
         }
 
     @classmethod
@@ -77,17 +77,30 @@ class SelectionMetricsSnapshot:
             pct_to_low=metrics.pct_to_low,
             pct_to_high_break=metrics.pct_to_high_break,
             pct_to_low_break=metrics.pct_to_low_break,
-            break_direction=float(metrics.break_direction.value),
+            break_direction=metrics.break_direction,
         )
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, object]) -> "SelectionMetricsSnapshot":
         values: Dict[str, float] = {}
+        break_direction: BreakDirection | None = None
         for key in SNAPSHOT_FIELDS:
             raw_value = data.get(key)
             if raw_value is None:
                 raise KeyError(f"missing '{key}' in metrics snapshot")
+            if key == "break_direction":
+                try:
+                    direction_value = int(float(raw_value))
+                except (TypeError, ValueError) as exc:
+                    raise ValueError("invalid break_direction value") from exc
+                try:
+                    break_direction = BreakDirection(direction_value)
+                except ValueError as exc:
+                    raise ValueError("unknown break_direction value") from exc
+                continue
             values[key] = float(raw_value)
+        if break_direction is None:
+            raise KeyError("missing 'break_direction' in metrics snapshot")
         return cls(
             atr=values["atr"],
             average_volume=values["average_volume"],
@@ -102,7 +115,7 @@ class SelectionMetricsSnapshot:
             pct_to_low=values["pct_to_low"],
             pct_to_high_break=values["pct_to_high_break"],
             pct_to_low_break=values["pct_to_low_break"],
-            break_direction=values["break_direction"],
+            break_direction=break_direction,
         )
 
 

--- a/tests/test_excel_storage.py
+++ b/tests/test_excel_storage.py
@@ -61,7 +61,7 @@ def _build_signal(identifier: str, score: float, triggered_at: datetime) -> Sign
         pct_to_low=-(11.0 + base),
         pct_to_high_break=12.0 + base,
         pct_to_low_break=13.0 + base,
-        break_direction=0.0,
+        break_direction=BreakDirection.NONE,
     )
     return Signal(
         id=f"sig-{identifier}",

--- a/tests/test_live_trading_runner.py
+++ b/tests/test_live_trading_runner.py
@@ -97,7 +97,7 @@ def _build_signal(
         pct_to_low=-11.0,
         pct_to_high_break=12.0,
         pct_to_low_break=13.0,
-        break_direction=0.0,
+        break_direction=BreakDirection.NONE,
     )
     return Signal(
         id=f"sig-{identifier}",


### PR DESCRIPTION
## Summary
- store `SelectionMetricsSnapshot.break_direction` as a `BreakDirection` and serialize via the enum value
- ensure snapshot deserialization handles enum values and invalid data gracefully
- update tests to build snapshots with the enum-based break direction

## Testing
- pytest tests/test_excel_storage.py tests/test_live_trading_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68cd2513a0d483209e5f678df8da89e3