### PR TITLE
Add Russian logging across orchestration and execution

### DIFF
--- a/bot/data/loader.py
+++ b/bot/data/loader.py
@@ -271,6 +271,7 @@ class CcxtMarketDataLoader(MarketDataLoader):
         end_ts = _to_millis(request.end)
         limit = request.limit or 1000
         cursor = since
+        bars_loaded = 0
 
         self._logger.info(
             "Загружаем OHLCV: %s %s %s с %s по %s (лимит %s)",
@@ -286,40 +287,45 @@ class CcxtMarketDataLoader(MarketDataLoader):
         timeframe_ms = int(timeframe_delta.total_seconds() * 1000)
 
         should_stop = False
-        while True:
-            batch = client.fetch_ohlcv(  # type: ignore[attr-defined]
-                request.symbol,
-                timeframe=timeframe,
-                since=cursor,
-                limit=limit,
-            )
-            if not batch:
-                break
-
-            for candle in batch:
-                open_ts = int(candle[0])
-                if open_ts >= end_ts:
-                    should_stop = True
-                    break
-                close_ts = open_ts + timeframe_ms
-                bar = _bar_from_ohlcv(
-                    exchange=request.exchange,
-                    symbol=request.symbol,
-                    timeframe=request.timeframe,
-                    open_ts=open_ts,
-                    close_ts=close_ts,
-                    ohlcv=candle,
-                    metrics_helper=metrics_helper,
+        try:
+            while True:
+                batch = client.fetch_ohlcv(  # type: ignore[attr-defined]
+                    request.symbol,
+                    timeframe=timeframe,
+                    since=cursor,
+                    limit=limit,
                 )
-                for resolved in direction_resolver.process(bar):
-                    yield resolved
+                if not batch:
+                    break
 
-            last_ts = int(batch[-1][0])
-            cursor = last_ts + timeframe_ms
-            if should_stop or cursor >= end_ts:
-                break
-        for remaining in direction_resolver.flush():
-            yield remaining
+                for candle in batch:
+                    open_ts = int(candle[0])
+                    if open_ts >= end_ts:
+                        should_stop = True
+                        break
+                    close_ts = open_ts + timeframe_ms
+                    bar = _bar_from_ohlcv(
+                        exchange=request.exchange,
+                        symbol=request.symbol,
+                        timeframe=request.timeframe,
+                        open_ts=open_ts,
+                        close_ts=close_ts,
+                        ohlcv=candle,
+                        metrics_helper=metrics_helper,
+                    )
+                    for resolved in direction_resolver.process(bar):
+                        bars_loaded += 1
+                        yield resolved
+
+                last_ts = int(batch[-1][0])
+                cursor = last_ts + timeframe_ms
+                if should_stop or cursor >= end_ts:
+                    break
+            for remaining in direction_resolver.flush():
+                bars_loaded += 1
+                yield remaining
+        finally:
+            self._logger.info("Загрузка OHLCV завершена, получено %s баров", bars_loaded)
 
 
 class WsLiveDataStream(LiveDataStream):
@@ -360,6 +366,7 @@ class WsLiveDataStream(LiveDataStream):
     def subscribe(self, listener: Callable[[LiveBarEvent], None]) -> None:
         with self._lock:
             self._listeners.append(listener)
+            self._logger.info("Добавлен слушатель потока, всего %s", len(self._listeners))
             if self._threads:
                 return
 
@@ -369,8 +376,10 @@ class WsLiveDataStream(LiveDataStream):
             ]
             for thread in self._threads:
                 thread.start()
+            self._logger.info("Запущены потоки подписки на Binance и Bybit")
 
     def close(self) -> None:
+        self._logger.info("Останавливаем поток котировок")
         self._stop_event.set()
         for app in list(self._apps):
             close = getattr(app, "close", None)

--- a/bot/domain/execution_service.py
+++ b/bot/domain/execution_service.py
@@ -70,6 +70,14 @@ class ExecutionService:
     ) -> Trade:
         levels = signal.levels
         trade_id = f"trade-{signal.signal_id}"
+        direction_name = "лонг" if signal.direction.is_long else "шорт"
+        self._logger.info(
+            "Выставляем ордера для %s %s %s: количество %.4f",
+            signal.exchange.value,
+            signal.symbol,
+            direction_name,
+            quantity,
+        )
         request = BracketOrderRequest(
             client_trade_id=trade_id,
             exchange=signal.exchange,
@@ -89,6 +97,12 @@ class ExecutionService:
         entry = execution.entry
         trade_timestamp = entry.updated_at or timestamp or signal.timestamp
         trade_status = self._map_order_status_to_trade_status(entry.status)
+        self._logger.info(
+            "Заявка %s принята: статус %s, исполнено %.4f",
+            trade_id,
+            entry.status.value,
+            entry.filled_qty,
+        )
 
         return Trade(
             trade_id=trade_id,
@@ -121,6 +135,12 @@ class ExecutionService:
         executed_qty = trade.executed_qty
         avg_entry_price = trade.avg_fill_price
 
+        self._logger.info(
+            "Закрываем сделку %s по причине %s, цена %.4f",
+            trade.trade_id,
+            reason.value,
+            price,
+        )
         if entry_snapshot is not None:
             executed_qty = entry_snapshot.filled_qty
             if entry_snapshot.avg_fill_price is not None:
@@ -190,6 +210,13 @@ class ExecutionService:
         )
 
         final_status = self._derive_close_status(reason, close_snapshot, final_qty)
+        self._logger.info(
+            "Результат закрытия %s: статус %s, объём %.4f, цена %.4f",
+            trade.trade_id,
+            final_status.value,
+            final_qty,
+            avg_fill_price if avg_fill_price is not None else 0.0,
+        )
 
         return Trade(
             trade_id=trade.trade_id,

--- a/bot/domain/orchestrator.py
+++ b/bot/domain/orchestrator.py
@@ -81,29 +81,47 @@ class Orchestrator:
         self._logger = get_logger(__name__)
 
     def start(self) -> None:
+        self._logger.info("Запускаем оркестратор: подписываемся на поток баров")
         self._deps.live_stream.subscribe(self._on_bar)
 
     def stop(self) -> None:
+        self._logger.info("Останавливаем оркестратор и поток данных")
         self._deps.live_stream.close()
 
     def backfill(self, request) -> None:  # type: ignore[no-untyped-def]
+        self._logger.info(
+            "Старт бэктеста: %s %s %s с %s по %s",
+            request.exchange.value,
+            request.symbol,
+            request.timeframe.value,
+            request.start,
+            request.end,
+        )
         simulated_trades: dict[str, SimulatedTrade] = {}
         last_bar: Bar | None = None
+        bars_processed = 0
+        signals_found = 0
+        trades_closed = 0
+        anomalies_found = 0
         for bar in self._deps.market_loader.load(request):
             last_bar = bar
+            bars_processed += 1
             closed = self._update_simulated_trades(simulated_trades, bar)
             if closed:
                 self._deps.diary.append_trades(closed)
+                trades_closed += len(closed)
 
             signal, anomaly = self._deps.analyzer.analyze_bar(bar)
 
             if anomaly is not None:
                 self._deps.diary.append_anomalies([anomaly])
+                anomalies_found += 1
 
             if signal is None:
                 continue
 
             self._deps.diary.append_signals([signal])
+            signals_found += 1
             simulated_trade = SimulatedTrade(
                 trade_id=f"backtest-{signal.signal_id}",
                 signal=signal,
@@ -119,6 +137,15 @@ class Orchestrator:
                 for state in simulated_trades.values()
             ]
             self._deps.diary.append_trades(expired)
+            trades_closed += len(expired)
+
+        self._logger.info(
+            "Бэктест завершён: баров %s, сигналов %s, закрытых сделок %s, аномалий %s",
+            bars_processed,
+            signals_found,
+            trades_closed,
+            anomalies_found,
+        )
 
     def _on_bar(self, event: LiveBarEvent) -> None:
         bar = event.bar
@@ -169,6 +196,12 @@ class Orchestrator:
         if signal is None:
             return
 
+        self._logger.info(
+            "Получен сигнал %s по %s %s",
+            signal.signal_id,
+            signal.exchange.value,
+            signal.symbol,
+        )
         try:
             self._deps.notifier.send_signal(signal)
         except Exception:
@@ -179,7 +212,27 @@ class Orchestrator:
         deposit = self._deps.balance_provider.current_deposit()
         order_size = self._deps.execution.calc_order_size_usdt(deposit_usdt=deposit)
         quantity = order_size / signal.levels.entry_price if signal.levels.entry_price else 0.0
+        self._logger.info(
+            "Депозит %.2f USDT, размер заявки %.2f USDT, количество %.4f",
+            deposit,
+            order_size,
+            quantity,
+        )
+        trade_id = f"trade-{signal.signal_id}"
+        self._logger.info(
+            "Открываем сделку %s: %s %s %s",
+            trade_id,
+            signal.exchange.value,
+            signal.symbol,
+            "лонг" if signal.direction.is_long else "шорт",
+        )
         trade = self._deps.execution.open_trade(signal, quantity=quantity)
+        self._logger.info(
+            "Сделка %s отправлена, статус %s, исполнено %.4f",
+            trade.trade_id,
+            trade.status.value,
+            trade.executed_qty,
+        )
         self._deps.diary.append_trades([trade])
         if trade.status is not TradeStatus.CANCELLED:
             self._register_active_trade(trade, bar)
@@ -207,6 +260,11 @@ class Orchestrator:
         self._symbol_cooldown[self._cooldown_key(bar)] = datetime.now(tz=config.TIMEZONE) + timedelta(
             seconds=config.SYMBOL_COOLDOWN_SEC
         )
+        self._logger.info(
+            "Кулдаун для %s включён на %s секунд",
+            self._cooldown_key(bar),
+            config.SYMBOL_COOLDOWN_SEC,
+        )
 
     @staticmethod
     def _cooldown_key(bar: Bar) -> str:
@@ -225,6 +283,7 @@ class Orchestrator:
         )
         history.record_bar(bar)
         self._active_trades[key] = history
+        self._logger.info("Сделка %s взята на сопровождение", trade.trade_id)
 
     def _manage_active_trade(self, trade_key: str, bar: Bar) -> None:
         state = self._active_trades.get(trade_key)
@@ -247,6 +306,9 @@ class Orchestrator:
             trade = state.trade
             if poll_result.outcome == "filled":
                 self._deps.diary.append_trades([trade])
+                self._logger.info(
+                    "Сделка %s исполнена, объём %.4f", trade.trade_id, trade.executed_qty
+                )
             elif poll_result.outcome in {"closed", "cancelled"}:
                 symbol_key = self._cooldown_key(bar)
                 last_imbalance = self._latest_imbalance.get(symbol_key)


### PR DESCRIPTION
## Summary
- add Russian-language info logs to orchestrator lifecycle, signal handling, and cooldowns
- extend execution service with logs around opening and closing trades
- log subscription lifecycle and historical data totals in the market data loader

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68d910e777b08320a5c91e8750ed78d6