### PR TITLE
Remove unused SignalRepository read methods

### DIFF
--- a/bot/data/repositories/signal_repository.py
+++ b/bot/data/repositories/signal_repository.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from threading import RLock
-from typing import Dict, List, Optional
+from typing import Dict
 
 from ...domain.models.entities import Signal
 from ..io.storage import Storage
@@ -18,14 +18,6 @@ class SignalRepository:
         with self._lock:
             self._cache[signal.id] = signal
             self._storage.save_signal(signal)
-
-    def get(self, signal_id: str) -> Optional[Signal]:
-        with self._lock:
-            return self._cache.get(signal_id)
-
-    def all(self) -> List[Signal]:
-        with self._lock:
-            return list(self._cache.values())
 
     def load(self) -> None:
         with self._lock:


### PR DESCRIPTION
## Summary
- remove the unused `get` and `all` methods from `SignalRepository`
- drop the now-unnecessary typing imports

## Testing
- pytest *(fails: missing optional dependency `openpyxl` required by excel storage tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d66c5e3ab08320bcb30d836dda9c98