### PR TITLE
Remove unused clock utilities

### DIFF
--- a/bot/utils/clock.py
+++ b/bot/utils/clock.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
 from datetime import datetime, timezone, tzinfo
-from time import sleep
-from typing import Iterator
 
 
 _APP_TIMEZONE: tzinfo = timezone.utc
@@ -20,13 +17,3 @@ def get_timezone() -> tzinfo:
 
 def utcnow() -> datetime:
     return datetime.now(_APP_TIMEZONE)
-
-
-def sleep_seconds(seconds: float) -> None:
-    sleep(max(0.0, seconds))
-
-
-@contextmanager
-def measure_time() -> Iterator[datetime]:
-    start = utcnow()
-    yield start


### PR DESCRIPTION
## Summary
- remove unused sleep and timing helpers from the clock utility
- drop related imports to keep the module interface limited to the timezone helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6670b7fd083208f9e17a2ececd32f