### PR TITLE
Remove redundant selector guard in live runner

### DIFF
--- a/bot/domain/services/live_runner.py
+++ b/bot/domain/services/live_runner.py
@@ -172,9 +172,6 @@ class LiveTradingRunner:
                 await asyncio.sleep(self._get_poll_delay(timeframe))
 
     async def _process_symbol(self, symbol: str, thresholds: Thresholds) -> None:
-        if self._selector is None:
-            self._logger.warning("Selector is not configured; skipping symbol %s", symbol)
-            return
         windows: Dict[Timeframe, Deque[Candle]] = {
             timeframe: deque(maxlen=self._window) for timeframe in self._timeframes
         }


### PR DESCRIPTION
## Summary
- remove the redundant selector None guard in `_process_symbol` because the service requires a selector instance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6706bfeb08320a4f52234d40e2bfb