### PR TITLE
Implement long and short signal rules

### DIFF
--- a/bot/domain/analyzer.py
+++ b/bot/domain/analyzer.py
@@ -16,11 +16,25 @@ from .models.signal_direction import SignalDirection
 class AnalyzerSettings:
     min_green_move_pct: float = config.ANOMALY_MIN_GROWTH_PCT
     min_volume_spike: float = config.ANOMALY_MIN_VOLUME_SPIKE
+    min_relative_volume: float = config.MIN_REL_VOL
+    max_relative_volume: float = config.MAX_REL_VOL
+    min_atr_mult: float = config.MIN_ATR_MULT
+    min_pct_move: float = config.MIN_PCT_MOVE
+    max_pct_move: float = config.MAX_PCT_MOVE
+    max_upper_wick_pct: float = config.MAX_UPPER_WICK_PCT
+    max_lower_wick_pct: float = config.MAX_LOWER_WICK_PCT
 
     def snapshot(self) -> ThresholdSnapshot:
         return ThresholdSnapshot(
             min_green_move_pct=self.min_green_move_pct,
             min_volume_spike=self.min_volume_spike,
+            min_relative_volume=self.min_relative_volume,
+            max_relative_volume=self.max_relative_volume,
+            min_atr_mult=self.min_atr_mult,
+            min_pct_move=self.min_pct_move,
+            max_pct_move=self.max_pct_move,
+            max_upper_wick_pct=self.max_upper_wick_pct,
+            max_lower_wick_pct=self.max_lower_wick_pct,
         )
 
 
@@ -31,43 +45,78 @@ class SignalAnalyzer:
         self._settings = AnalyzerSettings()
 
     def analyze_bar(self, bar: Bar, timestamp: Optional[datetime] = None) -> Optional[Signal]:
-        if not self._is_green(bar):
-            return None
+        metrics = bar.metrics
+        thresholds = self._settings
 
-        if not self._meets_move_threshold(bar):
-            return None
-
-        if not self._meets_volume_threshold(bar):
-            return None
-
-        levels = SignalLevels(
-            entry_price=bar.close,
-            take_profit_price=bar.high,
-            stop_loss_price=bar.low,
+        volume_within_bounds = (
+            thresholds.min_relative_volume
+            <= metrics.relative_volume
+            <= thresholds.max_relative_volume
         )
-        signal = Signal(
+        volume_outside_bounds = (
+            metrics.relative_volume < thresholds.min_relative_volume
+            or metrics.relative_volume > thresholds.max_relative_volume
+        )
+        atr_above_min = metrics.atr_mult > thresholds.min_atr_mult
+        atr_below_min = metrics.atr_mult < thresholds.min_atr_mult
+        pct_move_within_bounds = (
+            thresholds.min_pct_move
+            <= metrics.pct_move
+            <= thresholds.max_pct_move
+        )
+        pct_move_outside_bounds = (
+            metrics.pct_move > thresholds.max_pct_move
+            or metrics.pct_move < thresholds.min_pct_move
+        )
+        upper_wick_ok = metrics.upper_wick_pct < thresholds.max_upper_wick_pct
+        lower_wick_ok = metrics.lower_wick_pct < thresholds.max_lower_wick_pct
+
+        allow_long = (
+            volume_within_bounds
+            and atr_above_min
+            and pct_move_within_bounds
+            and upper_wick_ok
+            and lower_wick_ok
+        )
+        allow_short = (
+            volume_outside_bounds
+            and atr_below_min
+            and pct_move_outside_bounds
+            and upper_wick_ok
+            and lower_wick_ok
+        )
+
+        if not allow_long and not allow_short:
+            return None
+
+        if allow_long:
+            direction = SignalDirection.LONG
+            levels = SignalLevels(
+                entry_price=bar.close,
+                take_profit_price=bar.high,
+                stop_loss_price=bar.low,
+            )
+        else:
+            direction = SignalDirection.SHORT
+            levels = SignalLevels(
+                entry_price=bar.close,
+                take_profit_price=bar.low,
+                stop_loss_price=bar.high,
+            )
+
+        return Signal(
             signal_id=self._generate_signal_id(bar),
             bar=bar,
             timestamp=timestamp or bar.close_time,
             exchange=bar.exchange,
             symbol=bar.symbol,
             timeframe=bar.timeframe,
-            thresholds=self._settings.snapshot(),
-            direction=SignalDirection.LONG,
+            thresholds=thresholds.snapshot(),
+            direction=direction,
             levels=levels,
         )
-        return signal
 
     @staticmethod
     def _generate_signal_id(bar: Bar) -> str:
         return f"{bar.bar_id}:{uuid4().hex}"
 
-    @staticmethod
-    def _is_green(bar: Bar) -> bool:
-        return bar.close > bar.open
-
-    def _meets_move_threshold(self, bar: Bar) -> bool:
-        return bar.metrics.pct_move >= self._settings.min_green_move_pct
-
-    def _meets_volume_threshold(self, bar: Bar) -> bool:
-        return bar.metrics.relative_volume >= self._settings.min_volume_spike

--- a/bot/domain/models/signal.py
+++ b/bot/domain/models/signal.py
@@ -14,6 +14,13 @@ from .timeframe import Timeframe
 class ThresholdSnapshot:
     min_green_move_pct: float
     min_volume_spike: float
+    min_relative_volume: float
+    max_relative_volume: float
+    min_atr_mult: float
+    min_pct_move: float
+    max_pct_move: float
+    max_upper_wick_pct: float
+    max_lower_wick_pct: float
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
## Summary
- include strategy thresholds for long and short rules in analyzer settings snapshots
- compute long and short signal eligibility using bar metrics and emit direction-specific levels

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d80863210883209afe92e78ae45b7f