### PR TITLE
Poll exchange positions before finalizing trades

### DIFF
--- a/bot/domain/exchange_client.py
+++ b/bot/domain/exchange_client.py
@@ -59,6 +59,30 @@ class BracketOrderExecution:
     take_order_id: str | None
 
 
+class PositionStatus(str, Enum):
+    """High-level status of a symbol position returned by the exchange."""
+
+    NONE = "NONE"
+    OPEN = "OPEN"
+    CLOSED = "CLOSED"
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolPositionSnapshot:
+    """Snapshot describing position and linked orders for a symbol."""
+
+    exchange: Exchange
+    symbol: str
+    status: PositionStatus
+    side: SignalDirection | None
+    quantity: float
+    entry: OrderExecutionSnapshot | None
+    stop: OrderExecutionSnapshot | None
+    take: OrderExecutionSnapshot | None
+    close: OrderExecutionSnapshot | None
+    updated_at: datetime | None = None
+
+
 class ExchangeClient(Protocol):
     """Interface used by :class:`ExecutionService` to talk to an exchange."""
 
@@ -82,6 +106,14 @@ class ExchangeClient(Protocol):
     ) -> OrderExecutionSnapshot:
         ...  # pragma: no cover - interface definition
 
+    def fetch_position(
+        self,
+        *,
+        exchange: Exchange,
+        symbol: str,
+    ) -> SymbolPositionSnapshot:
+        ...  # pragma: no cover - interface definition
+
 
 @dataclass(slots=True)
 class InMemoryExchangeClient(ExchangeClient):
@@ -89,6 +121,8 @@ class InMemoryExchangeClient(ExchangeClient):
 
     def __post_init__(self) -> None:
         self._orders: dict[str, OrderExecutionSnapshot] = {}
+        self._positions: dict[tuple[str, str], dict[str, object]] = {}
+        self._order_to_symbol: dict[str, tuple[str, str]] = {}
 
     def submit_bracket_order(self, request: BracketOrderRequest) -> BracketOrderExecution:
         order_id = f"{request.client_trade_id}-entry-{uuid4().hex[:8]}"
@@ -104,20 +138,36 @@ class InMemoryExchangeClient(ExchangeClient):
 
         stop_id = f"{request.client_trade_id}-stop-{uuid4().hex[:8]}"
         take_id = f"{request.client_trade_id}-take-{uuid4().hex[:8]}"
-        self._orders[stop_id] = OrderExecutionSnapshot(
+        stop_snapshot = OrderExecutionSnapshot(
             order_id=stop_id,
             status=OrderStatus.NEW,
             filled_qty=0.0,
             avg_fill_price=None,
             updated_at=now,
         )
-        self._orders[take_id] = OrderExecutionSnapshot(
+        take_snapshot = OrderExecutionSnapshot(
             order_id=take_id,
             status=OrderStatus.NEW,
             filled_qty=0.0,
             avg_fill_price=None,
             updated_at=now,
         )
+        self._orders[stop_id] = stop_snapshot
+        self._orders[take_id] = take_snapshot
+
+        key = (request.exchange.value, request.symbol)
+        self._positions[key] = {
+            "status": PositionStatus.OPEN,
+            "side": request.side,
+            "quantity": request.quantity,
+            "entry_id": order_id,
+            "stop_id": stop_id,
+            "take_id": take_id,
+            "close_id": None,
+            "updated_at": now,
+        }
+        for oid in (order_id, stop_id, take_id):
+            self._order_to_symbol[oid] = key
 
         return BracketOrderExecution(entry=entry_snapshot, stop_order_id=stop_id, take_order_id=take_id)
 
@@ -137,6 +187,7 @@ class InMemoryExchangeClient(ExchangeClient):
             updated_at=datetime.now(tz=config.TIMEZONE),
         )
         self._orders[order_id] = cancelled
+        self._update_position_for_order(order_id, cancelled)
         return cancelled
 
     def close_position_market(
@@ -157,4 +208,105 @@ class InMemoryExchangeClient(ExchangeClient):
             updated_at=datetime.now(tz=config.TIMEZONE),
         )
         self._orders[order_id] = snapshot
+        key = (exchange.value, symbol)
+        position = self._positions.setdefault(
+            key,
+            {
+                "status": PositionStatus.CLOSED,
+                "side": side,
+                "quantity": 0.0,
+                "entry_id": None,
+                "stop_id": None,
+                "take_id": None,
+                "close_id": None,
+                "updated_at": snapshot.updated_at,
+            },
+        )
+        position["close_id"] = order_id
+        position["status"] = PositionStatus.CLOSED
+        position["quantity"] = 0.0
+        position["updated_at"] = snapshot.updated_at
+        if "side" not in position or position["side"] is None:
+            position["side"] = side
+        self._order_to_symbol[order_id] = key
         return snapshot
+
+    def fetch_position(
+        self,
+        *,
+        exchange: Exchange,
+        symbol: str,
+    ) -> SymbolPositionSnapshot:
+        key = (exchange.value, symbol)
+        position = self._positions.get(key)
+        if position is None:
+            return SymbolPositionSnapshot(
+                exchange=exchange,
+                symbol=symbol,
+                status=PositionStatus.NONE,
+                side=None,
+                quantity=0.0,
+                entry=None,
+                stop=None,
+                take=None,
+                close=None,
+            )
+
+        entry_id = position.get("entry_id")
+        stop_id = position.get("stop_id")
+        take_id = position.get("take_id")
+        close_id = position.get("close_id")
+
+        entry_snapshot = self._orders.get(entry_id) if isinstance(entry_id, str) else None
+        stop_snapshot = self._orders.get(stop_id) if isinstance(stop_id, str) else None
+        take_snapshot = self._orders.get(take_id) if isinstance(take_id, str) else None
+        close_snapshot = self._orders.get(close_id) if isinstance(close_id, str) else None
+
+        status: PositionStatus = position.get("status", PositionStatus.NONE)  # type: ignore[assignment]
+        if status is not PositionStatus.CLOSED:
+            if stop_snapshot and stop_snapshot.status is OrderStatus.FILLED:
+                status = PositionStatus.CLOSED
+            elif take_snapshot and take_snapshot.status is OrderStatus.FILLED:
+                status = PositionStatus.CLOSED
+            elif close_snapshot and close_snapshot.status is OrderStatus.FILLED:
+                status = PositionStatus.CLOSED
+            elif entry_snapshot and entry_snapshot.status is OrderStatus.CANCELLED:
+                status = PositionStatus.NONE
+
+        timestamps = [position.get("updated_at")]
+        for snapshot in (entry_snapshot, stop_snapshot, take_snapshot, close_snapshot):
+            if snapshot and snapshot.updated_at is not None:
+                timestamps.append(snapshot.updated_at)
+        updated_at = max((ts for ts in timestamps if isinstance(ts, datetime)), default=None)
+
+        position["status"] = status
+        position["updated_at"] = updated_at
+
+        return SymbolPositionSnapshot(
+            exchange=exchange,
+            symbol=symbol,
+            status=status,
+            side=position.get("side"),  # type: ignore[arg-type]
+            quantity=float(position.get("quantity", 0.0)),
+            entry=entry_snapshot,
+            stop=stop_snapshot,
+            take=take_snapshot,
+            close=close_snapshot,
+            updated_at=updated_at,
+        )
+
+    def _update_position_for_order(
+        self, order_id: str, snapshot: OrderExecutionSnapshot
+    ) -> None:
+        key = self._order_to_symbol.get(order_id)
+        if key is None:
+            return
+        position = self._positions.get(key)
+        if position is None:
+            return
+        position["updated_at"] = snapshot.updated_at
+        if order_id == position.get("entry_id") and snapshot.status is OrderStatus.CANCELLED:
+            position["status"] = PositionStatus.NONE
+            position["quantity"] = 0.0
+        if order_id == position.get("close_id") and snapshot.status is OrderStatus.FILLED:
+            position["status"] = PositionStatus.CLOSED

--- a/bot/domain/execution_service.py
+++ b/bot/domain/execution_service.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
-from typing import Callable, Optional, TypeVar
+from typing import Callable, Literal, Optional, TypeVar
 
 from bot import config
 from bot.utils.logging import get_logger
@@ -15,6 +15,8 @@ from .exchange_client import (
     ExchangeClientError,
     OrderExecutionSnapshot,
     OrderStatus,
+    PositionStatus,
+    SymbolPositionSnapshot,
 )
 from .models.close_reason import CloseReason
 from .models.signal import Signal
@@ -39,6 +41,8 @@ class ExecutionService:
 
     RETRY_ATTEMPTS = 3
     RETRY_DELAY_SEC = 0.5
+    POSITION_POLL_ATTEMPTS = 3
+    POSITION_POLL_INTERVAL_SEC = 0.5
 
     def __init__(
         self,
@@ -212,6 +216,35 @@ class ExecutionService:
             close_order_id=close_order_id,
         )
 
+    def poll_trade_state(
+        self,
+        trade: Trade,
+        *,
+        awaiting_close: bool = False,
+        poll_attempts: int | None = None,
+        poll_interval_sec: float | None = None,
+    ) -> "TradePollingResult | None":
+        """Poll exchange state and return a result if trade status changed."""
+
+        attempts = max(1, poll_attempts or self.POSITION_POLL_ATTEMPTS)
+        interval = poll_interval_sec or self.POSITION_POLL_INTERVAL_SEC
+
+        for _ in range(attempts):
+            try:
+                snapshot = self._with_retry(
+                    lambda: self._exchange.fetch_position(exchange=trade.exchange, symbol=trade.symbol),
+                    context=f"fetch position for {trade.exchange.value}:{trade.symbol}",
+                )
+            except ExchangeClientError:
+                return None
+
+            result = self._interpret_position_snapshot(trade, snapshot, awaiting_close=awaiting_close)
+            if result is not None:
+                return result
+            time.sleep(interval)
+
+        return None
+
     def should_move_to_breakeven(self, entry_price: float, last_price: float, side: SignalDirection) -> bool:
         """Return True when price progress warrants moving the stop to break-even."""
 
@@ -318,3 +351,115 @@ class ExecutionService:
         if reason in (CloseReason.AGGRESSION, CloseReason.MANUAL):
             return TradeStatus.CLOSED_MANUAL
         return TradeStatus.CANCELLED
+
+    def _interpret_position_snapshot(
+        self,
+        trade: Trade,
+        snapshot: SymbolPositionSnapshot,
+        *,
+        awaiting_close: bool,
+    ) -> "TradePollingResult | None":
+        if snapshot.status is PositionStatus.NONE:
+            if trade.status is TradeStatus.CANCELLED:
+                return None
+            cancelled_trade = replace(
+                trade,
+                status=TradeStatus.CANCELLED,
+                executed_qty=0.0,
+                reason_close=trade.reason_close or CloseReason.MANUAL,
+                timestamp_close=snapshot.updated_at or datetime.now(tz=config.TIMEZONE),
+            )
+            return TradePollingResult(trade=cancelled_trade, outcome="cancelled")
+
+        if snapshot.status is PositionStatus.OPEN:
+            entry = snapshot.entry
+            if entry is None:
+                return None
+            updates: dict[str, object] = {}
+            new_status = self._map_order_status_to_trade_status(entry.status)
+            if entry.filled_qty != trade.executed_qty:
+                updates["executed_qty"] = entry.filled_qty
+            if entry.avg_fill_price is not None and entry.avg_fill_price != trade.avg_fill_price:
+                updates["avg_fill_price"] = entry.avg_fill_price
+            if entry.updated_at and entry.updated_at != trade.timestamp_open:
+                updates["timestamp_open"] = entry.updated_at
+            if new_status != trade.status:
+                updates["status"] = new_status
+
+            if not updates:
+                return None
+
+            updated_trade = replace(trade, **updates)
+            if new_status is TradeStatus.OPENED:
+                return TradePollingResult(trade=updated_trade, outcome="filled")
+            if new_status is TradeStatus.CANCELLED:
+                return TradePollingResult(trade=updated_trade, outcome="cancelled")
+            return None
+
+        close_snapshot, reason = self._resolve_close_snapshot(trade, snapshot)
+        final_status = self._map_reason_to_status(reason)
+        updates = {
+            "reason_close": reason,
+        }
+
+        if final_status != trade.status:
+            updates["status"] = final_status
+
+        if close_snapshot and close_snapshot.filled_qty != trade.executed_qty:
+            updates["executed_qty"] = close_snapshot.filled_qty
+
+        if close_snapshot and close_snapshot.avg_fill_price is not None and close_snapshot.avg_fill_price != trade.avg_fill_price:
+            updates["avg_fill_price"] = close_snapshot.avg_fill_price
+
+        if close_snapshot and close_snapshot.order_id != trade.close_order_id:
+            updates["close_order_id"] = close_snapshot.order_id
+
+        timestamp_close = (
+            (close_snapshot.updated_at if close_snapshot and close_snapshot.updated_at else snapshot.updated_at)
+            or trade.timestamp_close
+            or datetime.now(tz=config.TIMEZONE)
+        )
+
+        if trade.timestamp_close != timestamp_close:
+            updates["timestamp_close"] = timestamp_close
+
+        updated_trade = replace(trade, **updates) if updates else trade
+
+        if awaiting_close or updates:
+            return TradePollingResult(trade=updated_trade, outcome="closed")
+        return None
+
+    def _resolve_close_snapshot(
+        self,
+        trade: Trade,
+        snapshot: SymbolPositionSnapshot,
+    ) -> tuple[OrderExecutionSnapshot | None, CloseReason]:
+        take_snapshot = snapshot.take
+        stop_snapshot = snapshot.stop
+        close_snapshot = snapshot.close
+
+        if take_snapshot and take_snapshot.status is OrderStatus.FILLED:
+            return take_snapshot, CloseReason.TAKE_PROFIT
+
+        if stop_snapshot and stop_snapshot.status is OrderStatus.FILLED:
+            return stop_snapshot, CloseReason.STOP_LOSS
+
+        if close_snapshot and close_snapshot.status is OrderStatus.FILLED:
+            return close_snapshot, trade.reason_close or CloseReason.MANUAL
+
+        if close_snapshot:
+            return close_snapshot, trade.reason_close or CloseReason.MANUAL
+
+        if take_snapshot and take_snapshot.status is OrderStatus.CANCELLED and trade.reason_close is CloseReason.TAKE_PROFIT:
+            return take_snapshot, CloseReason.TAKE_PROFIT
+
+        if stop_snapshot and stop_snapshot.status is OrderStatus.CANCELLED and trade.reason_close is CloseReason.STOP_LOSS:
+            return stop_snapshot, CloseReason.STOP_LOSS
+
+        return snapshot.entry, trade.reason_close or CloseReason.MANUAL
+
+
+@dataclass(frozen=True)
+class TradePollingResult:
+    trade: Trade
+    outcome: Literal["filled", "closed", "cancelled"]

--- a/bot/domain/orchestrator.py
+++ b/bot/domain/orchestrator.py
@@ -28,6 +28,7 @@ class ActiveTrade:
     trade: Trade
     highs: Deque[float]
     lows: Deque[float]
+    awaiting_close_confirmation: bool = False
 
     def record_bar(self, bar: Bar) -> None:
         self.highs.append(bar.high)
@@ -186,6 +187,26 @@ class Orchestrator:
             self._active_trades.pop(trade_key, None)
             return
 
+        poll_result = self._deps.execution.poll_trade_state(
+            trade,
+            awaiting_close=state.awaiting_close_confirmation,
+        )
+        if poll_result is not None:
+            state.trade = poll_result.trade
+            trade = state.trade
+            if poll_result.outcome == "filled":
+                self._deps.diary.append_trades([trade])
+            elif poll_result.outcome in {"closed", "cancelled"}:
+                symbol_key = self._cooldown_key(bar)
+                last_imbalance = self._latest_imbalance.get(symbol_key)
+                if last_imbalance is None:
+                    last_imbalance = self._deps.execution.last_recorded_imbalance(symbol_key)
+                self._finalize_trade(trade_key, trade, poll_result.outcome, last_imbalance)
+                return
+
+        if state.awaiting_close_confirmation:
+            return
+
         symbol_key = self._cooldown_key(bar)
         last_imbalance = self._latest_imbalance.get(symbol_key)
         if last_imbalance is None:
@@ -206,59 +227,13 @@ class Orchestrator:
                 price=close_price,
                 timestamp=bar.close_time,
             )
-            self._active_trades.pop(trade_key, None)
-            self._deps.diary.append_trades([closed_trade])
+            state.trade = closed_trade
+            state.awaiting_close_confirmation = True
             self._logger.info(
-                "Сделка %s закрыта из-за агрессии против позиции (дисбаланс %.2f)",
+                "Инициировано закрытие сделки %s из-за агрессии против позиции (дисбаланс %.2f)",
                 trade.trade_id,
                 last_imbalance,
             )
-
-            try:
-                self._deps.notifier.send_trade(closed_trade)
-            except Exception:
-                self._logger.exception(
-                    "Ошибка отправки уведомления о закрытии сделки %s",
-                    trade.trade_id,
-                )
-            return
-
-        close_reason = self._detect_close_reason(trade, bar)
-        if close_reason is not None:
-            close_price = (
-                trade.take_profit_price
-                if close_reason is CloseReason.TAKE_PROFIT
-                else trade.stop_loss_price
-            )
-            closed_trade = self._deps.execution.close_trade(
-                trade,
-                reason=close_reason,
-                price=close_price,
-                timestamp=bar.close_time,
-            )
-            self._active_trades.pop(trade_key, None)
-            self._deps.diary.append_trades([closed_trade])
-
-            if close_reason is CloseReason.TAKE_PROFIT:
-                self._logger.info(
-                    "Сделка %s закрыта по тейк-профиту на уровне %.4f",
-                    trade.trade_id,
-                    close_price,
-                )
-            else:
-                self._logger.info(
-                    "Сделка %s закрыта по стоп-лоссу на уровне %.4f",
-                    trade.trade_id,
-                    close_price,
-                )
-
-            try:
-                self._deps.notifier.send_trade(closed_trade)
-            except Exception:
-                self._logger.exception(
-                    "Ошибка отправки уведомления о закрытии сделки %s",
-                    trade.trade_id,
-                )
             return
 
         if trade.executed_qty <= 0:
@@ -318,16 +293,53 @@ class Orchestrator:
             return self._swing_detector.detect_swing_low(tuple(state.lows))
         return self._swing_detector.detect_swing_high(tuple(state.highs))
 
-    @staticmethod
-    def _detect_close_reason(trade: Trade, bar: Bar) -> CloseReason | None:
-        if trade.side.is_long:
-            if bar.low <= trade.stop_loss_price:
-                return CloseReason.STOP_LOSS
-            if bar.high >= trade.take_profit_price:
-                return CloseReason.TAKE_PROFIT
+    def _finalize_trade(
+        self,
+        trade_key: str,
+        trade: Trade,
+        outcome: str,
+        last_imbalance: float | None,
+    ) -> None:
+        self._active_trades.pop(trade_key, None)
+        self._deps.diary.append_trades([trade])
+
+        if outcome == "closed":
+            self._log_trade_closure(trade, last_imbalance)
         else:
-            if bar.high >= trade.stop_loss_price:
-                return CloseReason.STOP_LOSS
-            if bar.low <= trade.take_profit_price:
-                return CloseReason.TAKE_PROFIT
-        return None
+            self._logger.info("Сделка %s отменена биржей", trade.trade_id)
+
+        try:
+            self._deps.notifier.send_trade(trade)
+        except Exception:
+            self._logger.exception("Ошибка отправки уведомления о сделке %s", trade.trade_id)
+
+    def _log_trade_closure(self, trade: Trade, last_imbalance: float | None) -> None:
+        reason = trade.reason_close
+        if reason is CloseReason.TAKE_PROFIT:
+            price = trade.avg_fill_price or trade.take_profit_price
+            self._logger.info(
+                "Сделка %s закрыта по тейк-профиту на уровне %.4f",
+                trade.trade_id,
+                price,
+            )
+        elif reason is CloseReason.STOP_LOSS:
+            price = trade.avg_fill_price or trade.stop_loss_price
+            self._logger.info(
+                "Сделка %s закрыта по стоп-лоссу на уровне %.4f",
+                trade.trade_id,
+                price,
+            )
+        elif reason is CloseReason.AGGRESSION:
+            if last_imbalance is not None:
+                self._logger.info(
+                    "Сделка %s закрыта из-за агрессии против позиции (дисбаланс %.2f)",
+                    trade.trade_id,
+                    last_imbalance,
+                )
+            else:
+                self._logger.info(
+                    "Сделка %s закрыта из-за агрессии против позиции",
+                    trade.trade_id,
+                )
+        else:
+            self._logger.info("Сделка %s закрыта вручную", trade.trade_id)


### PR DESCRIPTION
## Summary
- add a symbol position snapshot DTO and fetch API to the exchange client to expose stop/take order states
- teach the execution service to poll exchange positions and translate them into trade lifecycle outcomes
- update the orchestrator to wait for exchange confirmation before retiring trades and logging/notifying results

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d84bff5c048320ad94d9587b50867d