### PR TITLE
Enforce AppMode for selection overrides lookup

### DIFF
--- a/bot/data/io/config_loader.py
+++ b/bot/data/io/config_loader.py
@@ -74,14 +74,10 @@ class AppConfig:
             return value.strip()
         return "UTC"
 
-    def selection_overrides_for(self, mode: AppMode | str) -> ModeSelectionOverrides:
-        if isinstance(mode, AppMode):
-            key = mode.value
-        else:
-            key = mode
-        if key == "backtest":
+    def selection_overrides_for(self, mode: AppMode) -> ModeSelectionOverrides:
+        if mode is AppMode.BACKTEST:
             return self.backtest.selection
-        if key == "live":
+        if mode is AppMode.LIVE:
             return self.live.selection
         return ModeSelectionOverrides()
 


### PR DESCRIPTION
## Summary
- require AppMode when retrieving mode-specific selection overrides and rely on enum identity

## Testing
- `pytest`
- `mypy bot` *(fails: existing typing issues in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68cd32766fdc8320a69ff3540680a8b9