### PR TITLE
Remove unused as_dict helper from SymbolProviderMapping

### DIFF
--- a/bot/data/io/config_models.py
+++ b/bot/data/io/config_models.py
@@ -456,9 +456,6 @@ class SymbolProviderMapping:
     def __iter__(self) -> Iterator[SymbolProviderRoute]:
         return iter(self.routes)
 
-    def as_dict(self) -> dict[str, str]:
-        return {route.symbol: route.provider for route in self.routes}
-
 
 def parse_symbol_provider_mapping(
     routes: tuple[SymbolProviderRoutePayload, ...]


### PR DESCRIPTION
## Summary
- remove the unused `as_dict` helper from `SymbolProviderMapping`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d673abc8688320a06fbc002fc9776e