### PR TITLE
Remove unused stream_candles interface from providers

### DIFF
--- a/bot/data/providers/base.py
+++ b/bot/data/providers/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import Any, AsyncGenerator, AsyncIterator, Dict, Iterable, List, Sequence, cast
+from typing import Dict, Iterable, List, Sequence
 
 from ...domain.enums import Exchange, Timeframe
 from ...domain.models.entities import Candle
@@ -71,12 +71,6 @@ class BaseExchangeProvider:
         if requested_limit is None or requested_limit <= 0:
             return max_limit
         return min(requested_limit, max_limit)
-
-    async def stream_candles(
-        self, symbol: str, timeframe: Timeframe
-    ) -> AsyncGenerator[Candle, None]:
-        raise NotImplementedError
-        yield cast(Candle, None)
 
     async def get_symbols(self) -> Iterable[str]:
         raise NotImplementedError

--- a/bot/data/providers/binance.py
+++ b/bot/data/providers/binance.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import asyncio
 import hmac
 import time
 from hashlib import sha256
-from typing import AsyncGenerator, Dict, List, Mapping, Protocol, Sequence, cast
+from typing import Dict, List, Mapping, Protocol, Sequence, cast
 from urllib.parse import urlencode
 
 try:
@@ -115,18 +114,6 @@ class BinanceFuturesProvider(BaseExchangeProvider):
         candles = self.map_candles(entries, symbol, timeframe)
         filtered = await self._filter_liquidity(candles)
         return self._sort_and_deduplicate(filtered)
-
-    async def stream_candles(
-        self, symbol: str, timeframe: Timeframe
-    ) -> AsyncGenerator[Candle, None]:
-        if not httpx:
-            raise RuntimeError("httpx is required for streaming via Binance API")
-        # Binance delivers partial candles via websocket; we approximate with polling for simplicity
-        while True:
-            candles = await self.fetch_ohlcv(symbol, timeframe, limit=1)
-            if candles:
-                yield candles[-1]
-            await asyncio.sleep(1)
 
     async def get_symbols(self) -> list[str]:
         await self.rate_limiter.throttle()

--- a/bot/data/providers/bybit.py
+++ b/bot/data/providers/bybit.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import asyncio
 import hmac
 import time
 from hashlib import sha256
-from typing import AsyncGenerator, Dict, List, Mapping, Protocol, Sequence, cast
+from typing import Dict, List, Mapping, Protocol, Sequence, cast
 from urllib.parse import urlencode
 
 try:
@@ -126,17 +125,6 @@ class BybitPerpetualProvider(BaseExchangeProvider):
         candles = self.map_candles(entries, symbol, timeframe)
         filtered = await self._filter_liquidity(candles)
         return self._sort_and_deduplicate(filtered)
-
-    async def stream_candles(
-        self, symbol: str, timeframe: Timeframe
-    ) -> AsyncGenerator[Candle, None]:
-        if not httpx:
-            raise RuntimeError("httpx is required for streaming via Bybit API")
-        while True:
-            candles = await self.fetch_ohlcv(symbol, timeframe, limit=1)
-            if candles:
-                yield candles[-1]
-            await asyncio.sleep(1)
 
     async def get_symbols(self) -> list[str]:
         await self.rate_limiter.throttle()

--- a/tests/test_provider_limits.py
+++ b/tests/test_provider_limits.py
@@ -15,9 +15,6 @@ class _StubProvider(BaseExchangeProvider):
     ):  # pragma: no cover - unused
         raise NotImplementedError
 
-    async def stream_candles(self, symbol: str, timeframe: Timeframe):  # pragma: no cover - unused
-        raise NotImplementedError
-
     async def get_symbols(self):  # pragma: no cover - unused
         raise NotImplementedError
 


### PR DESCRIPTION
## Summary
- remove the unused `stream_candles` hook from the base provider
- delete Binance and Bybit streaming stubs and clean related imports
- update provider tests to no longer reference the removed method

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d66cec96c08320aa7549e1d81c3b24