### PR TITLE
Implement Excel diary backend

### DIFF
--- a/bot/data/diary.py
+++ b/bot/data/diary.py
@@ -1,11 +1,13 @@
 """Workbook writers for signals and trades diaries."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from threading import Lock
 from typing import Iterable, Optional, Protocol
+
+from openpyxl import Workbook, load_workbook
 
 from bot.domain.models.anomaly import Anomaly, AnomalyThresholdSnapshot
 from bot.domain.models.bar import BarMetrics
@@ -76,32 +78,281 @@ class AnomalyRow(Row):
 
 
 class DiaryBackend(Protocol):
-    def append_rows(self, rows: Iterable[Row]) -> None:  # pragma: no cover - interface definition
-        # TODO: implement concrete persistence for diary rows.
+    def append_signals(self, rows: Iterable[SignalRow]) -> None:  # pragma: no cover - interface definition
+        ...
+
+    def append_trades(self, rows: Iterable[TradeRow]) -> None:  # pragma: no cover - interface definition
         ...
 
     def append_anomalies(self, rows: Iterable[AnomalyRow]) -> None:  # pragma: no cover - interface definition
         ...
 
 
+class WorkbookDiaryBackend(DiaryBackend):
+    """Persist diary rows into Excel workbooks under a target directory."""
+
+    _SIGNALS_HEADERS = [
+        "signal_id",
+        "timestamp",
+        "exchange",
+        "symbol",
+        "timeframe",
+        "direction",
+        "entry_price",
+        "take_profit_price",
+        "stop_loss_price",
+        "bar_id",
+        "metrics_pct_move",
+        "metrics_relative_volume",
+        "metrics_atr_mult",
+        "metrics_upper_wick_pct",
+        "metrics_body_pct",
+        "metrics_lower_wick_pct",
+        "metrics_pct_to_low_break",
+        "metrics_pct_to_high_break",
+        "metrics_break_direction",
+        "thresholds_min_green_move_pct",
+        "thresholds_min_volume_spike",
+        "thresholds_min_relative_volume",
+        "thresholds_max_relative_volume",
+        "thresholds_min_atr_mult",
+        "thresholds_min_pct_move",
+        "thresholds_max_pct_move",
+        "thresholds_max_upper_wick_pct",
+        "thresholds_max_lower_wick_pct",
+    ]
+
+    _TRADES_HEADERS = [
+        "trade_id",
+        "source_signal_id",
+        "timestamp_open",
+        "timestamp_close",
+        "exchange",
+        "symbol",
+        "timeframe",
+        "side",
+        "entry_price",
+        "take_profit_price",
+        "stop_loss_price",
+        "executed_qty",
+        "status",
+        "avg_fill_price",
+        "reason_close",
+        "sl_be_at",
+    ]
+
+    _ANOMALIES_HEADERS = [
+        "timestamp",
+        "exchange",
+        "symbol",
+        "timeframe",
+        "bar_id",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "metrics_pct_move",
+        "metrics_relative_volume",
+        "metrics_atr_mult",
+        "metrics_upper_wick_pct",
+        "metrics_body_pct",
+        "metrics_lower_wick_pct",
+        "metrics_pct_to_low_break",
+        "metrics_pct_to_high_break",
+        "metrics_break_direction",
+        "thresholds_min_green_move_pct",
+        "thresholds_min_volume_spike",
+        "thresholds_min_relative_volume",
+        "thresholds_min_atr_mult",
+    ]
+
+    def __init__(self, base_path: Path) -> None:
+        self._base_path = base_path
+        self._base_path.mkdir(parents=True, exist_ok=True)
+
+        self._signals_path = self._base_path / "signals.xlsx"
+        self._trades_path = self._base_path / "trades.xlsx"
+        self._anomalies_path = self._base_path / "anomalies.xlsx"
+
+        self._ensure_workbook(self._signals_path, self._SIGNALS_HEADERS, sheet_name="Signals")
+        self._ensure_workbook(self._trades_path, self._TRADES_HEADERS, sheet_name="Trades")
+        self._ensure_workbook(self._anomalies_path, self._ANOMALIES_HEADERS, sheet_name="Anomalies")
+
+    def append_signals(self, rows: Iterable[SignalRow]) -> None:
+        materialized = list(rows)
+        if not materialized:
+            return
+        self._append(self._signals_path, materialized, self._signal_values)
+
+    def append_trades(self, rows: Iterable[TradeRow]) -> None:
+        materialized = list(rows)
+        if not materialized:
+            return
+        self._append(self._trades_path, materialized, self._trade_values)
+
+    def append_anomalies(self, rows: Iterable[AnomalyRow]) -> None:
+        materialized = list(rows)
+        if not materialized:
+            return
+        self._append(self._anomalies_path, materialized, self._anomaly_values)
+
+    @staticmethod
+    def _ensure_workbook(path: Path, headers: list[str], *, sheet_name: str) -> None:
+        if path.exists():
+            workbook = load_workbook(path)
+            try:
+                sheet = workbook.active
+                if WorkbookDiaryBackend._needs_header(sheet):
+                    sheet.append(headers)
+                    workbook.save(path)
+            finally:
+                workbook.close()
+            return
+
+        workbook = Workbook()
+        try:
+            sheet = workbook.active
+            sheet.title = sheet_name
+            sheet.append(headers)
+            workbook.save(path)
+        finally:
+            workbook.close()
+
+    @staticmethod
+    def _needs_header(sheet) -> bool:  # type: ignore[no-any-unimported]
+        """Return True if the first row has no values and headers should be added."""
+
+        if sheet.max_row == 0:  # pragma: no cover - openpyxl always has at least 1 row
+            return True
+        first_row = sheet[1]
+        return all(cell.value is None for cell in first_row)
+
+    def _append(self, path: Path, rows: Iterable[Row], mapper) -> None:
+        workbook = load_workbook(path)
+        try:
+            sheet = workbook.active
+            for row in rows:
+                sheet.append(mapper(row))
+            workbook.save(path)
+        finally:
+            workbook.close()
+
+    @staticmethod
+    def _format_dt(value: Optional[datetime]) -> Optional[str]:
+        if value is None:
+            return None
+        return value.isoformat()
+
+    def _signal_values(self, row: SignalRow) -> list[object]:
+        metrics = row.metrics
+        thresholds = row.thresholds
+        return [
+            row.signal_id,
+            self._format_dt(row.timestamp),
+            row.exchange.value,
+            row.symbol,
+            row.timeframe.value,
+            row.direction.value,
+            row.entry_price,
+            row.take_profit_price,
+            row.stop_loss_price,
+            row.bar_id,
+            metrics.pct_move,
+            metrics.relative_volume,
+            metrics.atr_mult,
+            metrics.upper_wick_pct,
+            metrics.body_pct,
+            metrics.lower_wick_pct,
+            metrics.pct_to_low_break,
+            metrics.pct_to_high_break,
+            metrics.break_direction,
+            thresholds.min_green_move_pct,
+            thresholds.min_volume_spike,
+            thresholds.min_relative_volume,
+            thresholds.max_relative_volume,
+            thresholds.min_atr_mult,
+            thresholds.min_pct_move,
+            thresholds.max_pct_move,
+            thresholds.max_upper_wick_pct,
+            thresholds.max_lower_wick_pct,
+        ]
+
+    def _trade_values(self, row: TradeRow) -> list[object]:
+        return [
+            row.trade_id,
+            row.source_signal_id,
+            self._format_dt(row.timestamp_open),
+            self._format_dt(row.timestamp_close),
+            row.exchange.value,
+            row.symbol,
+            row.timeframe.value,
+            row.side.value,
+            row.entry_price,
+            row.take_profit_price,
+            row.stop_loss_price,
+            row.executed_qty,
+            row.status.value,
+            row.avg_fill_price,
+            row.reason_close.value if row.reason_close else None,
+            self._format_dt(row.sl_be_at),
+        ]
+
+    def _anomaly_values(self, row: AnomalyRow) -> list[object]:
+        metrics = row.metrics
+        thresholds = row.thresholds
+        return [
+            self._format_dt(row.timestamp),
+            row.exchange.value,
+            row.symbol,
+            row.timeframe.value,
+            row.bar_id,
+            row.open,
+            row.high,
+            row.low,
+            row.close,
+            row.volume,
+            metrics.pct_move,
+            metrics.relative_volume,
+            metrics.atr_mult,
+            metrics.upper_wick_pct,
+            metrics.body_pct,
+            metrics.lower_wick_pct,
+            metrics.pct_to_low_break,
+            metrics.pct_to_high_break,
+            metrics.break_direction,
+            thresholds.min_green_move_pct,
+            thresholds.min_volume_spike,
+            thresholds.min_relative_volume,
+            thresholds.min_atr_mult,
+        ]
+
+
 @dataclass(slots=True)
 class WorkbookDiary:
     path: Path
-    backend: DiaryBackend
-    _lock: Lock = Lock()
+    backend: Optional[DiaryBackend] = None
+    _lock: Lock = field(default_factory=Lock)
+
+    def __post_init__(self) -> None:
+        if self.backend is None:
+            self.backend = WorkbookDiaryBackend(self.path)
 
     def append_signals(self, signals: Iterable[Signal]) -> None:
         with self._lock:
+            assert self.backend is not None
             rows = [self._signal_to_row(signal) for signal in signals]
-            self.backend.append_rows(rows)
+            self.backend.append_signals(rows)
 
     def append_trades(self, trades: Iterable[Trade]) -> None:
         with self._lock:
+            assert self.backend is not None
             rows = [self._trade_to_row(trade) for trade in trades]
-            self.backend.append_rows(rows)
+            self.backend.append_trades(rows)
 
     def append_anomalies(self, anomalies: Iterable[Anomaly]) -> None:
         with self._lock:
+            assert self.backend is not None
             rows = [self._anomaly_to_row(anomaly) for anomaly in anomalies]
             self.backend.append_anomalies(rows)
 


### PR DESCRIPTION
## Summary
- add an Excel-backed implementation of `DiaryBackend` that manages the signals, trades, and anomalies workbooks
- default `WorkbookDiary` to build the Excel backend and ensure its lock is per-instance
- split the diary backend interface into separate append methods for signals and trades

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68d81a091a6083209c1fc94de00eb807