### PR TITLE
Remove unused provider lookup from SymbolUniverse

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -93,9 +93,6 @@ class SymbolUniverse:
     assignments: Dict[str, str]
     pipelines: Dict[str, tuple[str, ...]]
 
-    def provider_for(self, symbol: str) -> str | None:
-        return self.assignments.get(symbol)
-
     def symbols_for_provider(self, provider: str) -> tuple[str, ...]:
         return self.pipelines.get(provider, tuple())
 


### PR DESCRIPTION
## Summary
- remove the unused `provider_for` helper from `SymbolUniverse` now that no call sites rely on it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d673a3a6a08320a198c99dbd2f111d