### PR TITLE
Refine anomaly detection and domain typing

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,0 +1,1 @@
+"""Trading bot package."""

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,0 +1,51 @@
+"""Global configuration constants for the trading bot."""
+from __future__ import annotations
+
+from datetime import timezone
+from zoneinfo import ZoneInfo
+
+from bot.domain.models.timeframe import Timeframe
+
+TIMEZONE_NAME = "Europe/Belgrade"
+TIMEZONE = ZoneInfo(TIMEZONE_NAME)
+UTC = timezone.utc
+
+DEFAULT_TIMEFRAMES: tuple[Timeframe, ...] = (
+    Timeframe.M1,
+    Timeframe.M3,
+    Timeframe.M5,
+    Timeframe.M15,
+)
+
+VOL_WINDOW = 20
+ATR_WINDOW = 14
+
+MIN_REL_VOL = 40.0
+MAX_REL_VOL = 200.0
+MIN_ATR_MULT = 5.0
+MIN_PCT_MOVE = 5.0
+MAX_PCT_MOVE = 10.0
+MAX_UPPER_WICK_PCT = 100.0
+MAX_LOWER_WICK_PCT = 50.0
+
+MIN_ORDER_USDT = 10.0
+ORDER_PCT_OF_DEPOSIT = 0.0005
+DEPOSIT_REFRESH_MIN = 60
+
+TAKER_FEE_ENTRY_PCT = 0.04
+TAKER_FEE_EXIT_PCT = 0.04
+
+BREAKEVEN_TRIGGER_PCT = 0.5
+BREAKEVEN_OFFSET_PCT = 0.3
+TRAIL_SWING_WINDOW = 5
+TRAIL_SWING_CONFIRM = 2
+
+AGGR_WINDOW_SEC = 15
+AGGR_IMBALANCE_THRESHOLD = 0.62
+
+BAR_REPROCESS_THROTTLE_SEC = 3600
+
+LOG_TIME_FMT = "%H:%M:%S"
+
+ANOMALY_MIN_GROWTH_PCT = 3.0
+ANOMALY_MIN_VOLUME_SPIKE = 150.0

--- a/bot/data/__init__.py
+++ b/bot/data/__init__.py
@@ -1,0 +1,1 @@
+"""Data layer package."""

--- a/bot/data/accounting.py
+++ b/bot/data/accounting.py
@@ -1,0 +1,9 @@
+"""Account and balance related interfaces."""
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class BalanceProvider(Protocol):
+    def current_deposit(self) -> float:  # pragma: no cover - interface definition
+        ...

--- a/bot/data/diary.py
+++ b/bot/data/diary.py
@@ -1,0 +1,119 @@
+"""Workbook writers for signals and trades diaries."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from threading import Lock
+from typing import Iterable, Optional, Protocol
+
+from bot.domain.models.bar import BarMetrics
+from bot.domain.models.close_reason import CloseReason
+from bot.domain.models.exchange import Exchange
+from bot.domain.models.signal import Signal, ThresholdSnapshot
+from bot.domain.models.signal_direction import SignalDirection
+from bot.domain.models.timeframe import Timeframe
+from bot.domain.models.trade import Trade
+from bot.domain.models.trade_status import TradeStatus
+
+
+@dataclass(frozen=True, slots=True)
+class Row:
+    """Base diary row."""
+
+
+@dataclass(frozen=True, slots=True)
+class SignalRow(Row):
+    signal_id: str
+    timestamp: datetime
+    exchange: Exchange
+    symbol: str
+    timeframe: Timeframe
+    direction: SignalDirection
+    entry_price: float
+    take_profit_price: float
+    stop_loss_price: float
+    bar_id: str
+    metrics: BarMetrics
+    thresholds: ThresholdSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class TradeRow(Row):
+    trade_id: str
+    source_signal_id: str
+    timestamp_open: datetime
+    timestamp_close: Optional[datetime]
+    exchange: Exchange
+    symbol: str
+    timeframe: Timeframe
+    side: SignalDirection
+    entry_price: float
+    take_profit_price: float
+    stop_loss_price: float
+    executed_qty: float
+    status: TradeStatus
+    avg_fill_price: Optional[float]
+    reason_close: Optional[CloseReason]
+    sl_be_at: Optional[datetime]
+
+
+class DiaryBackend(Protocol):
+    def append_rows(self, rows: Iterable[Row]) -> None:  # pragma: no cover - interface definition
+        # TODO: implement concrete persistence for diary rows.
+        ...
+
+
+@dataclass(slots=True)
+class WorkbookDiary:
+    path: Path
+    backend: DiaryBackend
+    _lock: Lock = Lock()
+
+    def append_signals(self, signals: Iterable[Signal]) -> None:
+        with self._lock:
+            rows = [self._signal_to_row(signal) for signal in signals]
+            self.backend.append_rows(rows)
+
+    def append_trades(self, trades: Iterable[Trade]) -> None:
+        with self._lock:
+            rows = [self._trade_to_row(trade) for trade in trades]
+            self.backend.append_rows(rows)
+
+    @staticmethod
+    def _signal_to_row(signal: Signal) -> SignalRow:
+        return SignalRow(
+            signal_id=signal.signal_id,
+            timestamp=signal.timestamp,
+            exchange=signal.exchange,
+            symbol=signal.symbol,
+            timeframe=signal.timeframe,
+            direction=signal.direction,
+            entry_price=signal.levels.entry_price,
+            take_profit_price=signal.levels.take_profit_price,
+            stop_loss_price=signal.levels.stop_loss_price,
+            bar_id=signal.bar.bar_id,
+            metrics=signal.bar.metrics,
+            thresholds=signal.thresholds,
+        )
+
+    @staticmethod
+    def _trade_to_row(trade: Trade) -> TradeRow:
+        return TradeRow(
+            trade_id=trade.trade_id,
+            source_signal_id=trade.source_signal_id,
+            timestamp_open=trade.timestamp_open,
+            timestamp_close=trade.timestamp_close,
+            exchange=trade.exchange,
+            symbol=trade.symbol,
+            timeframe=trade.timeframe,
+            side=trade.side,
+            entry_price=trade.entry_price,
+            take_profit_price=trade.take_profit_price,
+            stop_loss_price=trade.stop_loss_price,
+            executed_qty=trade.executed_qty,
+            status=trade.status,
+            avg_fill_price=trade.avg_fill_price,
+            reason_close=trade.reason_close,
+            sl_be_at=trade.sl_be_at,
+        )

--- a/bot/data/loader.py
+++ b/bot/data/loader.py
@@ -1,0 +1,37 @@
+"""Market data loader abstractions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable, Iterable
+
+from bot.domain.models.bar import Bar
+from bot.domain.models.exchange import Exchange
+from bot.domain.models.timeframe import Timeframe
+
+
+@dataclass(frozen=True)
+class HistoricalRequest:
+    exchange: Exchange
+    symbol: str
+    timeframe: Timeframe
+    start: datetime
+    end: datetime
+    limit: int | None = None
+
+
+class MarketDataLoader:
+    """Base synchronous interface for loading historical bars."""
+
+    def load(self, request: HistoricalRequest) -> Iterable[Bar]:  # pragma: no cover - interface definition
+        raise NotImplementedError
+
+
+class LiveDataStream:
+    """Streaming interface that delivers closed bars to listeners."""
+
+    def subscribe(self, listener: Callable[[Bar], None]) -> None:  # pragma: no cover - interface definition
+        raise NotImplementedError
+
+    def close(self) -> None:  # pragma: no cover - interface definition
+        raise NotImplementedError

--- a/bot/data/notifier.py
+++ b/bot/data/notifier.py
@@ -1,0 +1,11 @@
+"""Notifier interface used by the orchestrator."""
+from __future__ import annotations
+
+from typing import Protocol
+
+from bot.domain.models.signal import Signal
+
+
+class Notifier(Protocol):
+    def send_signal(self, signal: Signal) -> None:  # pragma: no cover - interface definition
+        ...

--- a/bot/domain/__init__.py
+++ b/bot/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Domain layer package."""

--- a/bot/domain/analyzer.py
+++ b/bot/domain/analyzer.py
@@ -1,0 +1,73 @@
+"""Signal analyzer computing strategy decisions for closed bars."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+from uuid import uuid4
+
+from bot import config
+from .models.bar import Bar
+from .models.signal import Signal, SignalLevels, ThresholdSnapshot
+from .models.signal_direction import SignalDirection
+
+
+@dataclass(frozen=True)
+class AnalyzerSettings:
+    min_green_move_pct: float = config.ANOMALY_MIN_GROWTH_PCT
+    min_volume_spike: float = config.ANOMALY_MIN_VOLUME_SPIKE
+
+    def snapshot(self) -> ThresholdSnapshot:
+        return ThresholdSnapshot(
+            min_green_move_pct=self.min_green_move_pct,
+            min_volume_spike=self.min_volume_spike,
+        )
+
+
+class SignalAnalyzer:
+    """Evaluates bars and produces strategy signals."""
+
+    def __init__(self, settings: AnalyzerSettings | None = None) -> None:
+        self._settings = settings or AnalyzerSettings()
+
+    def analyze_bar(self, bar: Bar, timestamp: Optional[datetime] = None) -> Optional[Signal]:
+        if not self._is_green(bar):
+            return None
+
+        if not self._meets_move_threshold(bar):
+            return None
+
+        if not self._meets_volume_threshold(bar):
+            return None
+
+        levels = SignalLevels(
+            entry_price=bar.close,
+            take_profit_price=bar.high,
+            stop_loss_price=bar.low,
+        )
+        signal = Signal(
+            signal_id=self._generate_signal_id(bar),
+            bar=bar,
+            timestamp=timestamp or bar.close_time,
+            exchange=bar.exchange,
+            symbol=bar.symbol,
+            timeframe=bar.timeframe,
+            thresholds=self._settings.snapshot(),
+            direction=SignalDirection.LONG,
+            levels=levels,
+        )
+        return signal
+
+    @staticmethod
+    def _generate_signal_id(bar: Bar) -> str:
+        return f"{bar.bar_id}:{uuid4().hex}"
+
+    @staticmethod
+    def _is_green(bar: Bar) -> bool:
+        return bar.close > bar.open
+
+    def _meets_move_threshold(self, bar: Bar) -> bool:
+        return bar.metrics.pct_move >= self._settings.min_green_move_pct
+
+    def _meets_volume_threshold(self, bar: Bar) -> bool:
+        return bar.metrics.relative_volume >= self._settings.min_volume_spike

--- a/bot/domain/execution_service.py
+++ b/bot/domain/execution_service.py
@@ -1,0 +1,105 @@
+"""Execution service responsible for translating signals into trades."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from bot import config
+from .models.close_reason import CloseReason
+from .models.signal import Signal
+from .models.signal_direction import SignalDirection
+from .models.trade import Trade
+from .models.trade_status import TradeStatus
+
+
+@dataclass(frozen=True)
+class ExecutionSettings:
+    min_order_usdt: float = config.MIN_ORDER_USDT
+    order_pct_of_deposit: float = config.ORDER_PCT_OF_DEPOSIT
+    breakeven_trigger_pct: float = config.BREAKEVEN_TRIGGER_PCT
+    breakeven_offset_pct: float = config.BREAKEVEN_OFFSET_PCT
+
+
+class ExecutionService:
+    """Simple in-memory execution abstraction used by orchestrator and backtests."""
+
+    def __init__(self) -> None:
+        self._settings = ExecutionSettings()
+
+    def calc_order_size_usdt(self, deposit_usdt: float) -> float:
+        base_size = deposit_usdt * self._settings.order_pct_of_deposit
+        return max(self._settings.min_order_usdt, base_size)
+
+    def open_trade(
+        self,
+        signal: Signal,
+        quantity: float,
+        timestamp: Optional[datetime] = None,
+    ) -> Trade:
+        levels = signal.levels
+        trade = Trade(
+            trade_id=f"trade-{signal.signal_id}",
+            source_signal_id=signal.signal_id,
+            exchange=signal.exchange,
+            symbol=signal.symbol,
+            timeframe=signal.timeframe,
+            side=signal.direction,
+            timestamp_open=timestamp or signal.timestamp,
+            entry_price=levels.entry_price,
+            take_profit_price=levels.take_profit_price,
+            stop_loss_price=levels.stop_loss_price,
+            executed_qty=quantity,
+            status=TradeStatus.OPENED,
+        )
+        return trade
+
+    def close_trade(
+        self,
+        trade: Trade,
+        reason: CloseReason,
+        price: float,
+        timestamp: datetime,
+    ) -> Trade:
+        return Trade(
+            trade_id=trade.trade_id,
+            source_signal_id=trade.source_signal_id,
+            exchange=trade.exchange,
+            symbol=trade.symbol,
+            timeframe=trade.timeframe,
+            side=trade.side,
+            timestamp_open=trade.timestamp_open,
+            entry_price=trade.entry_price,
+            take_profit_price=trade.take_profit_price,
+            stop_loss_price=trade.stop_loss_price,
+            executed_qty=trade.executed_qty,
+            status=self._map_reason_to_status(reason),
+            timestamp_close=timestamp,
+            avg_fill_price=price,
+            reason_close=reason,
+            sl_be_at=trade.sl_be_at,
+        )
+
+    def should_move_to_breakeven(self, entry_price: float, last_price: float, side: SignalDirection) -> bool:
+        """Return True when price progress warrants moving the stop to break-even."""
+
+        move_pct = self._settings.breakeven_trigger_pct / 100.0
+        if side.is_long:
+            return last_price >= entry_price * (1 + move_pct)
+        return last_price <= entry_price * (1 - move_pct)
+
+    def breakeven_stop(self, entry_price: float, side: SignalDirection) -> float:
+        offset_pct = self._settings.breakeven_offset_pct / 100.0
+        if side.is_long:
+            return entry_price * (1 + offset_pct)
+        return entry_price * (1 - offset_pct)
+
+    @staticmethod
+    def _map_reason_to_status(reason: CloseReason) -> TradeStatus:
+        if reason is CloseReason.TAKE_PROFIT:
+            return TradeStatus.CLOSED_TP
+        if reason is CloseReason.STOP_LOSS:
+            return TradeStatus.CLOSED_SL
+        if reason in (CloseReason.AGGRESSION, CloseReason.MANUAL):
+            return TradeStatus.CLOSED_MANUAL
+        return TradeStatus.CANCELLED

--- a/bot/domain/models/__init__.py
+++ b/bot/domain/models/__init__.py
@@ -1,0 +1,1 @@
+"""Domain models package."""

--- a/bot/domain/models/bar.py
+++ b/bot/domain/models/bar.py
@@ -1,0 +1,37 @@
+"""Domain model describing a single closed bar with derived metrics."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from .exchange import Exchange
+from .timeframe import Timeframe
+
+
+@dataclass(frozen=True, slots=True)
+class BarMetrics:
+    pct_move: float
+    relative_volume: float
+    atr_mult: float
+    upper_wick_pct: float
+    body_pct: float
+    lower_wick_pct: float
+    pct_to_low_break: float
+    pct_to_high_break: float
+    break_direction: int
+
+
+@dataclass(frozen=True, slots=True)
+class Bar:
+    bar_id: str
+    exchange: Exchange
+    symbol: str
+    timeframe: Timeframe
+    open_time: datetime
+    close_time: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+    metrics: BarMetrics

--- a/bot/domain/models/close_reason.py
+++ b/bot/domain/models/close_reason.py
@@ -1,0 +1,11 @@
+"""Reasons that can close a trade."""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class CloseReason(str, Enum):
+    TAKE_PROFIT = "tp"
+    STOP_LOSS = "sl"
+    AGGRESSION = "aggression"
+    MANUAL = "manual"

--- a/bot/domain/models/exchange.py
+++ b/bot/domain/models/exchange.py
@@ -1,0 +1,9 @@
+"""Exchange enumeration."""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Exchange(str, Enum):
+    BINANCE = "binance"
+    BYBIT = "bybit"

--- a/bot/domain/models/signal.py
+++ b/bot/domain/models/signal.py
@@ -1,0 +1,36 @@
+"""Signal domain models used by the analyzer and orchestrator."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from .bar import Bar
+from .exchange import Exchange
+from .signal_direction import SignalDirection
+from .timeframe import Timeframe
+
+
+@dataclass(frozen=True, slots=True)
+class ThresholdSnapshot:
+    min_green_move_pct: float
+    min_volume_spike: float
+
+
+@dataclass(frozen=True, slots=True)
+class SignalLevels:
+    entry_price: float
+    take_profit_price: float
+    stop_loss_price: float
+
+
+@dataclass(frozen=True, slots=True)
+class Signal:
+    signal_id: str
+    bar: Bar
+    timestamp: datetime
+    exchange: Exchange
+    symbol: str
+    timeframe: Timeframe
+    thresholds: ThresholdSnapshot
+    direction: SignalDirection
+    levels: SignalLevels

--- a/bot/domain/models/signal_direction.py
+++ b/bot/domain/models/signal_direction.py
@@ -1,0 +1,17 @@
+"""Direction of a trading signal."""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class SignalDirection(str, Enum):
+    LONG = "long"
+    SHORT = "short"
+
+    @property
+    def is_long(self) -> bool:
+        return self is SignalDirection.LONG
+
+    @property
+    def is_short(self) -> bool:
+        return self is SignalDirection.SHORT

--- a/bot/domain/models/timeframe.py
+++ b/bot/domain/models/timeframe.py
@@ -1,0 +1,11 @@
+"""Chart timeframe enumeration."""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Timeframe(str, Enum):
+    M1 = "1m"
+    M3 = "3m"
+    M5 = "5m"
+    M15 = "15m"

--- a/bot/domain/models/trade.py
+++ b/bot/domain/models/trade.py
@@ -1,0 +1,32 @@
+"""Trade domain model used by execution and diary services."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from .close_reason import CloseReason
+from .exchange import Exchange
+from .signal_direction import SignalDirection
+from .timeframe import Timeframe
+from .trade_status import TradeStatus
+
+
+@dataclass(frozen=True, slots=True)
+class Trade:
+    trade_id: str
+    source_signal_id: str
+    exchange: Exchange
+    symbol: str
+    timeframe: Timeframe
+    side: SignalDirection
+    timestamp_open: datetime
+    entry_price: float
+    take_profit_price: float
+    stop_loss_price: float
+    executed_qty: float
+    status: TradeStatus
+    timestamp_close: Optional[datetime] = None
+    avg_fill_price: Optional[float] = None
+    reason_close: Optional[CloseReason] = None
+    sl_be_at: Optional[datetime] = None

--- a/bot/domain/models/trade_status.py
+++ b/bot/domain/models/trade_status.py
@@ -1,0 +1,12 @@
+"""Lifecycle statuses for a trade."""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class TradeStatus(str, Enum):
+    OPENED = "OPENED"
+    CLOSED_TP = "CLOSED_TP"
+    CLOSED_SL = "CLOSED_SL"
+    CLOSED_MANUAL = "CLOSED_MANUAL"
+    CANCELLED = "CANCELLED"

--- a/bot/domain/orchestrator.py
+++ b/bot/domain/orchestrator.py
@@ -1,0 +1,77 @@
+"""Orchestrator ties together data, analysis and execution layers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from bot import config
+from bot.data.accounting import BalanceProvider
+from bot.data.diary import WorkbookDiary
+from bot.data.loader import LiveDataStream, MarketDataLoader
+from bot.data.notifier import Notifier
+from .analyzer import SignalAnalyzer
+from .execution_service import ExecutionService
+from .models.bar import Bar
+
+
+@dataclass(slots=True)
+class OrchestratorDependencies:
+    market_loader: MarketDataLoader
+    live_stream: LiveDataStream
+    diary: WorkbookDiary
+    notifier: Notifier
+    analyzer: SignalAnalyzer
+    execution: ExecutionService
+    balance_provider: BalanceProvider
+
+
+class Orchestrator:
+    """Coordinates incoming data and delegates actions to other services."""
+
+    def __init__(self, dependencies: OrchestratorDependencies) -> None:
+        self._deps = dependencies
+        self._last_processed: dict[str, datetime] = {}
+
+    def start(self) -> None:
+        self._deps.live_stream.subscribe(self._on_bar)
+
+    def stop(self) -> None:
+        self._deps.live_stream.close()
+
+    def backfill(self, request) -> None:  # type: ignore[no-untyped-def]
+        for bar in self._deps.market_loader.load(request):
+            self._handle_bar(bar)
+
+    def _on_bar(self, bar: Bar) -> None:
+        if not self._should_process(bar):
+            return
+        self._handle_bar(bar)
+
+    def _handle_bar(self, bar: Bar) -> None:
+        signal = self._deps.analyzer.analyze_bar(bar)
+        if signal is None:
+            return
+
+        self._deps.notifier.send_signal(signal)
+        self._deps.diary.append_signals([signal])
+
+        deposit = self._deps.balance_provider.current_deposit()
+        order_size = self._deps.execution.calc_order_size_usdt(deposit_usdt=deposit)
+        quantity = order_size / signal.levels.entry_price if signal.levels.entry_price else 0.0
+        trade = self._deps.execution.open_trade(signal, quantity=quantity)
+        self._deps.diary.append_trades([trade])
+        self._register_processed(bar)
+
+    def _should_process(self, bar: Bar) -> bool:
+        key = self._bar_key(bar)
+        last = self._last_processed.get(key)
+        if last is None:
+            return True
+        return (datetime.now(tz=config.TIMEZONE) - last) >= timedelta(seconds=config.BAR_REPROCESS_THROTTLE_SEC)
+
+    def _register_processed(self, bar: Bar) -> None:
+        self._last_processed[self._bar_key(bar)] = datetime.now(tz=config.TIMEZONE)
+
+    @staticmethod
+    def _bar_key(bar: Bar) -> str:
+        return f"{bar.exchange.value}:{bar.symbol}:{bar.timeframe.value}:{bar.bar_id}"

--- a/bot/domain/swing_detector.py
+++ b/bot/domain/swing_detector.py
@@ -1,0 +1,48 @@
+"""Utility class detecting swing highs/lows for trailing stops."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Sequence
+
+from bot import config
+
+
+@dataclass(frozen=True)
+class SwingDetectorSettings:
+    """Configuration for swing detection heuristics."""
+
+    window: int = config.TRAIL_SWING_WINDOW
+    confirmation: int = config.TRAIL_SWING_CONFIRM
+
+
+class SwingDetector:
+    """Detects swing points used for trailing stop adjustments."""
+
+    def __init__(self) -> None:
+        self._settings = SwingDetectorSettings()
+
+    def detect_swing_high(self, highs: Sequence[float]) -> float | None:
+        return self._detect_pivot(highs, compare=max)
+
+    def detect_swing_low(self, lows: Sequence[float]) -> float | None:
+        return self._detect_pivot(lows, compare=min)
+
+    def _detect_pivot(self, values: Sequence[float], compare: Callable[[Sequence[float]], float]) -> float | None:
+        """Return the latest pivot value if it confirms as an extreme."""
+
+        window = self._settings.window
+        confirm = self._settings.confirmation
+        required = window + confirm
+        if len(values) < required or window <= 0:
+            return None
+
+        pivot_index = len(values) - confirm - 1
+        start_index = max(0, pivot_index - window + 1)
+        candidate_slice = values[start_index : pivot_index + confirm + 1]
+        if not candidate_slice:
+            return None
+
+        pivot_value = values[pivot_index]
+        if pivot_value == compare(candidate_slice):
+            return float(pivot_value)
+        return None

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,0 +1,16 @@
+"""Entry points for running the trading bot in different modes."""
+from __future__ import annotations
+
+from bot.data.loader import HistoricalRequest
+from bot.domain.orchestrator import Orchestrator, OrchestratorDependencies
+
+
+def run_live(dependencies: OrchestratorDependencies) -> Orchestrator:
+    orchestrator = Orchestrator(dependencies)
+    orchestrator.start()
+    return orchestrator
+
+
+def run_backtest(dependencies: OrchestratorDependencies, request: HistoricalRequest) -> None:
+    orchestrator = Orchestrator(dependencies)
+    orchestrator.backfill(request)

--- a/bot/utils/__init__.py
+++ b/bot/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers package."""

--- a/bot/utils/locks.py
+++ b/bot/utils/locks.py
@@ -1,0 +1,15 @@
+"""Lock helpers for thread-safe operations."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from threading import Lock
+from typing import Iterator
+
+
+@contextmanager
+def locked(lock: Lock) -> Iterator[None]:
+    lock.acquire()
+    try:
+        yield
+    finally:
+        lock.release()

--- a/bot/utils/logging.py
+++ b/bot/utils/logging.py
@@ -1,0 +1,22 @@
+"""Logging helpers for the trading bot."""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from bot import config
+
+
+def setup_logging(name: str = "bot") -> logging.Logger:
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(fmt="%(asctime)s %(message)s", datefmt=config.LOG_TIME_FMT)
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    return logging.getLogger(name if name else "bot")

--- a/bot/utils/math_ops.py
+++ b/bot/utils/math_ops.py
@@ -1,0 +1,26 @@
+"""Mathematical helper functions."""
+from __future__ import annotations
+
+from typing import Iterable
+
+_EPSILON = 1e-12
+
+
+def safe_div(numerator: float, denominator: float) -> float:
+    if abs(denominator) <= _EPSILON:
+        return 0.0
+    return numerator / denominator
+
+
+def median(values: Iterable[float]) -> float:
+    sorted_values = sorted(values)
+    if not sorted_values:
+        return 0.0
+    mid = len(sorted_values) // 2
+    if len(sorted_values) % 2 == 1:
+        return float(sorted_values[mid])
+    return float((sorted_values[mid - 1] + sorted_values[mid]) / 2)
+
+
+def to_percent(value: float) -> float:
+    return value * 100.0

--- a/bot/utils/prints_aggregator.py
+++ b/bot/utils/prints_aggregator.py
@@ -1,0 +1,41 @@
+"""Aggregates aggressive trade prints to compute imbalances."""
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Deque
+
+from bot import config
+
+
+@dataclass(slots=True)
+class TradePrint:
+    timestamp: datetime
+    is_buy: bool
+    quantity: float
+
+
+class PrintsAggregator:
+    def __init__(self) -> None:
+        self._window = timedelta(seconds=config.AGGR_WINDOW_SEC)
+        self._prints: Deque[TradePrint] = deque()
+
+    def add_print(self, trade_print: TradePrint) -> None:
+        self._prints.append(trade_print)
+        self._drop_expired(trade_print.timestamp)
+
+    def imbalance(self) -> float:
+        total_qty = sum(p.quantity for p in self._prints)
+        if total_qty == 0:
+            return 0.0
+        buy_qty = sum(p.quantity for p in self._prints if p.is_buy)
+        return buy_qty / total_qty
+
+    def clear(self) -> None:
+        self._prints.clear()
+
+    def _drop_expired(self, now: datetime) -> None:
+        cutoff = now - self._window
+        while self._prints and self._prints[0].timestamp < cutoff:
+            self._prints.popleft()


### PR DESCRIPTION
## Summary
- refactor domain models to use dedicated enums and anomaly thresholds drawn from configuration
- update the analyzer and execution flow so signals are directional anomalies that may be absent when criteria fail
- introduce typed diary rows plus a balance provider dependency so orchestration logs only real trades

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68d7d88a53d4832083ddf8a09f3024fa