### PR TITLE
Remove websocket configuration from exchange providers

### DIFF
--- a/bot/app.py
+++ b/bot/app.py
@@ -59,7 +59,6 @@ def _create_binance_provider(
 ) -> BinanceFuturesProvider:
     return BinanceFuturesProvider(
         config.api_base,
-        config.ws_base,
         config.rate_limit_per_minute,
         config.min_quote_volume,
         api_key=api_key,
@@ -74,7 +73,6 @@ def _create_bybit_provider(
 ) -> BybitPerpetualProvider:
     return BybitPerpetualProvider(
         config.api_base,
-        config.ws_base,
         config.rate_limit_per_minute,
         config.min_quote_volume,
         api_key=api_key,

--- a/bot/data/io/config_models.py
+++ b/bot/data/io/config_models.py
@@ -135,7 +135,6 @@ class ProviderKind(str, Enum):
 class ExchangeProviderConfig:
     name: str
     api_base: str
-    ws_base: str
     rate_limit_per_minute: int
     min_quote_volume: float
     api_key: ProviderCredential = field(default_factory=ProviderCredential)
@@ -147,7 +146,6 @@ class ExchangeProviderConfig:
         cls, name: str, payload: ProviderConfigPayload
     ) -> "ExchangeProviderConfig":
         api_base = payload.api_base.strip() if payload.api_base else ""
-        ws_base = payload.ws_base.strip() if payload.ws_base else ""
         rate_limit = _coerce_positive_int(payload.rate_limit_per_minute, 60)
         min_quote_volume = _coerce_non_negative_float(payload.min_quote_volume)
         api_key = ProviderCredential.from_payload(payload.api_key)
@@ -155,7 +153,6 @@ class ExchangeProviderConfig:
         instance = cls(
             name=name,
             api_base=api_base,
-            ws_base=ws_base,
             rate_limit_per_minute=rate_limit,
             min_quote_volume=min_quote_volume,
             api_key=api_key,

--- a/bot/data/io/config_types.py
+++ b/bot/data/io/config_types.py
@@ -257,7 +257,6 @@ class ProviderCredentialPayload:
 class ProviderConfigPayload:
     name: str
     api_base: str = ""
-    ws_base: str = ""
     rate_limit_per_minute: int | None = None
     min_quote_volume: float | None = None
     api_key: ProviderCredentialPayload = field(default_factory=ProviderCredentialPayload)
@@ -679,7 +678,6 @@ def _parse_provider_credentials(
 def _parse_provider_section(name: str, value: object) -> ProviderConfigPayload:
     mapping = _as_mapping(value or {}, f"providers.{name}")
     api_base = _stringify(mapping.get("api_base")) if mapping.get("api_base") is not None else ""
-    ws_base = _stringify(mapping.get("ws_base")) if mapping.get("ws_base") is not None else ""
     rate_limit = _optional_int(mapping.get("rate_limit_per_minute"))
     min_quote_volume = _optional_float(mapping.get("min_quote_volume"))
     prefix = name.upper()
@@ -688,7 +686,6 @@ def _parse_provider_section(name: str, value: object) -> ProviderConfigPayload:
     return ProviderConfigPayload(
         name=name,
         api_base=api_base,
-        ws_base=ws_base,
         rate_limit_per_minute=rate_limit,
         min_quote_volume=min_quote_volume,
         api_key=api_key,

--- a/bot/data/providers/base.py
+++ b/bot/data/providers/base.py
@@ -34,12 +34,10 @@ class BaseExchangeProvider:
     def __init__(
         self,
         api_base: str,
-        ws_base: str,
         rate_limit_per_minute: int,
         min_quote_volume: float,
     ) -> None:
         self._api_base = api_base
-        self._ws_base = ws_base
         self._rate_limiter = RateLimiter(rate_limit_per_minute)
         self._min_quote_volume = min_quote_volume
         self._logger = get_logger(self.__class__.__name__)

--- a/bot/data/providers/binance.py
+++ b/bot/data/providers/binance.py
@@ -55,14 +55,13 @@ class BinanceFuturesProvider(BaseExchangeProvider):
     def __init__(
         self,
         api_base: str,
-        ws_base: str,
         rate_limit_per_minute: int,
         min_quote_volume: float,
         session: _HttpClient | None = None,
         api_key: str | None = None,
         api_secret: str | None = None,
     ) -> None:
-        super().__init__(api_base, ws_base, rate_limit_per_minute, min_quote_volume)
+        super().__init__(api_base, rate_limit_per_minute, min_quote_volume)
         self._session: _HttpClient | None = session or (
             httpx.AsyncClient(timeout=10.0) if httpx else None
         )

--- a/bot/data/providers/bybit.py
+++ b/bot/data/providers/bybit.py
@@ -56,14 +56,13 @@ class BybitPerpetualProvider(BaseExchangeProvider):
     def __init__(
         self,
         api_base: str,
-        ws_base: str,
         rate_limit_per_minute: int,
         min_quote_volume: float,
         session: _HttpClient | None = None,
         api_key: str | None = None,
         api_secret: str | None = None,
     ) -> None:
-        super().__init__(api_base, ws_base, rate_limit_per_minute, min_quote_volume)
+        super().__init__(api_base, rate_limit_per_minute, min_quote_volume)
         self._session: _HttpClient | None = session or (
             httpx.AsyncClient(timeout=10.0) if httpx else None
         )

--- a/settings.toml
+++ b/settings.toml
@@ -20,13 +20,11 @@ max_records = 1000
 
 [providers.binance]
 api_base = "https://fapi.binance.com"
-ws_base = "wss://fstream.binance.com/ws"
 rate_limit_per_minute = 1200
 min_quote_volume = 500000.0
 
 [providers.bybit]
 api_base = "https://api.bybit.com"
-ws_base = "wss://stream.bybit.com/v5/public/linear"
 rate_limit_per_minute = 600
 min_quote_volume = 250000.0
 

--- a/tests/test_config_parsing.py
+++ b/tests/test_config_parsing.py
@@ -166,14 +166,12 @@ def test_provider_configs_are_typed_and_resolve_credentials(monkeypatch) -> None
             "providers": {
                 "binance": {
                     "api_base": "https://fapi.binance.com",
-                    "ws_base": "wss://fstream.binance.com/ws",
                     "rate_limit_per_minute": "1200",
                     "min_quote_volume": "500000",
                     "api_key_env": "BINANCE_KEY",
                 },
                 "bybit": {
                     "api_base": "https://api.bybit.com",
-                    "ws_base": "wss://stream.bybit.com/v5/public/linear",
                     "rate_limit_per_minute": 600,
                     "min_quote_volume": 250000,
                     "api_secret": "super-secret",
@@ -190,7 +188,6 @@ def test_provider_configs_are_typed_and_resolve_credentials(monkeypatch) -> None
     assert isinstance(binance_cfg, BinanceProviderConfig)
     assert binance_cfg.kind is ProviderKind.BINANCE
     assert binance_cfg.api_base == "https://fapi.binance.com"
-    assert binance_cfg.ws_base == "wss://fstream.binance.com/ws"
     assert binance_cfg.rate_limit_per_minute == 1200
     assert binance_cfg.min_quote_volume == 500000.0
     assert binance_cfg.api_key_env == "BINANCE_KEY"

--- a/tests/test_provider_history.py
+++ b/tests/test_provider_history.py
@@ -36,7 +36,6 @@ def test_binance_fetch_ohlcv_forwards_since_and_sorts() -> None:
     session = _FakeSession(payload)
     provider = BinanceFuturesProvider(
         api_base="https://example.com",
-        ws_base="wss://example.com/ws",
         rate_limit_per_minute=60,
         min_quote_volume=0.0,
         session=session,
@@ -76,7 +75,6 @@ def test_bybit_fetch_ohlcv_forwards_since_and_sorts() -> None:
     session = _FakeSession(payload)
     provider = BybitPerpetualProvider(
         api_base="https://example.com",
-        ws_base="wss://example.com/ws",
         rate_limit_per_minute=60,
         min_quote_volume=0.0,
         session=session,
@@ -105,7 +103,6 @@ def test_binance_get_symbols_filters_trading_pairs() -> None:
     session = _FakeSession(payload)
     provider = BinanceFuturesProvider(
         api_base="https://example.com",
-        ws_base="wss://example.com/ws",
         rate_limit_per_minute=60,
         min_quote_volume=0.0,
         session=session,
@@ -124,7 +121,6 @@ def test_binance_get_24h_quote_volume_uses_typed_payload() -> None:
     session = _FakeSession(payload)
     provider = BinanceFuturesProvider(
         api_base="https://example.com",
-        ws_base="wss://example.com/ws",
         rate_limit_per_minute=60,
         min_quote_volume=0.0,
         session=session,
@@ -139,7 +135,6 @@ def test_binance_update_deposit_prefers_available_balance() -> None:
     session = _FakeSession([])
     provider = BinanceFuturesProvider(
         api_base="https://example.com",
-        ws_base="wss://example.com/ws",
         rate_limit_per_minute=60,
         min_quote_volume=0.0,
         session=session,
@@ -182,7 +177,6 @@ def test_bybit_get_symbols_extracts_linear_trading_pairs() -> None:
     session = _FakeSession(payload)
     provider = BybitPerpetualProvider(
         api_base="https://example.com",
-        ws_base="wss://example.com/ws",
         rate_limit_per_minute=60,
         min_quote_volume=0.0,
         session=session,
@@ -206,7 +200,6 @@ def test_bybit_get_24h_quote_volume_handles_optional_fields() -> None:
     session = _FakeSession(payload)
     provider = BybitPerpetualProvider(
         api_base="https://example.com",
-        ws_base="wss://example.com/ws",
         rate_limit_per_minute=60,
         min_quote_volume=0.0,
         session=session,
@@ -221,7 +214,6 @@ def test_bybit_update_deposit_prefers_available_to_withdraw() -> None:
     session = _FakeSession({})
     provider = BybitPerpetualProvider(
         api_base="https://example.com",
-        ws_base="wss://example.com/ws",
         rate_limit_per_minute=60,
         min_quote_volume=0.0,
         session=session,

--- a/tests/test_provider_limits.py
+++ b/tests/test_provider_limits.py
@@ -45,7 +45,6 @@ class _StubBybitProvider(_StubProvider):
 def test_resolve_ohlcv_limit(provider_cls, expected_limit, requested_limit):
     provider = provider_cls(
         api_base="https://example.com",
-        ws_base="wss://example.com/ws",
         rate_limit_per_minute=1200,
         min_quote_volume=1.0,
     )


### PR DESCRIPTION
## Summary
- drop the websocket base URL parameter from exchange providers and their configuration models
- update provider factories and default settings to only rely on REST API settings
- refresh tests to build providers without websocket configuration values

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'openpyxl')*

------
https://chatgpt.com/codex/tasks/task_e_68d676e4c948832082de2d77e88f92a5