### PR TITLE
fix: align binance client with review feedback

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -1,6 +1,7 @@
 """Global configuration constants for the trading bot."""
 from __future__ import annotations
 
+import os
 from datetime import timezone
 from zoneinfo import ZoneInfo
 
@@ -51,3 +52,8 @@ ANOMALY_MIN_GROWTH_PCT = 3.0
 ANOMALY_MIN_ATR_MULT = 3.0
 ANOMALY_MIN_RELATIVE_VOLUME = 3.0
 ANOMALY_MIN_VOLUME_SPIKE = 3.0
+
+BINANCE_API_URL = os.environ.get("BINANCE_API_URL", "https://fapi.binance.com")
+BINANCE_API_KEY: str | None = os.environ.get("BINANCE_API_KEY")
+BINANCE_API_SECRET: str | None = os.environ.get("BINANCE_API_SECRET")
+BINANCE_RECV_WINDOW: int = int(os.getenv("BINANCE_RECV_WINDOW", "5000"))

--- a/bot/domain/exchange_client.py
+++ b/bot/domain/exchange_client.py
@@ -1,11 +1,18 @@
 """Client abstractions for interacting with external exchanges."""
 from __future__ import annotations
 
+import hashlib
+import hmac
+import logging
+import time
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from typing import Protocol
+from urllib.parse import urlencode
 from uuid import uuid4
+
+import requests
 
 from bot import config
 from bot.domain.models.exchange import Exchange
@@ -112,6 +119,9 @@ class ExchangeClient(Protocol):
         exchange: Exchange,
         symbol: str,
     ) -> SymbolPositionSnapshot:
+        ...  # pragma: no cover - interface definition
+
+    def fetch_positions(self, *, exchange: Exchange) -> list[SymbolPositionSnapshot]:
         ...  # pragma: no cover - interface definition
 
 
@@ -295,6 +305,14 @@ class InMemoryExchangeClient(ExchangeClient):
             updated_at=updated_at,
         )
 
+    def fetch_positions(self, *, exchange: Exchange) -> list[SymbolPositionSnapshot]:
+        snapshots: list[SymbolPositionSnapshot] = []
+        for (exchange_value, symbol), _ in self._positions.items():
+            if exchange_value != exchange.value:
+                continue
+            snapshots.append(self.fetch_position(exchange=exchange, symbol=symbol))
+        return snapshots
+
     def _update_position_for_order(
         self, order_id: str, snapshot: OrderExecutionSnapshot
     ) -> None:
@@ -310,3 +328,412 @@ class InMemoryExchangeClient(ExchangeClient):
             position["quantity"] = 0.0
         if order_id == position.get("close_id") and snapshot.status is OrderStatus.FILLED:
             position["status"] = PositionStatus.CLOSED
+
+
+class BinanceExchangeClient(ExchangeClient):
+    """Concrete exchange client that talks to Binance Futures REST API."""
+
+    _ORDER_ENDPOINT = "/fapi/v1/order"
+    _POSITION_ENDPOINT = "/fapi/v2/positionRisk"
+
+    _BINANCE_STATUS_MAP: dict[str, OrderStatus] = {
+        "NEW": OrderStatus.NEW,
+        "PARTIALLY_FILLED": OrderStatus.PARTIALLY_FILLED,
+        "FILLED": OrderStatus.FILLED,
+        "CANCELED": OrderStatus.CANCELLED,
+        "PENDING_CANCEL": OrderStatus.CANCELLED,
+        "EXPIRED": OrderStatus.CANCELLED,
+        "REJECTED": OrderStatus.CANCELLED,
+    }
+
+    def __init__(
+        self,
+        api_key: str,
+        api_secret: str,
+        *,
+        base_url: str | None = None,
+        recv_window: int | None = None,
+        timeout: float | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._api_secret = api_secret.encode("utf-8")
+        self._base_url = (base_url or config.BINANCE_API_URL).rstrip("/")
+        self._recv_window = recv_window if recv_window is not None else config.BINANCE_RECV_WINDOW
+        self._timeout = timeout or 10.0
+        self._session = requests.Session()
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self._order_cache: dict[str, OrderExecutionSnapshot] = {}
+        self._order_symbol: dict[str, str] = {}
+        self._symbol_orders: dict[tuple[str, str], dict[str, object]] = {}
+
+    def submit_bracket_order(self, request: BracketOrderRequest) -> BracketOrderExecution:
+        symbol = request.symbol.upper()
+        side = self._direction_to_side(request.side)
+        entry_client_id = self._client_order_id(request.client_trade_id, "entry")
+        stop_client_id = self._client_order_id(request.client_trade_id, "stop")
+        take_client_id = self._client_order_id(request.client_trade_id, "take")
+
+        entry_payload = {
+            "symbol": symbol,
+            "side": side,
+            "type": "MARKET",
+            "quantity": self._format_decimal(request.quantity),
+            "newClientOrderId": entry_client_id,
+        }
+
+        entry_data_raw = self._signed_request("POST", self._ORDER_ENDPOINT, entry_payload)
+        entry_data = self._expect_dict(entry_data_raw)
+        entry_snapshot = self._snapshot_from_payload(entry_data)
+        self._cache_order(entry_snapshot, symbol)
+
+        opposing_side = self._opposite_side(request.side)
+        stop_payload = {
+            "symbol": symbol,
+            "side": opposing_side,
+            "type": "STOP_MARKET",
+            "stopPrice": self._format_decimal(request.stop_loss_price),
+            "quantity": self._format_decimal(request.quantity),
+            "reduceOnly": "true",
+            "newClientOrderId": stop_client_id,
+        }
+
+        take_payload = {
+            "symbol": symbol,
+            "side": opposing_side,
+            "type": "TAKE_PROFIT_MARKET",
+            "stopPrice": self._format_decimal(request.take_profit_price),
+            "quantity": self._format_decimal(request.quantity),
+            "reduceOnly": "true",
+            "newClientOrderId": take_client_id,
+        }
+
+        try:
+            stop_data_raw = self._signed_request("POST", self._ORDER_ENDPOINT, stop_payload)
+            take_data_raw = self._signed_request("POST", self._ORDER_ENDPOINT, take_payload)
+            stop_data = self._expect_dict(stop_data_raw)
+            take_data = self._expect_dict(take_data_raw)
+        except ExchangeClientError:
+            try:
+                self.cancel_order(entry_snapshot.order_id)
+            except ExchangeClientError:
+                self._logger.exception(
+                    "Не удалось отменить входной ордер %s после ошибки", entry_snapshot.order_id
+                )
+            raise
+
+        stop_snapshot = self._snapshot_from_payload(stop_data)
+        take_snapshot = self._snapshot_from_payload(take_data)
+
+        self._cache_order(stop_snapshot, symbol)
+        self._cache_order(take_snapshot, symbol)
+
+        key = (request.exchange.value, symbol)
+        self._symbol_orders[key] = {
+            "entry": entry_snapshot.order_id,
+            "stop": stop_snapshot.order_id,
+            "take": take_snapshot.order_id,
+            "side": request.side,
+            "quantity": float(request.quantity),
+        }
+
+        return BracketOrderExecution(
+            entry=entry_snapshot,
+            stop_order_id=stop_snapshot.order_id,
+            take_order_id=take_snapshot.order_id,
+        )
+
+    def fetch_order(self, order_id: str) -> OrderExecutionSnapshot:
+        return self._fetch_order_remote(order_id)
+
+    def cancel_order(self, order_id: str) -> OrderExecutionSnapshot:
+        symbol = self._order_symbol.get(order_id)
+        if symbol is None:
+            raise ExchangeClientError(f"Неизвестен символ ордера {order_id}")
+        payload = {"symbol": symbol, "orderId": order_id}
+        data_raw = self._signed_request("DELETE", self._ORDER_ENDPOINT, payload)
+        data = self._expect_dict(data_raw)
+        snapshot = self._snapshot_from_payload(data)
+        self._cache_order(snapshot, symbol)
+        self._update_symbol_order(order_id, snapshot.status)
+        return snapshot
+
+    def close_position_market(
+        self,
+        *,
+        exchange: Exchange,
+        symbol: str,
+        side: SignalDirection,
+        quantity: float,
+        price_hint: float | None = None,
+    ) -> OrderExecutionSnapshot:
+        if exchange is not Exchange.BINANCE:
+            raise ExchangeClientError("Поддерживается только Binance Futures")
+
+        symbol_fmt = symbol.upper()
+        opposing_side = self._opposite_side(side)
+        close_client_id = self._client_order_id(f"close-{symbol_fmt}", uuid4().hex[:6])
+        payload = {
+            "symbol": symbol_fmt,
+            "side": opposing_side,
+            "type": "MARKET",
+            "quantity": self._format_decimal(quantity),
+            "reduceOnly": "true",
+            "newClientOrderId": close_client_id,
+        }
+        if price_hint is not None:
+            payload["priceProtect"] = "true"
+
+        data_raw = self._signed_request("POST", self._ORDER_ENDPOINT, payload)
+        data = self._expect_dict(data_raw)
+        snapshot = self._snapshot_from_payload(data)
+        self._cache_order(snapshot, symbol_fmt)
+
+        key = (exchange.value, symbol_fmt)
+        orders = self._symbol_orders.setdefault(key, {})
+        orders["close"] = snapshot.order_id
+        if "side" not in orders:
+            orders["side"] = side
+        if "quantity" not in orders:
+            orders["quantity"] = float(quantity)
+
+        return snapshot
+
+    def fetch_position(
+        self,
+        *,
+        exchange: Exchange,
+        symbol: str,
+    ) -> SymbolPositionSnapshot:
+        if exchange is not Exchange.BINANCE:
+            raise ExchangeClientError("Поддерживается только Binance Futures")
+
+        symbol_fmt = symbol.upper()
+        params = {"symbol": symbol_fmt}
+        data = self._signed_request("GET", self._POSITION_ENDPOINT, params)
+        position_info = data[0] if isinstance(data, list) and data else None
+        return self._build_position_snapshot(exchange, symbol_fmt, position_info)
+
+    def fetch_positions(self, *, exchange: Exchange) -> list[SymbolPositionSnapshot]:
+        if exchange is not Exchange.BINANCE:
+            raise ExchangeClientError("Поддерживается только Binance Futures")
+
+        data = self._signed_request("GET", self._POSITION_ENDPOINT, {})
+        snapshots: list[SymbolPositionSnapshot] = []
+        if isinstance(data, list):
+            for item in data:
+                symbol = str(item.get("symbol", ""))
+                if not symbol:
+                    continue
+                snapshots.append(self._build_position_snapshot(exchange, symbol.upper(), item))
+        return snapshots
+
+    def _build_position_snapshot(
+        self,
+        exchange: Exchange,
+        symbol: str,
+        position_info: dict[str, object] | None,
+    ) -> SymbolPositionSnapshot:
+        quantity_value = 0.0
+        side: SignalDirection | None = None
+        updated_at: datetime | None = None
+
+        if position_info:
+            raw_quantity = self._safe_float(position_info.get("positionAmt"))
+            update_time = self._safe_int(position_info.get("updateTime"))
+            if update_time:
+                updated_at = self._to_datetime(update_time)
+            if raw_quantity is not None:
+                quantity_value = abs(raw_quantity)
+                if raw_quantity > 0:
+                    side = SignalDirection.LONG
+                elif raw_quantity < 0:
+                    side = SignalDirection.SHORT
+
+        key = (exchange.value, symbol)
+        orders = self._symbol_orders.get(key, {})
+
+        entry_snapshot = self._refresh_order_if_known(orders.get("entry"))
+        stop_snapshot = self._refresh_order_if_known(orders.get("stop"))
+        take_snapshot = self._refresh_order_if_known(orders.get("take"))
+        close_snapshot = self._refresh_order_if_known(orders.get("close"))
+
+        stored_side = orders.get("side")
+        if side is None and stored_side is not None:
+            side = stored_side  # type: ignore[assignment]
+
+        status = PositionStatus.NONE
+        if quantity_value > 0:
+            status = PositionStatus.OPEN
+        else:
+            if close_snapshot and close_snapshot.status is OrderStatus.FILLED:
+                status = PositionStatus.CLOSED
+            elif stop_snapshot and stop_snapshot.status is OrderStatus.FILLED:
+                status = PositionStatus.CLOSED
+            elif take_snapshot and take_snapshot.status is OrderStatus.FILLED:
+                status = PositionStatus.CLOSED
+            elif entry_snapshot and entry_snapshot.status is OrderStatus.CANCELLED:
+                status = PositionStatus.NONE
+            elif entry_snapshot and entry_snapshot.status is OrderStatus.FILLED:
+                status = PositionStatus.CLOSED
+
+        if updated_at is None:
+            timestamps = [
+                snapshot.updated_at
+                for snapshot in (entry_snapshot, stop_snapshot, take_snapshot, close_snapshot)
+                if snapshot and snapshot.updated_at is not None
+            ]
+            updated_at = max(timestamps) if timestamps else None
+
+        return SymbolPositionSnapshot(
+            exchange=exchange,
+            symbol=symbol,
+            status=status,
+            side=side,
+            quantity=quantity_value,
+            entry=entry_snapshot,
+            stop=stop_snapshot,
+            take=take_snapshot,
+            close=close_snapshot,
+            updated_at=updated_at,
+        )
+
+    def _fetch_order_remote(self, order_id: str) -> OrderExecutionSnapshot:
+        symbol = self._order_symbol.get(order_id)
+        if symbol is None:
+            raise ExchangeClientError(f"Неизвестен символ ордера {order_id}")
+        payload = {"symbol": symbol, "orderId": order_id}
+        data_raw = self._signed_request("GET", self._ORDER_ENDPOINT, payload)
+        data = self._expect_dict(data_raw)
+        snapshot = self._snapshot_from_payload(data)
+        self._cache_order(snapshot, symbol)
+        return snapshot
+
+    def _refresh_order_if_known(self, order_id: str | None) -> OrderExecutionSnapshot | None:
+        if order_id is None:
+            return None
+        try:
+            return self._fetch_order_remote(order_id)
+        except ExchangeClientError:
+            return self._order_cache.get(order_id)
+
+    def _signed_request(
+        self,
+        method: str,
+        path: str,
+        params: dict[str, object],
+    ) -> dict[str, object] | list[dict[str, object]]:
+        timestamp = int(time.time() * 1000)
+        payload = {key: value for key, value in params.items() if value is not None}
+        payload["timestamp"] = timestamp
+        if self._recv_window:
+            payload["recvWindow"] = self._recv_window
+        query = urlencode(payload, doseq=True)
+        signature = hmac.new(self._api_secret, query.encode("utf-8"), hashlib.sha256).hexdigest()
+        payload["signature"] = signature
+
+        url = f"{self._base_url}{path}"
+        headers = {"X-MBX-APIKEY": self._api_key}
+
+        try:
+            response = self._session.request(
+                method,
+                url,
+                params=payload,
+                headers=headers,
+                timeout=self._timeout,
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover - network errors
+            raise ExchangeClientError(f"Ошибка сети при обращении к Binance API: {exc}") from exc
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise ExchangeClientError("Неверный формат ответа Binance API") from exc
+
+        if isinstance(data, dict) and "code" in data and data.get("code") not in (None, 0):
+            message = data.get("msg") or str(data)
+            raise ExchangeClientError(f"Binance API вернула ошибку: {message}")
+
+        return data
+
+    def _snapshot_from_payload(self, payload: dict[str, object]) -> OrderExecutionSnapshot:
+        order_id = str(payload.get("orderId"))
+        status_raw = str(payload.get("status", "NEW"))
+        status = self._BINANCE_STATUS_MAP.get(status_raw.upper(), OrderStatus.CANCELLED)
+        filled_qty = self._safe_float(payload.get("executedQty")) or 0.0
+        avg_fill = self._safe_float(payload.get("avgPrice"))
+        if avg_fill is not None and avg_fill <= 0:
+            avg_fill = None
+        update_time = self._safe_int(
+            payload.get("updateTime")
+            or payload.get("workingTime")
+            or payload.get("transactTime")
+        )
+        updated_at = self._to_datetime(update_time) if update_time else None
+
+        return OrderExecutionSnapshot(
+            order_id=order_id,
+            status=status,
+            filled_qty=filled_qty,
+            avg_fill_price=avg_fill,
+            updated_at=updated_at,
+        )
+
+    def _cache_order(self, snapshot: OrderExecutionSnapshot, symbol: str) -> None:
+        self._order_cache[snapshot.order_id] = snapshot
+        self._order_symbol[snapshot.order_id] = symbol
+
+    def _update_symbol_order(self, order_id: str, status: OrderStatus) -> None:
+        if status is not OrderStatus.CANCELLED:
+            return
+        for orders in self._symbol_orders.values():
+            for key, value in list(orders.items()):
+                if isinstance(value, str) and value == order_id:
+                    orders.pop(key, None)
+
+    @staticmethod
+    def _expect_dict(payload: dict[str, object] | list[dict[str, object]]) -> dict[str, object]:
+        if not isinstance(payload, dict):
+            raise ExchangeClientError("Неожиданный формат ответа Binance API")
+        return payload
+
+    @staticmethod
+    def _direction_to_side(direction: SignalDirection) -> str:
+        return "BUY" if direction.is_long else "SELL"
+
+    @staticmethod
+    def _opposite_side(direction: SignalDirection) -> str:
+        return "SELL" if direction.is_long else "BUY"
+
+    @staticmethod
+    def _client_order_id(prefix: str, suffix: str) -> str:
+        base = prefix.replace(" ", "")
+        candidate = f"{base[:20]}-{suffix}"
+        return candidate[:32]
+
+    @staticmethod
+    def _format_decimal(value: float) -> str:
+        return ("{:.10f}".format(value)).rstrip("0").rstrip(".") or "0"
+
+    @staticmethod
+    def _safe_float(value: object) -> float | None:
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _safe_int(value: object) -> int | None:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _to_datetime(timestamp_ms: int) -> datetime:
+        return datetime.fromtimestamp(timestamp_ms / 1000, tz=config.UTC).astimezone(config.TIMEZONE)

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,7 +1,10 @@
 """Entry points for running the trading bot in different modes."""
 from __future__ import annotations
 
+from bot import config
 from bot.data.loader import HistoricalRequest
+from bot.domain.exchange_client import BinanceExchangeClient, ExchangeClient, InMemoryExchangeClient
+from bot.domain.execution_service import ExecutionService
 from bot.domain.orchestrator import Orchestrator, OrchestratorDependencies
 
 
@@ -14,3 +17,23 @@ def run_live(dependencies: OrchestratorDependencies) -> Orchestrator:
 def run_backtest(dependencies: OrchestratorDependencies, request: HistoricalRequest) -> None:
     orchestrator = Orchestrator(dependencies)
     orchestrator.backfill(request)
+
+
+def create_exchange_client() -> ExchangeClient:
+    """Create an exchange client suitable for the current runtime."""
+
+    if config.BINANCE_API_KEY and config.BINANCE_API_SECRET:
+        return BinanceExchangeClient(
+            api_key=config.BINANCE_API_KEY,
+            api_secret=config.BINANCE_API_SECRET,
+            base_url=config.BINANCE_API_URL,
+            recv_window=config.BINANCE_RECV_WINDOW,
+        )
+    return InMemoryExchangeClient()
+
+
+def create_execution_service() -> ExecutionService:
+    """Factory that wires :class:`ExecutionService` for live trading."""
+
+    exchange_client = create_exchange_client()
+    return ExecutionService(exchange_client)


### PR DESCRIPTION
## Summary
- implement a Binance-backed ExchangeClient with signed REST calls for bracket orders, cancellations, market closes and position polling
- extend the exchange client protocol with bulk position retrieval and update the in-memory client to conform
- expose Binance API configuration and factories so production wiring picks up the real client when credentials are present
- adjust the Binance client to submit market entries, trust cached side metadata, and simplify the receive-window configuration hook

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68d8cbe28eac8320b0130b842423a0a2