### PR TITLE
Remove unused batch selector helper

### DIFF
--- a/bot/domain/services/selector_service.py
+++ b/bot/domain/services/selector_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from math import fabs
-from typing import Iterable, List, Sequence
+from typing import List, Sequence
 
 from ..enums import BreakDirection, Side
 from ..models.entities import Candle, Signal, Thresholds
@@ -222,11 +222,3 @@ class SignalSelectorService:
         )
         return SelectionResult(signals=[signal], rejected=[])
 
-    def batch_select(
-        self, batch: Iterable[tuple[str, Sequence[Candle], Thresholds]]
-    ) -> List[Signal]:
-        signals: List[Signal] = []
-        for symbol, candles, thresholds in batch:
-            result = self.select(symbol, candles, thresholds)
-            signals.extend(result.signals)
-        return signals


### PR DESCRIPTION
## Summary
- remove the unused `batch_select` helper from `SignalSelectorService`
- clean up the typing imports to match the reduced API

## Testing
- pytest *(fails: missing optional dependency `openpyxl` required by unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d66706303c8320942244f8ecaa63c0