### PR TITLE
Remove rejected trade status enum value

### DIFF
--- a/bot/domain/enums.py
+++ b/bot/domain/enums.py
@@ -40,4 +40,3 @@ class TradeStatus(str, Enum):
     OPENED = "opened"
     CLOSED_TP = "closed_tp"
     CLOSED_SL = "closed_sl"
-    REJECTED = "rejected"


### PR DESCRIPTION
## Summary
- remove the TradeStatus.REJECTED enum member, which is no longer needed
- verified there are no other references to the removed status in the project

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d66e1f2d08832083ef6d6d0decc408