### PR TITLE
Refine config models for typed top-level sections

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -113,8 +113,7 @@ def load_config() -> AppConfig:
 
 
 def init_storage(config: AppConfig) -> Storage:
-    path_setting = config.get("storage.path", "var/state.xlsx")
-    storage_path = Path(path_setting)
+    storage_path = Path(config.storage.path)
     if storage_path.suffix.lower() != ".xlsx":
         storage_path = storage_path.with_suffix(".xlsx")
     storage_path.parent.mkdir(parents=True, exist_ok=True)
@@ -494,18 +493,13 @@ def resolve_mode(config: AppConfig, cli_args: Sequence[str] | None = None) -> Ap
     if cli_mode is not None:
         return cli_mode
 
-    config_mode_raw = config.get("mode")
-    if isinstance(config_mode_raw, str) and not config_mode_raw.strip():
-        config_mode_raw = None
-    if config_mode_raw is not None:
-        return AppMode.parse(config_mode_raw)
-
-    return AppMode.BACKTEST
+    config_mode = config.time.mode or config.default_mode
+    return config_mode
 
 
 async def main_async(cli_args: Sequence[str] | None = None) -> None:
     config = load_config()
-    timezone_name = config.timezone_name
+    timezone_name = config.time.zone
     timezone_warning: str | None = None
     try:
         app_timezone = ZoneInfo(timezone_name)
@@ -517,7 +511,7 @@ async def main_async(cli_args: Sequence[str] | None = None) -> None:
             else ""
         )
     init_clock(app_timezone)
-    configure_logging(config.get("logging.level", "INFO"))
+    configure_logging(config.logging.level)
     logger = get_logger("app")
     if timezone_warning:
         logger.warning(timezone_warning)

--- a/bot/data/io/config_loader.py
+++ b/bot/data/io/config_loader.py
@@ -13,10 +13,13 @@ from .config_models import (
     DedupConfig,
     ExchangeProviderConfig,
     LiveConfig,
+    LoggingConfig,
     MetricsConfig,
     ModeSelectionOverrides,
+    StorageConfig,
     SymbolSelectionConfig,
     ThresholdsConfig,
+    TimeConfig,
     parse_exchange_provider_configs,
     parse_symbol_provider_mapping,
 )
@@ -34,21 +37,37 @@ class AppConfig:
     providers: dict[str, ExchangeProviderConfig] = field(init=False)
     metrics: MetricsConfig = field(init=False)
     dedup: DedupConfig = field(init=False)
+    storage: StorageConfig = field(init=False)
+    logging: LoggingConfig = field(init=False)
+    time: TimeConfig = field(init=False)
+    _default_mode_raw: Any = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
-        self.thresholds = ThresholdsConfig.from_raw(self.get("thresholds", {}))
-        self.symbol_selection = SymbolSelectionConfig.from_raw(
-            self.get("symbols.selection", {})
-        )
-        self.symbol_provider_mapping = parse_symbol_provider_mapping(
-            self.get("symbols.providers", {})
-        )
-        self.backtest = BacktestConfig.from_raw(self.get("backtest", {}))
-        self.live = LiveConfig.from_raw(self.get("live", {}))
-        self.metrics = MetricsConfig.from_raw(self.get("metrics", {}))
-        self.dedup = DedupConfig.from_raw(self.get("dedup", {}))
+        raw = self.raw
+
+        self.storage = StorageConfig.from_raw(raw.get("storage"))
+        self.logging = LoggingConfig.from_raw(raw.get("logging"))
+        self.time = TimeConfig.from_raw(raw.get("time"))
+        self._default_mode_raw = raw.get("mode")
+
+        thresholds_raw = raw.get("thresholds", {})
+        self.thresholds = ThresholdsConfig.from_raw(thresholds_raw)
+
+        symbols_raw = raw.get("symbols")
+        selection_raw: Any = {}
+        providers_raw: Any = {}
+        if isinstance(symbols_raw, Mapping):
+            selection_raw = symbols_raw.get("selection", {})
+            providers_raw = symbols_raw.get("providers", {})
+        self.symbol_selection = SymbolSelectionConfig.from_raw(selection_raw)
+        self.symbol_provider_mapping = parse_symbol_provider_mapping(providers_raw)
+
+        self.backtest = BacktestConfig.from_raw(raw.get("backtest"))
+        self.live = LiveConfig.from_raw(raw.get("live"))
+        self.metrics = MetricsConfig.from_raw(raw.get("metrics"))
+        self.dedup = DedupConfig.from_raw(raw.get("dedup"))
         env_values: dict[str, str] = {}
-        env_raw = self.get("env", {})
+        env_raw = raw.get("env", {})
         if isinstance(env_raw, Mapping):
             for key, value in env_raw.items():
                 if not isinstance(key, str):
@@ -57,22 +76,8 @@ class AppConfig:
                     continue
                 env_values[key] = str(value)
         self.env = env_values
-        self.providers = parse_exchange_provider_configs(self.get("providers", {}))
-
-    def get(self, path: str, default: Any = None) -> Any:
-        cursor: Any = self.raw
-        for part in path.split('.'):
-            if not isinstance(cursor, Mapping) or part not in cursor:
-                return default
-            cursor = cursor[part]
-        return cursor
-
-    @property
-    def timezone_name(self) -> str:
-        value = self.get("time.zone")
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-        return "UTC"
+        providers_raw = raw.get("providers", {})
+        self.providers = parse_exchange_provider_configs(providers_raw)
 
     def selection_overrides_for(self, mode: AppMode) -> ModeSelectionOverrides:
         if mode is AppMode.BACKTEST:
@@ -80,6 +85,21 @@ class AppConfig:
         if mode is AppMode.LIVE:
             return self.live.selection
         return ModeSelectionOverrides()
+
+    @property
+    def default_mode(self) -> AppMode:
+        parsed = _parse_optional_mode(self._default_mode_raw)
+        if parsed is not None:
+            return parsed
+        return AppMode.BACKTEST
+
+
+def _parse_optional_mode(value: Any) -> AppMode | None:
+    if value is None:
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    return AppMode.parse(value)
 
 
 class ConfigLoader:

--- a/bot/data/io/config_models.py
+++ b/bot/data/io/config_models.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Iterable, Mapping, Sequence, Tuple, TypeVar
 
+from ...app_modes import AppMode
 from ...domain.enums import Timeframe
 from ...domain.models.entities import ThresholdMetric as DomainThresholdMetric
 from ...domain.models.entities import Thresholds as DomainThresholds
@@ -149,6 +150,77 @@ def _normalize_str(value: Any) -> str | None:
         candidate = value.strip()
         return candidate or None
     return str(value)
+
+
+@dataclass(slots=True)
+class StorageConfig:
+    path: str = "var/state.xlsx"
+
+    @classmethod
+    def from_raw(cls, raw: Any) -> "StorageConfig":
+        path_value: Any
+        if isinstance(raw, Mapping):
+            path_value = raw.get("path")
+        else:
+            path_value = raw
+        if isinstance(path_value, str):
+            candidate = path_value.strip()
+            if candidate:
+                return cls(path=candidate)
+        elif path_value is not None:
+            return cls(path=str(path_value))
+        return cls()
+
+
+@dataclass(slots=True)
+class LoggingConfig:
+    level: str = "INFO"
+
+    @classmethod
+    def from_raw(cls, raw: Any) -> "LoggingConfig":
+        level_value: Any
+        if isinstance(raw, Mapping):
+            level_value = raw.get("level")
+        else:
+            level_value = raw
+        if isinstance(level_value, str):
+            candidate = level_value.strip()
+            if candidate:
+                return cls(level=candidate.upper())
+        elif level_value is not None:
+            return cls(level=str(level_value).upper())
+        return cls()
+
+
+def _parse_optional_mode(value: Any) -> AppMode | None:
+    if value is None:
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    return AppMode.parse(value)
+
+
+@dataclass(slots=True)
+class TimeConfig:
+    zone: str = "UTC"
+    mode: AppMode | None = None
+
+    @classmethod
+    def from_raw(cls, raw: Any) -> "TimeConfig":
+        zone = "UTC"
+        mode: AppMode | None = None
+        if isinstance(raw, Mapping):
+            zone_raw = raw.get("zone")
+            if isinstance(zone_raw, str) and zone_raw.strip():
+                zone = zone_raw.strip()
+            elif zone_raw is not None:
+                zone = str(zone_raw)
+            mode = _parse_optional_mode(raw.get("mode"))
+        elif isinstance(raw, str) and raw.strip():
+            zone = raw.strip()
+        elif raw is not None:
+            zone = str(raw)
+        return cls(zone=zone, mode=mode)
 
 
 @dataclass(slots=True)

--- a/tests/test_config_parsing.py
+++ b/tests/test_config_parsing.py
@@ -29,6 +29,10 @@ def test_symbol_selection_and_overrides_are_typed() -> None:
                 "window": "25",
                 "allow": ["btcusdt"],
             },
+            "storage": {"path": " data/state "},
+            "logging": {"level": "debug"},
+            "time": {"zone": "Europe/Belgrade", "mode": "live"},
+            "mode": "backtest",
         }
     )
 
@@ -50,6 +54,12 @@ def test_symbol_selection_and_overrides_are_typed() -> None:
     assert live_cfg.window == 25
     assert config.symbol_provider_mapping["BTCUSDT"] == "binance"
     assert config.symbol_provider_mapping["default"] == "bybit"
+    assert config.storage.path == "data/state"
+    assert config.logging.level == "DEBUG"
+    assert config.time.zone == "Europe/Belgrade"
+    assert config.time.mode is AppMode.LIVE
+    assert config.default_mode is AppMode.BACKTEST
+    assert not hasattr(config, "get")
 
 
 def test_metrics_and_dedup_configs_are_typed() -> None:

--- a/tests/test_timezones.py
+++ b/tests/test_timezones.py
@@ -9,7 +9,7 @@ from bot.utils.clock import get_timezone, init_clock
 
 def test_app_config_timezone_defaults_to_utc() -> None:
     config = AppConfig(raw={})
-    assert config.timezone_name == "UTC"
+    assert config.time.zone == "UTC"
 
 
 def test_map_ohlcv_uses_configured_timezone() -> None:


### PR DESCRIPTION
## Summary
- introduce typed storage, logging, and time dataclasses for app configuration
- hydrate the new config models in AppConfig and expose a typed default mode
- update app wiring to consume the typed settings and expand config parsing tests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cd34b3e1588320a8518e08a4213bf9