### PR TITLE
Refactor Excel persistence to use typed sheet rows

### DIFF
--- a/bot/data/io/excel_rows.py
+++ b/bot/data/io/excel_rows.py
@@ -2,208 +2,304 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from datetime import datetime
-from typing import Any, Iterable, Mapping, Optional, Sequence, Union
+from typing import ClassVar, Iterable, Mapping, Sequence
 
-JSONPrimitive = Union[str, int, float, bool, None]
-JSONValue = Union[JSONPrimitive, "JSONList", "JSONDict"]
+
+JSONPrimitive = str | int | float | bool | None
+JSONValue = JSONPrimitive | list["JSONValue"] | dict[str, "JSONValue"]
 JSONList = list[JSONValue]
 JSONDict = dict[str, JSONValue]
-JSONMapping = Mapping[str, JSONValue]
 
 
-def _require_str(value: Any, field: str) -> str:
-    if value is None:
-        raise ValueError(f"Missing required value for '{field}'")
-    if isinstance(value, str):
-        return value
-    if isinstance(value, datetime):
-        return value.isoformat()
-    return str(value)
+class _RowParser:
+    """Utility mixin providing coercion helpers using duck typing."""
 
+    @staticmethod
+    def _require_text(value: object, field: str) -> str:
+        if value is None:
+            raise ValueError(f"Missing required value for '{field}'")
+        if hasattr(value, "isoformat"):
+            try:
+                return value.isoformat()  # type: ignore[call-arg]
+            except Exception:
+                pass
+        return f"{value}"
 
-def _optional_str(value: Any) -> Optional[str]:
-    if value is None:
-        return None
-    if isinstance(value, str):
-        return value
-    if isinstance(value, datetime):
-        return value.isoformat()
-    return str(value)
-
-
-def _require_float(value: Any, field: str) -> float:
-    if value is None:
-        raise ValueError(f"Missing required value for '{field}'")
-    return float(value)
-
-
-def _optional_float(value: Any) -> Optional[float]:
-    if value is None:
-        return None
-    return float(value)
-
-
-def _require_int(value: Any, field: str) -> int:
-    if value is None:
-        raise ValueError(f"Missing required value for '{field}'")
-    return int(value)
-
-
-def _ensure_bool(value: Any, *, default: bool = False) -> bool:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        lowered = value.strip().lower()
-        if lowered in {"true", "1", "yes"}:
-            return True
-        if lowered in {"false", "0", "no"}:
-            return False
-    if value is None:
-        return default
-    return bool(value)
-
-
-def _ensure_json_value(value: Any) -> JSONValue:
-    if isinstance(value, (str, int, float, bool)) or value is None:
-        return value
-    if isinstance(value, Mapping):
-        return {str(key): _ensure_json_value(val) for key, val in value.items()}
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        return [_ensure_json_value(item) for item in value]
-    return str(value)
-
-
-def _load_json_value(raw: Any) -> JSONValue | None:
-    if raw in (None, ""):
-        return None
-    if isinstance(raw, (dict, list)):
-        return _ensure_json_value(raw)
-    if isinstance(raw, str):
-        try:
-            parsed = json.loads(raw)
-        except (TypeError, json.JSONDecodeError):
+    @staticmethod
+    def _optional_text(value: object | None) -> str | None:
+        if value is None:
             return None
-        return _ensure_json_value(parsed)
-    return _ensure_json_value(raw)
+        if hasattr(value, "isoformat"):
+            try:
+                return value.isoformat()  # type: ignore[call-arg]
+            except Exception:
+                return f"{value}"
+        return f"{value}"
 
+    @staticmethod
+    def _require_float(value: object, field: str) -> float:
+        if value is None:
+            raise ValueError(f"Missing required value for '{field}'")
+        try:
+            return float(value)  # type: ignore[arg-type]
+        except Exception as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Unable to convert '{field}' to float") from exc
 
-def _load_json_dict(raw: Any) -> JSONDict:
-    loaded = _load_json_value(raw)
-    if isinstance(loaded, dict):
-        return loaded
-    return {}
+    @staticmethod
+    def _optional_float(value: object | None) -> float | None:
+        if value is None:
+            return None
+        try:
+            return float(value)  # type: ignore[arg-type]
+        except Exception:  # pragma: no cover - defensive
+            return None
 
+    @staticmethod
+    def _optional_int(value: object | None) -> int | None:
+        if value is None:
+            return None
+        try:
+            return int(value)  # type: ignore[arg-type]
+        except Exception:  # pragma: no cover - defensive
+            return None
 
-def _load_json_list(raw: Any) -> JSONList:
-    loaded = _load_json_value(raw)
-    if isinstance(loaded, list):
-        return loaded
-    return []
+    @staticmethod
+    def _require_int(value: object, field: str) -> int:
+        converted = _RowParser._optional_int(value)
+        if converted is None:
+            raise ValueError(f"Missing required value for '{field}'")
+        return converted
 
+    @staticmethod
+    def _optional_bool(value: object | None) -> bool | None:
+        if value is None:
+            return None
+        text = f"{value}".strip().lower()
+        if text in {"true", "1", "yes"}:
+            return True
+        if text in {"false", "0", "no"}:
+            return False
+        return bool(value)
 
-def _load_json_dict_list(raw: Any) -> list[JSONDict]:
-    result: list[JSONDict] = []
-    for entry in _load_json_list(raw):
-        if isinstance(entry, dict):
-            result.append(entry)
-    return result
+    @staticmethod
+    def _require_bool(value: object, field: str) -> bool:
+        converted = _RowParser._optional_bool(value)
+        if converted is None:
+            raise ValueError(f"Missing required value for '{field}'")
+        return converted
 
+    @classmethod
+    def _parse_json(cls, value: object | None) -> JSONValue | None:
+        if value in (None, ""):
+            return None
+        if hasattr(value, "items"):
+            try:
+                items = value.items()  # type: ignore[attr-defined]
+            except Exception:  # pragma: no cover - defensive
+                return None
+            return {
+                cls._require_text(key, "json_key"): cls._normalize_json(val)
+                for key, val in items
+            }
+        if hasattr(value, "strip"):
+            text = f"{value}".strip()
+            if not text:
+                return None
+            try:
+                loaded = json.loads(text)
+            except Exception:
+                return None
+            return cls._normalize_json(loaded)
+        try:
+            iterable = iter(value)  # type: ignore[arg-type]
+        except Exception:
+            return cls._normalize_json(value)
+        return [cls._normalize_json(item) for item in iterable]
 
-def _ensure_json_dict(mapping: JSONMapping | None) -> JSONDict:
-    if mapping is None:
-        return {}
-    return {str(key): _ensure_json_value(value) for key, value in mapping.items()}
+    @classmethod
+    def _normalize_json(cls, value: object | None) -> JSONValue:
+        if value is None:
+            return None
+        if hasattr(value, "isoformat"):
+            try:
+                return value.isoformat()  # type: ignore[call-arg]
+            except Exception:
+                return f"{value}"
+        if hasattr(value, "items"):
+            try:
+                items = value.items()  # type: ignore[attr-defined]
+            except Exception:  # pragma: no cover - defensive
+                return f"{value}"
+            return {
+                cls._require_text(key, "json_key"): cls._normalize_json(val)
+                for key, val in items
+            }
+        if hasattr(value, "strip"):
+            return f"{value}"
+        try:
+            iterable = iter(value)  # type: ignore[arg-type]
+        except Exception:
+            pass
+        else:
+            return [cls._normalize_json(item) for item in iterable]
+        try:
+            return float(value)  # type: ignore[arg-type]
+        except Exception:
+            return f"{value}"
 
 
 @dataclass(frozen=True)
-class ThresholdMetricPayload:
+class ThresholdMetricPayload(_RowParser):
     name: str
     min_value: float | None = None
     max_value: float | None = None
     min_abs_value: float | None = None
 
     @classmethod
-    def from_mapping(cls, raw: JSONMapping) -> "ThresholdMetricPayload" | None:
-        name_value = raw.get("name")
-        if not isinstance(name_value, str):
+    def from_mapping(cls, raw: Mapping[str, object]) -> "ThresholdMetricPayload" | None:
+        try:
+            name_value = raw["name"]
+        except KeyError:
             return None
-        min_value = raw.get("min_value")
-        max_value = raw.get("max_value")
-        min_abs_value = raw.get("min_abs_value")
-        return cls(
-            name=name_value,
-            min_value=float(min_value) if isinstance(min_value, (int, float)) else None,
-            max_value=float(max_value) if isinstance(max_value, (int, float)) else None,
-            min_abs_value=float(min_abs_value)
-            if isinstance(min_abs_value, (int, float))
-            else None,
-        )
+        name = cls._require_text(name_value, "name")
+        minimum = cls._optional_float(raw.get("min_value"))
+        maximum = cls._optional_float(raw.get("max_value"))
+        min_abs = cls._optional_float(raw.get("min_abs_value"))
+        return cls(name=name, min_value=minimum, max_value=maximum, min_abs_value=min_abs)
+
+    def to_mapping(self) -> JSONDict:
+        data: JSONDict = {"name": self.name}
+        if self.min_value is not None:
+            data["min_value"] = self.min_value
+        if self.max_value is not None:
+            data["max_value"] = self.max_value
+        if self.min_abs_value is not None:
+            data["min_abs_value"] = self.min_abs_value
+        return data
 
 
 @dataclass(frozen=True)
-class SignalMetricPayload:
+class SignalMetricPayload(_RowParser):
     name: str
     value: float
     passed: bool
     threshold: ThresholdMetricPayload | None
 
     @classmethod
-    def from_mapping(cls, raw: JSONMapping) -> "SignalMetricPayload" | None:
-        name_value = raw.get("name")
-        value_value = raw.get("value")
-        if not isinstance(name_value, str):
+    def from_mapping(cls, raw: Mapping[str, object]) -> "SignalMetricPayload" | None:
+        try:
+            name_value = raw["name"]
+            value_value = raw["value"]
+        except KeyError:
             return None
-        if not isinstance(value_value, (int, float)):
+        name = cls._require_text(name_value, "name")
+        try:
+            value = float(value_value)  # type: ignore[arg-type]
+        except Exception:
             return None
-        passed_value = raw.get("passed", False)
-        threshold_raw = raw.get("threshold")
-        threshold: ThresholdMetricPayload | None = None
-        if isinstance(threshold_raw, Mapping):
-            threshold = ThresholdMetricPayload.from_mapping(threshold_raw)
-        return cls(
-            name=name_value,
-            value=float(value_value),
-            passed=bool(passed_value),
-            threshold=threshold,
-        )
+        passed = bool(raw.get("passed", False))
+        threshold_mapping = raw.get("threshold")
+        threshold_payload: ThresholdMetricPayload | None = None
+        try:
+            mapping = dict(threshold_mapping)  # type: ignore[arg-type]
+        except Exception:
+            threshold_payload = None
+        else:
+            threshold_payload = ThresholdMetricPayload.from_mapping(mapping)
+        return cls(name=name, value=value, passed=passed, threshold=threshold_payload)
+
+    def to_mapping(self) -> JSONDict:
+        data: JSONDict = {
+            "name": self.name,
+            "value": self.value,
+            "passed": self.passed,
+        }
+        if self.threshold is not None:
+            data["threshold"] = self.threshold.to_mapping()
+        return data
 
 
 @dataclass(frozen=True)
-class ThresholdPayload:
+class ThresholdRow(_RowParser):
     raw: JSONDict
     metadata: JSONDict
-    metrics: list[ThresholdMetricPayload]
+    metrics: tuple[ThresholdMetricPayload, ...]
     created_at: str | None
     updated_at: str | None
     allow_long: bool | None
     allow_short: bool | None
 
     @classmethod
-    def from_mapping(cls, raw: JSONMapping) -> "ThresholdPayload":
-        metadata_raw = raw.get("metadata")
-        metadata = _ensure_json_dict(metadata_raw if isinstance(metadata_raw, Mapping) else None)
-        metrics_entries: list[ThresholdMetricPayload] = []
-        metrics_raw = raw.get("metrics")
-        if isinstance(metrics_raw, Sequence) and not isinstance(metrics_raw, (str, bytes, bytearray)):
-            for entry in metrics_raw:
-                if isinstance(entry, Mapping):
-                    metric = ThresholdMetricPayload.from_mapping(entry)
-                    if metric is not None:
-                        metrics_entries.append(metric)
-        created_at_raw = raw.get("created_at")
-        updated_at_raw = raw.get("updated_at")
-        allow_long_raw = raw.get("allow_long")
-        allow_short_raw = raw.get("allow_short")
+    def empty(cls) -> "ThresholdRow":
         return cls(
-            raw=_ensure_json_dict(raw),
-            metadata=metadata,
-            metrics=metrics_entries,
-            created_at=str(created_at_raw) if isinstance(created_at_raw, str) else None,
-            updated_at=str(updated_at_raw) if isinstance(updated_at_raw, str) else None,
-            allow_long=_ensure_bool(allow_long_raw) if allow_long_raw is not None else None,
-            allow_short=_ensure_bool(allow_short_raw) if allow_short_raw is not None else None,
+            raw={},
+            metadata={},
+            metrics=(),
+            created_at=None,
+            updated_at=None,
+            allow_long=None,
+            allow_short=None,
         )
+
+    @classmethod
+    def from_cell(cls, value: object | None) -> "ThresholdRow":
+        parsed = cls._parse_json(value)
+        if parsed is None:
+            return cls.empty()
+        try:
+            mapping = dict(parsed)  # type: ignore[arg-type]
+        except Exception:
+            return cls.empty()
+        return cls.from_mapping(mapping)
+
+    @classmethod
+    def from_mapping(cls, mapping: Mapping[str, object] | JSONDict) -> "ThresholdRow":
+        data: JSONDict = {
+            cls._require_text(key, "threshold_key"): cls._normalize_json(value)
+            for key, value in mapping.items()
+        }
+        metadata_raw = data.get("metadata")
+        try:
+            metadata_mapping = dict(metadata_raw)  # type: ignore[arg-type]
+        except Exception:
+            metadata_mapping = {}
+        metadata: JSONDict = {
+            cls._require_text(key, "metadata_key"): cls._normalize_json(value)
+            for key, value in metadata_mapping.items()
+        }
+        metrics_raw = data.get("metrics")
+        metrics_entries: list[ThresholdMetricPayload] = []
+        try:
+            iterator = iter(metrics_raw)  # type: ignore[arg-type]
+        except Exception:
+            iterator = iter(())
+        for entry in iterator:
+            try:
+                metric_mapping = dict(entry)  # type: ignore[arg-type]
+            except Exception:
+                continue
+            metric = ThresholdMetricPayload.from_mapping(metric_mapping)
+            if metric is not None:
+                metrics_entries.append(metric)
+        data["metadata"] = metadata
+        metrics_data = [metric.to_mapping() for metric in metrics_entries]
+        data["metrics"] = metrics_data
+        created_at = cls._optional_text(data.get("created_at"))
+        updated_at = cls._optional_text(data.get("updated_at"))
+        allow_long = cls._optional_bool(data.get("allow_long"))
+        allow_short = cls._optional_bool(data.get("allow_short"))
+        return cls(
+            raw=data,
+            metadata=metadata,
+            metrics=tuple(metrics_entries),
+            created_at=created_at,
+            updated_at=updated_at,
+            allow_long=allow_long,
+            allow_short=allow_short,
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(self.raw, sort_keys=True)
 
     def get_first(self, keys: Iterable[str]) -> JSONValue | None:
         for key in keys:
@@ -243,8 +339,8 @@ class SignalPayload:
     timeframe: str | None
     allow_long: bool
     allow_short: bool
-    thresholds: ThresholdPayload
-    metrics: list[SignalMetricPayload]
+    thresholds: ThresholdRow
+    metrics: tuple[SignalMetricPayload, ...]
     metrics_snapshot: JSONDict | None
     metadata: JSONDict
 
@@ -275,12 +371,41 @@ class TradePayload:
     updated_at: str | None
     allow_long: bool
     allow_short: bool
-    thresholds_snapshot: ThresholdPayload | None
+    thresholds_snapshot: ThresholdRow | None
     metadata: JSONDict
 
 
 @dataclass(frozen=True)
-class StoredSignalRow:
+class SignalRow(_RowParser):
+    HEADERS: ClassVar[tuple[str, ...]] = (
+        "id",
+        "candle_id",
+        "symbol",
+        "exchange",
+        "timeframe",
+        "candle_timeframe",
+        "side",
+        "direction",
+        "score",
+        "triggered_at",
+        "created_at",
+        "updated_at",
+        "allow_long",
+        "allow_short",
+        "candle_open",
+        "candle_high",
+        "candle_low",
+        "candle_close",
+        "candle_volume",
+        "candle_quote_volume",
+        "candle_started_at",
+        "candle_closed_at",
+        "thresholds_json",
+        "metrics_json",
+        "metrics_snapshot_json",
+        "metadata_json",
+    )
+
     id: str
     candle_id: str | None
     symbol: str
@@ -303,154 +428,122 @@ class StoredSignalRow:
     candle_quote_volume: float | None
     candle_started_at: str
     candle_closed_at: str
-    thresholds_json: str
-    metrics_json: str
-    metrics_snapshot_json: str | None
-    metadata_json: str
+    thresholds: ThresholdRow
+    metrics: tuple[SignalMetricPayload, ...]
+    metrics_snapshot: JSONDict | None
+    metadata: JSONDict
 
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "id", _require_str(self.id, "id"))
-        object.__setattr__(self, "candle_id", _optional_str(self.candle_id))
-        object.__setattr__(self, "symbol", _require_str(self.symbol, "symbol"))
-        object.__setattr__(self, "exchange", _require_str(self.exchange, "exchange"))
-        object.__setattr__(self, "timeframe", _optional_str(self.timeframe))
-        object.__setattr__(self, "candle_timeframe", _optional_str(self.candle_timeframe))
-        object.__setattr__(self, "side", _require_str(self.side, "side"))
-        object.__setattr__(self, "direction", _require_int(self.direction, "direction"))
-        object.__setattr__(self, "score", _require_float(self.score, "score"))
-        object.__setattr__(self, "triggered_at", _require_str(self.triggered_at, "triggered_at"))
-        object.__setattr__(self, "created_at", _optional_str(self.created_at))
-        object.__setattr__(self, "updated_at", _optional_str(self.updated_at))
-        object.__setattr__(self, "allow_long", _ensure_bool(self.allow_long, default=True))
-        object.__setattr__(self, "allow_short", _ensure_bool(self.allow_short, default=True))
-        object.__setattr__(self, "candle_open", _require_float(self.candle_open, "candle_open"))
-        object.__setattr__(self, "candle_high", _require_float(self.candle_high, "candle_high"))
-        object.__setattr__(self, "candle_low", _require_float(self.candle_low, "candle_low"))
-        object.__setattr__(self, "candle_close", _require_float(self.candle_close, "candle_close"))
-        object.__setattr__(self, "candle_volume", _require_float(self.candle_volume, "candle_volume"))
-        object.__setattr__(self, "candle_quote_volume", _optional_float(self.candle_quote_volume))
-        object.__setattr__(self, "candle_started_at", _require_str(self.candle_started_at, "candle_started_at"))
-        object.__setattr__(self, "candle_closed_at", _require_str(self.candle_closed_at, "candle_closed_at"))
-        object.__setattr__(self, "thresholds_json", _require_str(self.thresholds_json, "thresholds_json"))
-        object.__setattr__(self, "metrics_json", _require_str(self.metrics_json, "metrics_json"))
-        object.__setattr__(self, "metrics_snapshot_json", _optional_str(self.metrics_snapshot_json))
-        object.__setattr__(self, "metadata_json", _require_str(self.metadata_json, "metadata_json"))
-
-    def to_excel_row(self) -> dict[str, object]:
-        return {
-            "id": self.id,
-            "candle_id": self.candle_id,
-            "symbol": self.symbol,
-            "exchange": self.exchange,
-            "timeframe": self.timeframe,
-            "candle_timeframe": self.candle_timeframe,
-            "side": self.side,
-            "direction": self.direction,
-            "score": self.score,
-            "triggered_at": self.triggered_at,
-            "created_at": self.created_at,
-            "updated_at": self.updated_at,
-            "allow_long": self.allow_long,
-            "allow_short": self.allow_short,
-            "candle_open": self.candle_open,
-            "candle_high": self.candle_high,
-            "candle_low": self.candle_low,
-            "candle_close": self.candle_close,
-            "candle_volume": self.candle_volume,
-            "candle_quote_volume": self.candle_quote_volume,
-            "candle_started_at": self.candle_started_at,
-            "candle_closed_at": self.candle_closed_at,
-            "thresholds_json": self.thresholds_json,
-            "metrics_json": self.metrics_json,
-            "metrics_snapshot_json": self.metrics_snapshot_json,
-            "metadata_json": self.metadata_json,
-        }
+    def as_excel_values(self) -> list[object]:
+        metrics_json = [metric.to_mapping() for metric in self.metrics]
+        snapshot_json = None
+        if self.metrics_snapshot is not None:
+            snapshot_json = json.dumps(self.metrics_snapshot, sort_keys=True)
+        return [
+            self.id,
+            self.candle_id,
+            self.symbol,
+            self.exchange,
+            self.timeframe,
+            self.candle_timeframe,
+            self.side,
+            self.direction,
+            self.score,
+            self.triggered_at,
+            self.created_at,
+            self.updated_at,
+            self.allow_long,
+            self.allow_short,
+            self.candle_open,
+            self.candle_high,
+            self.candle_low,
+            self.candle_close,
+            self.candle_volume,
+            self.candle_quote_volume,
+            self.candle_started_at,
+            self.candle_closed_at,
+            self.thresholds.to_json(),
+            json.dumps(metrics_json, sort_keys=True),
+            snapshot_json,
+            json.dumps(self.metadata, sort_keys=True),
+        ]
 
     @classmethod
-    def from_excel_row(cls, row: Mapping[str, object]) -> SignalPayload:
-        identifier = _require_str(row.get("id"), "id")
-        candle_id = _optional_str(row.get("candle_id"))
-        symbol = _require_str(row.get("symbol"), "symbol")
-        exchange = _require_str(row.get("exchange"), "exchange")
-        timeframe = _optional_str(row.get("timeframe"))
-        candle_timeframe = _optional_str(row.get("candle_timeframe"))
-        side = _require_str(row.get("side"), "side")
-        direction = _require_int(row.get("direction"), "direction")
-        score = _require_float(row.get("score"), "score")
-        triggered_at = _require_str(row.get("triggered_at"), "triggered_at")
-        created_at = _optional_str(row.get("created_at"))
-        updated_at = _optional_str(row.get("updated_at"))
-        allow_long = _ensure_bool(row.get("allow_long", True), default=True)
-        allow_short = _ensure_bool(row.get("allow_short", True), default=True)
-        candle_open = _require_float(row.get("candle_open"), "candle_open")
-        candle_high = _require_float(row.get("candle_high"), "candle_high")
-        candle_low = _require_float(row.get("candle_low"), "candle_low")
-        candle_close = _require_float(row.get("candle_close"), "candle_close")
-        candle_volume = _require_float(row.get("candle_volume"), "candle_volume")
-        candle_quote_volume = _optional_float(row.get("candle_quote_volume"))
-        candle_started_at = _require_str(row.get("candle_started_at"), "candle_started_at")
-        candle_closed_at = _require_str(row.get("candle_closed_at"), "candle_closed_at")
-        thresholds_json = _require_str(row.get("thresholds_json"), "thresholds_json")
-        metrics_json = _require_str(row.get("metrics_json"), "metrics_json")
-        metrics_snapshot_json = _optional_str(row.get("metrics_snapshot_json"))
-        metadata_json = _require_str(row.get("metadata_json"), "metadata_json")
-
-        thresholds_mapping = _load_json_dict(thresholds_json)
-        metrics_raw = _load_json_dict_list(metrics_json)
-        metadata_mapping = _load_json_dict(metadata_json)
-        snapshot_raw = _load_json_value(metrics_snapshot_json)
-        metrics_snapshot = snapshot_raw if isinstance(snapshot_raw, dict) else None
-        thresholds = ThresholdPayload.from_mapping(thresholds_mapping)
-        metrics: list[SignalMetricPayload] = []
-        for entry in metrics_raw:
-            metric = SignalMetricPayload.from_mapping(entry)
+    def from_excel_row(cls, headers: Sequence[str], values: Sequence[object]) -> "SignalRow":
+        mapping: dict[str, object] = {
+            headers[idx]: values[idx] for idx in range(min(len(headers), len(values)))
+        }
+        metrics_raw = cls._parse_json(mapping.get("metrics_json"))
+        metrics_entries: list[SignalMetricPayload] = []
+        try:
+            iterator = iter(metrics_raw)  # type: ignore[arg-type]
+        except Exception:
+            iterator = iter(())
+        for entry in iterator:
+            try:
+                metric_mapping = dict(entry)  # type: ignore[arg-type]
+            except Exception:
+                continue
+            metric = SignalMetricPayload.from_mapping(metric_mapping)
             if metric is not None:
-                metrics.append(metric)
-        candle = CandlePayload(
-            id=candle_id,
-            symbol=symbol,
-            exchange=exchange,
-            timeframe=candle_timeframe or timeframe,
-            open=candle_open,
-            high=candle_high,
-            low=candle_low,
-            close=candle_close,
-            volume=candle_volume,
-            quote_volume=candle_quote_volume,
-            started_at=candle_started_at,
-            closed_at=candle_closed_at,
-        )
-        return SignalPayload(
-            id=identifier,
-            candle_id=candle_id,
-            candle=candle,
-            side=side,
-            direction=direction,
-            score=score,
-            triggered_at=triggered_at,
-            created_at=created_at,
-            updated_at=updated_at,
-            timeframe=timeframe,
-            allow_long=allow_long,
-            allow_short=allow_short,
+                metrics_entries.append(metric)
+        snapshot_raw = cls._parse_json(mapping.get("metrics_snapshot_json"))
+        snapshot_dict: JSONDict | None = None
+        if snapshot_raw:
+            try:
+                snapshot_items = snapshot_raw.items()  # type: ignore[attr-defined]
+            except Exception:
+                snapshot_dict = None
+            else:
+                snapshot_dict = {
+                    cls._require_text(key, "snapshot_key"): cls._normalize_json(value)
+                    for key, value in snapshot_items
+                }
+        metadata_raw = cls._parse_json(mapping.get("metadata_json"))
+        metadata_dict: JSONDict = {}
+        if metadata_raw:
+            try:
+                metadata_mapping = dict(metadata_raw)  # type: ignore[arg-type]
+            except Exception:
+                metadata_mapping = {}
+            metadata_dict = {
+                cls._require_text(key, "metadata_key"): cls._normalize_json(value)
+                for key, value in metadata_mapping.items()
+            }
+        thresholds = ThresholdRow.from_cell(mapping.get("thresholds_json"))
+        return cls(
+            id=cls._require_text(mapping.get("id"), "id"),
+            candle_id=cls._optional_text(mapping.get("candle_id")),
+            symbol=cls._require_text(mapping.get("symbol"), "symbol"),
+            exchange=cls._require_text(mapping.get("exchange"), "exchange"),
+            timeframe=cls._optional_text(mapping.get("timeframe")),
+            candle_timeframe=cls._optional_text(mapping.get("candle_timeframe")),
+            side=cls._require_text(mapping.get("side"), "side"),
+            direction=cls._require_int(mapping.get("direction"), "direction"),
+            score=cls._require_float(mapping.get("score"), "score"),
+            triggered_at=cls._require_text(mapping.get("triggered_at"), "triggered_at"),
+            created_at=cls._optional_text(mapping.get("created_at")),
+            updated_at=cls._optional_text(mapping.get("updated_at")),
+            allow_long=cls._require_bool(mapping.get("allow_long", True), "allow_long"),
+            allow_short=cls._require_bool(mapping.get("allow_short", True), "allow_short"),
+            candle_open=cls._require_float(mapping.get("candle_open"), "candle_open"),
+            candle_high=cls._require_float(mapping.get("candle_high"), "candle_high"),
+            candle_low=cls._require_float(mapping.get("candle_low"), "candle_low"),
+            candle_close=cls._require_float(mapping.get("candle_close"), "candle_close"),
+            candle_volume=cls._require_float(mapping.get("candle_volume"), "candle_volume"),
+            candle_quote_volume=cls._optional_float(mapping.get("candle_quote_volume")),
+            candle_started_at=cls._require_text(
+                mapping.get("candle_started_at"), "candle_started_at"
+            ),
+            candle_closed_at=cls._require_text(
+                mapping.get("candle_closed_at"), "candle_closed_at"
+            ),
             thresholds=thresholds,
-            metrics=metrics,
-            metrics_snapshot=metrics_snapshot,
-            metadata=metadata_mapping,
+            metrics=tuple(metrics_entries),
+            metrics_snapshot=snapshot_dict,
+            metadata=metadata_dict,
         )
 
     def to_payload(self) -> SignalPayload:
-        thresholds_mapping = _load_json_dict(self.thresholds_json)
-        metrics_raw = _load_json_dict_list(self.metrics_json)
-        metadata_mapping = _load_json_dict(self.metadata_json)
-        snapshot_raw = _load_json_value(self.metrics_snapshot_json)
-        metrics_snapshot = snapshot_raw if isinstance(snapshot_raw, dict) else None
-        thresholds = ThresholdPayload.from_mapping(thresholds_mapping)
-        metrics: list[SignalMetricPayload] = []
-        for entry in metrics_raw:
-            metric = SignalMetricPayload.from_mapping(entry)
-            if metric is not None:
-                metrics.append(metric)
         candle = CandlePayload(
             id=self.candle_id,
             symbol=self.symbol,
@@ -478,15 +571,44 @@ class StoredSignalRow:
             timeframe=self.timeframe,
             allow_long=self.allow_long,
             allow_short=self.allow_short,
-            thresholds=thresholds,
-            metrics=metrics,
-            metrics_snapshot=metrics_snapshot,
-            metadata=metadata_mapping,
+            thresholds=self.thresholds,
+            metrics=self.metrics,
+            metrics_snapshot=self.metrics_snapshot,
+            metadata=self.metadata,
         )
 
 
 @dataclass(frozen=True)
-class StoredTradeRow:
+class TradeRow(_RowParser):
+    HEADERS: ClassVar[tuple[str, ...]] = (
+        "id",
+        "signal_id",
+        "source_signal_id",
+        "exchange",
+        "symbol",
+        "timeframe",
+        "side",
+        "status",
+        "entry_price",
+        "size",
+        "used_margin",
+        "exit_price",
+        "tp_price",
+        "sl_price",
+        "tp_pct",
+        "sl_pct",
+        "opened_at",
+        "closed_at",
+        "pnl",
+        "pnl_pct",
+        "created_at",
+        "updated_at",
+        "allow_long",
+        "allow_short",
+        "thresholds_snapshot_json",
+        "metadata_json",
+    )
+
     id: str
     signal_id: str
     source_signal_id: str | None
@@ -511,145 +633,100 @@ class StoredTradeRow:
     updated_at: str | None
     allow_long: bool
     allow_short: bool
-    thresholds_snapshot_json: str | None
-    metadata_json: str
+    thresholds_snapshot: ThresholdRow | None
+    metadata: JSONDict
 
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "id", _require_str(self.id, "id"))
-        object.__setattr__(self, "signal_id", _require_str(self.signal_id, "signal_id"))
-        object.__setattr__(self, "source_signal_id", _optional_str(self.source_signal_id))
-        object.__setattr__(self, "exchange", _require_str(self.exchange, "exchange"))
-        object.__setattr__(self, "symbol", _require_str(self.symbol, "symbol"))
-        object.__setattr__(self, "timeframe", _optional_str(self.timeframe))
-        object.__setattr__(self, "side", _require_str(self.side, "side"))
-        object.__setattr__(self, "status", _require_str(self.status, "status"))
-        object.__setattr__(self, "entry_price", _require_float(self.entry_price, "entry_price"))
-        object.__setattr__(self, "size", _require_float(self.size, "size"))
-        object.__setattr__(self, "used_margin", _require_float(self.used_margin, "used_margin"))
-        object.__setattr__(self, "exit_price", _optional_float(self.exit_price))
-        object.__setattr__(self, "tp_price", _optional_float(self.tp_price))
-        object.__setattr__(self, "sl_price", _optional_float(self.sl_price))
-        object.__setattr__(self, "tp_pct", _optional_float(self.tp_pct))
-        object.__setattr__(self, "sl_pct", _optional_float(self.sl_pct))
-        object.__setattr__(self, "opened_at", _optional_str(self.opened_at))
-        object.__setattr__(self, "closed_at", _optional_str(self.closed_at))
-        object.__setattr__(self, "pnl", _optional_float(self.pnl))
-        object.__setattr__(self, "pnl_pct", _optional_float(self.pnl_pct))
-        object.__setattr__(self, "created_at", _optional_str(self.created_at))
-        object.__setattr__(self, "updated_at", _optional_str(self.updated_at))
-        object.__setattr__(self, "allow_long", _ensure_bool(self.allow_long, default=True))
-        object.__setattr__(self, "allow_short", _ensure_bool(self.allow_short, default=True))
-        object.__setattr__(self, "thresholds_snapshot_json", _optional_str(self.thresholds_snapshot_json))
-        object.__setattr__(self, "metadata_json", _require_str(self.metadata_json, "metadata_json"))
-
-    def to_excel_row(self) -> dict[str, object]:
-        return {
-            "id": self.id,
-            "signal_id": self.signal_id,
-            "source_signal_id": self.source_signal_id,
-            "exchange": self.exchange,
-            "symbol": self.symbol,
-            "timeframe": self.timeframe,
-            "side": self.side,
-            "status": self.status,
-            "entry_price": self.entry_price,
-            "size": self.size,
-            "used_margin": self.used_margin,
-            "exit_price": self.exit_price,
-            "tp_price": self.tp_price,
-            "sl_price": self.sl_price,
-            "tp_pct": self.tp_pct,
-            "sl_pct": self.sl_pct,
-            "opened_at": self.opened_at,
-            "closed_at": self.closed_at,
-            "pnl": self.pnl,
-            "pnl_pct": self.pnl_pct,
-            "created_at": self.created_at,
-            "updated_at": self.updated_at,
-            "allow_long": self.allow_long,
-            "allow_short": self.allow_short,
-            "thresholds_snapshot_json": self.thresholds_snapshot_json,
-            "metadata_json": self.metadata_json,
-        }
-
-    @classmethod
-    def from_excel_row(cls, row: Mapping[str, object]) -> TradePayload:
-        identifier = _require_str(row.get("id"), "id")
-        signal_id = _require_str(row.get("signal_id"), "signal_id")
-        source_signal_id = _optional_str(row.get("source_signal_id"))
-        exchange = _require_str(row.get("exchange"), "exchange")
-        symbol = _require_str(row.get("symbol"), "symbol")
-        timeframe = _optional_str(row.get("timeframe"))
-        side = _require_str(row.get("side"), "side")
-        status = _require_str(row.get("status"), "status")
-        entry_price = _require_float(row.get("entry_price"), "entry_price")
-        size = _require_float(row.get("size"), "size")
-        used_margin_raw = (
-            row.get("used_margin")
-            if row.get("used_margin") is not None
-            else row.get("used_amount", row.get("size"))
-        )
-        used_margin = _require_float(used_margin_raw, "used_margin")
-        exit_price = _optional_float(row.get("exit_price"))
-        tp_price = _optional_float(row.get("tp_price"))
-        sl_price = _optional_float(row.get("sl_price"))
-        tp_pct = _optional_float(row.get("tp_pct"))
-        sl_pct = _optional_float(row.get("sl_pct"))
-        opened_at = _optional_str(row.get("opened_at"))
-        closed_at = _optional_str(row.get("closed_at"))
-        pnl = _optional_float(row.get("pnl"))
-        pnl_pct = _optional_float(row.get("pnl_pct"))
-        created_at = _optional_str(row.get("created_at"))
-        updated_at = _optional_str(row.get("updated_at"))
-        allow_long = _ensure_bool(row.get("allow_long", True), default=True)
-        allow_short = _ensure_bool(row.get("allow_short", True), default=True)
-        thresholds_snapshot_json = _optional_str(row.get("thresholds_snapshot_json"))
-        metadata_json = _require_str(row.get("metadata_json"), "metadata_json")
-
-        snapshot_raw = _load_json_value(thresholds_snapshot_json)
-        thresholds_snapshot = (
-            ThresholdPayload.from_mapping(snapshot_raw)
-            if isinstance(snapshot_raw, Mapping)
+    def as_excel_values(self) -> list[object]:
+        snapshot_json = (
+            self.thresholds_snapshot.to_json()
+            if self.thresholds_snapshot is not None
             else None
         )
-        metadata_mapping = _load_json_dict(metadata_json)
-        return TradePayload(
-            id=identifier,
-            signal_id=signal_id,
-            source_signal_id=source_signal_id,
-            exchange=exchange,
-            symbol=symbol,
-            timeframe=timeframe,
-            side=side,
-            status=status,
-            entry_price=entry_price,
-            size=size,
-            used_margin=used_margin,
-            exit_price=exit_price,
-            tp_price=tp_price,
-            sl_price=sl_price,
-            tp_pct=tp_pct,
-            sl_pct=sl_pct,
-            opened_at=opened_at,
-            closed_at=closed_at,
-            pnl=pnl,
-            pnl_pct=pnl_pct,
-            created_at=created_at,
-            updated_at=updated_at,
-            allow_long=allow_long,
-            allow_short=allow_short,
-            thresholds_snapshot=thresholds_snapshot,
-            metadata=metadata_mapping,
+        return [
+            self.id,
+            self.signal_id,
+            self.source_signal_id,
+            self.exchange,
+            self.symbol,
+            self.timeframe,
+            self.side,
+            self.status,
+            self.entry_price,
+            self.size,
+            self.used_margin,
+            self.exit_price,
+            self.tp_price,
+            self.sl_price,
+            self.tp_pct,
+            self.sl_pct,
+            self.opened_at,
+            self.closed_at,
+            self.pnl,
+            self.pnl_pct,
+            self.created_at,
+            self.updated_at,
+            self.allow_long,
+            self.allow_short,
+            snapshot_json,
+            json.dumps(self.metadata, sort_keys=True),
+        ]
+
+    @classmethod
+    def from_excel_row(cls, headers: Sequence[str], values: Sequence[object]) -> "TradeRow":
+        mapping: dict[str, object] = {
+            headers[idx]: values[idx] for idx in range(min(len(headers), len(values)))
+        }
+        thresholds_snapshot = ThresholdRow.from_cell(mapping.get("thresholds_snapshot_json"))
+        if not thresholds_snapshot.raw:
+            thresholds_snapshot_value: ThresholdRow | None = None
+        else:
+            thresholds_snapshot_value = thresholds_snapshot
+        metadata_raw = cls._parse_json(mapping.get("metadata_json"))
+        metadata: JSONDict = {}
+        if metadata_raw:
+            try:
+                metadata_mapping = dict(metadata_raw)  # type: ignore[arg-type]
+            except Exception:
+                metadata_mapping = {}
+            metadata = {
+                cls._require_text(key, "metadata_key"): cls._normalize_json(value)
+                for key, value in metadata_mapping.items()
+            }
+        used_margin_value = mapping.get("used_margin")
+        if used_margin_value is None:
+            used_margin_value = mapping.get("used_amount")
+        if used_margin_value is None:
+            used_margin_value = mapping.get("size")
+        return cls(
+            id=cls._require_text(mapping.get("id"), "id"),
+            signal_id=cls._require_text(mapping.get("signal_id"), "signal_id"),
+            source_signal_id=cls._optional_text(mapping.get("source_signal_id")),
+            exchange=cls._require_text(mapping.get("exchange"), "exchange"),
+            symbol=cls._require_text(mapping.get("symbol"), "symbol"),
+            timeframe=cls._optional_text(mapping.get("timeframe")),
+            side=cls._require_text(mapping.get("side"), "side"),
+            status=cls._require_text(mapping.get("status"), "status"),
+            entry_price=cls._require_float(mapping.get("entry_price"), "entry_price"),
+            size=cls._require_float(mapping.get("size"), "size"),
+            used_margin=cls._require_float(used_margin_value, "used_margin"),
+            exit_price=cls._optional_float(mapping.get("exit_price")),
+            tp_price=cls._optional_float(mapping.get("tp_price")),
+            sl_price=cls._optional_float(mapping.get("sl_price")),
+            tp_pct=cls._optional_float(mapping.get("tp_pct")),
+            sl_pct=cls._optional_float(mapping.get("sl_pct")),
+            opened_at=cls._optional_text(mapping.get("opened_at")),
+            closed_at=cls._optional_text(mapping.get("closed_at")),
+            pnl=cls._optional_float(mapping.get("pnl")),
+            pnl_pct=cls._optional_float(mapping.get("pnl_pct")),
+            created_at=cls._optional_text(mapping.get("created_at")),
+            updated_at=cls._optional_text(mapping.get("updated_at")),
+            allow_long=cls._require_bool(mapping.get("allow_long", True), "allow_long"),
+            allow_short=cls._require_bool(mapping.get("allow_short", True), "allow_short"),
+            thresholds_snapshot=thresholds_snapshot_value,
+            metadata=metadata,
         )
 
     def to_payload(self) -> TradePayload:
-        snapshot_raw = _load_json_value(self.thresholds_snapshot_json)
-        thresholds_snapshot = (
-            ThresholdPayload.from_mapping(snapshot_raw)
-            if isinstance(snapshot_raw, Mapping)
-            else None
-        )
-        metadata_mapping = _load_json_dict(self.metadata_json)
         return TradePayload(
             id=self.id,
             signal_id=self.signal_id,
@@ -675,46 +752,52 @@ class StoredTradeRow:
             updated_at=self.updated_at,
             allow_long=self.allow_long,
             allow_short=self.allow_short,
-            thresholds_snapshot=thresholds_snapshot,
-            metadata=metadata_mapping,
+            thresholds_snapshot=self.thresholds_snapshot,
+            metadata=self.metadata,
         )
 
 
 @dataclass(frozen=True)
-class StoredStateRow:
+class StateRow(_RowParser):
+    HEADERS: ClassVar[tuple[str, ...]] = (
+        "key",
+        "asset",
+        "deposit_amount",
+        "deposit_updated_at",
+        "used_amount",
+    )
+
     key: str
     asset: str
     deposit_amount: float
     deposit_updated_at: str | None
     used_amount: float
 
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "key", _require_str(self.key, "key"))
-        object.__setattr__(self, "asset", _require_str(self.asset, "asset"))
-        object.__setattr__(self, "deposit_amount", _require_float(self.deposit_amount, "deposit_amount"))
-        object.__setattr__(self, "deposit_updated_at", _optional_str(self.deposit_updated_at))
-        object.__setattr__(self, "used_amount", _require_float(self.used_amount, "used_amount"))
-
-    def to_excel_row(self) -> dict[str, object]:
-        return {
-            "key": self.key,
-            "asset": self.asset,
-            "deposit_amount": self.deposit_amount,
-            "deposit_updated_at": self.deposit_updated_at,
-            "used_amount": self.used_amount,
-        }
+    def as_excel_values(self) -> list[object]:
+        return [
+            self.key,
+            self.asset,
+            self.deposit_amount,
+            self.deposit_updated_at,
+            self.used_amount,
+        ]
 
     @classmethod
-    def from_excel_row(cls, row: Mapping[str, object]) -> "StoredStateRow":
-        key_value = _optional_str(row.get("key")) or "default"
-        asset_value = _optional_str(row.get("asset")) or "USDT"
-        deposit_amount = _optional_float(row.get("deposit_amount")) or 0.0
-        deposit_updated_at = _optional_str(row.get("deposit_updated_at"))
-        used_amount = _optional_float(row.get("used_amount")) or 0.0
+    def from_excel_row(cls, headers: Sequence[str], values: Sequence[object]) -> "StateRow":
+        mapping: dict[str, object] = {
+            headers[idx]: values[idx] for idx in range(min(len(headers), len(values)))
+        }
+        key_value = cls._optional_text(mapping.get("key")) or "default"
+        asset_value = cls._optional_text(mapping.get("asset")) or "USDT"
+        deposit_amount = cls._optional_float(mapping.get("deposit_amount")) or 0.0
+        deposit_updated_at = cls._optional_text(mapping.get("deposit_updated_at"))
+        used_amount = cls._optional_float(mapping.get("used_amount"))
+        if used_amount is None:
+            used_amount = cls._optional_float(mapping.get("used")) or 0.0
         return cls(
             key=key_value,
             asset=asset_value,
             deposit_amount=deposit_amount,
             deposit_updated_at=deposit_updated_at,
-            used_amount=used_amount,
+            used_amount=used_amount or 0.0,
         )

--- a/bot/data/io/excel_writer.py
+++ b/bot/data/io/excel_writer.py
@@ -2,18 +2,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from threading import RLock
-from typing import Any, Dict, Iterable, List, Optional, cast
+from typing import Any, Iterable, List, Optional, Sequence, cast
 
 from openpyxl import Workbook, load_workbook
 from openpyxl.worksheet.worksheet import Worksheet
 
-from .excel_rows import (
-    SignalPayload,
-    StoredSignalRow,
-    StoredStateRow,
-    StoredTradeRow,
-    TradePayload,
-)
+from .excel_rows import SignalPayload, SignalRow, StateRow, TradePayload, TradeRow
 
 
 @dataclass(frozen=True)
@@ -102,11 +96,11 @@ class ExcelWriter:
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
-    def write_signal(self, row: StoredSignalRow) -> None:
+    def write_signal(self, row: SignalRow) -> None:
         with self._lock:
             wb = self._load()
             ws = self._get_sheet(wb, self.SIGNAL_SHEET)
-            self._upsert_row(ws, self.SIGNAL_SHEET.headers, "id", row.to_excel_row())
+            self._upsert_row(ws, self.SIGNAL_SHEET.headers, "id", row.as_excel_values())
             wb.save(self._path)
 
     def read_signals(self) -> List[SignalPayload]:
@@ -114,15 +108,15 @@ class ExcelWriter:
             wb = self._load()
             ws = self._get_sheet(wb, self.SIGNAL_SHEET)
             return [
-                StoredSignalRow.from_excel_row(row)
-                for row in self._iter_rows(ws, self.SIGNAL_SHEET.headers)
+                row.to_payload()
+                for row in self._iter_rows(ws, self.SIGNAL_SHEET.headers, SignalRow)
             ]
 
-    def write_trade(self, row: StoredTradeRow) -> None:
+    def write_trade(self, row: TradeRow) -> None:
         with self._lock:
             wb = self._load()
             ws = self._get_sheet(wb, self.TRADE_SHEET)
-            self._upsert_row(ws, self.TRADE_SHEET.headers, "id", row.to_excel_row())
+            self._upsert_row(ws, self.TRADE_SHEET.headers, "id", row.as_excel_values())
             wb.save(self._path)
 
     def read_trades(self) -> List[TradePayload]:
@@ -130,28 +124,28 @@ class ExcelWriter:
             wb = self._load()
             ws = self._get_sheet(wb, self.TRADE_SHEET)
             return [
-                StoredTradeRow.from_excel_row(row)
-                for row in self._iter_rows(ws, self.TRADE_SHEET.headers)
+                row.to_payload()
+                for row in self._iter_rows(ws, self.TRADE_SHEET.headers, TradeRow)
             ]
 
-    def write_state(self, row: StoredStateRow) -> None:
+    def write_state(self, row: StateRow) -> None:
         with self._lock:
             wb = self._load()
             ws = self._get_sheet(wb, self.STATE_SHEET)
-            self._upsert_row(ws, self.STATE_SHEET.headers, "key", row.to_excel_row())
+            self._upsert_row(ws, self.STATE_SHEET.headers, "key", row.as_excel_values())
             wb.save(self._path)
 
-    def read_state(self, key: Optional[str] = None) -> Optional[StoredStateRow]:
+    def read_state(self, key: Optional[str] = None) -> Optional[StateRow]:
         with self._lock:
             wb = self._load()
             ws = self._get_sheet(wb, self.STATE_SHEET)
             if key is None:
-                for row in self._iter_rows(ws, self.STATE_SHEET.headers):
-                    return StoredStateRow.from_excel_row(row)
+                for row in self._iter_rows(ws, self.STATE_SHEET.headers, StateRow):
+                    return row
             else:
-                for row in self._iter_rows(ws, self.STATE_SHEET.headers):
-                    if row.get("key") == key:
-                        return StoredStateRow.from_excel_row(row)
+                for row in self._iter_rows(ws, self.STATE_SHEET.headers, StateRow):
+                    if row.key == key:
+                        return row
             return None
 
     # ------------------------------------------------------------------
@@ -187,80 +181,60 @@ class ExcelWriter:
         if ws.max_row == 0:
             self._write_headers(ws, config.headers)
         if config is self.STATE_SHEET:
-            self._ensure_state_sheet_schema(ws)
+            self._upgrade_state_sheet(ws)
         return ws
 
-    def _ensure_state_sheet_schema(self, sheet: Worksheet) -> None:
+    def _upgrade_state_sheet(self, sheet: Worksheet) -> None:
         expected = self.STATE_SHEET.headers
         existing_headers = [cell.value for cell in sheet[1]] if sheet.max_row else []
-        if existing_headers[: len(expected)] == expected:
+        if existing_headers[: len(expected)] == list(expected):
             return
-        legacy_headers = ["asset", "deposit_amount", "deposit_updated_at", "used_amount"]
-        if existing_headers[: len(legacy_headers)] == legacy_headers:
-            rows: List[Dict[str, object]] = []
-            for excel_row in sheet.iter_rows(min_row=2, values_only=True):
-                if all(value is None for value in excel_row):
+        rows: List[StateRow] = []
+        if existing_headers:
+            normalized_headers = [
+                str(header) if header is not None else ""
+                for header in existing_headers
+            ]
+            for values in sheet.iter_rows(min_row=2, values_only=True):
+                if all(value is None for value in values):
                     continue
-                rows.append(
-                    {
-                        header: excel_row[idx] if idx < len(excel_row) else None
-                        for idx, header in enumerate(legacy_headers)
-                    }
-                )
-            self._write_headers(sheet, expected)
-            for stored in rows:
-                sheet.append(
-                    [
-                        "default",
-                        stored.get("asset"),
-                        stored.get("deposit_amount"),
-                        stored.get("deposit_updated_at"),
-                        stored.get("used_amount"),
-                    ]
-                )
-        else:
-            self._write_headers(sheet, expected)
+                rows.append(StateRow.from_excel_row(normalized_headers, values))
+        self._write_headers(sheet, expected)
+        for row in rows:
+            sheet.append(row.as_excel_values())
 
     def _write_headers(self, sheet: Worksheet, headers: Iterable[str]) -> None:
         sheet.delete_rows(1, sheet.max_row)
         sheet.append(list(headers))
 
     def _iter_rows(
-        self, sheet: Worksheet, headers: List[str]
-    ) -> Iterable[Dict[str, object]]:
+        self, sheet: Worksheet, headers: List[str], row_type
+    ) -> Iterable:
         for row in sheet.iter_rows(min_row=2, values_only=True):
             if all(value is None for value in row):
                 continue
-            yield {
-                header: row[idx] if idx < len(row) else None
-                for idx, header in enumerate(headers)
-            }
+            yield row_type.from_excel_row(headers, row)
 
     def _upsert_row(
         self,
         sheet: Worksheet,
         headers: List[str],
         key_column: str,
-        row: Dict[str, object],
+        row_values: Sequence[object],
     ) -> None:
+        row_list = list(row_values)
+        if len(row_list) < len(headers):
+            row_list.extend([None] * (len(headers) - len(row_list)))
         key_index = headers.index(key_column)
-        key_value = row.get(key_column)
+        key_value = row_list[key_index]
         if key_value is None:
             raise ValueError(f"Missing '{key_column}' in row data")
         for excel_row in sheet.iter_rows(min_row=2):
             cell_value = excel_row[key_index].value
             if cell_value == key_value:
-                for idx, header in enumerate(headers):
-                    excel_row[idx].value = cast(Any, row.get(header))
+                for idx, _ in enumerate(headers):
+                    excel_row[idx].value = cast(Any, row_list[idx])
                 break
         else:
-            sheet.append([row.get(header) for header in headers])
-
-    def _replace_all_rows(
-        self, sheet: Worksheet, headers: List[str], rows: List[Dict[str, object]]
-    ) -> None:
-        if sheet.max_row > 1:
-            sheet.delete_rows(2, sheet.max_row)
-        for row in rows:
-            sheet.append([row.get(header) for header in headers])
+            sheet.append(row_list)
 

--- a/bot/data/io/storage.py
+++ b/bot/data/io/storage.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from dataclasses import asdict
 from datetime import datetime
 from pathlib import Path
@@ -29,12 +28,12 @@ from .excel_rows import (
     JSONValue,
     SignalMetricPayload,
     SignalPayload,
-    StoredSignalRow,
-    StoredStateRow,
-    StoredTradeRow,
+    SignalRow,
+    StateRow,
     ThresholdMetricPayload,
-    ThresholdPayload,
+    ThresholdRow,
     TradePayload,
+    TradeRow,
 )
 from .excel_writer import ExcelWriter
 
@@ -89,7 +88,7 @@ class Storage:
         *,
         key: Optional[str] = None,
     ) -> None:
-        stored_row = StoredStateRow(
+        stored_row = StateRow(
             key=key or "default",
             asset=asset,
             deposit_amount=deposit_amount,
@@ -131,7 +130,7 @@ class Storage:
             min_abs_value=payload.min_abs_value,
         )
 
-    def _deserialize_thresholds(self, payload: ThresholdPayload) -> Thresholds:
+    def _deserialize_thresholds(self, payload: ThresholdRow) -> Thresholds:
         metrics = [self._deserialize_threshold_metric(metric) for metric in payload.metrics]
         metadata_payload = ThresholdsMetadataPayload.from_mapping(payload.metadata)
         metadata = ThresholdsMetadata.from_mapping(metadata_payload)
@@ -404,32 +403,42 @@ class Storage:
     # ------------------------------------------------------------------
     # Serialization helpers
     # ------------------------------------------------------------------
-    def _serialize_signal(self, signal: Signal) -> StoredSignalRow:
-        thresholds = asdict(signal.thresholds)
+    def _serialize_signal(self, signal: Signal) -> SignalRow:
+        thresholds_mapping = asdict(signal.thresholds)
         if signal.thresholds.created_at:
-            thresholds["created_at"] = signal.thresholds.created_at.isoformat()
+            thresholds_mapping["created_at"] = signal.thresholds.created_at.isoformat()
         if signal.thresholds.updated_at:
-            thresholds["updated_at"] = signal.thresholds.updated_at.isoformat()
-        thresholds["metadata"] = (
+            thresholds_mapping["updated_at"] = signal.thresholds.updated_at.isoformat()
+        thresholds_mapping["metadata"] = (
             signal.thresholds.metadata.to_dict()
             if signal.thresholds.metadata
             else {}
         )
-        metrics: List[Dict[str, Any]] = []
+        thresholds_row = ThresholdRow.from_mapping(thresholds_mapping)
+        metrics_payloads: List[SignalMetricPayload] = []
         for metric in signal.metrics:
-            metric_dict = asdict(metric)
-            threshold = metric_dict.get("threshold")
-            if isinstance(threshold, dict):
-                metric_dict["threshold"] = threshold
-            metrics.append(metric_dict)
-        metadata = json.dumps(self._signal_metadata_to_mapping(signal.metadata), sort_keys=True)
-        snapshot_json = None
-        if signal.metrics_snapshot is not None:
-            snapshot_json = json.dumps(
-                signal.metrics_snapshot.to_mapping(), sort_keys=True
+            threshold_payload = None
+            if metric.threshold is not None:
+                threshold_payload = ThresholdMetricPayload(
+                    name=metric.threshold.name,
+                    min_value=metric.threshold.min_value,
+                    max_value=metric.threshold.max_value,
+                    min_abs_value=metric.threshold.min_abs_value,
+                )
+            metrics_payloads.append(
+                SignalMetricPayload(
+                    name=metric.name,
+                    value=metric.value,
+                    passed=metric.passed,
+                    threshold=threshold_payload,
+                )
             )
+        metadata_mapping = self._signal_metadata_to_mapping(signal.metadata)
+        snapshot_mapping: JSONDict | None = None
+        if signal.metrics_snapshot is not None:
+            snapshot_mapping = signal.metrics_snapshot.to_mapping()
         candle = signal.candle
-        return StoredSignalRow(
+        return SignalRow(
             id=signal.id,
             candle_id=signal.candle_id or candle.id,
             symbol=candle.symbol,
@@ -452,30 +461,28 @@ class Storage:
             candle_quote_volume=candle.quote_volume,
             candle_started_at=candle.started_at.isoformat(),
             candle_closed_at=candle.closed_at.isoformat(),
-            thresholds_json=json.dumps(thresholds, sort_keys=True),
-            metrics_json=json.dumps(metrics, sort_keys=True),
-            metrics_snapshot_json=snapshot_json,
-            metadata_json=metadata,
+            thresholds=thresholds_row,
+            metrics=tuple(metrics_payloads),
+            metrics_snapshot=snapshot_mapping,
+            metadata=metadata_mapping,
         )
 
-    def _serialize_trade(self, trade: Trade) -> StoredTradeRow:
-        thresholds_snapshot = None
+    def _serialize_trade(self, trade: Trade) -> TradeRow:
+        thresholds_snapshot_row: ThresholdRow | None = None
         if trade.thresholds_snapshot:
-            snapshot = asdict(trade.thresholds_snapshot)
+            snapshot_mapping = asdict(trade.thresholds_snapshot)
             if trade.thresholds_snapshot.created_at:
-                snapshot["created_at"] = trade.thresholds_snapshot.created_at.isoformat()
+                snapshot_mapping["created_at"] = trade.thresholds_snapshot.created_at.isoformat()
             if trade.thresholds_snapshot.updated_at:
-                snapshot["updated_at"] = trade.thresholds_snapshot.updated_at.isoformat()
-            snapshot["metadata"] = (
+                snapshot_mapping["updated_at"] = trade.thresholds_snapshot.updated_at.isoformat()
+            snapshot_mapping["metadata"] = (
                 trade.thresholds_snapshot.metadata.to_dict()
                 if trade.thresholds_snapshot.metadata
                 else {}
             )
-            thresholds_snapshot = json.dumps(snapshot, sort_keys=True)
-        metadata_json = json.dumps(
-            self._trade_metadata_to_mapping(trade.metadata), sort_keys=True
-        )
-        return StoredTradeRow(
+            thresholds_snapshot_row = ThresholdRow.from_mapping(snapshot_mapping)
+        metadata_mapping = self._trade_metadata_to_mapping(trade.metadata)
+        return TradeRow(
             id=trade.id,
             signal_id=trade.signal_id,
             source_signal_id=trade.source_signal_id,
@@ -500,8 +507,8 @@ class Storage:
             updated_at=trade.updated_at.isoformat() if trade.updated_at else None,
             allow_long=bool(trade.allow_long),
             allow_short=bool(trade.allow_short),
-            thresholds_snapshot_json=thresholds_snapshot,
-            metadata_json=metadata_json,
+            thresholds_snapshot=thresholds_snapshot_row,
+            metadata=metadata_mapping,
         )
 
     @staticmethod

--- a/tests/test_excel_storage.py
+++ b/tests/test_excel_storage.py
@@ -8,11 +8,7 @@ from zoneinfo import ZoneInfo
 import pytest
 from openpyxl import load_workbook
 
-from bot.data.io.excel_rows import (
-    SignalPayload,
-    StoredStateRow,
-    TradePayload,
-)
+from bot.data.io.excel_rows import SignalPayload, StateRow, TradePayload
 from bot.data.io.storage import Storage
 from bot.data.repositories.signal_repository import SignalRepository
 from bot.data.repositories.state_repository import StateRepository
@@ -302,5 +298,5 @@ def test_state_repository_persists_per_provider(tmp_path) -> None:
     assert {"binance", "bybit"}.issubset(keys)
 
     stored_state = storage._writer.read_state("binance")
-    assert stored_state and isinstance(stored_state, StoredStateRow)
+    assert stored_state and isinstance(stored_state, StateRow)
     assert stored_state.deposit_amount == pytest.approx(1_000.0)


### PR DESCRIPTION
## Summary
- replace the Excel row helper layer with strongly typed dataclasses that handle parsing, serialization, and JSON normalization
- update the Excel writer to operate on typed row objects and migrate legacy state sheets through typed transformations
- adjust storage serialization/deserialization and tests to consume the new row abstractions end-to-end

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd533dffa08320ae329bd5f3dc1d1b