### PR TITLE
Remove unused imports from bot app

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-import asyncio
 import contextlib
 import sys
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from typing import Dict, Iterable, Protocol, Sequence, TypeVar, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError


### PR DESCRIPTION
## Summary
- remove the duplicate asyncio import and unused datetime import from `bot/app.py`
- ensure the remaining import block stays sorted

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_68d6705f05608320a3f565a0b529b336