### PR TITLE
Add metadata wrapper for threshold metrics

### DIFF
--- a/bot/domain/models/metadata.py
+++ b/bot/domain/models/metadata.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, Mapping, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, Mapping, Type, TypeVar
 
 from ..enums import TradeStatus
+
+if TYPE_CHECKING:
+    from .entities import ThresholdMetric
 
 
 T = TypeVar("T", bound="_SerializableDataclass")
@@ -23,11 +26,68 @@ class _SerializableDataclass:
         raise NotImplementedError
 
 @dataclass(slots=True)
+class ThresholdMetricMetadata(_SerializableDataclass):
+    name: str
+    min_value: float | None = None
+    max_value: float | None = None
+    min_abs_value: float | None = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {"name": self.name}
+        if self.min_value is not None:
+            data["min_value"] = self.min_value
+        if self.max_value is not None:
+            data["max_value"] = self.max_value
+        if self.min_abs_value is not None:
+            data["min_abs_value"] = self.min_abs_value
+        if self.extra:
+            data.update(self.extra)
+        return data
+
+    @classmethod
+    def from_mapping(
+        cls, raw: Mapping[str, Any] | None
+    ) -> "ThresholdMetricMetadata" | None:
+        if not raw or "name" not in raw:
+            return None
+        known = {"name", "min_value", "max_value", "min_abs_value"}
+        extra = {key: raw[key] for key in raw.keys() - known}
+
+        def _to_float(value: Any) -> float | None:
+            try:
+                return float(value) if value is not None else None
+            except (TypeError, ValueError):
+                return None
+
+        return cls(
+            name=str(raw["name"]),
+            min_value=_to_float(raw.get("min_value")),
+            max_value=_to_float(raw.get("max_value")),
+            min_abs_value=_to_float(raw.get("min_abs_value")),
+            extra=extra,
+        )
+
+    @classmethod
+    def from_threshold(
+        cls, threshold: "ThresholdMetric" | None
+    ) -> "ThresholdMetricMetadata" | None:
+        if threshold is None:
+            return None
+        return cls(
+            name=threshold.name,
+            min_value=threshold.min_value,
+            max_value=threshold.max_value,
+            min_abs_value=threshold.min_abs_value,
+        )
+
+
+@dataclass(slots=True)
 class EvaluationMetadata(_SerializableDataclass):
     name: str
     value: float | None = None
     passed: bool | None = None
-    threshold: Dict[str, Any] | None = None
+    threshold: ThresholdMetricMetadata | None = None
     extra: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -37,7 +97,7 @@ class EvaluationMetadata(_SerializableDataclass):
         if self.passed is not None:
             data["passed"] = self.passed
         if self.threshold is not None:
-            data["threshold"] = self.threshold
+            data["threshold"] = self.threshold.to_dict()
         if self.extra:
             data.update(self.extra)
         return data
@@ -49,7 +109,9 @@ class EvaluationMetadata(_SerializableDataclass):
         known = {"name", "value", "passed", "threshold"}
         extra = {key: raw[key] for key in raw.keys() - known}
         threshold = raw.get("threshold")
-        threshold_dict = dict(threshold) if isinstance(threshold, Mapping) else None
+        threshold_metadata = ThresholdMetricMetadata.from_mapping(
+            threshold if isinstance(threshold, Mapping) else None
+        )
         value = raw.get("value")
         try:
             value_f = float(value) if value is not None else None
@@ -65,7 +127,7 @@ class EvaluationMetadata(_SerializableDataclass):
             name=str(raw["name"]),
             value=value_f,
             passed=passed_bool,
-            threshold=threshold_dict,
+            threshold=threshold_metadata,
             extra=extra,
         )
 

--- a/bot/domain/services/selector_service.py
+++ b/bot/domain/services/selector_service.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from math import fabs
 from typing import Iterable, List, Sequence
 
 from ..enums import BreakDirection, Side
 from ..models.entities import Candle, Signal, Thresholds
-from ..models.metadata import EvaluationMetadata, SignalMetadata
+from ..models.metadata import (
+    EvaluationMetadata,
+    SignalMetadata,
+    ThresholdMetricMetadata,
+)
 from .metrics_service import Metrics, MetricsService, SelectionMetricsSnapshot
 from ...utils import ids
 from ...utils.clock import utcnow
@@ -188,9 +192,9 @@ class SignalSelectorService:
                 name=evaluation.name,
                 value=evaluation.value,
                 passed=evaluation.passed,
-                threshold=asdict(evaluation.threshold)
-                if evaluation.threshold is not None
-                else None,
+                threshold=ThresholdMetricMetadata.from_threshold(
+                    evaluation.threshold
+                ),
             )
             for evaluation in evaluations
         ]

--- a/tests/test_excel_storage.py
+++ b/tests/test_excel_storage.py
@@ -16,7 +16,12 @@ from bot.data.repositories.state_repository import StateRepository
 from bot.data.repositories.trade_repository import TradeRepository
 from bot.domain.enums import BreakDirection, Exchange, Side, Timeframe, TradeStatus
 from bot.domain.models.entities import Candle, Signal, Thresholds, Trade
-from bot.domain.models.metadata import SignalMetadata, TradeMetadata
+from bot.domain.models.metadata import (
+    EvaluationMetadata,
+    SignalMetadata,
+    ThresholdMetricMetadata,
+    TradeMetadata,
+)
 from bot.domain.services.metrics_service import SelectionMetricsSnapshot
 
 
@@ -79,7 +84,17 @@ def _build_signal(identifier: str, score: float, triggered_at: datetime) -> Sign
         allow_long=True,
         allow_short=True,
         metrics_snapshot=snapshot,
-        metadata=SignalMetadata(extra={"note": "initial"}),
+        metadata=SignalMetadata(
+            extra={"note": "initial"},
+            evaluations=[
+                EvaluationMetadata(
+                    name="atr",
+                    value=thresholds.min_relative_volume,
+                    passed=True,
+                    threshold=ThresholdMetricMetadata(name="atr", min_value=1.0),
+                )
+            ],
+        ),
     )
 
 
@@ -128,6 +143,11 @@ def test_signal_repository_updates_excel(tmp_path) -> None:
     assert loaded_signals[signal.id].triggered_at.tzinfo is not None
     assert loaded_signals[signal.id].metrics_snapshot == signal.metrics_snapshot
     assert loaded_signals[signal.id].metadata is not None
+    evaluations = loaded_signals[signal.id].metadata.evaluations
+    assert evaluations
+    assert isinstance(evaluations[0].threshold, ThresholdMetricMetadata)
+    assert evaluations[0].threshold is not None
+    assert evaluations[0].threshold.min_value == pytest.approx(1.0)
     assert "metrics" not in loaded_signals[signal.id].metadata.extra
     assert loaded_signals[signal.id].metadata.extra.get("note") == "initial"
 

--- a/tests/test_signal_selector.py
+++ b/tests/test_signal_selector.py
@@ -6,6 +6,7 @@ import pytest
 
 from bot.domain.enums import Exchange, Side, Timeframe
 from bot.domain.models.entities import Candle, ThresholdMetric, Thresholds
+from bot.domain.models.metadata import ThresholdMetricMetadata
 from bot.domain.services.metrics_service import MetricsService
 from bot.domain.services.selector_service import SignalSelectorService
 
@@ -106,6 +107,12 @@ def test_select_allows_long_when_thresholds_met(selector: SignalSelectorService)
     assert signal.metrics_snapshot is not None
     assert signal.metrics_snapshot.pct_move == pytest.approx(6.0)
     assert signal.metadata is not None
+    assert signal.metadata.evaluations
+    threshold_meta = signal.metadata.evaluations[0].threshold
+    assert isinstance(threshold_meta, ThresholdMetricMetadata)
+    assert threshold_meta is not None
+    assert threshold_meta.name == "atr"
+    assert threshold_meta.min_value == pytest.approx(5.0)
     assert "metrics" not in signal.metadata.extra
 
 


### PR DESCRIPTION
## Summary
- add a ThresholdMetricMetadata dataclass to serialize threshold data in evaluation metadata
- update selector service and storage tests to use the typed threshold metadata bridge

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd2c88e6a08320831c79c6bd1b8bd7