### PR TITLE
Refine metadata models with typed payloads

### DIFF
--- a/bot/data/io/config_models.py
+++ b/bot/data/io/config_models.py
@@ -10,7 +10,7 @@ from ...app_modes import AppMode
 from ...domain.enums import Timeframe
 from ...domain.models.entities import ThresholdMetric as DomainThresholdMetric
 from ...domain.models.entities import Thresholds as DomainThresholds
-from ...domain.models.metadata import ThresholdsMetadata
+from ...domain.models.metadata import ThresholdsMetadata, ThresholdsMetadataPayload
 from .config_types import (
     BacktestSection,
     DedupSection,
@@ -469,9 +469,10 @@ class ThresholdConfig:
         else:
             data = raw
         metadata_raw = data.get("metadata")
-        metadata = ThresholdsMetadata.from_mapping(
+        metadata_payload = ThresholdsMetadataPayload.from_mapping(
             metadata_raw if isinstance(metadata_raw, Mapping) else None
         )
+        metadata = ThresholdsMetadata.from_mapping(metadata_payload)
         metrics_raw = data.get("metrics") or ()
         metrics: list[ThresholdMetricConfig] = []
         for item in metrics_raw:
@@ -481,17 +482,26 @@ class ThresholdConfig:
         short_pct_move_ranges = _parse_range_list(
             data.get("short_pct_move_ranges")
         )
-        metadata_extra = metadata.extra if metadata else {}
-        if not short_pct_move_ranges and metadata_extra:
-            short_pct_move_ranges = _parse_range_list(
-                metadata_extra.get("short_pct_move_ranges")
+        if not short_pct_move_ranges and metadata:
+            short_pct_move_ranges = tuple(
+                (
+                    range_value.minimum,
+                    range_value.maximum,
+                )
+                for range_value in metadata.short_pct_move_ranges
+                if not range_value.is_empty()
             )
         short_relative_volume_ranges = _parse_range_list(
             data.get("short_relative_volume_ranges")
         )
-        if not short_relative_volume_ranges and metadata_extra:
-            short_relative_volume_ranges = _parse_range_list(
-                metadata_extra.get("short_relative_volume_ranges")
+        if not short_relative_volume_ranges and metadata:
+            short_relative_volume_ranges = tuple(
+                (
+                    range_value.minimum,
+                    range_value.maximum,
+                )
+                for range_value in metadata.short_relative_volume_ranges
+                if not range_value.is_empty()
             )
         return cls(
             id=str(data.get("id")) if data.get("id") is not None else None,

--- a/bot/data/io/storage.py
+++ b/bot/data/io/storage.py
@@ -17,8 +17,11 @@ from ...domain.models.entities import (
 )
 from ...domain.models.metadata import (
     SignalMetadata,
+    SignalMetadataPayload,
     ThresholdsMetadata,
+    ThresholdsMetadataPayload,
     TradeMetadata,
+    TradeMetadataPayload,
 )
 from ...domain.services.metrics_service import SelectionMetricsSnapshot
 from .excel_rows import (
@@ -130,11 +133,13 @@ class Storage:
 
     def _deserialize_thresholds(self, payload: ThresholdPayload) -> Thresholds:
         metrics = [self._deserialize_threshold_metric(metric) for metric in payload.metrics]
-        metadata = ThresholdsMetadata.from_mapping(payload.metadata)
+        metadata_payload = ThresholdsMetadataPayload.from_mapping(payload.metadata)
+        metadata = ThresholdsMetadata.from_mapping(metadata_payload)
         created_at_raw = payload.created_at
         updated_at_raw = payload.updated_at
 
         short_pct_move_ranges: List[tuple[float | None, float | None]] = []
+        short_relative_volume_ranges: List[tuple[float | None, float | None]] = []
         ranges_raw = payload.raw.get("short_pct_move_ranges")
         if isinstance(ranges_raw, list):
             for entry in ranges_raw:
@@ -176,54 +181,21 @@ class Storage:
                 else:
                     continue
                 short_pct_move_ranges.append((min_value, max_value))
-        if not short_pct_move_ranges and metadata and metadata.extra:
-            extra_ranges = metadata.extra.get("short_pct_move_ranges")
-            if isinstance(extra_ranges, list):
-                for entry in extra_ranges:
-                    min_value = None
-                    max_value = None
-                    if isinstance(entry, dict):
-                        min_raw = entry.get("min")
-                        if min_raw is None:
-                            min_raw = entry.get("min_value")
-                        max_raw = entry.get("max")
-                        if max_raw is None:
-                            max_raw = entry.get("max_value")
-                        if min_raw is None:
-                            continue
-                        try:
-                            min_value = float(cast(Union[int, float, str], min_raw))
-                        except (TypeError, ValueError):
-                            continue
-                        if max_raw is not None:
-                            try:
-                                max_value = float(cast(Union[int, float, str], max_raw))
-                            except (TypeError, ValueError):
-                                max_value = None
-                    elif isinstance(entry, (list, tuple)) and entry:
-                        sequence_entry = cast(Sequence[JSONValue], entry)
-                        first_value = sequence_entry[0]
-                        try:
-                            min_value = (
-                                float(cast(Union[int, float, str], first_value))
-                                if first_value is not None
-                                else None
-                            )
-                        except (TypeError, ValueError):
-                            min_value = None
-                        if len(sequence_entry) > 1:
-                            second_value = sequence_entry[1]
-                            try:
-                                max_value = (
-                                    float(cast(Union[int, float, str], second_value))
-                                    if second_value is not None
-                                    else None
-                                )
-                            except (TypeError, ValueError):
-                                max_value = None
-                    if min_value is None and max_value is None:
-                        continue
-                    short_pct_move_ranges.append((min_value, max_value))
+        if not short_pct_move_ranges and metadata:
+            for range_value in metadata.short_pct_move_ranges:
+                if range_value.is_empty():
+                    continue
+                short_pct_move_ranges.append(
+                    (range_value.minimum, range_value.maximum)
+                )
+
+        if metadata:
+            for range_value in metadata.short_relative_volume_ranges:
+                if range_value.is_empty():
+                    continue
+                short_relative_volume_ranges.append(
+                    (range_value.minimum, range_value.maximum)
+                )
 
         def _float_from_value(value: JSONValue | None) -> float:
             if isinstance(value, (int, float)):
@@ -271,6 +243,7 @@ class Storage:
                 ["max_lower_wick_pct", "maxLowerWickPct", "Y", "y"]
             ),
             short_pct_move_ranges=short_pct_move_ranges,
+            short_relative_volume_ranges=short_relative_volume_ranges,
             allow_long=self._to_bool(
                 payload.raw.get("allow_long", payload.allow_long), default_allow_long
             ),
@@ -332,14 +305,14 @@ class Storage:
         )
         thresholds = self._deserialize_thresholds(payload.thresholds)
         metrics = [self._deserialize_signal_metric(metric) for metric in payload.metrics]
-        metadata_dict: Dict[str, Any] = dict(payload.metadata)
+        metadata_mapping = payload.metadata
         metrics_snapshot = self._deserialize_metrics_snapshot(payload.metrics_snapshot)
         if metrics_snapshot is None:
-            legacy_snapshot = metadata_dict.get("metrics")
+            legacy_snapshot = metadata_mapping.get("metrics")
             if isinstance(legacy_snapshot, Mapping):
                 metrics_snapshot = self._deserialize_metrics_snapshot(legacy_snapshot)
-                if metrics_snapshot is not None:
-                    metadata_dict.pop("metrics", None)
+        metadata_payload = SignalMetadataPayload.from_mapping(metadata_mapping)
+        signal_metadata = SignalMetadata.from_mapping(metadata_payload)
         created_at_raw = payload.created_at
         updated_at_raw = payload.updated_at
         timeframe_raw = payload.timeframe
@@ -366,7 +339,7 @@ class Storage:
             allow_long=self._to_bool(payload.allow_long, thresholds.allow_long),
             allow_short=self._to_bool(payload.allow_short, thresholds.allow_short),
             metrics_snapshot=metrics_snapshot,
-            metadata=SignalMetadata.from_mapping(metadata_dict),
+            metadata=signal_metadata,
         )
 
     def deserialize_trade(self, payload: TradePayload) -> Trade:
@@ -375,29 +348,28 @@ class Storage:
             if payload.thresholds_snapshot is not None
             else None
         )
-        metadata_dict: Dict[str, Any] = dict(payload.metadata)
+        metadata_payload = TradeMetadataPayload.from_mapping(payload.metadata)
+        trade_metadata = TradeMetadata.from_mapping(metadata_payload)
         created_at_raw = payload.created_at
         updated_at_raw = payload.updated_at
         timeframe_raw = payload.timeframe
         timeframe = Timeframe(timeframe_raw) if isinstance(timeframe_raw, str) else None
         if timeframe is None and thresholds_snapshot and thresholds_snapshot.metadata:
             meta_tf = thresholds_snapshot.metadata.timeframe
-            if isinstance(meta_tf, Timeframe):
+            if meta_tf is not None:
                 timeframe = meta_tf
             else:
-                extra_tf = thresholds_snapshot.metadata.extra.get("timeframe")
-                if isinstance(extra_tf, str):
+                raw_tf = thresholds_snapshot.metadata.timeframe_raw
+                if isinstance(raw_tf, str):
                     try:
-                        timeframe = Timeframe(extra_tf)
+                        timeframe = Timeframe(raw_tf)
                     except ValueError:
                         timeframe = None
-        if timeframe is None:
-            meta_tf = metadata_dict.get("timeframe")
-            if isinstance(meta_tf, str):
-                try:
-                    timeframe = Timeframe(meta_tf)
-                except ValueError:
-                    timeframe = None
+        if timeframe is None and trade_metadata and trade_metadata.timeframe:
+            try:
+                timeframe = Timeframe(trade_metadata.timeframe)
+            except ValueError:
+                timeframe = None
         source_signal_id = payload.source_signal_id or payload.signal_id
         trade = Trade(
             id=payload.id,
@@ -425,7 +397,7 @@ class Storage:
             allow_long=self._to_bool(payload.allow_long),
             allow_short=self._to_bool(payload.allow_short),
             thresholds_snapshot=thresholds_snapshot,
-            metadata=TradeMetadata.from_mapping(metadata_dict),
+            metadata=trade_metadata,
         )
         return trade
 

--- a/bot/domain/models/metadata.py
+++ b/bot/domain/models/metadata.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, Mapping, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, Mapping, Sequence, Type, TypeVar
 
 from ..enums import Timeframe, TradeStatus
 
@@ -16,56 +16,390 @@ T = TypeVar("T", bound="_SerializableDataclass")
 class _SerializableDataclass:
     """Utility mixin for metadata dataclasses."""
 
-    extra: Dict[str, Any]
-
     def to_dict(self) -> Dict[str, Any]:  # pragma: no cover - overridden
         raise NotImplementedError
 
     @classmethod
-    def from_mapping(cls: Type[T], raw: Mapping[str, Any] | None) -> T | None:
+    def from_mapping(cls: Type[T], raw: Any) -> T | None:  # pragma: no cover - overridden
         raise NotImplementedError
 
-@dataclass(slots=True)
-class ThresholdsMetadata(_SerializableDataclass):
-    timeframe: Timeframe | None = None
-    extra: Dict[str, Any] = field(default_factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
-        data: Dict[str, Any] = {}
-        if self.timeframe is not None:
-            data["timeframe"] = (
-                self.timeframe.value
-                if isinstance(self.timeframe, Timeframe)
-                else str(self.timeframe)
-            )
-        if self.extra:
-            data.update(self.extra)
-        return data
+# ---------------------------------------------------------------------------
+# Helper utilities
+# ---------------------------------------------------------------------------
+
+def _to_optional_float(value: Any) -> float | None:
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    return bool(value)
+
+
+# ---------------------------------------------------------------------------
+# Range metadata structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class ThresholdRange:
+    minimum: float | None = None
+    maximum: float | None = None
+
+    def is_empty(self) -> bool:
+        return self.minimum is None and self.maximum is None
+
+    def to_mapping(self) -> Dict[str, float | None]:
+        mapping: Dict[str, float | None] = {}
+        if self.minimum is not None:
+            mapping["min"] = self.minimum
+        if self.maximum is not None:
+            mapping["max"] = self.maximum
+        return mapping
+
+
+def _parse_range_sequence(raw: Any) -> tuple[ThresholdRange, ...]:
+    if not isinstance(raw, Sequence) or isinstance(raw, (str, bytes, bytearray)):
+        return ()
+    ranges: list[ThresholdRange] = []
+    for entry in raw:
+        minimum: float | None = None
+        maximum: float | None = None
+        if isinstance(entry, Mapping):
+            min_raw = entry.get("min", entry.get("min_value"))
+            max_raw = entry.get("max", entry.get("max_value"))
+            minimum = _to_optional_float(min_raw)
+            maximum = _to_optional_float(max_raw)
+        elif isinstance(entry, Sequence) and not isinstance(entry, (str, bytes, bytearray)):
+            sequence_entry = list(entry)
+            if sequence_entry:
+                minimum = _to_optional_float(sequence_entry[0])
+            if len(sequence_entry) > 1:
+                maximum = _to_optional_float(sequence_entry[1])
+        if minimum is None and maximum is None:
+            continue
+        ranges.append(ThresholdRange(minimum=minimum, maximum=maximum))
+    return tuple(ranges)
+
+
+# ---------------------------------------------------------------------------
+# Payload dataclasses used for typed deserialization
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class ThresholdsMetadataPayload:
+    timeframe: Timeframe | None = None
+    timeframe_raw: str | None = None
+    short_pct_move_ranges: tuple[ThresholdRange, ...] = ()
+    short_relative_volume_ranges: tuple[ThresholdRange, ...] = ()
+    note: str | None = None
 
     @classmethod
     def from_mapping(
         cls, raw: Mapping[str, Any] | None
+    ) -> "ThresholdsMetadataPayload" | None:
+        if raw is None:
+            return None
+        timeframe: Timeframe | None = None
+        timeframe_raw: str | None = None
+        timeframe_value = raw.get("timeframe")
+        if isinstance(timeframe_value, Timeframe):
+            timeframe = timeframe_value
+        elif isinstance(timeframe_value, str):
+            try:
+                timeframe = Timeframe(timeframe_value)
+            except ValueError:
+                timeframe_raw = timeframe_value
+        note_value = raw.get("note")
+        note = str(note_value) if isinstance(note_value, str) else None
+        short_pct_move_ranges = _parse_range_sequence(raw.get("short_pct_move_ranges"))
+        short_relative_volume_ranges = _parse_range_sequence(
+            raw.get("short_relative_volume_ranges")
+        )
+        return cls(
+            timeframe=timeframe,
+            timeframe_raw=timeframe_raw,
+            short_pct_move_ranges=short_pct_move_ranges,
+            short_relative_volume_ranges=short_relative_volume_ranges,
+            note=note,
+        )
+
+
+@dataclass(slots=True)
+class ThresholdMetricMetadataPayload:
+    name: str
+    min_value: float | None = None
+    max_value: float | None = None
+    min_abs_value: float | None = None
+
+    @classmethod
+    def from_mapping(
+        cls, raw: Mapping[str, Any] | None
+    ) -> "ThresholdMetricMetadataPayload" | None:
+        if raw is None:
+            return None
+        name_value = raw.get("name")
+        if not isinstance(name_value, str):
+            return None
+        return cls(
+            name=name_value,
+            min_value=_to_optional_float(raw.get("min_value")),
+            max_value=_to_optional_float(raw.get("max_value")),
+            min_abs_value=_to_optional_float(raw.get("min_abs_value")),
+        )
+
+
+@dataclass(slots=True)
+class EvaluationMetadataPayload:
+    name: str
+    value: float | None = None
+    passed: bool | None = None
+    threshold: ThresholdMetricMetadataPayload | None = None
+
+    @classmethod
+    def from_mapping(
+        cls, raw: Mapping[str, Any] | None
+    ) -> "EvaluationMetadataPayload" | None:
+        if raw is None:
+            return None
+        name_value = raw.get("name")
+        if not isinstance(name_value, str):
+            return None
+        threshold_raw = raw.get("threshold")
+        threshold_payload = None
+        if isinstance(threshold_raw, Mapping):
+            threshold_payload = ThresholdMetricMetadataPayload.from_mapping(threshold_raw)
+        return cls(
+            name=name_value,
+            value=_to_optional_float(raw.get("value")),
+            passed=_parse_bool(raw.get("passed")),
+            threshold=threshold_payload,
+        )
+
+
+@dataclass(slots=True)
+class DepositSnapshotMetadataPayload:
+    asset: str | None = None
+    balance: float | None = None
+    updated_at: datetime | None = None
+    raw: Dict[str, Any] | None = None
+
+    @classmethod
+    def from_mapping(
+        cls, raw: Mapping[str, Any] | None
+    ) -> "DepositSnapshotMetadataPayload" | None:
+        if raw is None:
+            return None
+        asset_value = raw.get("asset")
+        asset = str(asset_value) if isinstance(asset_value, str) else None
+        balance = _to_optional_float(raw.get("balance"))
+        updated_raw = raw.get("updated_at")
+        updated_at = None
+        if isinstance(updated_raw, str):
+            try:
+                updated_at = datetime.fromisoformat(updated_raw)
+            except ValueError:
+                updated_at = None
+        raw_snapshot = raw.get("raw")
+        raw_mapping = dict(raw_snapshot) if isinstance(raw_snapshot, Mapping) else None
+        return cls(asset=asset, balance=balance, updated_at=updated_at, raw=raw_mapping)
+
+
+@dataclass(slots=True)
+class BacktestMetadataPayload:
+    result_pct: float | None = None
+    pct_to_high_break: float | None = None
+    pct_to_low_break: float | None = None
+    note: str | None = None
+
+    @classmethod
+    def from_mapping(
+        cls, raw: Mapping[str, Any] | None
+    ) -> "BacktestMetadataPayload" | None:
+        if raw is None:
+            return None
+        note_value = raw.get("note")
+        note = str(note_value) if isinstance(note_value, str) else None
+        return cls(
+            result_pct=_to_optional_float(raw.get("result_pct")),
+            pct_to_high_break=_to_optional_float(raw.get("pct_to_high_break")),
+            pct_to_low_break=_to_optional_float(raw.get("pct_to_low_break")),
+            note=note,
+        )
+
+
+@dataclass(slots=True)
+class LiveMetadataPayload:
+    result_pct: float | None = None
+    closed_status: TradeStatus | None = None
+    note: str | None = None
+
+    @classmethod
+    def from_mapping(
+        cls, raw: Mapping[str, Any] | None
+    ) -> "LiveMetadataPayload" | None:
+        if raw is None:
+            return None
+        status_raw = raw.get("closed_status")
+        closed_status = None
+        if isinstance(status_raw, TradeStatus):
+            closed_status = status_raw
+        elif isinstance(status_raw, str):
+            try:
+                closed_status = TradeStatus(status_raw)
+            except ValueError:
+                closed_status = None
+        note_value = raw.get("note")
+        note = str(note_value) if isinstance(note_value, str) else None
+        return cls(
+            result_pct=_to_optional_float(raw.get("result_pct")),
+            closed_status=closed_status,
+            note=note,
+        )
+
+
+@dataclass(slots=True)
+class SignalMetadataPayload:
+    symbol: str | None = None
+    timeframe: str | None = None
+    source_signal_id: str | None = None
+    evaluations: tuple[EvaluationMetadataPayload, ...] = ()
+    note: str | None = None
+
+    @classmethod
+    def from_mapping(
+        cls, raw: Mapping[str, Any] | None
+    ) -> "SignalMetadataPayload" | None:
+        if raw is None:
+            return None
+        symbol_value = raw.get("symbol")
+        timeframe_value = raw.get("timeframe")
+        source_signal_value = raw.get("source_signal_id")
+        note_value = raw.get("note")
+        evaluations_raw = raw.get("evaluations")
+        evaluations: list[EvaluationMetadataPayload] = []
+        if isinstance(evaluations_raw, Sequence) and not isinstance(
+            evaluations_raw, (str, bytes, bytearray)
+        ):
+            for entry in evaluations_raw:
+                if isinstance(entry, Mapping):
+                    evaluation = EvaluationMetadataPayload.from_mapping(entry)
+                    if evaluation is not None:
+                        evaluations.append(evaluation)
+        return cls(
+            symbol=str(symbol_value) if isinstance(symbol_value, str) else None,
+            timeframe=str(timeframe_value) if isinstance(timeframe_value, str) else None,
+            source_signal_id=(
+                str(source_signal_value)
+                if isinstance(source_signal_value, str)
+                else None
+            ),
+            evaluations=tuple(evaluations),
+            note=str(note_value) if isinstance(note_value, str) else None,
+        )
+
+
+@dataclass(slots=True)
+class TradeMetadataPayload:
+    mode: str | None = None
+    timeframe: str | None = None
+    note: str | None = None
+    deposit_snapshot: DepositSnapshotMetadataPayload | None = None
+    backtest: BacktestMetadataPayload | None = None
+    live: LiveMetadataPayload | None = None
+
+    @classmethod
+    def from_mapping(
+        cls, raw: Mapping[str, Any] | None
+    ) -> "TradeMetadataPayload" | None:
+        if raw is None:
+            return None
+        deposit_raw = raw.get("deposit_snapshot")
+        backtest_raw = raw.get("backtest")
+        live_raw = raw.get("live")
+        note_value = raw.get("note")
+        mode_value = raw.get("mode")
+        timeframe_value = raw.get("timeframe")
+        return cls(
+            mode=str(mode_value) if isinstance(mode_value, str) else None,
+            timeframe=str(timeframe_value) if isinstance(timeframe_value, str) else None,
+            note=str(note_value) if isinstance(note_value, str) else None,
+            deposit_snapshot=DepositSnapshotMetadataPayload.from_mapping(
+                deposit_raw if isinstance(deposit_raw, Mapping) else None
+            ),
+            backtest=BacktestMetadataPayload.from_mapping(
+                backtest_raw if isinstance(backtest_raw, Mapping) else None
+            ),
+            live=LiveMetadataPayload.from_mapping(
+                live_raw if isinstance(live_raw, Mapping) else None
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Domain metadata dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class ThresholdsMetadata(_SerializableDataclass):
+    timeframe: Timeframe | None = None
+    timeframe_raw: str | None = None
+    short_pct_move_ranges: tuple[ThresholdRange, ...] = field(default_factory=tuple)
+    short_relative_volume_ranges: tuple[ThresholdRange, ...] = field(default_factory=tuple)
+    note: str | None = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {}
+        if self.timeframe_raw is not None:
+            data["timeframe"] = self.timeframe_raw
+        elif self.timeframe is not None:
+            data["timeframe"] = self.timeframe.value
+        if self.short_pct_move_ranges:
+            data["short_pct_move_ranges"] = [
+                range_value.to_mapping()
+                for range_value in self.short_pct_move_ranges
+                if not range_value.is_empty()
+            ]
+        if self.short_relative_volume_ranges:
+            data["short_relative_volume_ranges"] = [
+                range_value.to_mapping()
+                for range_value in self.short_relative_volume_ranges
+                if not range_value.is_empty()
+            ]
+        if self.note is not None:
+            data["note"] = self.note
+        return data
+
+    @classmethod
+    def from_mapping(
+        cls, payload: ThresholdsMetadataPayload | None
     ) -> "ThresholdsMetadata" | None:
-        if not raw or not isinstance(raw, Mapping):
+        if payload is None:
             return None
-        extra: Dict[str, Any] = {
-            key: raw[key] for key in raw.keys() - {"timeframe"}
-        }
-        timeframe_value: Timeframe | None = None
-        if "timeframe" in raw:
-            timeframe_raw = raw["timeframe"]
-            if isinstance(timeframe_raw, Timeframe):
-                timeframe_value = timeframe_raw
-            elif isinstance(timeframe_raw, str):
-                try:
-                    timeframe_value = Timeframe(timeframe_raw)
-                except ValueError:
-                    extra.setdefault("timeframe", timeframe_raw)
-            else:
-                extra.setdefault("timeframe", timeframe_raw)
-        if timeframe_value is None and not extra:
+        if (
+            payload.timeframe is None
+            and payload.timeframe_raw is None
+            and not payload.short_pct_move_ranges
+            and not payload.short_relative_volume_ranges
+            and payload.note is None
+        ):
             return None
-        return cls(timeframe=timeframe_value, extra=extra)
+        return cls(
+            timeframe=payload.timeframe,
+            timeframe_raw=payload.timeframe_raw,
+            short_pct_move_ranges=payload.short_pct_move_ranges,
+            short_relative_volume_ranges=payload.short_relative_volume_ranges,
+            note=payload.note,
+        )
 
 
 @dataclass(slots=True)
@@ -74,7 +408,6 @@ class ThresholdMetricMetadata(_SerializableDataclass):
     min_value: float | None = None
     max_value: float | None = None
     min_abs_value: float | None = None
-    extra: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         data: Dict[str, Any] = {"name": self.name}
@@ -84,31 +417,19 @@ class ThresholdMetricMetadata(_SerializableDataclass):
             data["max_value"] = self.max_value
         if self.min_abs_value is not None:
             data["min_abs_value"] = self.min_abs_value
-        if self.extra:
-            data.update(self.extra)
         return data
 
     @classmethod
     def from_mapping(
-        cls, raw: Mapping[str, Any] | None
+        cls, payload: ThresholdMetricMetadataPayload | None
     ) -> "ThresholdMetricMetadata" | None:
-        if not raw or "name" not in raw:
+        if payload is None:
             return None
-        known = {"name", "min_value", "max_value", "min_abs_value"}
-        extra = {key: raw[key] for key in raw.keys() - known}
-
-        def _to_float(value: Any) -> float | None:
-            try:
-                return float(value) if value is not None else None
-            except (TypeError, ValueError):
-                return None
-
         return cls(
-            name=str(raw["name"]),
-            min_value=_to_float(raw.get("min_value")),
-            max_value=_to_float(raw.get("max_value")),
-            min_abs_value=_to_float(raw.get("min_abs_value")),
-            extra=extra,
+            name=payload.name,
+            min_value=payload.min_value,
+            max_value=payload.max_value,
+            min_abs_value=payload.min_abs_value,
         )
 
     @classmethod
@@ -131,7 +452,6 @@ class EvaluationMetadata(_SerializableDataclass):
     value: float | None = None
     passed: bool | None = None
     threshold: ThresholdMetricMetadata | None = None
-    extra: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         data: Dict[str, Any] = {"name": self.name}
@@ -141,37 +461,19 @@ class EvaluationMetadata(_SerializableDataclass):
             data["passed"] = self.passed
         if self.threshold is not None:
             data["threshold"] = self.threshold.to_dict()
-        if self.extra:
-            data.update(self.extra)
         return data
 
     @classmethod
-    def from_mapping(cls, raw: Mapping[str, Any] | None) -> "EvaluationMetadata" | None:
-        if not raw or "name" not in raw:
+    def from_mapping(
+        cls, payload: EvaluationMetadataPayload | None
+    ) -> "EvaluationMetadata" | None:
+        if payload is None:
             return None
-        known = {"name", "value", "passed", "threshold"}
-        extra = {key: raw[key] for key in raw.keys() - known}
-        threshold = raw.get("threshold")
-        threshold_metadata = ThresholdMetricMetadata.from_mapping(
-            threshold if isinstance(threshold, Mapping) else None
-        )
-        value = raw.get("value")
-        try:
-            value_f = float(value) if value is not None else None
-        except (TypeError, ValueError):
-            value_f = None
-        passed = raw.get("passed")
-        passed_bool = None
-        if isinstance(passed, bool):
-            passed_bool = passed
-        elif passed is not None:
-            passed_bool = bool(passed)
         return cls(
-            name=str(raw["name"]),
-            value=value_f,
-            passed=passed_bool,
-            threshold=threshold_metadata,
-            extra=extra,
+            name=payload.name,
+            value=payload.value,
+            passed=payload.passed,
+            threshold=ThresholdMetricMetadata.from_mapping(payload.threshold),
         )
 
 
@@ -181,7 +483,6 @@ class DepositSnapshotMetadata(_SerializableDataclass):
     balance: float | None = None
     updated_at: datetime | None = None
     raw: Dict[str, Any] | None = None
-    extra: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         data: Dict[str, Any] = {}
@@ -193,40 +494,26 @@ class DepositSnapshotMetadata(_SerializableDataclass):
             data["updated_at"] = self.updated_at.isoformat()
         if self.raw is not None:
             data["raw"] = self.raw
-        if self.extra:
-            data.update(self.extra)
         return data
 
     @classmethod
     def from_mapping(
-        cls, raw: Mapping[str, Any] | None
+        cls, payload: DepositSnapshotMetadataPayload | None
     ) -> "DepositSnapshotMetadata" | None:
-        if not raw:
+        if payload is None:
             return None
-        known = {"asset", "balance", "updated_at", "raw"}
-        extra = {key: raw[key] for key in raw.keys() - known}
-        updated_at_value = raw.get("updated_at")
-        updated_at = None
-        if isinstance(updated_at_value, str):
-            try:
-                updated_at = datetime.fromisoformat(updated_at_value)
-            except ValueError:
-                updated_at = None
-        balance = raw.get("balance")
-        try:
-            balance_value = float(balance) if balance is not None else None
-        except (TypeError, ValueError):
-            balance_value = None
-        asset_value = raw.get("asset")
-        asset = str(asset_value) if asset_value is not None else None
-        raw_snapshot = raw.get("raw")
-        raw_dict = dict(raw_snapshot) if isinstance(raw_snapshot, Mapping) else None
+        if (
+            payload.asset is None
+            and payload.balance is None
+            and payload.updated_at is None
+            and payload.raw is None
+        ):
+            return None
         return cls(
-            asset=asset,
-            balance=balance_value,
-            updated_at=updated_at,
-            raw=raw_dict,
-            extra=extra,
+            asset=payload.asset,
+            balance=payload.balance,
+            updated_at=payload.updated_at,
+            raw=payload.raw,
         )
 
 
@@ -235,7 +522,7 @@ class BacktestMetadata(_SerializableDataclass):
     result_pct: float | None = None
     pct_to_high_break: float | None = None
     pct_to_low_break: float | None = None
-    extra: Dict[str, Any] = field(default_factory=dict)
+    note: str | None = None
 
     def to_dict(self) -> Dict[str, Any]:
         data: Dict[str, Any] = {}
@@ -245,27 +532,28 @@ class BacktestMetadata(_SerializableDataclass):
             data["pct_to_high_break"] = self.pct_to_high_break
         if self.pct_to_low_break is not None:
             data["pct_to_low_break"] = self.pct_to_low_break
-        if self.extra:
-            data.update(self.extra)
+        if self.note is not None:
+            data["note"] = self.note
         return data
 
     @classmethod
-    def from_mapping(cls, raw: Mapping[str, Any] | None) -> "BacktestMetadata" | None:
-        if not raw:
+    def from_mapping(
+        cls, payload: BacktestMetadataPayload | None
+    ) -> "BacktestMetadata" | None:
+        if payload is None:
             return None
-        known = {"result_pct", "pct_to_high_break", "pct_to_low_break"}
-        extra = {key: raw[key] for key in raw.keys() - known}
-        def _to_float(value: Any) -> float | None:
-            try:
-                return float(value) if value is not None else None
-            except (TypeError, ValueError):
-                return None
-
+        if (
+            payload.result_pct is None
+            and payload.pct_to_high_break is None
+            and payload.pct_to_low_break is None
+            and payload.note is None
+        ):
+            return None
         return cls(
-            result_pct=_to_float(raw.get("result_pct")),
-            pct_to_high_break=_to_float(raw.get("pct_to_high_break")),
-            pct_to_low_break=_to_float(raw.get("pct_to_low_break")),
-            extra=extra,
+            result_pct=payload.result_pct,
+            pct_to_high_break=payload.pct_to_high_break,
+            pct_to_low_break=payload.pct_to_low_break,
+            note=payload.note,
         )
 
 
@@ -273,7 +561,7 @@ class BacktestMetadata(_SerializableDataclass):
 class LiveMetadata(_SerializableDataclass):
     result_pct: float | None = None
     closed_status: TradeStatus | None = None
-    extra: Dict[str, Any] = field(default_factory=dict)
+    note: str | None = None
 
     def to_dict(self) -> Dict[str, Any]:
         data: Dict[str, Any] = {}
@@ -281,32 +569,22 @@ class LiveMetadata(_SerializableDataclass):
             data["result_pct"] = self.result_pct
         if self.closed_status is not None:
             data["closed_status"] = self.closed_status.value
-        if self.extra:
-            data.update(self.extra)
+        if self.note is not None:
+            data["note"] = self.note
         return data
 
     @classmethod
-    def from_mapping(cls, raw: Mapping[str, Any] | None) -> "LiveMetadata" | None:
-        if not raw:
+    def from_mapping(
+        cls, payload: LiveMetadataPayload | None
+    ) -> "LiveMetadata" | None:
+        if payload is None:
             return None
-        known = {"result_pct", "closed_status"}
-        extra = {key: raw[key] for key in raw.keys() - known}
-        result_pct = raw.get("result_pct")
-        try:
-            result_pct_value = float(result_pct) if result_pct is not None else None
-        except (TypeError, ValueError):
-            result_pct_value = None
-        status_raw = raw.get("closed_status")
-        closed_status = None
-        if isinstance(status_raw, str):
-            try:
-                closed_status = TradeStatus(status_raw)
-            except ValueError:
-                closed_status = None
+        if payload.result_pct is None and payload.closed_status is None and payload.note is None:
+            return None
         return cls(
-            result_pct=result_pct_value,
-            closed_status=closed_status,
-            extra=extra,
+            result_pct=payload.result_pct,
+            closed_status=payload.closed_status,
+            note=payload.note,
         )
 
 
@@ -316,7 +594,7 @@ class SignalMetadata(_SerializableDataclass):
     timeframe: str | None = None
     source_signal_id: str | None = None
     evaluations: list[EvaluationMetadata] = field(default_factory=list)
-    extra: Dict[str, Any] = field(default_factory=dict)
+    note: str | None = None
 
     def to_dict(self) -> Dict[str, Any]:
         data: Dict[str, Any] = {}
@@ -328,41 +606,38 @@ class SignalMetadata(_SerializableDataclass):
             data["source_signal_id"] = self.source_signal_id
         if self.evaluations:
             data["evaluations"] = [evaluation.to_dict() for evaluation in self.evaluations]
-        if self.extra:
-            data.update(self.extra)
+        if self.note is not None:
+            data["note"] = self.note
         return data
 
     @classmethod
-    def from_mapping(cls, raw: Mapping[str, Any] | None) -> "SignalMetadata" | None:
-        if not raw:
+    def from_mapping(
+        cls, payload: SignalMetadataPayload | None
+    ) -> "SignalMetadata" | None:
+        if payload is None:
             return None
-        symbol = raw.get("symbol")
-        timeframe = raw.get("timeframe")
-        source_signal_id = raw.get("source_signal_id")
-        evaluations_raw = raw.get("evaluations")
-        evaluations: list[EvaluationMetadata] = []
-        if isinstance(evaluations_raw, list):
-            for evaluation_raw in evaluations_raw:
-                if isinstance(evaluation_raw, Mapping):
-                    evaluation = EvaluationMetadata.from_mapping(evaluation_raw)
-                    if evaluation is not None:
-                        evaluations.append(evaluation)
-        known = {"symbol", "timeframe", "source_signal_id", "evaluations"}
-        extra = {key: raw[key] for key in raw.keys() - known}
+        evaluations = [
+            evaluation
+            for evaluation in (
+                EvaluationMetadata.from_mapping(item)
+                for item in payload.evaluations
+            )
+            if evaluation is not None
+        ]
         if (
-            symbol is None
-            and timeframe is None
-            and source_signal_id is None
+            payload.symbol is None
+            and payload.timeframe is None
+            and payload.source_signal_id is None
             and not evaluations
-            and not extra
+            and payload.note is None
         ):
             return None
         return cls(
-            symbol=str(symbol) if isinstance(symbol, str) else None,
-            timeframe=str(timeframe) if isinstance(timeframe, str) else None,
-            source_signal_id=str(source_signal_id) if isinstance(source_signal_id, str) else None,
+            symbol=payload.symbol,
+            timeframe=payload.timeframe,
+            source_signal_id=payload.source_signal_id,
             evaluations=evaluations,
-            extra=extra,
+            note=payload.note,
         )
 
 
@@ -373,17 +648,7 @@ class TradeMetadata(_SerializableDataclass):
     deposit_snapshot: DepositSnapshotMetadata | None = None
     backtest: BacktestMetadata | None = None
     live: LiveMetadata | None = None
-    extra: Dict[str, Any] = field(default_factory=dict)
-
-    def ensure_backtest(self) -> BacktestMetadata:
-        if self.backtest is None:
-            self.backtest = BacktestMetadata()
-        return self.backtest
-
-    def ensure_live(self) -> LiveMetadata:
-        if self.live is None:
-            self.live = LiveMetadata()
-        return self.live
+    note: str | None = None
 
     def to_dict(self) -> Dict[str, Any]:
         data: Dict[str, Any] = {}
@@ -397,37 +662,33 @@ class TradeMetadata(_SerializableDataclass):
             data["backtest"] = self.backtest.to_dict()
         if self.live is not None:
             data["live"] = self.live.to_dict()
-        if self.extra:
-            data.update(self.extra)
+        if self.note is not None:
+            data["note"] = self.note
         return data
 
     @classmethod
-    def from_mapping(cls, raw: Mapping[str, Any] | None) -> "TradeMetadata" | None:
-        if not raw:
+    def from_mapping(
+        cls, payload: TradeMetadataPayload | None
+    ) -> "TradeMetadata" | None:
+        if payload is None:
             return None
-        mode = raw.get("mode")
-        timeframe = raw.get("timeframe")
-        deposit_snapshot = DepositSnapshotMetadata.from_mapping(
-            raw.get("deposit_snapshot"))
-        backtest = BacktestMetadata.from_mapping(raw.get("backtest"))
-        live = LiveMetadata.from_mapping(raw.get("live"))
-        known = {"mode", "timeframe", "deposit_snapshot", "backtest", "live"}
-        extra = {key: raw[key] for key in raw.keys() - known}
+        deposit_snapshot = DepositSnapshotMetadata.from_mapping(payload.deposit_snapshot)
+        backtest = BacktestMetadata.from_mapping(payload.backtest)
+        live = LiveMetadata.from_mapping(payload.live)
         if (
-            mode is None
-            and timeframe is None
+            payload.mode is None
+            and payload.timeframe is None
             and deposit_snapshot is None
             and backtest is None
             and live is None
-            and not extra
+            and payload.note is None
         ):
             return None
         return cls(
-            mode=str(mode) if isinstance(mode, str) else None,
-            timeframe=str(timeframe) if isinstance(timeframe, str) else None,
+            mode=payload.mode,
+            timeframe=payload.timeframe,
             deposit_snapshot=deposit_snapshot,
             backtest=backtest,
             live=live,
-            extra=extra,
+            note=payload.note,
         )
-

--- a/bot/domain/services/backtest_runner.py
+++ b/bot/domain/services/backtest_runner.py
@@ -6,6 +6,7 @@ from typing import Sequence
 from ..enums import Side, Timeframe, TradeStatus
 from ..models.entities import Candle, Signal, Thresholds, Trade
 from ..models.metadata import (
+    BacktestMetadata,
     DepositSnapshotMetadata,
     SignalMetadata,
     TradeMetadata,
@@ -118,7 +119,11 @@ class BacktestRunner:
                     allow_long=signal.allow_long,
                     allow_short=signal.allow_short,
                     thresholds_snapshot=signal.thresholds,
-                    metadata=TradeMetadata(mode="backtest", deposit_snapshot=snapshot),
+                    metadata=TradeMetadata(
+                        mode="backtest",
+                        deposit_snapshot=snapshot,
+                        backtest=BacktestMetadata(),
+                    ),
                 )
                 self._tp_sl_service.assign(signal, trade)
                 trade.opened_at = signal.candle.closed_at
@@ -204,8 +209,12 @@ class BacktestRunner:
             trade.pnl = trade.size * (result_pct / 100)
             trade.pnl_pct = result_pct
             if trade.metadata is None:
-                trade.metadata = TradeMetadata(mode="backtest")
-            backtest_meta = trade.metadata.ensure_backtest()
+                trade.metadata = TradeMetadata(
+                    mode="backtest", backtest=BacktestMetadata()
+                )
+            if trade.metadata.backtest is None:
+                trade.metadata.backtest = BacktestMetadata()
+            backtest_meta = trade.metadata.backtest
             backtest_meta.result_pct = result_pct
             backtest_meta.pct_to_high_break = pct_to_high_break
             backtest_meta.pct_to_low_break = pct_to_low_break

--- a/bot/domain/services/live_runner.py
+++ b/bot/domain/services/live_runner.py
@@ -14,7 +14,7 @@ from ...utils.logging import get_logger
 from ...utils.clock import utcnow
 from ..enums import Timeframe, TradeStatus
 from ..models.entities import Candle, Signal, Thresholds, Trade
-from ..models.metadata import DepositSnapshotMetadata, TradeMetadata
+from ..models.metadata import DepositSnapshotMetadata, LiveMetadata, TradeMetadata
 from .dedup_policy import DeduplicationPolicy
 from .selector_service import SignalSelectorService
 from .tp_sl_service import TpSlService
@@ -86,7 +86,9 @@ class LiveTradingRunner:
             allow_long=signal.allow_long,
             allow_short=signal.allow_short,
             thresholds_snapshot=signal.thresholds,
-            metadata=TradeMetadata(mode="live", deposit_snapshot=snapshot_metadata),
+            metadata=TradeMetadata(
+                mode="live", deposit_snapshot=snapshot_metadata, live=LiveMetadata()
+            ),
         )
         self._tp_sl_service.assign(signal, trade)
         self._signals.save(signal)
@@ -150,8 +152,10 @@ class LiveTradingRunner:
                     )
                     trade.updated_at = utcnow()
                     if trade.metadata is None:
-                        trade.metadata = TradeMetadata(mode="live")
-                    live_meta = trade.metadata.ensure_live()
+                        trade.metadata = TradeMetadata(mode="live", live=LiveMetadata())
+                    if trade.metadata.live is None:
+                        trade.metadata.live = LiveMetadata()
+                    live_meta = trade.metadata.live
                     if result_pct is not None:
                         live_meta.result_pct = result_pct
                     live_meta.closed_status = status

--- a/tests/test_config_parsing.py
+++ b/tests/test_config_parsing.py
@@ -141,7 +141,7 @@ def test_build_thresholds_uses_typed_models() -> None:
     assert isinstance(default_cfg.metadata, ThresholdsMetadata)
     assert default_cfg.metadata is not None
     assert default_cfg.metadata.timeframe is Timeframe.M15
-    assert default_cfg.metadata.extra["note"] == "default"
+    assert default_cfg.metadata.note == "default"
 
     eth_cfg = thresholds["ETHUSDT"]
     assert eth_cfg.min_pct_move == 0.25

--- a/tests/test_excel_storage.py
+++ b/tests/test_excel_storage.py
@@ -89,7 +89,7 @@ def _build_signal(identifier: str, score: float, triggered_at: datetime) -> Sign
         allow_short=True,
         metrics_snapshot=snapshot,
         metadata=SignalMetadata(
-            extra={"note": "initial"},
+            note="initial",
             evaluations=[
                 EvaluationMetadata(
                     name="atr",
@@ -119,7 +119,7 @@ def _build_trade(identifier: str, opened_at: datetime) -> Trade:
         created_at=opened_at,
         allow_long=True,
         allow_short=True,
-        metadata=TradeMetadata(extra={"note": "initial"}),
+        metadata=TradeMetadata(note="initial"),
     )
 
 
@@ -157,8 +157,8 @@ def test_signal_repository_updates_excel(tmp_path) -> None:
     assert isinstance(evaluations[0].threshold, ThresholdMetricMetadata)
     assert evaluations[0].threshold is not None
     assert evaluations[0].threshold.min_value == pytest.approx(1.0)
-    assert "metrics" not in loaded_signals[signal.id].metadata.extra
-    assert loaded_signals[signal.id].metadata.extra.get("note") == "initial"
+    assert "metrics" not in loaded_signals[signal.id].metadata.to_dict()
+    assert loaded_signals[signal.id].metadata.note == "initial"
 
     stored_payloads = storage._writer.read_signals()
     assert stored_payloads and isinstance(stored_payloads[0], SignalPayload)
@@ -217,7 +217,7 @@ def test_trade_repository_updates_excel(tmp_path) -> None:
     assert loaded_trades[trade.id].opened_at == trade.opened_at
     assert loaded_trades[trade.id].opened_at and loaded_trades[trade.id].opened_at.tzinfo is not None
     assert loaded_trades[trade.id].metadata is not None
-    assert loaded_trades[trade.id].metadata.extra.get("note") == "initial"
+    assert loaded_trades[trade.id].metadata.note == "initial"
 
     rows = _read_sheet_rows(workbook_path, "Trades")
     assert len(rows) == 1

--- a/tests/test_signal_selector.py
+++ b/tests/test_signal_selector.py
@@ -113,7 +113,7 @@ def test_select_allows_long_when_thresholds_met(selector: SignalSelectorService)
     assert threshold_meta is not None
     assert threshold_meta.name == "atr"
     assert threshold_meta.min_value == pytest.approx(5.0)
-    assert "metrics" not in signal.metadata.extra
+    assert "metrics" not in signal.metadata.to_dict()
 
 
 def test_select_redirects_to_short_when_long_body_growth_too_small(


### PR DESCRIPTION
## Summary
- replace generic metadata extras with typed payload dataclasses and explicit note/range fields
- update storage/config parsing and runners to work with typed metadata objects and explicit backtest/live metadata
- adjust tests to assert against the new typed metadata API

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd4f5e31c48320a7bc28a0331ef316