### PR TITLE
Remove unused short ID helper

### DIFF
--- a/bot/utils/ids.py
+++ b/bot/utils/ids.py
@@ -1,13 +1,7 @@
 from __future__ import annotations
 
-import secrets
 import uuid
 
 
 def uuid_str() -> str:
     return str(uuid.uuid4())
-
-
-def short_id(length: int = 12) -> str:
-    alphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
-    return "".join(secrets.choice(alphabet) for _ in range(length))


### PR DESCRIPTION
## Summary
- remove the unused `short_id` helper from `bot/utils/ids.py`
- drop the `secrets` import now that the helper is gone

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6670b7ed083209165e06b72aa84ba