### PR TITLE
Short-circuit signal analysis when no anomaly

### DIFF
--- a/bot/domain/analyzer.py
+++ b/bot/domain/analyzer.py
@@ -59,6 +59,9 @@ class SignalAnalyzer:
         self, bar: Bar, timestamp: Optional[datetime] = None
     ) -> Tuple[Optional[Signal], Optional[Anomaly]]:
         anomaly = self.detect_anomaly(bar)
+        if anomaly is None:
+            return None, anomaly
+
         metrics = bar.metrics
         thresholds = self._settings
 


### PR DESCRIPTION
## Summary
- return early from `SignalAnalyzer.analyze_bar` when no anomaly is detected to skip signal computation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d80e36dd808320b6ba8c6efc416e86