### PR TITLE
Integrate exchange client into execution flow

### DIFF
--- a/bot/data/diary.py
+++ b/bot/data/diary.py
@@ -54,11 +54,16 @@ class TradeRow(Row):
     entry_price: float
     take_profit_price: float
     stop_loss_price: float
+    requested_qty: float
     executed_qty: float
     status: TradeStatus
     avg_fill_price: Optional[float]
     reason_close: Optional[CloseReason]
     sl_be_at: Optional[datetime]
+    order_id: Optional[str]
+    stop_order_id: Optional[str]
+    take_order_id: Optional[str]
+    close_order_id: Optional[str]
 
 
 @dataclass(frozen=True, slots=True)
@@ -134,11 +139,16 @@ class WorkbookDiaryBackend(DiaryBackend):
         "entry_price",
         "take_profit_price",
         "stop_loss_price",
+        "requested_qty",
         "executed_qty",
         "status",
         "avg_fill_price",
         "reason_close",
         "sl_be_at",
+        "order_id",
+        "stop_order_id",
+        "take_order_id",
+        "close_order_id",
     ]
 
     _ANOMALIES_HEADERS = [
@@ -291,11 +301,16 @@ class WorkbookDiaryBackend(DiaryBackend):
             row.entry_price,
             row.take_profit_price,
             row.stop_loss_price,
+            row.requested_qty,
             row.executed_qty,
             row.status.value,
             row.avg_fill_price,
             row.reason_close.value if row.reason_close else None,
             self._format_dt(row.sl_be_at),
+            row.order_id,
+            row.stop_order_id,
+            row.take_order_id,
+            row.close_order_id,
         ]
 
     def _anomaly_values(self, row: AnomalyRow) -> list[object]:
@@ -387,11 +402,16 @@ class WorkbookDiary:
             entry_price=trade.entry_price,
             take_profit_price=trade.take_profit_price,
             stop_loss_price=trade.stop_loss_price,
+            requested_qty=trade.requested_qty,
             executed_qty=trade.executed_qty,
             status=trade.status,
             avg_fill_price=trade.avg_fill_price,
             reason_close=trade.reason_close,
             sl_be_at=trade.sl_be_at,
+            order_id=trade.order_id,
+            stop_order_id=trade.stop_order_id,
+            take_order_id=trade.take_order_id,
+            close_order_id=trade.close_order_id,
         )
 
     @staticmethod

--- a/bot/data/notifier.py
+++ b/bot/data/notifier.py
@@ -132,6 +132,8 @@ class TelegramNotifier(Notifier):
 
     def _format_trade(self, trade: Trade) -> str:
         status_titles = {
+            TradeStatus.PENDING: "🕒 Ордер размещён",
+            TradeStatus.PARTIALLY_FILLED: "🟡 Сделка частично исполнена",
             TradeStatus.OPENED: "🟢 Открыта сделка",
             TradeStatus.CLOSED_TP: "🎯 Сделка закрыта по тейк-профиту",
             TradeStatus.CLOSED_SL: "🛑 Сделка закрыта по стоп-лоссу",
@@ -154,7 +156,8 @@ class TelegramNotifier(Notifier):
             f"Инструмент: {trade.symbol}",
             f"Таймфрейм: {trade.timeframe.value}",
             f"Направление: {direction}",
-            f"Объём: {trade.executed_qty:.4f}",
+            f"Запрошенный объём: {trade.requested_qty:.4f}",
+            f"Исполненный объём: {trade.executed_qty:.4f}",
             f"Вход: {trade.entry_price:.4f}",
             f"TP: {trade.take_profit_price:.4f}",
             f"SL: {trade.stop_loss_price:.4f}",
@@ -169,6 +172,14 @@ class TelegramNotifier(Notifier):
         if trade.sl_be_at is not None:
             sl_time = _to_timezone(trade.sl_be_at)
             lines.append(f"SL в безубытке с: {sl_time:%Y-%m-%d %H:%M}")
+        if trade.order_id is not None:
+            lines.append(f"Ордер входа: {trade.order_id}")
+        if trade.stop_order_id is not None:
+            lines.append(f"Стоп-ордер: {trade.stop_order_id}")
+        if trade.take_order_id is not None:
+            lines.append(f"Тейк-ордер: {trade.take_order_id}")
+        if trade.close_order_id is not None:
+            lines.append(f"Ордер закрытия: {trade.close_order_id}")
         return "\n".join(lines)
 
 

--- a/bot/domain/exchange_client.py
+++ b/bot/domain/exchange_client.py
@@ -1,0 +1,160 @@
+"""Client abstractions for interacting with external exchanges."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Protocol
+from uuid import uuid4
+
+from bot import config
+from bot.domain.models.exchange import Exchange
+from bot.domain.models.signal_direction import SignalDirection
+
+
+class ExchangeClientError(RuntimeError):
+    """Raised when an exchange operation fails or the network is unavailable."""
+
+
+class OrderStatus(str, Enum):
+    """Lifecycle statuses for orders maintained by :class:`ExchangeClient`."""
+
+    NEW = "NEW"
+    PARTIALLY_FILLED = "PARTIALLY_FILLED"
+    FILLED = "FILLED"
+    CANCELLED = "CANCELLED"
+
+
+@dataclass(frozen=True, slots=True)
+class BracketOrderRequest:
+    """Request data required to submit a bracket (entry + stop/take) order."""
+
+    client_trade_id: str
+    exchange: Exchange
+    symbol: str
+    side: SignalDirection
+    quantity: float
+    entry_price: float
+    take_profit_price: float
+    stop_loss_price: float
+
+
+@dataclass(frozen=True, slots=True)
+class OrderExecutionSnapshot:
+    """Snapshot describing the execution state of a single exchange order."""
+
+    order_id: str
+    status: OrderStatus
+    filled_qty: float
+    avg_fill_price: float | None
+    updated_at: datetime | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BracketOrderExecution:
+    """Result of submitting a bracket order to the exchange."""
+
+    entry: OrderExecutionSnapshot
+    stop_order_id: str | None
+    take_order_id: str | None
+
+
+class ExchangeClient(Protocol):
+    """Interface used by :class:`ExecutionService` to talk to an exchange."""
+
+    def submit_bracket_order(self, request: BracketOrderRequest) -> BracketOrderExecution:
+        ...  # pragma: no cover - interface definition
+
+    def fetch_order(self, order_id: str) -> OrderExecutionSnapshot:
+        ...  # pragma: no cover - interface definition
+
+    def cancel_order(self, order_id: str) -> OrderExecutionSnapshot:
+        ...  # pragma: no cover - interface definition
+
+    def close_position_market(
+        self,
+        *,
+        exchange: Exchange,
+        symbol: str,
+        side: SignalDirection,
+        quantity: float,
+        price_hint: float | None = None,
+    ) -> OrderExecutionSnapshot:
+        ...  # pragma: no cover - interface definition
+
+
+@dataclass(slots=True)
+class InMemoryExchangeClient(ExchangeClient):
+    """Simplified exchange client used for tests and local backtests."""
+
+    def __post_init__(self) -> None:
+        self._orders: dict[str, OrderExecutionSnapshot] = {}
+
+    def submit_bracket_order(self, request: BracketOrderRequest) -> BracketOrderExecution:
+        order_id = f"{request.client_trade_id}-entry-{uuid4().hex[:8]}"
+        now = datetime.now(tz=config.TIMEZONE)
+        entry_snapshot = OrderExecutionSnapshot(
+            order_id=order_id,
+            status=OrderStatus.FILLED,
+            filled_qty=request.quantity,
+            avg_fill_price=request.entry_price,
+            updated_at=now,
+        )
+        self._orders[order_id] = entry_snapshot
+
+        stop_id = f"{request.client_trade_id}-stop-{uuid4().hex[:8]}"
+        take_id = f"{request.client_trade_id}-take-{uuid4().hex[:8]}"
+        self._orders[stop_id] = OrderExecutionSnapshot(
+            order_id=stop_id,
+            status=OrderStatus.NEW,
+            filled_qty=0.0,
+            avg_fill_price=None,
+            updated_at=now,
+        )
+        self._orders[take_id] = OrderExecutionSnapshot(
+            order_id=take_id,
+            status=OrderStatus.NEW,
+            filled_qty=0.0,
+            avg_fill_price=None,
+            updated_at=now,
+        )
+
+        return BracketOrderExecution(entry=entry_snapshot, stop_order_id=stop_id, take_order_id=take_id)
+
+    def fetch_order(self, order_id: str) -> OrderExecutionSnapshot:
+        snapshot = self._orders.get(order_id)
+        if snapshot is None:
+            raise ExchangeClientError(f"Order {order_id} not found")
+        return snapshot
+
+    def cancel_order(self, order_id: str) -> OrderExecutionSnapshot:
+        snapshot = self.fetch_order(order_id)
+        cancelled = OrderExecutionSnapshot(
+            order_id=order_id,
+            status=OrderStatus.CANCELLED,
+            filled_qty=snapshot.filled_qty,
+            avg_fill_price=snapshot.avg_fill_price,
+            updated_at=datetime.now(tz=config.TIMEZONE),
+        )
+        self._orders[order_id] = cancelled
+        return cancelled
+
+    def close_position_market(
+        self,
+        *,
+        exchange: Exchange,  # noqa: ARG002 - required by the interface
+        symbol: str,  # noqa: ARG002 - required by the interface
+        side: SignalDirection,  # noqa: ARG002 - required by the interface
+        quantity: float,
+        price_hint: float | None = None,
+    ) -> OrderExecutionSnapshot:
+        order_id = f"mkt-close-{uuid4().hex[:8]}"
+        snapshot = OrderExecutionSnapshot(
+            order_id=order_id,
+            status=OrderStatus.FILLED,
+            filled_qty=quantity,
+            avg_fill_price=price_hint,
+            updated_at=datetime.now(tz=config.TIMEZONE),
+        )
+        self._orders[order_id] = snapshot
+        return snapshot

--- a/bot/domain/execution_service.py
+++ b/bot/domain/execution_service.py
@@ -1,11 +1,21 @@
 """Execution service responsible for translating signals into trades."""
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
+from typing import Callable, Optional, TypeVar
 
 from bot import config
+from bot.utils.logging import get_logger
+from .exchange_client import (
+    BracketOrderExecution,
+    BracketOrderRequest,
+    ExchangeClient,
+    ExchangeClientError,
+    OrderExecutionSnapshot,
+    OrderStatus,
+)
 from .models.close_reason import CloseReason
 from .models.signal import Signal
 from .models.signal_direction import SignalDirection
@@ -21,12 +31,29 @@ class ExecutionSettings:
     breakeven_offset_pct: float = config.BREAKEVEN_OFFSET_PCT
 
 
-class ExecutionService:
-    """Simple in-memory execution abstraction used by orchestrator and backtests."""
+_T = TypeVar("_T")
 
-    def __init__(self) -> None:
-        self._settings = ExecutionSettings()
+
+class ExecutionService:
+    """Translate domain signals into concrete exchange operations."""
+
+    RETRY_ATTEMPTS = 3
+    RETRY_DELAY_SEC = 0.5
+
+    def __init__(
+        self,
+        exchange_client: ExchangeClient,
+        *,
+        settings: ExecutionSettings | None = None,
+        retry_attempts: int | None = None,
+        retry_delay_sec: float | None = None,
+    ) -> None:
+        self._exchange = exchange_client
+        self._settings = settings or ExecutionSettings()
         self._latest_imbalance: dict[str, float] = {}
+        self._retry_attempts = max(1, retry_attempts or self.RETRY_ATTEMPTS)
+        self._retry_delay_sec = retry_delay_sec or self.RETRY_DELAY_SEC
+        self._logger = get_logger(__name__)
 
     def calc_order_size_usdt(self, deposit_usdt: float) -> float:
         base_size = deposit_usdt * self._settings.order_pct_of_deposit
@@ -39,21 +66,46 @@ class ExecutionService:
         timestamp: Optional[datetime] = None,
     ) -> Trade:
         levels = signal.levels
-        trade = Trade(
-            trade_id=f"trade-{signal.signal_id}",
+        trade_id = f"trade-{signal.signal_id}"
+        request = BracketOrderRequest(
+            client_trade_id=trade_id,
+            exchange=signal.exchange,
+            symbol=signal.symbol,
+            side=signal.direction,
+            quantity=quantity,
+            entry_price=levels.entry_price,
+            take_profit_price=levels.take_profit_price,
+            stop_loss_price=levels.stop_loss_price,
+        )
+
+        execution = self._with_retry(
+            lambda: self._exchange.submit_bracket_order(request),
+            context=f"submit bracket order for {trade_id}",
+        )
+
+        entry = execution.entry
+        trade_timestamp = entry.updated_at or timestamp or signal.timestamp
+        trade_status = self._map_order_status_to_trade_status(entry.status)
+
+        return Trade(
+            trade_id=trade_id,
             source_signal_id=signal.signal_id,
             exchange=signal.exchange,
             symbol=signal.symbol,
             timeframe=signal.timeframe,
             side=signal.direction,
-            timestamp_open=timestamp or signal.timestamp,
+            timestamp_open=trade_timestamp,
             entry_price=levels.entry_price,
             take_profit_price=levels.take_profit_price,
             stop_loss_price=levels.stop_loss_price,
-            executed_qty=quantity,
-            status=TradeStatus.OPENED,
+            requested_qty=quantity,
+            executed_qty=entry.filled_qty,
+            status=trade_status,
+            avg_fill_price=entry.avg_fill_price,
+            order_id=entry.order_id,
+            stop_order_id=execution.stop_order_id,
+            take_order_id=execution.take_order_id,
         )
-        return trade
 
     def close_trade(
         self,
@@ -62,6 +114,80 @@ class ExecutionService:
         price: float,
         timestamp: datetime,
     ) -> Trade:
+        entry_snapshot = self._fetch_optional(trade.order_id, context="fetch entry order before close")
+        executed_qty = trade.executed_qty
+        avg_entry_price = trade.avg_fill_price
+
+        if entry_snapshot is not None:
+            executed_qty = entry_snapshot.filled_qty
+            if entry_snapshot.avg_fill_price is not None:
+                avg_entry_price = entry_snapshot.avg_fill_price
+
+        stop_snapshot = self._fetch_optional(trade.stop_order_id, context="fetch stop order before close")
+        take_snapshot = self._fetch_optional(trade.take_order_id, context="fetch take order before close")
+
+        close_snapshot: OrderExecutionSnapshot | None = None
+        close_order_id = trade.close_order_id
+
+        if reason is CloseReason.TAKE_PROFIT and take_snapshot and take_snapshot.status is OrderStatus.FILLED:
+            close_snapshot = take_snapshot
+            close_order_id = take_snapshot.order_id
+        elif reason is CloseReason.STOP_LOSS and stop_snapshot and stop_snapshot.status is OrderStatus.FILLED:
+            close_snapshot = stop_snapshot
+            close_order_id = stop_snapshot.order_id
+        else:
+            if (
+                trade.order_id
+                and entry_snapshot is not None
+                and entry_snapshot.status in (OrderStatus.NEW, OrderStatus.PARTIALLY_FILLED)
+            ):
+                try:
+                    entry_snapshot = self._with_retry(
+                        lambda: self._exchange.cancel_order(trade.order_id),
+                        context=f"cancel entry order {trade.order_id}",
+                    )
+                except ExchangeClientError:
+                    self._logger.warning("Не удалось отменить ордер %s", trade.order_id)
+
+            if entry_snapshot is not None:
+                executed_qty = entry_snapshot.filled_qty
+                if entry_snapshot.avg_fill_price is not None:
+                    avg_entry_price = entry_snapshot.avg_fill_price
+
+            if executed_qty > 0:
+                try:
+                    close_snapshot = self._with_retry(
+                        lambda: self._exchange.close_position_market(
+                            exchange=trade.exchange,
+                            symbol=trade.symbol,
+                            side=trade.side,
+                            quantity=executed_qty,
+                            price_hint=price,
+                        ),
+                        context=f"close position for {trade.trade_id}",
+                    )
+                    close_order_id = close_snapshot.order_id
+                except ExchangeClientError:
+                    self._logger.exception(
+                        "Не удалось закрыть сделку %s по рынку", trade.trade_id
+                    )
+
+        self._cancel_if_open(trade.stop_order_id, stop_snapshot)
+        self._cancel_if_open(trade.take_order_id, take_snapshot)
+
+        timestamp_close = timestamp
+        if close_snapshot and close_snapshot.updated_at is not None:
+            timestamp_close = close_snapshot.updated_at
+
+        final_qty = close_snapshot.filled_qty if close_snapshot else executed_qty
+        avg_fill_price = (
+            close_snapshot.avg_fill_price
+            if close_snapshot and close_snapshot.avg_fill_price is not None
+            else price if final_qty > 0 else avg_entry_price
+        )
+
+        final_status = self._derive_close_status(reason, close_snapshot, final_qty)
+
         return Trade(
             trade_id=trade.trade_id,
             source_signal_id=trade.source_signal_id,
@@ -73,12 +199,17 @@ class ExecutionService:
             entry_price=trade.entry_price,
             take_profit_price=trade.take_profit_price,
             stop_loss_price=trade.stop_loss_price,
-            executed_qty=trade.executed_qty,
-            status=self._map_reason_to_status(reason),
-            timestamp_close=timestamp,
-            avg_fill_price=price,
+            requested_qty=trade.requested_qty,
+            executed_qty=final_qty,
+            status=final_status,
+            timestamp_close=timestamp_close,
+            avg_fill_price=avg_fill_price,
             reason_close=reason,
             sl_be_at=trade.sl_be_at,
+            order_id=trade.order_id,
+            stop_order_id=trade.stop_order_id,
+            take_order_id=trade.take_order_id,
+            close_order_id=close_order_id,
         )
 
     def should_move_to_breakeven(self, entry_price: float, last_price: float, side: SignalDirection) -> bool:
@@ -104,6 +235,79 @@ class ExecutionService:
         """Return last recorded imbalance if available."""
 
         return self._latest_imbalance.get(symbol_key)
+
+    def _with_retry(self, func: Callable[[], _T], *, context: str) -> _T:
+        attempt = 1
+        delay = self._retry_delay_sec
+        while True:
+            try:
+                return func()
+            except ExchangeClientError as exc:
+                if attempt >= self._retry_attempts:
+                    self._logger.error(
+                        "Операция биржи '%s' завершилась ошибкой после %s попыток", context, attempt
+                    )
+                    raise
+                self._logger.warning(
+                    "Операция биржи '%s' не удалась на попытке %s/%s: %s",
+                    context,
+                    attempt,
+                    self._retry_attempts,
+                    exc,
+                )
+                time.sleep(delay)
+                delay *= 2
+                attempt += 1
+
+    def _fetch_optional(
+        self, order_id: str | None, *, context: str
+    ) -> OrderExecutionSnapshot | None:
+        if order_id is None:
+            return None
+        try:
+            return self._with_retry(lambda: self._exchange.fetch_order(order_id), context=context)
+        except ExchangeClientError:
+            self._logger.warning("Не удалось получить состояние ордера %s", order_id)
+            return None
+
+    def _cancel_if_open(
+        self, order_id: str | None, snapshot: OrderExecutionSnapshot | None
+    ) -> None:
+        if order_id is None:
+            return
+        state = snapshot or self._fetch_optional(order_id, context=f"refresh order {order_id}")
+        if state is None:
+            return
+        if state.status in (OrderStatus.NEW, OrderStatus.PARTIALLY_FILLED):
+            try:
+                self._with_retry(lambda: self._exchange.cancel_order(order_id), context=f"cancel order {order_id}")
+            except ExchangeClientError:
+                self._logger.warning("Не удалось отменить ордер %s", order_id)
+
+    @staticmethod
+    def _map_order_status_to_trade_status(status: OrderStatus) -> TradeStatus:
+        if status is OrderStatus.NEW:
+            return TradeStatus.PENDING
+        if status is OrderStatus.PARTIALLY_FILLED:
+            return TradeStatus.PARTIALLY_FILLED
+        if status is OrderStatus.FILLED:
+            return TradeStatus.OPENED
+        return TradeStatus.CANCELLED
+
+    def _derive_close_status(
+        self,
+        reason: CloseReason,
+        snapshot: OrderExecutionSnapshot | None,
+        executed_qty: float,
+    ) -> TradeStatus:
+        if executed_qty <= 0:
+            return TradeStatus.CANCELLED
+        if snapshot is None:
+            return self._map_reason_to_status(reason)
+        mapped = self._map_order_status_to_trade_status(snapshot.status)
+        if mapped is TradeStatus.OPENED:
+            return self._map_reason_to_status(reason)
+        return mapped
 
     @staticmethod
     def _map_reason_to_status(reason: CloseReason) -> TradeStatus:

--- a/bot/domain/models/trade.py
+++ b/bot/domain/models/trade.py
@@ -24,9 +24,14 @@ class Trade:
     entry_price: float
     take_profit_price: float
     stop_loss_price: float
+    requested_qty: float
     executed_qty: float
     status: TradeStatus
     timestamp_close: Optional[datetime] = None
     avg_fill_price: Optional[float] = None
     reason_close: Optional[CloseReason] = None
     sl_be_at: Optional[datetime] = None
+    order_id: Optional[str] = None
+    stop_order_id: Optional[str] = None
+    take_order_id: Optional[str] = None
+    close_order_id: Optional[str] = None

--- a/bot/domain/models/trade_status.py
+++ b/bot/domain/models/trade_status.py
@@ -5,6 +5,8 @@ from enum import Enum
 
 
 class TradeStatus(str, Enum):
+    PENDING = "PENDING"
+    PARTIALLY_FILLED = "PARTIALLY_FILLED"
     OPENED = "OPENED"
     CLOSED_TP = "CLOSED_TP"
     CLOSED_SL = "CLOSED_SL"

--- a/bot/domain/orchestrator.py
+++ b/bot/domain/orchestrator.py
@@ -17,6 +17,7 @@ from .execution_service import ExecutionService
 from .models.bar import Bar
 from .models.close_reason import CloseReason
 from .models.trade import Trade
+from .models.trade_status import TradeStatus
 from .swing_detector import SwingDetector
 
 
@@ -128,7 +129,8 @@ class Orchestrator:
         quantity = order_size / signal.levels.entry_price if signal.levels.entry_price else 0.0
         trade = self._deps.execution.open_trade(signal, quantity=quantity)
         self._deps.diary.append_trades([trade])
-        self._register_active_trade(trade, bar)
+        if trade.status is not TradeStatus.CANCELLED:
+            self._register_active_trade(trade, bar)
 
         try:
             self._deps.notifier.send_trade(trade)
@@ -179,6 +181,10 @@ class Orchestrator:
 
         state.record_bar(bar)
         trade = state.trade
+
+        if trade.status is TradeStatus.CANCELLED:
+            self._active_trades.pop(trade_key, None)
+            return
 
         symbol_key = self._cooldown_key(bar)
         last_imbalance = self._latest_imbalance.get(symbol_key)
@@ -253,6 +259,9 @@ class Orchestrator:
                     "Ошибка отправки уведомления о закрытии сделки %s",
                     trade.trade_id,
                 )
+            return
+
+        if trade.executed_qty <= 0:
             return
 
         updated_trade = trade


### PR DESCRIPTION
## Summary
- introduce an exchange client abstraction (with an in-memory fallback) that reports order execution snapshots and identifiers
- update the execution service to submit and close bracket orders through the exchange client with retry logic while persisting identifiers in the trade model and diary
- adjust orchestrator and notifier logic to handle the richer trade status lifecycle, partial fills, and new trade fields

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68d846f6864883209be31fb03babf6c6