### PR TITLE
Expose rate limiter property on exchange providers

### DIFF
--- a/bot/data/providers/base.py
+++ b/bot/data/providers/base.py
@@ -44,6 +44,10 @@ class BaseExchangeProvider:
         self._min_quote_volume = min_quote_volume
         self._logger = get_logger(self.__class__.__name__)
 
+    @property
+    def rate_limiter(self) -> RateLimiter:
+        return self._rate_limiter
+
     async def _filter_liquidity(self, candles: Sequence[Candle]) -> List[Candle]:
         filtered: List[Candle] = []
         for candle in candles:
@@ -91,9 +95,6 @@ class BaseExchangeProvider:
         self, entries: Iterable[OhlcvSnapshot], symbol: str, timeframe: Timeframe
     ) -> List[Candle]:
         return [map_ohlcv(item, symbol, self.exchange, timeframe) for item in entries]
-
-    async def ensure_rate_limit(self) -> None:
-        await self._rate_limiter.throttle()
 
     def _sort_and_deduplicate(self, candles: Iterable[Candle]) -> List[Candle]:
         """Return candles ordered by start time without duplicates."""

--- a/bot/data/providers/binance.py
+++ b/bot/data/providers/binance.py
@@ -98,7 +98,7 @@ class BinanceFuturesProvider(BaseExchangeProvider):
         limit: int,
         since: int | None = None,
     ) -> List[Candle]:
-        await self.ensure_rate_limit()
+        await self.rate_limiter.throttle()
         if not self._session:
             raise RuntimeError("httpx is required to fetch candles from Binance")
         limit = self.resolve_ohlcv_limit(limit)
@@ -129,7 +129,7 @@ class BinanceFuturesProvider(BaseExchangeProvider):
             await asyncio.sleep(1)
 
     async def get_symbols(self) -> list[str]:
-        await self.ensure_rate_limit()
+        await self.rate_limiter.throttle()
         if not self._session:
             raise RuntimeError("httpx is required to fetch symbols from Binance")
         endpoint = f"{self._api_base}/fapi/v1/exchangeInfo"
@@ -142,7 +142,7 @@ class BinanceFuturesProvider(BaseExchangeProvider):
         return [symbol for symbol in trading if not symbol.endswith("_PERP")]  # filter illiquid synthetics
 
     async def get_24h_quote_volume(self) -> Dict[str, float]:
-        await self.ensure_rate_limit()
+        await self.rate_limiter.throttle()
         if not self._session:
             raise RuntimeError("httpx is required to fetch statistics from Binance")
         endpoint = f"{self._api_base}/fapi/v1/ticker/24hr"
@@ -154,7 +154,7 @@ class BinanceFuturesProvider(BaseExchangeProvider):
         return {ticker.symbol: ticker.quote_volume for ticker in tickers}
 
     async def update_deposit(self) -> DepositSnapshot:
-        await self.ensure_rate_limit()
+        await self.rate_limiter.throttle()
         endpoint = f"{self._api_base}/fapi/v2/balance"
         response = await self._authenticated_get(endpoint)
         response.raise_for_status()

--- a/bot/data/providers/bybit.py
+++ b/bot/data/providers/bybit.py
@@ -105,7 +105,7 @@ class BybitPerpetualProvider(BaseExchangeProvider):
         limit: int,
         since: int | None = None,
     ) -> List[Candle]:
-        await self.ensure_rate_limit()
+        await self.rate_limiter.throttle()
         if not self._session:
             raise RuntimeError("httpx is required to fetch candles from Bybit")
         limit = self.resolve_ohlcv_limit(limit)
@@ -139,7 +139,7 @@ class BybitPerpetualProvider(BaseExchangeProvider):
             await asyncio.sleep(1)
 
     async def get_symbols(self) -> list[str]:
-        await self.ensure_rate_limit()
+        await self.rate_limiter.throttle()
         if not self._session:
             raise RuntimeError("httpx is required to fetch symbols from Bybit")
         endpoint = f"{self._api_base}/derivatives/v3/public/instruments-info"
@@ -153,7 +153,7 @@ class BybitPerpetualProvider(BaseExchangeProvider):
         return trading
 
     async def get_24h_quote_volume(self) -> Dict[str, float]:
-        await self.ensure_rate_limit()
+        await self.rate_limiter.throttle()
         if not self._session:
             raise RuntimeError("httpx is required to fetch statistics from Bybit")
         endpoint = f"{self._api_base}/derivatives/v3/public/tickers"
@@ -172,7 +172,7 @@ class BybitPerpetualProvider(BaseExchangeProvider):
         return volumes
 
     async def update_deposit(self) -> DepositSnapshot:
-        await self.ensure_rate_limit()
+        await self.rate_limiter.throttle()
         endpoint = f"{self._api_base}/v5/account/wallet-balance"
         params = {"accountType": "UNIFIED"}
         response = await self._authenticated_get(endpoint, params=params)


### PR DESCRIPTION
## Summary
- add a rate_limiter property to BaseExchangeProvider so consumers throttle requests directly
- update Binance and Bybit providers to await the rate limiter before each API call

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd4e7624bc832097fadc630865f7bf