### PR TITLE
Add structured thresholds metadata handling

### DIFF
--- a/bot/data/io/config_models.py
+++ b/bot/data/io/config_models.py
@@ -9,6 +9,7 @@ from typing import Any, Iterable, Mapping, Sequence, Tuple, TypeVar
 from ...domain.enums import Timeframe
 from ...domain.models.entities import ThresholdMetric as DomainThresholdMetric
 from ...domain.models.entities import Thresholds as DomainThresholds
+from ...domain.models.metadata import ThresholdsMetadata
 
 
 _DEFAULT_BACKTEST_TIMEFRAMES: tuple[Timeframe, ...] = (
@@ -361,7 +362,7 @@ class ThresholdConfig:
     short_relative_volume_ranges: tuple[tuple[float | None, float | None], ...] = field(
         default_factory=tuple
     )
-    metadata: Mapping[str, Any] = field(default_factory=dict)
+    metadata: ThresholdsMetadata | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
@@ -370,7 +371,9 @@ class ThresholdConfig:
         if raw is None or not isinstance(raw, Mapping):
             raw = {}
         metadata_raw = raw.get("metadata")
-        metadata = metadata_raw if isinstance(metadata_raw, Mapping) else {}
+        metadata = ThresholdsMetadata.from_mapping(
+            metadata_raw if isinstance(metadata_raw, Mapping) else None
+        )
         metrics_raw = raw.get("metrics")
         metrics: list[ThresholdMetricConfig] = []
         if isinstance(metrics_raw, Iterable) and not isinstance(
@@ -382,16 +385,17 @@ class ThresholdConfig:
                     if metric is not None:
                         metrics.append(metric)
         short_pct_move_ranges = _parse_range_list(raw.get("short_pct_move_ranges"))
-        if not short_pct_move_ranges and metadata:
+        metadata_extra = metadata.extra if metadata else {}
+        if not short_pct_move_ranges and metadata_extra:
             short_pct_move_ranges = _parse_range_list(
-                metadata.get("short_pct_move_ranges")
+                metadata_extra.get("short_pct_move_ranges")
             )
         short_relative_volume_ranges = _parse_range_list(
             raw.get("short_relative_volume_ranges")
         )
-        if not short_relative_volume_ranges and metadata:
+        if not short_relative_volume_ranges and metadata_extra:
             short_relative_volume_ranges = _parse_range_list(
-                metadata.get("short_relative_volume_ranges")
+                metadata_extra.get("short_relative_volume_ranges")
             )
         return cls(
             id=str(raw.get("id")) if raw.get("id") is not None else None,
@@ -447,7 +451,7 @@ class ThresholdConfig:
             allow_long=self.allow_long,
             allow_short=self.allow_short,
             metrics=[metric.to_domain() for metric in self.metrics],
-            metadata=dict(self.metadata),
+            metadata=self.metadata,
             created_at=self.created_at,
             updated_at=self.updated_at,
         )

--- a/bot/data/io/storage.py
+++ b/bot/data/io/storage.py
@@ -15,7 +15,11 @@ from ...domain.models.entities import (
     Thresholds,
     Trade,
 )
-from ...domain.models.metadata import SignalMetadata, TradeMetadata
+from ...domain.models.metadata import (
+    SignalMetadata,
+    ThresholdsMetadata,
+    TradeMetadata,
+)
 from ...domain.services.metrics_service import SelectionMetricsSnapshot
 from .excel_rows import StoredSignalRow, StoredStateRow, StoredTradeRow
 from .excel_writer import ExcelWriter
@@ -122,9 +126,10 @@ class Storage:
             for metric_raw in metrics_raw:
                 if isinstance(metric_raw, dict) and "name" in metric_raw:
                     metrics.append(self._deserialize_threshold_metric(metric_raw))
-        metadata = raw.get("metadata", {})
-        if not isinstance(metadata, dict):
-            metadata = {}
+        metadata_raw = raw.get("metadata")
+        metadata = ThresholdsMetadata.from_mapping(
+            metadata_raw if isinstance(metadata_raw, Mapping) else None
+        )
         created_at_raw = raw.get("created_at")
         updated_at_raw = raw.get("updated_at")
         short_pct_move_ranges: List[tuple[float, Optional[float]]] = []
@@ -150,6 +155,47 @@ class Storage:
                 else:
                     continue
                 short_pct_move_ranges.append((min_value, max_value))
+        if not short_pct_move_ranges and metadata and metadata.extra:
+            extra_ranges = metadata.extra.get("short_pct_move_ranges")
+            if isinstance(extra_ranges, list):
+                for entry in extra_ranges:
+                    min_value = None
+                    max_value = None
+                    if isinstance(entry, dict):
+                        min_raw = entry.get("min")
+                        if min_raw is None:
+                            min_raw = entry.get("min_value")
+                        max_raw = entry.get("max")
+                        if max_raw is None:
+                            max_raw = entry.get("max_value")
+                        if min_raw is None:
+                            continue
+                        try:
+                            min_value = float(min_raw)
+                        except (TypeError, ValueError):
+                            continue
+                        if max_raw is not None:
+                            try:
+                                max_value = float(max_raw)
+                            except (TypeError, ValueError):
+                                max_value = None
+                    elif isinstance(entry, (list, tuple)) and entry:
+                        try:
+                            min_value = float(entry[0]) if entry[0] is not None else None
+                        except (TypeError, ValueError):
+                            min_value = None
+                        if len(entry) > 1:
+                            try:
+                                max_value = (
+                                    float(entry[1])
+                                    if entry[1] is not None
+                                    else None
+                                )
+                            except (TypeError, ValueError):
+                                max_value = None
+                    if min_value is None and max_value is None:
+                        continue
+                    short_pct_move_ranges.append((min_value, max_value))
         def _get_float_from_keys(keys: list[str]) -> float:
             for key in keys:
                 if raw.get(key) is not None:
@@ -290,13 +336,17 @@ class Storage:
         updated_at_raw = raw.get("updated_at")
         timeframe_raw = raw.get("timeframe")
         timeframe = Timeframe(timeframe_raw) if isinstance(timeframe_raw, str) else None
-        if timeframe is None and thresholds_snapshot and isinstance(thresholds_snapshot.metadata, dict):
-            meta_tf = thresholds_snapshot.metadata.get("timeframe")
-            if isinstance(meta_tf, str):
-                try:
-                    timeframe = Timeframe(meta_tf)
-                except ValueError:
-                    timeframe = None
+        if timeframe is None and thresholds_snapshot and thresholds_snapshot.metadata:
+            meta_tf = thresholds_snapshot.metadata.timeframe
+            if isinstance(meta_tf, Timeframe):
+                timeframe = meta_tf
+            else:
+                extra_tf = thresholds_snapshot.metadata.extra.get("timeframe")
+                if isinstance(extra_tf, str):
+                    try:
+                        timeframe = Timeframe(extra_tf)
+                    except ValueError:
+                        timeframe = None
         if timeframe is None:
             meta_tf = metadata_dict.get("timeframe")
             if isinstance(meta_tf, str):
@@ -344,7 +394,11 @@ class Storage:
             thresholds["created_at"] = signal.thresholds.created_at.isoformat()
         if signal.thresholds.updated_at:
             thresholds["updated_at"] = signal.thresholds.updated_at.isoformat()
-        thresholds["metadata"] = dict(signal.thresholds.metadata or {})
+        thresholds["metadata"] = (
+            signal.thresholds.metadata.to_dict()
+            if signal.thresholds.metadata
+            else {}
+        )
         metrics: List[Dict[str, Any]] = []
         for metric in signal.metrics:
             metric_dict = asdict(metric)
@@ -396,7 +450,11 @@ class Storage:
                 snapshot["created_at"] = trade.thresholds_snapshot.created_at.isoformat()
             if trade.thresholds_snapshot.updated_at:
                 snapshot["updated_at"] = trade.thresholds_snapshot.updated_at.isoformat()
-            snapshot["metadata"] = dict(trade.thresholds_snapshot.metadata or {})
+            snapshot["metadata"] = (
+                trade.thresholds_snapshot.metadata.to_dict()
+                if trade.thresholds_snapshot.metadata
+                else {}
+            )
             thresholds_snapshot = json.dumps(snapshot, sort_keys=True)
         metadata_json = json.dumps(
             self._trade_metadata_to_mapping(trade.metadata), sort_keys=True

--- a/bot/domain/models/entities.py
+++ b/bot/domain/models/entities.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from ..enums import BreakDirection, Exchange, Side, Timeframe, TradeStatus
-from .metadata import SignalMetadata, TradeMetadata
+from .metadata import SignalMetadata, ThresholdsMetadata, TradeMetadata
 
 
 if TYPE_CHECKING:
@@ -55,7 +55,7 @@ class Thresholds:
     allow_long: bool = True
     allow_short: bool = True
     metrics: List[ThresholdMetric] = field(default_factory=list)
-    metadata: SignalMetadata | None = None
+    metadata: ThresholdsMetadata | None = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 

--- a/bot/domain/models/metadata.py
+++ b/bot/domain/models/metadata.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, Mapping, Type, TypeVar
 
-from ..enums import TradeStatus
+from ..enums import Timeframe, TradeStatus
 
 if TYPE_CHECKING:
     from .entities import ThresholdMetric
@@ -24,6 +24,49 @@ class _SerializableDataclass:
     @classmethod
     def from_mapping(cls: Type[T], raw: Mapping[str, Any] | None) -> T | None:
         raise NotImplementedError
+
+@dataclass(slots=True)
+class ThresholdsMetadata(_SerializableDataclass):
+    timeframe: Timeframe | None = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {}
+        if self.timeframe is not None:
+            data["timeframe"] = (
+                self.timeframe.value
+                if isinstance(self.timeframe, Timeframe)
+                else str(self.timeframe)
+            )
+        if self.extra:
+            data.update(self.extra)
+        return data
+
+    @classmethod
+    def from_mapping(
+        cls, raw: Mapping[str, Any] | None
+    ) -> "ThresholdsMetadata" | None:
+        if not raw or not isinstance(raw, Mapping):
+            return None
+        extra: Dict[str, Any] = {
+            key: raw[key] for key in raw.keys() - {"timeframe"}
+        }
+        timeframe_value: Timeframe | None = None
+        if "timeframe" in raw:
+            timeframe_raw = raw["timeframe"]
+            if isinstance(timeframe_raw, Timeframe):
+                timeframe_value = timeframe_raw
+            elif isinstance(timeframe_raw, str):
+                try:
+                    timeframe_value = Timeframe(timeframe_raw)
+                except ValueError:
+                    extra.setdefault("timeframe", timeframe_raw)
+            else:
+                extra.setdefault("timeframe", timeframe_raw)
+        if timeframe_value is None and not extra:
+            return None
+        return cls(timeframe=timeframe_value, extra=extra)
+
 
 @dataclass(slots=True)
 class ThresholdMetricMetadata(_SerializableDataclass):

--- a/tests/test_config_parsing.py
+++ b/tests/test_config_parsing.py
@@ -7,6 +7,7 @@ from bot.data.io.config_models import (
     ProviderKind,
 )
 from bot.domain.enums import Timeframe
+from bot.domain.models.metadata import ThresholdsMetadata
 
 
 def test_symbol_selection_and_overrides_are_typed() -> None:
@@ -90,17 +91,22 @@ def test_build_thresholds_uses_typed_models() -> None:
                 "default": {
                     "min_relative_volume": "1.5",
                     "allow_long": False,
-                    "short_pct_move_ranges": [
-                        {"min": 0.5, "max": 1.0},
-                    ],
                     "metrics": [
                         {"name": "rsi", "min_value": "5", "max_value": 60},
                     ],
+                    "metadata": {
+                        "timeframe": "15m",
+                        "short_pct_move_ranges": [
+                            {"min": 0.5, "max": 1.0},
+                        ],
+                        "note": "default",
+                    },
                 },
                 "symbols": {
                     "ETHUSDT": {
                         "min_pct_move": "0.25",
                         "allow_short": False,
+                        "metadata": {"timeframe": "5m"},
                     }
                 },
             }
@@ -116,10 +122,17 @@ def test_build_thresholds_uses_typed_models() -> None:
     assert default_cfg.metrics[0].name == "rsi"
     assert default_cfg.metrics[0].min_value == 5.0
     assert default_cfg.metrics[0].max_value == 60.0
+    assert isinstance(default_cfg.metadata, ThresholdsMetadata)
+    assert default_cfg.metadata is not None
+    assert default_cfg.metadata.timeframe is Timeframe.M15
+    assert default_cfg.metadata.extra["note"] == "default"
 
     eth_cfg = thresholds["ETHUSDT"]
     assert eth_cfg.min_pct_move == 0.25
     assert eth_cfg.allow_short is False
+    assert isinstance(eth_cfg.metadata, ThresholdsMetadata)
+    assert eth_cfg.metadata is not None
+    assert eth_cfg.metadata.timeframe is Timeframe.M5
 
 
 def test_provider_configs_are_typed_and_resolve_credentials(monkeypatch) -> None:

--- a/tests/test_excel_storage.py
+++ b/tests/test_excel_storage.py
@@ -20,6 +20,7 @@ from bot.domain.models.metadata import (
     EvaluationMetadata,
     SignalMetadata,
     ThresholdMetricMetadata,
+    ThresholdsMetadata,
     TradeMetadata,
 )
 from bot.domain.services.metrics_service import SelectionMetricsSnapshot
@@ -50,7 +51,7 @@ def _build_signal(identifier: str, score: float, triggered_at: datetime) -> Sign
         id=f"thr-{identifier}",
         min_relative_volume=1.0,
         max_relative_volume=5.0,
-        metadata={"timeframe": Timeframe.M15.value},
+        metadata=ThresholdsMetadata(timeframe=Timeframe.M15),
     )
     base = score / 10.0
     snapshot = SelectionMetricsSnapshot(
@@ -142,6 +143,11 @@ def test_signal_repository_updates_excel(tmp_path) -> None:
     assert loaded_signals[signal.id].triggered_at == signal.triggered_at
     assert loaded_signals[signal.id].triggered_at.tzinfo is not None
     assert loaded_signals[signal.id].metrics_snapshot == signal.metrics_snapshot
+    assert isinstance(loaded_signals[signal.id].thresholds.metadata, ThresholdsMetadata)
+    assert (
+        loaded_signals[signal.id].thresholds.metadata
+        and loaded_signals[signal.id].thresholds.metadata.timeframe is Timeframe.M15
+    )
     assert loaded_signals[signal.id].metadata is not None
     evaluations = loaded_signals[signal.id].metadata.evaluations
     assert evaluations
@@ -187,6 +193,10 @@ def test_signal_repository_updates_excel(tmp_path) -> None:
     loaded_signals = {loaded.id: loaded for loaded in storage.load_signals()}
     assert loaded_signals[signal.id].updated_at == updated_signal.updated_at
     assert loaded_signals[signal.id].updated_at.tzinfo is not None
+    assert (
+        loaded_signals[signal.id].thresholds.metadata
+        and loaded_signals[signal.id].thresholds.metadata.timeframe is Timeframe.M15
+    )
     assert loaded_signals[another_signal.id].triggered_at == another_signal.triggered_at
     assert loaded_signals[another_signal.id].triggered_at.tzinfo is not None
     assert loaded_signals[another_signal.id].metrics_snapshot == another_signal.metrics_snapshot

--- a/tests/test_live_trading_runner.py
+++ b/tests/test_live_trading_runner.py
@@ -15,6 +15,7 @@ from bot.data.repositories.state_repository import StateRepository
 from bot.data.repositories.trade_repository import TradeRepository
 from bot.domain.enums import BreakDirection, Exchange, Side, Timeframe, TradeStatus
 from bot.domain.models.entities import Candle, Signal, Thresholds
+from bot.domain.models.metadata import ThresholdsMetadata
 from bot.domain.services.metrics_service import SelectionMetricsSnapshot
 from bot.domain.services.dedup_policy import DeduplicationPolicy
 from bot.domain.services.live_runner import LiveTradingRunner
@@ -81,7 +82,7 @@ def _build_signal(
         id=f"thr-{identifier}",
         min_relative_volume=1.0,
         max_relative_volume=5.0,
-        metadata={"timeframe": timeframe.value},
+        metadata=ThresholdsMetadata(timeframe=timeframe),
     )
     snapshot = SelectionMetricsSnapshot(
         atr=1.0,


### PR DESCRIPTION
## Summary
- add a ThresholdsMetadata dataclass to capture timeframe-aware threshold metadata and serialization helpers
- update threshold config and storage layers to round-trip metadata via the new dataclass
- refresh tests/fixtures to build ThresholdsMetadata instances and validate persistence/deserialization

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd2f2913d48320bf185f980235a419