### PR TITLE
Add typed config validation and strict mypy check

### DIFF
--- a/bot/data/io/config_loader.py
+++ b/bot/data/io/config_loader.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import os
 import tomllib
+from datetime import datetime
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Mapping
+from typing import Dict, Mapping, Sequence, cast
 
 from bot.app_modes import AppMode
+from bot.domain.enums import Timeframe
 
 from .config_models import (
     BacktestConfig,
@@ -23,11 +25,36 @@ from .config_models import (
     parse_exchange_provider_configs,
     parse_symbol_provider_mapping,
 )
+from .config_types import (
+    AppConfigData,
+    BacktestSection,
+    DedupSection,
+    LiveSection,
+    LoggingSection,
+    MetricsSection,
+    ModeSelectionSection,
+    NumberInput,
+    ProviderSection,
+    ProvidersSection,
+    RangeEntry,
+    StorageSection,
+    SymbolSelectionSection,
+    SymbolsSection,
+    ThresholdMetricSection,
+    ThresholdSection,
+    ThresholdsSection,
+    TimeSection,
+)
+
+
+class ConfigStructureError(ValueError):
+    """Raised when a configuration file has an unexpected structure."""
 
 
 @dataclass(slots=True)
 class AppConfig:
-    raw: Dict[str, Any]
+    raw: Mapping[str, object] | AppConfigData
+    is_typed: bool = False
     env: dict[str, str] = field(init=False)
     thresholds: ThresholdsConfig = field(init=False)
     symbol_selection: SymbolSelectionConfig = field(init=False)
@@ -40,44 +67,39 @@ class AppConfig:
     storage: StorageConfig = field(init=False)
     logging: LoggingConfig = field(init=False)
     time: TimeConfig = field(init=False)
-    _default_mode_raw: Any = field(init=False, repr=False)
+    _default_mode_raw: object = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
-        raw = self.raw
+        data = (
+            cast(AppConfigData, self.raw)
+            if self.is_typed
+            else _coerce_app_config_data(self.raw)
+        )
+        self.raw = data
 
-        self.storage = StorageConfig.from_raw(raw.get("storage"))
-        self.logging = LoggingConfig.from_raw(raw.get("logging"))
-        self.time = TimeConfig.from_raw(raw.get("time"))
-        self._default_mode_raw = raw.get("mode")
+        self.storage = StorageConfig.from_raw(data.get("storage"))
+        self.logging = LoggingConfig.from_raw(data.get("logging"))
+        self.time = TimeConfig.from_raw(data.get("time"))
+        self._default_mode_raw = data.get("mode")
 
-        thresholds_raw = raw.get("thresholds", {})
-        self.thresholds = ThresholdsConfig.from_raw(thresholds_raw)
+        self.thresholds = ThresholdsConfig.from_raw(data.get("thresholds"))
 
-        symbols_raw = raw.get("symbols")
-        selection_raw: Any = {}
-        providers_raw: Any = {}
-        if isinstance(symbols_raw, Mapping):
-            selection_raw = symbols_raw.get("selection", {})
-            providers_raw = symbols_raw.get("providers", {})
+        symbols_raw = data.get("symbols")
+        selection_raw = symbols_raw.get("selection") if symbols_raw else None
+        providers_raw = symbols_raw.get("providers") if symbols_raw else None
         self.symbol_selection = SymbolSelectionConfig.from_raw(selection_raw)
         self.symbol_provider_mapping = parse_symbol_provider_mapping(providers_raw)
 
-        self.backtest = BacktestConfig.from_raw(raw.get("backtest"))
-        self.live = LiveConfig.from_raw(raw.get("live"))
-        self.metrics = MetricsConfig.from_raw(raw.get("metrics"))
-        self.dedup = DedupConfig.from_raw(raw.get("dedup"))
-        env_values: dict[str, str] = {}
-        env_raw = raw.get("env", {})
-        if isinstance(env_raw, Mapping):
-            for key, value in env_raw.items():
-                if not isinstance(key, str):
-                    continue
-                if value is None:
-                    continue
-                env_values[key] = str(value)
-        self.env = env_values
-        providers_raw = raw.get("providers", {})
-        self.providers = parse_exchange_provider_configs(providers_raw)
+        self.backtest = BacktestConfig.from_raw(data.get("backtest"))
+        self.live = LiveConfig.from_raw(data.get("live"))
+        self.metrics = MetricsConfig.from_raw(data.get("metrics"))
+        self.dedup = DedupConfig.from_raw(data.get("dedup"))
+
+        env_raw = data.get("env", {})
+        self.env = dict(env_raw)
+
+        providers_section = data.get("providers")
+        self.providers = parse_exchange_provider_configs(providers_section)
 
     def selection_overrides_for(self, mode: AppMode) -> ModeSelectionOverrides:
         if mode is AppMode.BACKTEST:
@@ -94,9 +116,11 @@ class AppConfig:
         return AppMode.BACKTEST
 
 
-def _parse_optional_mode(value: Any) -> AppMode | None:
+def _parse_optional_mode(value: object) -> AppMode | None:
     if value is None:
         return None
+    if isinstance(value, AppMode):
+        return value
     if isinstance(value, str) and not value.strip():
         return None
     return AppMode.parse(value)
@@ -121,7 +145,632 @@ class ConfigLoader:
     def load(self) -> AppConfig:
         data = tomllib.loads(self._settings_path.read_text(encoding="utf-8"))
         env_overrides = self._load_env()
-        for key, value in env_overrides.items():
-            data.setdefault("env", {})[key] = value
+        typed = _coerce_app_config_data(data, env_overrides=env_overrides)
+        for key, value in typed.get("env", {}).items():
             os.environ.setdefault(key, value)
-        return AppConfig(raw=data)
+        return AppConfig(raw=typed, is_typed=True)
+
+
+def _coerce_app_config_data(
+    raw: Mapping[str, object] | AppConfigData | None,
+    *,
+    env_overrides: Mapping[str, str] | None = None,
+) -> AppConfigData:
+    if raw is None or not isinstance(raw, Mapping):
+        raise ConfigStructureError("Top-level configuration must be a mapping.")
+    mapping = raw
+
+    data: AppConfigData = {}
+
+    mode_value = mapping.get("mode")
+    if mode_value is not None:
+        if isinstance(mode_value, AppMode):
+            data["mode"] = mode_value.value
+        elif isinstance(mode_value, str):
+            data["mode"] = mode_value
+        else:
+            raise ConfigStructureError("'mode' must be a string or AppMode value.")
+
+    env_section = _coerce_env_section(mapping.get("env"))
+    if env_overrides:
+        env_section.update(env_overrides)
+    if env_section:
+        data["env"] = env_section
+
+    storage_section = _coerce_storage_section(mapping.get("storage"))
+    if storage_section is not None:
+        data["storage"] = storage_section
+
+    logging_section = _coerce_logging_section(mapping.get("logging"))
+    if logging_section is not None:
+        data["logging"] = logging_section
+
+    time_section = _coerce_time_section(mapping.get("time"))
+    if time_section is not None:
+        data["time"] = time_section
+
+    thresholds_section = _coerce_thresholds_section(mapping.get("thresholds"))
+    if thresholds_section is not None:
+        data["thresholds"] = thresholds_section
+
+    symbols_section = _coerce_symbols_section(mapping.get("symbols"))
+    if symbols_section is not None:
+        data["symbols"] = symbols_section
+
+    backtest_section = _coerce_backtest_section(mapping.get("backtest"))
+    if backtest_section is not None:
+        data["backtest"] = backtest_section
+
+    live_section = _coerce_live_section(mapping.get("live"))
+    if live_section is not None:
+        data["live"] = live_section
+
+    metrics_section = _coerce_metrics_section(mapping.get("metrics"))
+    if metrics_section is not None:
+        data["metrics"] = metrics_section
+
+    dedup_section = _coerce_dedup_section(mapping.get("dedup"))
+    if dedup_section is not None:
+        data["dedup"] = dedup_section
+
+    providers_section = _coerce_providers_section(mapping.get("providers"))
+    if providers_section is not None:
+        data["providers"] = providers_section
+
+    return data
+
+
+def _coerce_env_section(value: object) -> dict[str, str]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ConfigStructureError("'env' must be a table of key/value pairs.")
+    env: dict[str, str] = {}
+    for key, raw_value in value.items():
+        if not isinstance(key, str):
+            raise ConfigStructureError("Environment variable keys must be strings.")
+        if raw_value is None:
+            continue
+        env[key] = str(raw_value)
+    return env
+
+
+def _coerce_storage_section(value: object) -> StorageSection | None:
+    if value is None:
+        return None
+    section: StorageSection = {}
+    if isinstance(value, Mapping):
+        path_value = value.get("path")
+        if path_value is None:
+            return section
+        section["path"] = str(path_value)
+        return section
+    if isinstance(value, (str, int, float, bool)):
+        section["path"] = str(value)
+        return section
+    raise ConfigStructureError("'storage' must be a string or table with a 'path'.")
+
+
+def _coerce_logging_section(value: object) -> LoggingSection | None:
+    if value is None:
+        return None
+    section: LoggingSection = {}
+    if isinstance(value, Mapping):
+        level = value.get("level")
+        if level is None:
+            return section
+        section["level"] = str(level)
+        return section
+    if isinstance(value, (str, int, float, bool)):
+        section["level"] = str(value)
+        return section
+    raise ConfigStructureError("'logging' must be a string or table with a 'level'.")
+
+
+def _coerce_time_section(value: object) -> TimeSection | None:
+    if value is None:
+        return None
+    section: TimeSection = {}
+    if isinstance(value, str):
+        section["zone"] = value
+        return section
+    if not isinstance(value, Mapping):
+        raise ConfigStructureError("'time' must be a table or string zone identifier.")
+    zone_raw = value.get("zone")
+    if zone_raw is not None:
+        section["zone"] = str(zone_raw)
+    mode_raw = value.get("mode")
+    if mode_raw is not None:
+        if isinstance(mode_raw, AppMode):
+            section["mode"] = mode_raw.value
+        elif isinstance(mode_raw, str):
+            section["mode"] = mode_raw
+        else:
+            raise ConfigStructureError("'time.mode' must be a string or AppMode value.")
+    return section
+
+
+def _coerce_metrics_section(value: object) -> MetricsSection | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ConfigStructureError("'metrics' must be a table.")
+    section: MetricsSection = {}
+    for key in ("atr_period", "volume_period", "momentum_period"):
+        if key in value:
+            section[key] = _coerce_number(value.get(key), f"metrics.{key}")
+    return section
+
+
+def _coerce_dedup_section(value: object) -> DedupSection | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ConfigStructureError("'dedup' must be a table.")
+    section: DedupSection = {}
+    for key in ("ttl_seconds", "max_records"):
+        if key in value:
+            section[key] = _coerce_number(value.get(key), f"dedup.{key}")
+    return section
+
+
+def _coerce_symbols_section(value: object) -> SymbolsSection | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ConfigStructureError("'symbols' must be a table.")
+    section: SymbolsSection = {}
+
+    selection = _coerce_symbol_selection_section(value.get("selection"))
+    if selection:
+        section["selection"] = selection
+
+    providers_raw = value.get("providers")
+    if providers_raw is not None:
+        section["providers"] = _coerce_symbol_provider_mapping(providers_raw)
+
+    return section
+
+
+def _coerce_symbol_selection_section(value: object) -> SymbolSelectionSection:
+    section: SymbolSelectionSection = {}
+    if value is None:
+        return section
+    if not isinstance(value, Mapping):
+        raise ConfigStructureError("'symbols.selection' must be a table.")
+    quote_suffix = value.get("quote_suffix")
+    if quote_suffix is not None:
+        section["quote_suffix"] = str(quote_suffix)
+    if "min_quote_volume" in value:
+        section["min_quote_volume"] = _coerce_number(
+            value.get("min_quote_volume"), "symbols.selection.min_quote_volume"
+        )
+    for key in ("allow", "deny"):
+        if key in value:
+            section[key] = _coerce_symbol_list(value.get(key), f"symbols.selection.{key}")
+    return section
+
+
+def _coerce_symbol_list(value: object, path: str) -> Sequence[str] | str:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        items: list[str] = []
+        for item in value:
+            if not isinstance(item, str):
+                raise ConfigStructureError(f"{path} items must be strings.")
+            items.append(item)
+        return tuple(items)
+    raise ConfigStructureError(f"{path} must be a string or sequence of strings.")
+
+
+def _coerce_symbol_provider_mapping(value: object) -> dict[str, str]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ConfigStructureError("'symbols.providers' must be a table.")
+    providers: dict[str, str] = {}
+    for key, raw_value in value.items():
+        if not isinstance(key, str) or not isinstance(raw_value, str):
+            raise ConfigStructureError(
+                "'symbols.providers' entries must map string symbols to strings."
+            )
+        providers[key] = raw_value
+    return providers
+
+
+def _coerce_thresholds_section(value: object) -> ThresholdsSection | None:
+    mapping: Mapping[str, object]
+    if value is None:
+        mapping = {}
+    elif isinstance(value, Mapping):
+        mapping = value
+    else:
+        raise ConfigStructureError("'thresholds' must be a table.")
+    section: ThresholdsSection = {}
+    section["default"] = _coerce_threshold_section(
+        mapping.get("default"), "thresholds.default"
+    )
+    symbols_raw = mapping.get("symbols")
+    if symbols_raw is not None:
+        if not isinstance(symbols_raw, Mapping):
+            raise ConfigStructureError("'thresholds.symbols' must be a table.")
+        symbols: dict[str, ThresholdSection] = {}
+        for key, raw_value in symbols_raw.items():
+            if not isinstance(key, str):
+                raise ConfigStructureError("Threshold symbol keys must be strings.")
+            symbols[key] = _coerce_threshold_section(
+                raw_value, f"thresholds.symbols.{key}"
+            )
+        section["symbols"] = symbols
+    return section
+
+
+def _coerce_threshold_section(value: object, path: str) -> ThresholdSection:
+    if value is None:
+        mapping: Mapping[str, object] = {}
+    elif isinstance(value, Mapping):
+        mapping = value
+    else:
+        raise ConfigStructureError(f"{path} must be a table.")
+
+    section: ThresholdSection = {}
+    identifier = mapping.get("id")
+    if identifier is not None:
+        if isinstance(identifier, (str, int, float, bool)):
+            section["id"] = identifier
+        else:
+            section["id"] = str(identifier)
+
+    min_relative = _coerce_float_from_keys(
+        mapping,
+        ["min_relative_volume", "minRelativeVolume", "S", "s"],
+        path,
+    )
+    if min_relative is not None:
+        section["min_relative_volume"] = min_relative
+    max_relative = _coerce_float_from_keys(
+        mapping,
+        ["max_relative_volume", "maxRelativeVolume", "T", "t"],
+        path,
+    )
+    if max_relative is not None:
+        section["max_relative_volume"] = max_relative
+    min_atr = _coerce_float_from_keys(
+        mapping, ["min_atr_mult", "minAtrMult", "U", "u"], path
+    )
+    if min_atr is not None:
+        section["min_atr_mult"] = min_atr
+    min_pct = _coerce_float_from_keys(
+        mapping, ["min_pct_move", "minPctMove", "V", "v"], path
+    )
+    if min_pct is not None:
+        section["min_pct_move"] = min_pct
+    max_pct = _coerce_float_from_keys(
+        mapping, ["max_pct_move", "maxPctMove", "W", "w"], path
+    )
+    if max_pct is not None:
+        section["max_pct_move"] = max_pct
+    max_upper = _coerce_float_from_keys(
+        mapping, ["max_upper_wick_pct", "maxUpperWickPct", "X", "x"], path
+    )
+    if max_upper is not None:
+        section["max_upper_wick_pct"] = max_upper
+    max_lower = _coerce_float_from_keys(
+        mapping, ["max_lower_wick_pct", "maxLowerWickPct", "Y", "y"], path
+    )
+    if max_lower is not None:
+        section["max_lower_wick_pct"] = max_lower
+
+    allow_long = mapping.get("allow_long")
+    if allow_long is not None:
+        section["allow_long"] = _coerce_boolish(allow_long, f"{path}.allow_long")
+    allow_short = mapping.get("allow_short")
+    if allow_short is not None:
+        section["allow_short"] = _coerce_boolish(allow_short, f"{path}.allow_short")
+
+    metrics_raw = mapping.get("metrics")
+    section["metrics"] = _coerce_threshold_metrics(metrics_raw, f"{path}.metrics")
+
+    section["short_pct_move_ranges"] = _coerce_range_sequence(
+        mapping.get("short_pct_move_ranges"), f"{path}.short_pct_move_ranges"
+    )
+    section["short_relative_volume_ranges"] = _coerce_range_sequence(
+        mapping.get("short_relative_volume_ranges"),
+        f"{path}.short_relative_volume_ranges",
+    )
+
+    metadata_raw = mapping.get("metadata")
+    if metadata_raw is not None:
+        section["metadata"] = _coerce_metadata(metadata_raw, f"{path}.metadata")
+
+    created_at = mapping.get("created_at")
+    if isinstance(created_at, (str, datetime)):
+        section["created_at"] = created_at
+    elif created_at is not None:
+        section["created_at"] = str(created_at)
+    updated_at = mapping.get("updated_at")
+    if isinstance(updated_at, (str, datetime)):
+        section["updated_at"] = updated_at
+    elif updated_at is not None:
+        section["updated_at"] = str(updated_at)
+
+    return section
+
+
+def _coerce_threshold_metrics(
+    value: object, path: str
+) -> Sequence[ThresholdMetricSection]:
+    if value is None:
+        return ()
+    if not isinstance(value, Sequence) or isinstance(value, (bytes, bytearray, str)):
+        raise ConfigStructureError(f"{path} must be an array of tables.")
+    metrics: list[ThresholdMetricSection] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            raise ConfigStructureError(f"{path}[{index}] must be a table.")
+        metrics.append(_coerce_threshold_metric(item))
+    return tuple(metrics)
+
+
+def _coerce_threshold_metric(raw: Mapping[str, object]) -> ThresholdMetricSection:
+    section: ThresholdMetricSection = {}
+    name_value = raw.get("name")
+    if name_value is not None:
+        section["name"] = str(name_value)
+    for key in ("min_value", "max_value", "min_abs_value"):
+        if key in raw:
+            section[key] = _coerce_number(raw.get(key), f"thresholds.metric.{key}")
+    return section
+
+
+def _coerce_range_sequence(value: object, path: str) -> Sequence[RangeEntry]:
+    if value is None:
+        return ()
+    if not isinstance(value, Sequence) or isinstance(value, (bytes, bytearray, str)):
+        raise ConfigStructureError(f"{path} must be an array.")
+    ranges: list[RangeEntry] = []
+    for index, entry in enumerate(value):
+        ranges.append(
+            _coerce_range_entry(entry, f"{path}[{index}]")
+        )
+    return tuple(ranges)
+
+
+def _coerce_range_entry(value: object, path: str) -> RangeEntry:
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        result: dict[str, NumberInput | None] = {}
+        for key, raw_value in value.items():
+            if not isinstance(key, str):
+                raise ConfigStructureError(f"{path} keys must be strings.")
+            result[key] = _coerce_number(raw_value, f"{path}.{key}")
+        return result
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        return tuple(_coerce_number(item, f"{path}[{index}]") for index, item in enumerate(value))
+    if isinstance(value, (str, int, float, bool)):
+        return _coerce_number(value, path)
+    raise ConfigStructureError(f"{path} must be a mapping, sequence, or number.")
+
+
+def _coerce_metadata(value: object, path: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ConfigStructureError(f"{path} must be a table.")
+    metadata: dict[str, object] = {}
+    for key, raw_value in value.items():
+        if not isinstance(key, str):
+            raise ConfigStructureError(f"{path} keys must be strings.")
+        metadata[key] = raw_value
+    return metadata
+
+
+def _coerce_backtest_section(value: object) -> BacktestSection | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ConfigStructureError("'backtest' must be a table.")
+    section: BacktestSection = {}
+    if "enabled" in value:
+        enabled_raw = value.get("enabled")
+        if enabled_raw is not None:
+            section["enabled"] = _coerce_boolish(enabled_raw, "backtest.enabled")
+    if "window" in value:
+        section["window"] = _coerce_number(value.get("window"), "backtest.window")
+    if "timeframes" in value:
+        section["timeframes"] = _coerce_timeframes(
+            value.get("timeframes"), "backtest.timeframes"
+        )
+    if "timeframe" in value:
+        timeframe_raw = value.get("timeframe")
+        if timeframe_raw is not None:
+            section["timeframe"] = timeframe_raw
+    if "limit" in value:
+        section["limit"] = _coerce_number(value.get("limit"), "backtest.limit")
+    if "history_batches" in value:
+        section["history_batches"] = _coerce_number(
+            value.get("history_batches"), "backtest.history_batches"
+        )
+    selection = _coerce_mode_selection_section(value, "backtest")
+    if "allow" in selection:
+        section["allow"] = selection["allow"]
+    if "deny" in selection:
+        section["deny"] = selection["deny"]
+    if "symbols" in selection:
+        section["symbols"] = selection["symbols"]
+    return section
+
+
+def _coerce_timeframes(value: object, path: str) -> Sequence[str | Timeframe]:
+    if value is None:
+        return ()
+    if isinstance(value, (str, Timeframe)):
+        return (value,)
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        items: list[str | Timeframe] = []
+        for index, item in enumerate(value):
+            if isinstance(item, (str, Timeframe)):
+                items.append(item)
+            else:
+                raise ConfigStructureError(
+                    f"{path}[{index}] must be a timeframe identifier."
+                )
+        return tuple(items)
+    raise ConfigStructureError(f"{path} must be a string or sequence of strings.")
+
+
+def _coerce_mode_selection_section(
+    value: Mapping[str, object], path: str
+) -> ModeSelectionSection:
+    section: ModeSelectionSection = {}
+    for key in ("allow", "deny", "symbols"):
+        if key in value:
+            section[key] = _coerce_symbol_list(value.get(key), f"{path}.{key}")
+    return section
+
+
+def _coerce_live_section(value: object) -> LiveSection | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ConfigStructureError("'live' must be a table.")
+    section: LiveSection = {}
+    if "enabled" in value:
+        enabled_raw = value.get("enabled")
+        if enabled_raw is not None:
+            section["enabled"] = _coerce_boolish(enabled_raw, "live.enabled")
+    if "providers" in value:
+        section["providers"] = _coerce_provider_sequence(
+            value.get("providers"), "live.providers"
+        )
+    if "provider" in value:
+        provider_raw = value.get("provider")
+        if provider_raw is not None:
+            section["provider"] = str(provider_raw)
+    if "timeframe" in value:
+        timeframe_raw = value.get("timeframe")
+        if timeframe_raw is not None:
+            section["timeframe"] = timeframe_raw
+    if "window" in value:
+        section["window"] = _coerce_number(value.get("window"), "live.window")
+    selection = _coerce_mode_selection_section(value, "live")
+    if "allow" in selection:
+        section["allow"] = selection["allow"]
+    if "deny" in selection:
+        section["deny"] = selection["deny"]
+    if "symbols" in selection:
+        section["symbols"] = selection["symbols"]
+    return section
+
+
+def _coerce_provider_sequence(value: object, path: str) -> Sequence[str] | str:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        providers: list[str] = []
+        for item in value:
+            if not isinstance(item, str):
+                raise ConfigStructureError(f"{path} entries must be strings.")
+            providers.append(item)
+        return tuple(providers)
+    raise ConfigStructureError(f"{path} must be a string or sequence of strings.")
+
+
+def _coerce_providers_section(value: object) -> ProvidersSection | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ConfigStructureError("'providers' must be a table.")
+    providers: ProvidersSection = {}
+    for key, raw_value in value.items():
+        if not isinstance(key, str):
+            raise ConfigStructureError("Provider names must be strings.")
+        providers[key] = _coerce_provider_section(raw_value, f"providers.{key}")
+    return providers
+
+
+def _coerce_provider_section(value: object, path: str) -> ProviderSection:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ConfigStructureError(f"{path} must be a table.")
+    section: ProviderSection = {}
+    api_base = value.get("api_base")
+    if api_base is not None:
+        section["api_base"] = str(api_base)
+    ws_base = value.get("ws_base")
+    if ws_base is not None:
+        section["ws_base"] = str(ws_base)
+    api_key = value.get("api_key")
+    if api_key is not None:
+        section["api_key"] = str(api_key)
+    api_key_env = value.get("api_key_env")
+    if api_key_env is not None:
+        section["api_key_env"] = str(api_key_env)
+    api_secret = value.get("api_secret")
+    if api_secret is not None:
+        section["api_secret"] = str(api_secret)
+    api_secret_env = value.get("api_secret_env")
+    if api_secret_env is not None:
+        section["api_secret_env"] = str(api_secret_env)
+    rate_limit = _coerce_number(value.get("rate_limit_per_minute"), f"{path}.rate_limit_per_minute")
+    if rate_limit is not None:
+        section["rate_limit_per_minute"] = rate_limit
+    min_volume = _coerce_number(value.get("min_quote_volume"), f"{path}.min_quote_volume")
+    if min_volume is not None:
+        section["min_quote_volume"] = min_volume
+    return section
+
+
+def _coerce_boolish(value: object, path: str) -> bool | str | int | float:
+    if isinstance(value, (bool, str, int, float)):
+        return value
+    if value is None:
+        return False
+    raise ConfigStructureError(f"{path} must be a boolean, number, or string.")
+
+
+def _coerce_number(value: object, path: str) -> NumberInput:
+    if value is None:
+        return None
+    if isinstance(value, (int, float, bool, str)):
+        return value
+    raise ConfigStructureError(f"{path} must be numeric or string.")
+
+
+def _coerce_optional_float_value(value: NumberInput, path: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return float(value)
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            return float(stripped)
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise ConfigStructureError(f"{path} must be numeric.") from exc
+    raise ConfigStructureError(f"{path} must be numeric.")
+
+
+def _coerce_float_from_keys(
+    mapping: Mapping[str, object], keys: Sequence[str], path: str
+) -> float | None:
+    for key in keys:
+        if key in mapping:
+            number = _coerce_optional_float_value(
+                _coerce_number(mapping.get(key), f"{path}.{key}"),
+                f"{path}.{key}",
+            )
+            if number is not None:
+                return number
+    return None
+
+

--- a/bot/data/io/config_models.py
+++ b/bot/data/io/config_models.py
@@ -4,13 +4,32 @@ import os
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any, Iterable, Mapping, Sequence, Tuple, TypeVar
+from typing import Iterable, Mapping, Sequence, Tuple, TypeVar, cast
 
 from ...app_modes import AppMode
 from ...domain.enums import Timeframe
 from ...domain.models.entities import ThresholdMetric as DomainThresholdMetric
 from ...domain.models.entities import Thresholds as DomainThresholds
 from ...domain.models.metadata import ThresholdsMetadata
+from .config_types import (
+    BacktestSection,
+    DedupSection,
+    LiveSection,
+    LoggingSection,
+    MetricsSection,
+    ModeSelectionSection,
+    NumberInput,
+    ProviderSection,
+    ProvidersSection,
+    RangeEntry,
+    StorageSection,
+    SymbolSelectionSection,
+    SymbolSetInput,
+    ThresholdMetricSection,
+    ThresholdSection,
+    ThresholdsSection,
+    TimeSection,
+)
 
 
 _DEFAULT_BACKTEST_TIMEFRAMES: tuple[Timeframe, ...] = (
@@ -21,7 +40,7 @@ _DEFAULT_BACKTEST_TIMEFRAMES: tuple[Timeframe, ...] = (
 )
 
 
-def _to_optional_float(value: Any) -> float | None:
+def _to_optional_float(value: NumberInput) -> float | None:
     if value is None:
         return None
     if isinstance(value, (int, float)):
@@ -34,7 +53,7 @@ def _to_optional_float(value: Any) -> float | None:
     return None
 
 
-def _to_bool(value: Any, default: bool) -> bool:
+def _to_bool(value: bool | str | int | float | None, default: bool) -> bool:
     if isinstance(value, bool):
         return value
     if isinstance(value, str):
@@ -48,7 +67,7 @@ def _to_bool(value: Any, default: bool) -> bool:
     return bool(value)
 
 
-def _to_int(value: Any, default: int, minimum: int | None = None) -> int:
+def _to_int(value: NumberInput, default: int, minimum: int | None = None) -> int:
     if isinstance(value, bool):
         candidate: int | None = 1 if value else 0
     elif isinstance(value, (int, float)):
@@ -67,7 +86,7 @@ def _to_int(value: Any, default: int, minimum: int | None = None) -> int:
     return candidate
 
 
-def _to_optional_int(value: Any) -> int | None:
+def _to_optional_int(value: NumberInput) -> int | None:
     if value is None:
         return None
     if isinstance(value, bool):
@@ -82,18 +101,23 @@ def _to_optional_int(value: Any) -> int | None:
     return None
 
 
-def _normalize_symbol_set(value: Any) -> frozenset[str]:
+def _normalize_symbol_set(value: SymbolSetInput | Sequence[str] | None) -> frozenset[str]:
+    if value is None:
+        return frozenset()
     symbols: set[str] = set()
     if isinstance(value, str):
-        value = [value]
-    if isinstance(value, Iterable):
-        for item in value:
-            if isinstance(item, str) and item.strip():
-                symbols.add(item.strip().upper())
+        items: Iterable[str] = [value]
+    elif isinstance(value, Sequence):
+        items = value
+    else:
+        return frozenset()
+    for item in items:
+        if isinstance(item, str) and item.strip():
+            symbols.add(item.strip().upper())
     return frozenset(symbols)
 
 
-def _parse_range_entry(entry: Any) -> tuple[float | None, float | None] | None:
+def _parse_range_entry(entry: RangeEntry) -> tuple[float | None, float | None] | None:
     min_value: float | None = None
     max_value: float | None = None
     if isinstance(entry, Mapping):
@@ -117,8 +141,10 @@ def _parse_range_entry(entry: Any) -> tuple[float | None, float | None] | None:
     return (min_value, max_value)
 
 
-def _parse_range_list(source: Any) -> tuple[tuple[float | None, float | None], ...]:
-    if not isinstance(source, Iterable) or isinstance(source, (str, bytes, bytearray)):
+def _parse_range_list(
+    source: Sequence[RangeEntry] | None,
+) -> tuple[tuple[float | None, float | None], ...]:
+    if not source:
         return tuple()
     parsed: list[tuple[float | None, float | None]] = []
     for entry in source:
@@ -128,7 +154,7 @@ def _parse_range_list(source: Any) -> tuple[tuple[float | None, float | None], .
     return tuple(parsed)
 
 
-def _parse_datetime(value: Any) -> datetime | None:
+def _parse_datetime(value: datetime | str | None) -> datetime | None:
     if isinstance(value, datetime):
         return value
     if isinstance(value, str) and value.strip():
@@ -143,7 +169,7 @@ def _float_or_default(value: float | None) -> float:
     return value if value is not None else 0.0
 
 
-def _normalize_str(value: Any) -> str | None:
+def _normalize_str(value: str | int | float | bool | None) -> str | None:
     if value is None:
         return None
     if isinstance(value, str):
@@ -157,18 +183,15 @@ class StorageConfig:
     path: str = "var/state.xlsx"
 
     @classmethod
-    def from_raw(cls, raw: Any) -> "StorageConfig":
-        path_value: Any
-        if isinstance(raw, Mapping):
-            path_value = raw.get("path")
-        else:
-            path_value = raw
-        if isinstance(path_value, str):
-            candidate = path_value.strip()
-            if candidate:
-                return cls(path=candidate)
-        elif path_value is not None:
-            return cls(path=str(path_value))
+    def from_raw(cls, raw: StorageSection | None) -> "StorageConfig":
+        if not raw:
+            return cls()
+        path_value = raw.get("path")
+        if path_value is None:
+            return cls()
+        candidate = str(path_value).strip()
+        if candidate:
+            return cls(path=candidate)
         return cls()
 
 
@@ -177,22 +200,19 @@ class LoggingConfig:
     level: str = "INFO"
 
     @classmethod
-    def from_raw(cls, raw: Any) -> "LoggingConfig":
-        level_value: Any
-        if isinstance(raw, Mapping):
-            level_value = raw.get("level")
-        else:
-            level_value = raw
-        if isinstance(level_value, str):
-            candidate = level_value.strip()
-            if candidate:
-                return cls(level=candidate.upper())
-        elif level_value is not None:
-            return cls(level=str(level_value).upper())
+    def from_raw(cls, raw: LoggingSection | None) -> "LoggingConfig":
+        if not raw:
+            return cls()
+        level_value = raw.get("level")
+        if level_value is None:
+            return cls()
+        candidate = str(level_value).strip()
+        if candidate:
+            return cls(level=candidate.upper())
         return cls()
 
 
-def _parse_optional_mode(value: Any) -> AppMode | None:
+def _parse_optional_mode(value: str | AppMode | None) -> AppMode | None:
     if value is None:
         return None
     if isinstance(value, str) and not value.strip():
@@ -206,20 +226,16 @@ class TimeConfig:
     mode: AppMode | None = None
 
     @classmethod
-    def from_raw(cls, raw: Any) -> "TimeConfig":
+    def from_raw(cls, raw: TimeSection | None) -> "TimeConfig":
         zone = "UTC"
         mode: AppMode | None = None
-        if isinstance(raw, Mapping):
+        if raw:
             zone_raw = raw.get("zone")
-            if isinstance(zone_raw, str) and zone_raw.strip():
-                zone = zone_raw.strip()
-            elif zone_raw is not None:
-                zone = str(zone_raw)
+            if zone_raw is not None:
+                candidate = str(zone_raw).strip()
+                if candidate:
+                    zone = candidate
             mode = _parse_optional_mode(raw.get("mode"))
-        elif isinstance(raw, str) and raw.strip():
-            zone = raw.strip()
-        elif raw is not None:
-            zone = str(raw)
         return cls(zone=zone, mode=mode)
 
 
@@ -230,10 +246,12 @@ class ProviderCredential:
 
     @classmethod
     def from_mapping(
-        cls, raw: Mapping[str, Any], key: str, default_env: str | None = None
+        cls, raw: ProviderSection, key: str, default_env: str | None = None
     ) -> "ProviderCredential":
-        value = _normalize_str(raw.get(key))
-        env_key = _normalize_str(raw.get(f"{key}_env"))
+        value = _normalize_str(cast(str | int | float | bool | None, raw.get(key)))
+        env_key = _normalize_str(
+            cast(str | int | float | bool | None, raw.get(f"{key}_env"))
+        )
         if env_key is None:
             env_key = default_env
         return cls(value=value, env_key=env_key)
@@ -280,20 +298,22 @@ class ExchangeProviderConfig:
     def from_mapping(
         cls: type[ProviderConfigT],
         name: str,
-        raw: Mapping[str, Any] | None,
+        raw: ProviderSection | None,
     ) -> ProviderConfigT:
-        if raw is None or not isinstance(raw, Mapping):
-            raw = {}
+        if raw is None:
+            data: ProviderSection = ProviderSection()
+        else:
+            data = raw
         prefix = name.upper()
-        api_base = _normalize_str(raw.get("api_base")) or ""
-        ws_base = _normalize_str(raw.get("ws_base")) or ""
-        rate_limit = _to_int(raw.get("rate_limit_per_minute"), 60, minimum=1)
-        min_volume = _to_optional_float(raw.get("min_quote_volume")) or 0.0
+        api_base = _normalize_str(data.get("api_base")) or ""
+        ws_base = _normalize_str(data.get("ws_base")) or ""
+        rate_limit = _to_int(data.get("rate_limit_per_minute"), 60, minimum=1)
+        min_volume = _to_optional_float(data.get("min_quote_volume")) or 0.0
         api_key = ProviderCredential.from_mapping(
-            raw, "api_key", f"{prefix}_API_KEY"
+            data, "api_key", f"{prefix}_API_KEY"
         )
         api_secret = ProviderCredential.from_mapping(
-            raw, "api_secret", f"{prefix}_API_SECRET"
+            data, "api_secret", f"{prefix}_API_SECRET"
         )
         instance = cls(
             name=name,
@@ -337,19 +357,16 @@ _PROVIDER_CONFIG_TYPES: dict[str, tuple[ProviderKind, type[ExchangeProviderConfi
 
 
 def parse_exchange_provider_configs(
-    raw: Any,
+    raw: ProvidersSection | None,
 ) -> dict[str, ExchangeProviderConfig]:
-    if not isinstance(raw, Mapping):
+    if not raw:
         return {}
     providers: dict[str, ExchangeProviderConfig] = {}
     for name, value in raw.items():
-        if not isinstance(name, str):
-            continue
         kind, config_cls = _PROVIDER_CONFIG_TYPES.get(
             name.lower(), (ProviderKind.GENERIC, ExchangeProviderConfig)
         )
-        mapping = value if isinstance(value, Mapping) else {}
-        config = config_cls.from_mapping(name, mapping)
+        config = config_cls.from_mapping(name, value)
         config.kind = kind
         providers[name] = config
     return providers
@@ -362,13 +379,15 @@ class MetricsConfig:
     momentum_period: int = 5
 
     @classmethod
-    def from_raw(cls, raw: Any) -> "MetricsConfig":
-        if not isinstance(raw, Mapping):
-            raw = {}
+    def from_raw(cls, raw: MetricsSection | None) -> "MetricsConfig":
+        if raw is None:
+            data: MetricsSection = MetricsSection()
+        else:
+            data = raw
         return cls(
-            atr_period=_to_int(raw.get("atr_period"), 14, minimum=1),
-            volume_period=_to_int(raw.get("volume_period"), 20, minimum=1),
-            momentum_period=_to_int(raw.get("momentum_period"), 5, minimum=1),
+            atr_period=_to_int(data.get("atr_period"), 14, minimum=1),
+            volume_period=_to_int(data.get("volume_period"), 20, minimum=1),
+            momentum_period=_to_int(data.get("momentum_period"), 5, minimum=1),
         )
 
 
@@ -378,12 +397,14 @@ class DedupConfig:
     max_records: int = 1_000
 
     @classmethod
-    def from_raw(cls, raw: Any) -> "DedupConfig":
-        if not isinstance(raw, Mapping):
-            raw = {}
+    def from_raw(cls, raw: DedupSection | None) -> "DedupConfig":
+        if raw is None:
+            data: DedupSection = DedupSection()
+        else:
+            data = raw
         return cls(
-            ttl_seconds=_to_int(raw.get("ttl_seconds"), 14_400, minimum=1),
-            max_records=_to_int(raw.get("max_records"), 1_000, minimum=1),
+            ttl_seconds=_to_int(data.get("ttl_seconds"), 14_400, minimum=1),
+            max_records=_to_int(data.get("max_records"), 1_000, minimum=1),
         )
 
 
@@ -395,12 +416,15 @@ class ThresholdMetricConfig:
     min_abs_value: float | None = None
 
     @classmethod
-    def from_mapping(cls, raw: Mapping[str, Any]) -> "ThresholdMetricConfig" | None:
+    def from_mapping(cls, raw: ThresholdMetricSection) -> "ThresholdMetricConfig" | None:
         name = raw.get("name")
-        if not isinstance(name, str) or not name.strip():
+        if name is None:
+            return None
+        candidate = name.strip()
+        if not candidate:
             return None
         return cls(
-            name=name.strip(),
+            name=candidate,
             min_value=_to_optional_float(raw.get("min_value")),
             max_value=_to_optional_float(raw.get("max_value")),
             min_abs_value=_to_optional_float(raw.get("min_abs_value")),
@@ -439,40 +463,40 @@ class ThresholdConfig:
     updated_at: datetime | None = None
 
     @classmethod
-    def from_mapping(cls, raw: Mapping[str, Any] | None) -> "ThresholdConfig":
-        if raw is None or not isinstance(raw, Mapping):
-            raw = {}
-        metadata_raw = raw.get("metadata")
+    def from_mapping(cls, raw: ThresholdSection | None) -> "ThresholdConfig":
+        if raw is None:
+            data: ThresholdSection = ThresholdSection()
+        else:
+            data = raw
+        metadata_raw = data.get("metadata")
         metadata = ThresholdsMetadata.from_mapping(
             metadata_raw if isinstance(metadata_raw, Mapping) else None
         )
-        metrics_raw = raw.get("metrics")
+        metrics_raw = data.get("metrics") or ()
         metrics: list[ThresholdMetricConfig] = []
-        if isinstance(metrics_raw, Iterable) and not isinstance(
-            metrics_raw, (str, bytes, bytearray)
-        ):
-            for item in metrics_raw:
-                if isinstance(item, Mapping):
-                    metric = ThresholdMetricConfig.from_mapping(item)
-                    if metric is not None:
-                        metrics.append(metric)
-        short_pct_move_ranges = _parse_range_list(raw.get("short_pct_move_ranges"))
+        for item in metrics_raw:
+            metric = ThresholdMetricConfig.from_mapping(item)
+            if metric is not None:
+                metrics.append(metric)
+        short_pct_move_ranges = _parse_range_list(
+            data.get("short_pct_move_ranges")
+        )
         metadata_extra = metadata.extra if metadata else {}
         if not short_pct_move_ranges and metadata_extra:
             short_pct_move_ranges = _parse_range_list(
                 metadata_extra.get("short_pct_move_ranges")
             )
         short_relative_volume_ranges = _parse_range_list(
-            raw.get("short_relative_volume_ranges")
+            data.get("short_relative_volume_ranges")
         )
         if not short_relative_volume_ranges and metadata_extra:
             short_relative_volume_ranges = _parse_range_list(
                 metadata_extra.get("short_relative_volume_ranges")
             )
         return cls(
-            id=str(raw.get("id")) if raw.get("id") is not None else None,
+            id=str(data.get("id")) if data.get("id") is not None else None,
             min_relative_volume=_coerce_from_keys(
-                raw,
+                data,
                 [
                     "min_relative_volume",
                     "minRelativeVolume",
@@ -481,7 +505,7 @@ class ThresholdConfig:
                 ],
             ),
             max_relative_volume=_coerce_from_keys(
-                raw,
+                data,
                 [
                     "max_relative_volume",
                     "maxRelativeVolume",
@@ -489,23 +513,29 @@ class ThresholdConfig:
                     "t",
                 ],
             ),
-            min_atr_mult=_coerce_from_keys(raw, ["min_atr_mult", "minAtrMult", "U", "u"]),
-            min_pct_move=_coerce_from_keys(raw, ["min_pct_move", "minPctMove", "V", "v"]),
-            max_pct_move=_coerce_from_keys(raw, ["max_pct_move", "maxPctMove", "W", "w"]),
+            min_atr_mult=_coerce_from_keys(
+                data, ["min_atr_mult", "minAtrMult", "U", "u"]
+            ),
+            min_pct_move=_coerce_from_keys(
+                data, ["min_pct_move", "minPctMove", "V", "v"]
+            ),
+            max_pct_move=_coerce_from_keys(
+                data, ["max_pct_move", "maxPctMove", "W", "w"]
+            ),
             max_upper_wick_pct=_coerce_from_keys(
-                raw, ["max_upper_wick_pct", "maxUpperWickPct", "X", "x"]
+                data, ["max_upper_wick_pct", "maxUpperWickPct", "X", "x"]
             ),
             max_lower_wick_pct=_coerce_from_keys(
-                raw, ["max_lower_wick_pct", "maxLowerWickPct", "Y", "y"]
+                data, ["max_lower_wick_pct", "maxLowerWickPct", "Y", "y"]
             ),
-            allow_long=_to_bool(raw.get("allow_long"), True),
-            allow_short=_to_bool(raw.get("allow_short"), True),
+            allow_long=_to_bool(data.get("allow_long"), True),
+            allow_short=_to_bool(data.get("allow_short"), True),
             metrics=tuple(metrics),
             short_pct_move_ranges=short_pct_move_ranges,
             short_relative_volume_ranges=short_relative_volume_ranges,
             metadata=metadata,
-            created_at=_parse_datetime(raw.get("created_at")),
-            updated_at=_parse_datetime(raw.get("updated_at")),
+            created_at=_parse_datetime(data.get("created_at")),
+            updated_at=_parse_datetime(data.get("updated_at")),
         )
 
     def to_domain(self) -> DomainThresholds:
@@ -530,13 +560,17 @@ class ThresholdConfig:
 
 
 def _coerce_from_keys(
-    raw: Mapping[str, Any], keys: Sequence[str], fallback: float | None = None
+    raw: Mapping[str, object],
+    keys: Sequence[str],
+    fallback: float | None = None,
 ) -> float | None:
     for key in keys:
         if key in raw:
-            value = _to_optional_float(raw.get(key))
-            if value is not None:
-                return value
+            candidate = raw.get(key)
+            if isinstance(candidate, (str, int, float, bool)) or candidate is None:
+                value = _to_optional_float(candidate)
+                if value is not None:
+                    return value
     return fallback
 
 
@@ -546,17 +580,16 @@ class ThresholdsConfig:
     symbols: dict[str, ThresholdConfig]
 
     @classmethod
-    def from_raw(cls, raw: Any) -> "ThresholdsConfig":
-        if not isinstance(raw, Mapping):
-            raw = {}
-        default_raw = raw.get("default") if isinstance(raw, Mapping) else None
-        default_cfg = ThresholdConfig.from_mapping(default_raw)
+    def from_raw(cls, raw: ThresholdsSection | None) -> "ThresholdsConfig":
+        if raw is None:
+            data: ThresholdsSection = ThresholdsSection()
+        else:
+            data = raw
+        default_cfg = ThresholdConfig.from_mapping(data.get("default"))
         symbols_cfg: dict[str, ThresholdConfig] = {}
-        symbols_raw = raw.get("symbols") if isinstance(raw, Mapping) else None
-        if isinstance(symbols_raw, Mapping):
-            for key, value in symbols_raw.items():
-                if isinstance(key, str):
-                    symbols_cfg[key] = ThresholdConfig.from_mapping(value)
+        symbols_raw = data.get("symbols") or {}
+        for key, value in symbols_raw.items():
+            symbols_cfg[key] = ThresholdConfig.from_mapping(value)
         return cls(default=default_cfg, symbols=symbols_cfg)
 
 
@@ -568,19 +601,24 @@ class SymbolSelectionConfig:
     deny: frozenset[str] = field(default_factory=frozenset)
 
     @classmethod
-    def from_raw(cls, raw: Any) -> "SymbolSelectionConfig":
-        if not isinstance(raw, Mapping):
-            raw = {}
-        quote_suffix_raw = raw.get("quote_suffix", "USDT")
-        quote_suffix = str(quote_suffix_raw).upper() if quote_suffix_raw is not None else "USDT"
-        if not quote_suffix:
-            quote_suffix = "USDT"
-        min_quote_volume = _to_optional_float(raw.get("min_quote_volume")) or 5_000_000.0
+    def from_raw(cls, raw: SymbolSelectionSection | None) -> "SymbolSelectionConfig":
+        if raw is None:
+            data: SymbolSelectionSection = SymbolSelectionSection()
+        else:
+            data = raw
+        quote_suffix = "USDT"
+        quote_suffix_raw = data.get("quote_suffix")
+        if quote_suffix_raw is not None:
+            candidate = str(quote_suffix_raw).strip().upper()
+            if candidate:
+                quote_suffix = candidate
+        min_volume_value = data.get("min_quote_volume")
+        min_quote_volume = _to_optional_float(min_volume_value) or 5_000_000.0
         return cls(
             quote_suffix=quote_suffix,
             min_quote_volume=min_quote_volume,
-            allow=_normalize_symbol_set(raw.get("allow")),
-            deny=_normalize_symbol_set(raw.get("deny")),
+            allow=_normalize_symbol_set(data.get("allow")),
+            deny=_normalize_symbol_set(data.get("deny")),
         )
 
 
@@ -591,13 +629,15 @@ class ModeSelectionOverrides:
     symbols: frozenset[str] = field(default_factory=frozenset)
 
     @classmethod
-    def from_raw(cls, raw: Any) -> "ModeSelectionOverrides":
-        if not isinstance(raw, Mapping):
-            raw = {}
+    def from_raw(cls, raw: ModeSelectionSection | None) -> "ModeSelectionOverrides":
+        if raw is None:
+            data: ModeSelectionSection = ModeSelectionSection()
+        else:
+            data = raw
         return cls(
-            allow=_normalize_symbol_set(raw.get("allow")),
-            deny=_normalize_symbol_set(raw.get("deny")),
-            symbols=_normalize_symbol_set(raw.get("symbols")),
+            allow=_normalize_symbol_set(data.get("allow")),
+            deny=_normalize_symbol_set(data.get("deny")),
+            symbols=_normalize_symbol_set(data.get("symbols")),
         )
 
 
@@ -611,22 +651,24 @@ class BacktestConfig:
     selection: ModeSelectionOverrides
 
     @classmethod
-    def from_raw(cls, raw: Any) -> "BacktestConfig":
-        if not isinstance(raw, Mapping):
-            raw = {}
-        enabled = _to_bool(raw.get("enabled"), True)
-        window = _to_int(raw.get("window"), 50, minimum=1)
-        timeframes = _parse_timeframes(raw.get("timeframes"))
+    def from_raw(cls, raw: BacktestSection | None) -> "BacktestConfig":
+        if raw is None:
+            data: BacktestSection = BacktestSection()
+        else:
+            data = raw
+        enabled = _to_bool(data.get("enabled"), True)
+        window = _to_int(data.get("window"), 50, minimum=1)
+        timeframes = _parse_timeframes(data.get("timeframes"))
         if not timeframes:
-            single_timeframe = raw.get("timeframe")
+            single_timeframe = data.get("timeframe")
             timeframe_value = _parse_timeframe(single_timeframe)
             if timeframe_value is not None:
                 timeframes = (timeframe_value,)
         if not timeframes:
             timeframes = _DEFAULT_BACKTEST_TIMEFRAMES
-        limit = _to_optional_int(raw.get("limit"))
-        history_batches = _to_int(raw.get("history_batches"), 10, minimum=1)
-        selection = ModeSelectionOverrides.from_raw(raw)
+        limit = _to_optional_int(data.get("limit"))
+        history_batches = _to_int(data.get("history_batches"), 10, minimum=1)
+        selection = ModeSelectionOverrides.from_raw(data)
         return cls(
             enabled=enabled,
             window=window,
@@ -637,20 +679,26 @@ class BacktestConfig:
         )
 
 
-def _parse_timeframes(value: Any) -> tuple[Timeframe, ...]:
+def _parse_timeframes(
+    value: Sequence[str | Timeframe] | str | Timeframe | None,
+) -> tuple[Timeframe, ...]:
+    if value is None:
+        return tuple()
     if isinstance(value, (str, Timeframe)):
-        value = [value]
-    if not isinstance(value, Iterable) or isinstance(value, (bytes, bytearray)):
+        candidates: Iterable[str | Timeframe] = [value]
+    elif isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray)):
+        candidates = value
+    else:
         return tuple()
     parsed: list[Timeframe] = []
-    for item in value:
+    for item in candidates:
         timeframe = _parse_timeframe(item)
         if timeframe is not None:
             parsed.append(timeframe)
     return tuple(parsed)
 
 
-def _parse_timeframe(value: Any) -> Timeframe | None:
+def _parse_timeframe(value: str | Timeframe | None) -> Timeframe | None:
     if isinstance(value, Timeframe):
         return value
     if isinstance(value, str) and value.strip():
@@ -670,14 +718,16 @@ class LiveConfig:
     selection: ModeSelectionOverrides
 
     @classmethod
-    def from_raw(cls, raw: Any) -> "LiveConfig":
-        if not isinstance(raw, Mapping):
-            raw = {}
-        enabled = _to_bool(raw.get("enabled"), True)
-        providers = _parse_providers(raw)
-        timeframe = _parse_timeframe(raw.get("timeframe")) or Timeframe.M5
-        window = _to_int(raw.get("window"), 50, minimum=1)
-        selection = ModeSelectionOverrides.from_raw(raw)
+    def from_raw(cls, raw: LiveSection | None) -> "LiveConfig":
+        if raw is None:
+            data: LiveSection = LiveSection()
+        else:
+            data = raw
+        enabled = _to_bool(data.get("enabled"), True)
+        providers = _parse_providers(data)
+        timeframe = _parse_timeframe(data.get("timeframe")) or Timeframe.M5
+        window = _to_int(data.get("window"), 50, minimum=1)
+        selection = ModeSelectionOverrides.from_raw(data)
         return cls(
             enabled=enabled,
             providers=providers,
@@ -687,33 +737,36 @@ class LiveConfig:
         )
 
 
-def _parse_providers(raw: Mapping[str, Any]) -> tuple[str, ...]:
+def _parse_providers(raw: LiveSection) -> tuple[str, ...]:
     providers_value = raw.get("providers")
+    providers: list[str]
     if isinstance(providers_value, str):
-        providers = [providers_value]
-    elif isinstance(providers_value, Iterable) and not isinstance(
-        providers_value, (bytes, bytearray)
+        candidate = providers_value.strip()
+        providers = [candidate] if candidate else []
+    elif isinstance(providers_value, Sequence) and not isinstance(
+        providers_value, (bytes, bytearray, str)
     ):
         providers = [
-            str(value)
-            for value in providers_value
-            if isinstance(value, str) and value.strip()
+            item.strip()
+            for item in providers_value
+            if isinstance(item, str) and item.strip()
         ]
     else:
         providers = []
     if not providers:
         single = raw.get("provider")
-        if isinstance(single, str) and single.strip():
-            providers = [single.strip()]
+        if isinstance(single, str):
+            candidate = single.strip()
+            if candidate:
+                providers = [candidate]
     return tuple(providers)
 
 
-def parse_symbol_provider_mapping(raw: Any) -> dict[str, str]:
+def parse_symbol_provider_mapping(raw: dict[str, str] | None) -> dict[str, str]:
+    if not raw:
+        return {}
     mapping: dict[str, str] = {}
-    if isinstance(raw, Mapping):
-        for key, value in raw.items():
-            if not isinstance(key, str) or not isinstance(value, str):
-                continue
-            normalized = "default" if key.lower() == "default" else key.upper()
-            mapping[normalized] = value
+    for key, value in raw.items():
+        normalized = "default" if key.lower() == "default" else key.upper()
+        mapping[normalized] = value
     return mapping

--- a/bot/data/io/config_types.py
+++ b/bot/data/io/config_types.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Mapping, Sequence, TypedDict
+
+from ...domain.enums import Timeframe
+
+TomlPrimitive = str | int | float | bool | None
+NumberInput = int | float | str | bool | None
+SymbolSetInput = str | Sequence[str]
+RangeEntry = (
+    Mapping[str, NumberInput | None]
+    | Sequence[NumberInput | None]
+    | NumberInput
+    | None
+)
+
+
+class StorageSection(TypedDict, total=False):
+    path: str
+
+
+class LoggingSection(TypedDict, total=False):
+    level: str
+
+
+class TimeSection(TypedDict, total=False):
+    zone: str
+    mode: str
+
+
+class MetricsSection(TypedDict, total=False):
+    atr_period: NumberInput
+    volume_period: NumberInput
+    momentum_period: NumberInput
+
+
+class DedupSection(TypedDict, total=False):
+    ttl_seconds: NumberInput
+    max_records: NumberInput
+
+
+class ModeSelectionSection(TypedDict, total=False):
+    allow: SymbolSetInput
+    deny: SymbolSetInput
+    symbols: SymbolSetInput
+
+
+class SymbolSelectionSection(ModeSelectionSection, total=False):
+    quote_suffix: str
+    min_quote_volume: NumberInput
+
+
+class SymbolsSection(TypedDict, total=False):
+    selection: SymbolSelectionSection
+    providers: dict[str, str]
+
+
+class BacktestSection(ModeSelectionSection, total=False):
+    enabled: bool | str | int | float
+    window: NumberInput
+    timeframes: Sequence[str | Timeframe]
+    timeframe: str | Timeframe
+    limit: NumberInput
+    history_batches: NumberInput
+
+
+class LiveSection(ModeSelectionSection, total=False):
+    enabled: bool | str | int | float
+    providers: Sequence[str] | str
+    provider: str
+    timeframe: str | Timeframe
+    window: NumberInput
+
+
+class ProviderSection(TypedDict, total=False):
+    api_base: str
+    ws_base: str
+    rate_limit_per_minute: NumberInput
+    min_quote_volume: NumberInput
+    api_key: str
+    api_key_env: str
+    api_secret: str
+    api_secret_env: str
+
+
+ProvidersSection = dict[str, ProviderSection]
+
+
+class ThresholdMetricSection(TypedDict, total=False):
+    name: str
+    min_value: NumberInput
+    max_value: NumberInput
+    min_abs_value: NumberInput
+
+
+class ThresholdSection(TypedDict, total=False):
+    id: str | int | float | bool
+    min_relative_volume: NumberInput
+    max_relative_volume: NumberInput
+    min_atr_mult: NumberInput
+    min_pct_move: NumberInput
+    max_pct_move: NumberInput
+    max_upper_wick_pct: NumberInput
+    max_lower_wick_pct: NumberInput
+    allow_long: bool | str | int | float
+    allow_short: bool | str | int | float
+    metrics: Sequence[ThresholdMetricSection]
+    short_pct_move_ranges: Sequence[RangeEntry]
+    short_relative_volume_ranges: Sequence[RangeEntry]
+    metadata: Mapping[str, object]
+    created_at: str | datetime
+    updated_at: str | datetime
+
+
+class ThresholdsSection(TypedDict, total=False):
+    default: ThresholdSection
+    symbols: dict[str, ThresholdSection]
+
+
+class AppConfigData(TypedDict, total=False):
+    mode: str
+    env: dict[str, str]
+    storage: StorageSection
+    logging: LoggingSection
+    time: TimeSection
+    thresholds: ThresholdsSection
+    symbols: SymbolsSection
+    backtest: BacktestSection
+    live: LiveSection
+    metrics: MetricsSection
+    dedup: DedupSection
+    providers: ProvidersSection

--- a/tests/test_config_parsing.py
+++ b/tests/test_config_parsing.py
@@ -1,6 +1,12 @@
+import shutil
+import subprocess
+import sys
+
+import pytest
+
 from bot.app import build_thresholds
 from bot.app_modes import AppMode
-from bot.data.io.config_loader import AppConfig
+from bot.data.io.config_loader import AppConfig, ConfigStructureError
 from bot.data.io.config_models import (
     BinanceProviderConfig,
     BybitProviderConfig,
@@ -191,3 +197,31 @@ def test_provider_configs_are_typed_and_resolve_credentials(monkeypatch) -> None
     assert bybit_cfg.api_secret_env == "BYBIT_API_SECRET"
     assert bybit_cfg.get_api_key(config.env) == "from-env"
     assert bybit_cfg.get_api_secret(config.env) == "super-secret"
+
+
+def test_invalid_symbols_section_raises() -> None:
+    with pytest.raises(ConfigStructureError):
+        AppConfig(raw={"symbols": []})
+
+
+def test_mypy_strict_on_io_module() -> None:
+    if shutil.which("mypy") is None:
+        pytest.skip("mypy is not installed")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "mypy",
+            "--strict",
+            "--ignore-missing-imports",
+            "--follow-imports=skip",
+            "bot/data/io/config_loader.py",
+            "bot/data/io/config_models.py",
+            "bot/data/io/config_types.py",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout


### PR DESCRIPTION
## Summary
* add TypedDict definitions for the configuration schema and reuse them across the loader and models for strong typing
* tighten config parsing by coercing TOML data into the new typed sections and surfacing clear structure errors
* adjust configuration models and tests to align with the typed inputs and enforce mypy --strict on the IO module

## Testing
* `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cd3a7502708320a6ee15c8304fde74