### PR TITLE
Introduce structured metadata models

### DIFF
--- a/bot/data/io/storage.py
+++ b/bot/data/io/storage.py
@@ -15,6 +15,7 @@ from ...domain.models.entities import (
     Thresholds,
     Trade,
 )
+from ...domain.models.metadata import SignalMetadata, TradeMetadata
 from ...domain.services.metrics_service import SelectionMetricsSnapshot
 from .excel_rows import StoredSignalRow, StoredStateRow, StoredTradeRow
 from .excel_writer import ExcelWriter
@@ -238,18 +239,16 @@ class Storage:
             for metric_raw in metrics_raw:
                 if isinstance(metric_raw, dict) and "name" in metric_raw:
                     metrics.append(self._deserialize_signal_metric(metric_raw))
-        metadata = raw.get("metadata", {})
-        if not isinstance(metadata, dict):
-            metadata = {}
+        metadata_raw = raw.get("metadata")
+        metadata_dict = dict(metadata_raw) if isinstance(metadata_raw, Mapping) else {}
         snapshot_raw = raw.get("metrics_snapshot")
         metrics_snapshot = self._deserialize_metrics_snapshot(snapshot_raw)
         if metrics_snapshot is None:
-            legacy_snapshot = metadata.get("metrics")
+            legacy_snapshot = metadata_dict.get("metrics")
             if isinstance(legacy_snapshot, Mapping):
                 metrics_snapshot = self._deserialize_metrics_snapshot(legacy_snapshot)
                 if metrics_snapshot is not None:
-                    metadata = dict(metadata)
-                    metadata.pop("metrics", None)
+                    metadata_dict.pop("metrics", None)
         created_at_raw = raw.get("created_at")
         updated_at_raw = raw.get("updated_at")
         timeframe_raw = raw.get("timeframe")
@@ -276,7 +275,7 @@ class Storage:
             allow_long=self._to_bool(raw.get("allow_long", thresholds.allow_long), thresholds.allow_long),
             allow_short=self._to_bool(raw.get("allow_short", thresholds.allow_short), thresholds.allow_short),
             metrics_snapshot=metrics_snapshot,
-            metadata=metadata,
+            metadata=SignalMetadata.from_mapping(metadata_dict),
         )
 
     def deserialize_trade(self, raw: Dict[str, Any]) -> Trade:
@@ -285,9 +284,8 @@ class Storage:
             if raw.get("thresholds_snapshot")
             else None
         )
-        metadata = raw.get("metadata", {})
-        if not isinstance(metadata, dict):
-            metadata = {}
+        metadata_raw = raw.get("metadata")
+        metadata_dict = dict(metadata_raw) if isinstance(metadata_raw, Mapping) else {}
         created_at_raw = raw.get("created_at")
         updated_at_raw = raw.get("updated_at")
         timeframe_raw = raw.get("timeframe")
@@ -300,14 +298,12 @@ class Storage:
                 except ValueError:
                     timeframe = None
         if timeframe is None:
-            meta = raw.get("metadata")
-            if isinstance(meta, dict):
-                meta_tf = meta.get("timeframe")
-                if isinstance(meta_tf, str):
-                    try:
-                        timeframe = Timeframe(meta_tf)
-                    except ValueError:
-                        timeframe = None
+            meta_tf = metadata_dict.get("timeframe")
+            if isinstance(meta_tf, str):
+                try:
+                    timeframe = Timeframe(meta_tf)
+                except ValueError:
+                    timeframe = None
         source_signal_id = raw.get("source_signal_id") or raw.get("signal_id")
         trade = Trade(
             id=raw["id"],
@@ -335,7 +331,7 @@ class Storage:
             allow_long=self._to_bool(raw.get("allow_long", True)),
             allow_short=self._to_bool(raw.get("allow_short", True)),
             thresholds_snapshot=thresholds_snapshot,
-            metadata=metadata,
+            metadata=TradeMetadata.from_mapping(metadata_dict),
         )
         return trade
 
@@ -356,7 +352,7 @@ class Storage:
             if isinstance(threshold, dict):
                 metric_dict["threshold"] = threshold
             metrics.append(metric_dict)
-        metadata = json.dumps(signal.metadata or {}, sort_keys=True)
+        metadata = json.dumps(self._signal_metadata_to_mapping(signal.metadata), sort_keys=True)
         snapshot_json = None
         if signal.metrics_snapshot is not None:
             snapshot_json = json.dumps(
@@ -402,7 +398,9 @@ class Storage:
                 snapshot["updated_at"] = trade.thresholds_snapshot.updated_at.isoformat()
             snapshot["metadata"] = dict(trade.thresholds_snapshot.metadata or {})
             thresholds_snapshot = json.dumps(snapshot, sort_keys=True)
-        metadata_json = json.dumps(trade.metadata or {}, sort_keys=True)
+        metadata_json = json.dumps(
+            self._trade_metadata_to_mapping(trade.metadata), sort_keys=True
+        )
         return StoredTradeRow(
             id=trade.id,
             signal_id=trade.signal_id,
@@ -431,6 +429,18 @@ class Storage:
             thresholds_snapshot_json=thresholds_snapshot,
             metadata_json=metadata_json,
         )
+
+    @staticmethod
+    def _signal_metadata_to_mapping(metadata: SignalMetadata | None) -> Dict[str, Any]:
+        if metadata is None:
+            return {}
+        return metadata.to_dict()
+
+    @staticmethod
+    def _trade_metadata_to_mapping(metadata: TradeMetadata | None) -> Dict[str, Any]:
+        if metadata is None:
+            return {}
+        return metadata.to_dict()
 
     def _row_to_signal_payload(self, row: StoredSignalRow) -> Dict[str, Any]:
         thresholds_json = row.thresholds_json

--- a/bot/domain/models/entities.py
+++ b/bot/domain/models/entities.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from ..enums import BreakDirection, Exchange, Side, Timeframe, TradeStatus
+from .metadata import SignalMetadata, TradeMetadata
 
 
 if TYPE_CHECKING:
@@ -54,7 +55,7 @@ class Thresholds:
     allow_long: bool = True
     allow_short: bool = True
     metrics: List[ThresholdMetric] = field(default_factory=list)
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    metadata: SignalMetadata | None = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
@@ -84,7 +85,7 @@ class Signal:
     allow_long: bool = True
     allow_short: bool = True
     metrics_snapshot: SelectionMetricsSnapshot | None = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    metadata: SignalMetadata | None = None
 
 
 @dataclass(slots=True)
@@ -114,4 +115,4 @@ class Trade:
     allow_long: bool = True
     allow_short: bool = True
     thresholds_snapshot: Optional[Thresholds] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    metadata: TradeMetadata | None = None

--- a/bot/domain/models/metadata.py
+++ b/bot/domain/models/metadata.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Mapping, Type, TypeVar
+
+from ..enums import TradeStatus
+
+
+T = TypeVar("T", bound="_SerializableDataclass")
+
+
+class _SerializableDataclass:
+    """Utility mixin for metadata dataclasses."""
+
+    extra: Dict[str, Any]
+
+    def to_dict(self) -> Dict[str, Any]:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    @classmethod
+    def from_mapping(cls: Type[T], raw: Mapping[str, Any] | None) -> T | None:
+        raise NotImplementedError
+
+@dataclass(slots=True)
+class EvaluationMetadata(_SerializableDataclass):
+    name: str
+    value: float | None = None
+    passed: bool | None = None
+    threshold: Dict[str, Any] | None = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {"name": self.name}
+        if self.value is not None:
+            data["value"] = self.value
+        if self.passed is not None:
+            data["passed"] = self.passed
+        if self.threshold is not None:
+            data["threshold"] = self.threshold
+        if self.extra:
+            data.update(self.extra)
+        return data
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any] | None) -> "EvaluationMetadata" | None:
+        if not raw or "name" not in raw:
+            return None
+        known = {"name", "value", "passed", "threshold"}
+        extra = {key: raw[key] for key in raw.keys() - known}
+        threshold = raw.get("threshold")
+        threshold_dict = dict(threshold) if isinstance(threshold, Mapping) else None
+        value = raw.get("value")
+        try:
+            value_f = float(value) if value is not None else None
+        except (TypeError, ValueError):
+            value_f = None
+        passed = raw.get("passed")
+        passed_bool = None
+        if isinstance(passed, bool):
+            passed_bool = passed
+        elif passed is not None:
+            passed_bool = bool(passed)
+        return cls(
+            name=str(raw["name"]),
+            value=value_f,
+            passed=passed_bool,
+            threshold=threshold_dict,
+            extra=extra,
+        )
+
+
+@dataclass(slots=True)
+class DepositSnapshotMetadata(_SerializableDataclass):
+    asset: str | None = None
+    balance: float | None = None
+    updated_at: datetime | None = None
+    raw: Dict[str, Any] | None = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {}
+        if self.asset is not None:
+            data["asset"] = self.asset
+        if self.balance is not None:
+            data["balance"] = self.balance
+        if self.updated_at is not None:
+            data["updated_at"] = self.updated_at.isoformat()
+        if self.raw is not None:
+            data["raw"] = self.raw
+        if self.extra:
+            data.update(self.extra)
+        return data
+
+    @classmethod
+    def from_mapping(
+        cls, raw: Mapping[str, Any] | None
+    ) -> "DepositSnapshotMetadata" | None:
+        if not raw:
+            return None
+        known = {"asset", "balance", "updated_at", "raw"}
+        extra = {key: raw[key] for key in raw.keys() - known}
+        updated_at_value = raw.get("updated_at")
+        updated_at = None
+        if isinstance(updated_at_value, str):
+            try:
+                updated_at = datetime.fromisoformat(updated_at_value)
+            except ValueError:
+                updated_at = None
+        balance = raw.get("balance")
+        try:
+            balance_value = float(balance) if balance is not None else None
+        except (TypeError, ValueError):
+            balance_value = None
+        asset_value = raw.get("asset")
+        asset = str(asset_value) if asset_value is not None else None
+        raw_snapshot = raw.get("raw")
+        raw_dict = dict(raw_snapshot) if isinstance(raw_snapshot, Mapping) else None
+        return cls(
+            asset=asset,
+            balance=balance_value,
+            updated_at=updated_at,
+            raw=raw_dict,
+            extra=extra,
+        )
+
+
+@dataclass(slots=True)
+class BacktestMetadata(_SerializableDataclass):
+    result_pct: float | None = None
+    pct_to_high_break: float | None = None
+    pct_to_low_break: float | None = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {}
+        if self.result_pct is not None:
+            data["result_pct"] = self.result_pct
+        if self.pct_to_high_break is not None:
+            data["pct_to_high_break"] = self.pct_to_high_break
+        if self.pct_to_low_break is not None:
+            data["pct_to_low_break"] = self.pct_to_low_break
+        if self.extra:
+            data.update(self.extra)
+        return data
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any] | None) -> "BacktestMetadata" | None:
+        if not raw:
+            return None
+        known = {"result_pct", "pct_to_high_break", "pct_to_low_break"}
+        extra = {key: raw[key] for key in raw.keys() - known}
+        def _to_float(value: Any) -> float | None:
+            try:
+                return float(value) if value is not None else None
+            except (TypeError, ValueError):
+                return None
+
+        return cls(
+            result_pct=_to_float(raw.get("result_pct")),
+            pct_to_high_break=_to_float(raw.get("pct_to_high_break")),
+            pct_to_low_break=_to_float(raw.get("pct_to_low_break")),
+            extra=extra,
+        )
+
+
+@dataclass(slots=True)
+class LiveMetadata(_SerializableDataclass):
+    result_pct: float | None = None
+    closed_status: TradeStatus | None = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {}
+        if self.result_pct is not None:
+            data["result_pct"] = self.result_pct
+        if self.closed_status is not None:
+            data["closed_status"] = self.closed_status.value
+        if self.extra:
+            data.update(self.extra)
+        return data
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any] | None) -> "LiveMetadata" | None:
+        if not raw:
+            return None
+        known = {"result_pct", "closed_status"}
+        extra = {key: raw[key] for key in raw.keys() - known}
+        result_pct = raw.get("result_pct")
+        try:
+            result_pct_value = float(result_pct) if result_pct is not None else None
+        except (TypeError, ValueError):
+            result_pct_value = None
+        status_raw = raw.get("closed_status")
+        closed_status = None
+        if isinstance(status_raw, str):
+            try:
+                closed_status = TradeStatus(status_raw)
+            except ValueError:
+                closed_status = None
+        return cls(
+            result_pct=result_pct_value,
+            closed_status=closed_status,
+            extra=extra,
+        )
+
+
+@dataclass(slots=True)
+class SignalMetadata(_SerializableDataclass):
+    symbol: str | None = None
+    timeframe: str | None = None
+    source_signal_id: str | None = None
+    evaluations: list[EvaluationMetadata] = field(default_factory=list)
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {}
+        if self.symbol is not None:
+            data["symbol"] = self.symbol
+        if self.timeframe is not None:
+            data["timeframe"] = self.timeframe
+        if self.source_signal_id is not None:
+            data["source_signal_id"] = self.source_signal_id
+        if self.evaluations:
+            data["evaluations"] = [evaluation.to_dict() for evaluation in self.evaluations]
+        if self.extra:
+            data.update(self.extra)
+        return data
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any] | None) -> "SignalMetadata" | None:
+        if not raw:
+            return None
+        symbol = raw.get("symbol")
+        timeframe = raw.get("timeframe")
+        source_signal_id = raw.get("source_signal_id")
+        evaluations_raw = raw.get("evaluations")
+        evaluations: list[EvaluationMetadata] = []
+        if isinstance(evaluations_raw, list):
+            for evaluation_raw in evaluations_raw:
+                if isinstance(evaluation_raw, Mapping):
+                    evaluation = EvaluationMetadata.from_mapping(evaluation_raw)
+                    if evaluation is not None:
+                        evaluations.append(evaluation)
+        known = {"symbol", "timeframe", "source_signal_id", "evaluations"}
+        extra = {key: raw[key] for key in raw.keys() - known}
+        if (
+            symbol is None
+            and timeframe is None
+            and source_signal_id is None
+            and not evaluations
+            and not extra
+        ):
+            return None
+        return cls(
+            symbol=str(symbol) if isinstance(symbol, str) else None,
+            timeframe=str(timeframe) if isinstance(timeframe, str) else None,
+            source_signal_id=str(source_signal_id) if isinstance(source_signal_id, str) else None,
+            evaluations=evaluations,
+            extra=extra,
+        )
+
+
+@dataclass(slots=True)
+class TradeMetadata(_SerializableDataclass):
+    mode: str | None = None
+    timeframe: str | None = None
+    deposit_snapshot: DepositSnapshotMetadata | None = None
+    backtest: BacktestMetadata | None = None
+    live: LiveMetadata | None = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def ensure_backtest(self) -> BacktestMetadata:
+        if self.backtest is None:
+            self.backtest = BacktestMetadata()
+        return self.backtest
+
+    def ensure_live(self) -> LiveMetadata:
+        if self.live is None:
+            self.live = LiveMetadata()
+        return self.live
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {}
+        if self.mode is not None:
+            data["mode"] = self.mode
+        if self.timeframe is not None:
+            data["timeframe"] = self.timeframe
+        if self.deposit_snapshot is not None:
+            data["deposit_snapshot"] = self.deposit_snapshot.to_dict()
+        if self.backtest is not None:
+            data["backtest"] = self.backtest.to_dict()
+        if self.live is not None:
+            data["live"] = self.live.to_dict()
+        if self.extra:
+            data.update(self.extra)
+        return data
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any] | None) -> "TradeMetadata" | None:
+        if not raw:
+            return None
+        mode = raw.get("mode")
+        timeframe = raw.get("timeframe")
+        deposit_snapshot = DepositSnapshotMetadata.from_mapping(
+            raw.get("deposit_snapshot"))
+        backtest = BacktestMetadata.from_mapping(raw.get("backtest"))
+        live = LiveMetadata.from_mapping(raw.get("live"))
+        known = {"mode", "timeframe", "deposit_snapshot", "backtest", "live"}
+        extra = {key: raw[key] for key in raw.keys() - known}
+        if (
+            mode is None
+            and timeframe is None
+            and deposit_snapshot is None
+            and backtest is None
+            and live is None
+            and not extra
+        ):
+            return None
+        return cls(
+            mode=str(mode) if isinstance(mode, str) else None,
+            timeframe=str(timeframe) if isinstance(timeframe, str) else None,
+            deposit_snapshot=deposit_snapshot,
+            backtest=backtest,
+            live=live,
+            extra=extra,
+        )
+

--- a/bot/domain/services/backtest_runner.py
+++ b/bot/domain/services/backtest_runner.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Sequence
+from typing import Sequence
 
 from ..enums import Side, Timeframe, TradeStatus
 from ..models.entities import Candle, Signal, Thresholds, Trade
+from ..models.metadata import (
+    DepositSnapshotMetadata,
+    SignalMetadata,
+    TradeMetadata,
+)
 from ...data.providers.base import BaseExchangeProvider
 from ...data.repositories.signal_repository import SignalRepository
 from ...data.repositories.state_repository import StateRepository
@@ -78,7 +83,13 @@ class BacktestRunner:
                 if resolved_timeframe:
                     signal.timeframe = resolved_timeframe
                     signal.candle.timeframe = resolved_timeframe
-                    signal.metadata.setdefault("timeframe", resolved_timeframe.value)
+                    if signal.metadata is None:
+                        signal.metadata = SignalMetadata(
+                            symbol=signal.candle.symbol,
+                            timeframe=resolved_timeframe.value,
+                        )
+                    else:
+                        signal.metadata.timeframe = resolved_timeframe.value
                 accepted, key = self._dedup.should_accept(signal)
                 if not accepted:
                     self._logger.debug("Skipping duplicate signal %s", key)
@@ -87,7 +98,9 @@ class BacktestRunner:
                 snapshot = self._deposit_snapshot()
                 trade_size = self._calculate_trade_size()
                 timestamp = utcnow()
-                source_signal_id = signal.metadata.get("source_signal_id") or signal.id
+                source_signal_id = (
+                    signal.metadata.source_signal_id if signal.metadata else None
+                ) or signal.id
                 trade = Trade(
                     id=signal.id,
                     signal_id=signal.id,
@@ -105,7 +118,7 @@ class BacktestRunner:
                     allow_long=signal.allow_long,
                     allow_short=signal.allow_short,
                     thresholds_snapshot=signal.thresholds,
-                    metadata={"mode": "backtest", "deposit_snapshot": snapshot},
+                    metadata=TradeMetadata(mode="backtest", deposit_snapshot=snapshot),
                 )
                 self._tp_sl_service.assign(signal, trade)
                 trade.opened_at = signal.candle.closed_at
@@ -142,12 +155,13 @@ class BacktestRunner:
         balance = self._deposit.balance
         return max(10.0, 0.05 * balance) if balance > 0 else 10.0
 
-    def _deposit_snapshot(self) -> Dict[str, Any]:
-        return {
-            "asset": self._deposit.asset,
-            "balance": self._deposit.balance,
-            "updated_at": self._last_deposit_update.isoformat() if self._last_deposit_update else None,
-        }
+    def _deposit_snapshot(self) -> DepositSnapshotMetadata:
+        updated_at = self._last_deposit_update
+        return DepositSnapshotMetadata(
+            asset=self._deposit.asset,
+            balance=self._deposit.balance,
+            updated_at=updated_at,
+        )
 
     def _update_used_amount(self) -> None:
         open_amount = sum(
@@ -189,14 +203,12 @@ class BacktestRunner:
             trade.exit_price = exit_price
             trade.pnl = trade.size * (result_pct / 100)
             trade.pnl_pct = result_pct
-            backtest_meta = trade.metadata.setdefault("backtest", {})
-            backtest_meta.update(
-                {
-                    "result_pct": result_pct,
-                    "pct_to_high_break": pct_to_high_break,
-                    "pct_to_low_break": pct_to_low_break,
-                }
-            )
+            if trade.metadata is None:
+                trade.metadata = TradeMetadata(mode="backtest")
+            backtest_meta = trade.metadata.ensure_backtest()
+            backtest_meta.result_pct = result_pct
+            backtest_meta.pct_to_high_break = pct_to_high_break
+            backtest_meta.pct_to_low_break = pct_to_low_break
             trade.updated_at = utcnow()
             return
 

--- a/bot/domain/services/live_runner.py
+++ b/bot/domain/services/live_runner.py
@@ -14,6 +14,7 @@ from ...utils.logging import get_logger
 from ...utils.clock import utcnow
 from ..enums import Timeframe, TradeStatus
 from ..models.entities import Candle, Signal, Thresholds, Trade
+from ..models.metadata import DepositSnapshotMetadata, TradeMetadata
 from .dedup_policy import DeduplicationPolicy
 from .selector_service import SignalSelectorService
 from .tp_sl_service import TpSlService
@@ -60,7 +61,14 @@ class LiveTradingRunner:
         snapshot = await self.refresh_deposit()
         trade_size = self._calculate_trade_size()
         timestamp = utcnow()
-        source_signal_id = signal.metadata.get("source_signal_id") or signal.id
+        source_signal_id = (
+            signal.metadata.source_signal_id if signal.metadata else None
+        ) or signal.id
+        snapshot_metadata = DepositSnapshotMetadata(
+            asset=snapshot.asset,
+            balance=snapshot.balance,
+            updated_at=self._last_deposit_update,
+        )
         trade = Trade(
             id=signal.id,
             signal_id=signal.id,
@@ -78,16 +86,7 @@ class LiveTradingRunner:
             allow_long=signal.allow_long,
             allow_short=signal.allow_short,
             thresholds_snapshot=signal.thresholds,
-            metadata={
-                "mode": "live",
-                "deposit_snapshot": {
-                    "asset": snapshot.asset,
-                    "balance": snapshot.balance,
-                    "updated_at": self._last_deposit_update.isoformat()
-                    if self._last_deposit_update
-                    else None,
-                },
-            },
+            metadata=TradeMetadata(mode="live", deposit_snapshot=snapshot_metadata),
         )
         self._tp_sl_service.assign(signal, trade)
         self._signals.save(signal)
@@ -150,10 +149,12 @@ class LiveTradingRunner:
                         else None
                     )
                     trade.updated_at = utcnow()
-                    live_meta = trade.metadata.setdefault("live", {})
+                    if trade.metadata is None:
+                        trade.metadata = TradeMetadata(mode="live")
+                    live_meta = trade.metadata.ensure_live()
                     if result_pct is not None:
-                        live_meta["result_pct"] = result_pct
-                    live_meta["closed_status"] = status.value
+                        live_meta.result_pct = result_pct
+                    live_meta.closed_status = status
                     self._trades.save(trade)
                     self._update_used_amount()
                     return

--- a/bot/domain/services/selector_service.py
+++ b/bot/domain/services/selector_service.py
@@ -6,6 +6,7 @@ from typing import Iterable, List, Sequence
 
 from ..enums import BreakDirection, Side
 from ..models.entities import Candle, Signal, Thresholds
+from ..models.metadata import EvaluationMetadata, SignalMetadata
 from .metrics_service import Metrics, MetricsService, SelectionMetricsSnapshot
 from ...utils import ids
 from ...utils.clock import utcnow
@@ -182,6 +183,17 @@ class SignalSelectorService:
             direction = BreakDirection.HIGH_FIRST if side == Side.LONG else BreakDirection.LOW_FIRST
         candle = candles[-1]
         timestamp = utcnow()
+        evaluations_metadata = [
+            EvaluationMetadata(
+                name=evaluation.name,
+                value=evaluation.value,
+                passed=evaluation.passed,
+                threshold=asdict(evaluation.threshold)
+                if evaluation.threshold is not None
+                else None,
+            )
+            for evaluation in evaluations
+        ]
         signal = Signal(
             id=ids.uuid_str(),
             candle_id=candle.id,
@@ -198,11 +210,11 @@ class SignalSelectorService:
             allow_long=allow_long,
             allow_short=allow_short,
             metrics_snapshot=metrics_snapshot,
-            metadata={
-                "evaluations": [asdict(evaluation) for evaluation in evaluations],
-                "symbol": symbol,
-                "timeframe": candle.timeframe.value,
-            },
+            metadata=SignalMetadata(
+                evaluations=evaluations_metadata,
+                symbol=symbol,
+                timeframe=candle.timeframe.value,
+            ),
         )
         return SelectionResult(signals=[signal], rejected=[])
 

--- a/tests/test_excel_storage.py
+++ b/tests/test_excel_storage.py
@@ -16,6 +16,7 @@ from bot.data.repositories.state_repository import StateRepository
 from bot.data.repositories.trade_repository import TradeRepository
 from bot.domain.enums import BreakDirection, Exchange, Side, Timeframe, TradeStatus
 from bot.domain.models.entities import Candle, Signal, Thresholds, Trade
+from bot.domain.models.metadata import SignalMetadata, TradeMetadata
 from bot.domain.services.metrics_service import SelectionMetricsSnapshot
 
 
@@ -78,7 +79,7 @@ def _build_signal(identifier: str, score: float, triggered_at: datetime) -> Sign
         allow_long=True,
         allow_short=True,
         metrics_snapshot=snapshot,
-        metadata={"note": "initial"},
+        metadata=SignalMetadata(extra={"note": "initial"}),
     )
 
 
@@ -99,7 +100,7 @@ def _build_trade(identifier: str, opened_at: datetime) -> Trade:
         created_at=opened_at,
         allow_long=True,
         allow_short=True,
-        metadata={"note": "initial"},
+        metadata=TradeMetadata(extra={"note": "initial"}),
     )
 
 
@@ -126,7 +127,9 @@ def test_signal_repository_updates_excel(tmp_path) -> None:
     assert loaded_signals[signal.id].triggered_at == signal.triggered_at
     assert loaded_signals[signal.id].triggered_at.tzinfo is not None
     assert loaded_signals[signal.id].metrics_snapshot == signal.metrics_snapshot
-    assert "metrics" not in loaded_signals[signal.id].metadata
+    assert loaded_signals[signal.id].metadata is not None
+    assert "metrics" not in loaded_signals[signal.id].metadata.extra
+    assert loaded_signals[signal.id].metadata.extra.get("note") == "initial"
 
     stored_rows = storage._writer.read_signals()
     assert stored_rows and isinstance(stored_rows[0], StoredSignalRow)
@@ -179,6 +182,8 @@ def test_trade_repository_updates_excel(tmp_path) -> None:
     loaded_trades = {loaded.id: loaded for loaded in storage.load_trades()}
     assert loaded_trades[trade.id].opened_at == trade.opened_at
     assert loaded_trades[trade.id].opened_at and loaded_trades[trade.id].opened_at.tzinfo is not None
+    assert loaded_trades[trade.id].metadata is not None
+    assert loaded_trades[trade.id].metadata.extra.get("note") == "initial"
 
     rows = _read_sheet_rows(workbook_path, "Trades")
     assert len(rows) == 1

--- a/tests/test_live_trading_runner.py
+++ b/tests/test_live_trading_runner.py
@@ -180,7 +180,9 @@ async def _execute_take_profit(tmp_path) -> None:
     assert trade.exit_price == pytest.approx(trade.tp_price)
     assert trade.pnl_pct == pytest.approx(trade.tp_pct)
     assert trade.pnl == pytest.approx(trade.size * (trade.pnl_pct or 0) / 100)
-    assert trade.metadata.get("live", {}).get("closed_status") == TradeStatus.CLOSED_TP.value
+    assert trade.metadata is not None
+    assert trade.metadata.live is not None
+    assert trade.metadata.live.closed_status == TradeStatus.CLOSED_TP
 
 
 async def _execute_stop_loss(tmp_path) -> None:
@@ -248,7 +250,9 @@ async def _execute_stop_loss(tmp_path) -> None:
     assert trade.exit_price == pytest.approx(trade.sl_price)
     assert trade.pnl_pct == pytest.approx(trade.sl_pct)
     assert trade.pnl == pytest.approx(trade.size * (trade.pnl_pct or 0) / 100)
-    assert trade.metadata.get("live", {}).get("closed_status") == TradeStatus.CLOSED_SL.value
+    assert trade.metadata is not None
+    assert trade.metadata.live is not None
+    assert trade.metadata.live.closed_status == TradeStatus.CLOSED_SL
 
 
 def test_trade_watcher_closes_on_take_profit(tmp_path) -> None:

--- a/tests/test_signal_selector.py
+++ b/tests/test_signal_selector.py
@@ -105,7 +105,8 @@ def test_select_allows_long_when_thresholds_met(selector: SignalSelectorService)
     assert signal.side is Side.LONG
     assert signal.metrics_snapshot is not None
     assert signal.metrics_snapshot.pct_move == pytest.approx(6.0)
-    assert "metrics" not in signal.metadata
+    assert signal.metadata is not None
+    assert "metrics" not in signal.metadata.extra
 
 
 def test_select_redirects_to_short_when_long_body_growth_too_small(
@@ -282,4 +283,5 @@ def test_select_includes_timeframe_metadata(selector: SignalSelectorService) -> 
     assert len(result.signals) == 1
     signal = result.signals[0]
     assert signal.timeframe is Timeframe.M5
-    assert signal.metadata["timeframe"] == Timeframe.M5.value
+    assert signal.metadata is not None
+    assert signal.metadata.timeframe == Timeframe.M5.value


### PR DESCRIPTION
## Summary
- add structured metadata dataclasses that capture evaluations, timeframe overrides, deposits, and mode-specific results
- use the typed metadata objects across signal/trade producers and persistence so callers interact with structured APIs
- refresh storage serialization/deserialization and tests to cover round-trips with the new metadata types

## Testing
- pytest
- pytest tests/test_signal_selector.py

------
https://chatgpt.com/codex/tasks/task_e_68cd26fa38308320abfcb7d35be1f6f7