### PR TITLE
Remove unused symbols accessor

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -98,9 +98,6 @@ class SymbolUniverse:
     def provider_for(self, symbol: str) -> str | None:
         return self.assignments.get(symbol)
 
-    def symbols(self) -> tuple[str, ...]:
-        return tuple(self.assignments.keys())
-
     def symbols_for_provider(self, provider: str) -> tuple[str, ...]:
         return self.pipelines.get(provider, tuple())
 


### PR DESCRIPTION
## Summary
- remove the unused `symbols()` method from `SymbolUniverse`
- rely on the existing `assignments` mapping or `symbols_for_provider()` helper when enumerating symbols

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d66db0983c83208d049b1ba41de50d