### PR TITLE
Remove unused build_app_config helper

### DIFF
--- a/bot/data/io/config_loader.py
+++ b/bot/data/io/config_loader.py
@@ -35,8 +35,3 @@ class ConfigLoader:
         for variable in payload.env.variables:
             os.environ.setdefault(variable.key, variable.value)
         return AppConfig(payload=payload)
-
-
-def build_app_config(raw: Mapping[str, object]) -> AppConfig:
-    payload = parse_app_config_payload(raw)
-    return AppConfig(payload=payload)


### PR DESCRIPTION
## Summary
- remove the unused build_app_config helper from the config loader module
- rely on ConfigLoader for constructing AppConfig instances

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_68d6670845ac832094bd37f10c6dff00