### PR TITLE
Refine runtime configuration handling

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 
 import os
 from datetime import timezone
+from typing import Final
 from zoneinfo import ZoneInfo
 
+from bot.domain.models.exchange import Exchange
 from bot.domain.models.timeframe import Timeframe
 
 TIMEZONE_NAME = 'Europe/Belgrade'

--- a/bot/domain/models/runtime.py
+++ b/bot/domain/models/runtime.py
@@ -1,0 +1,26 @@
+"""Runtime configuration value objects."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+from bot.domain.models.timeframe import Timeframe
+
+
+class RuntimeMode(str, Enum):
+    """Supported runtime modes for the trading bot."""
+
+    LIVE = "live"
+    BACKTEST = "backtest"
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestSettings:
+    """Runtime settings required to launch a historical backtest."""
+
+    symbol: str
+    timeframe: Timeframe
+    start: datetime
+    end: datetime
+    limit: int | None = None

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,8 +1,18 @@
 """Entry points for running the trading bot in different modes."""
 from __future__ import annotations
 
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Mapping
+
+import ccxt
+
 from bot import config
-from bot.data.loader import HistoricalRequest
+from bot.data.accounting import CcxtBalanceProvider
+from bot.data.diary import WorkbookDiary
+from bot.data.loader import CcxtMarketDataLoader, HistoricalRequest, WsLiveDataStream
+from bot.data.notifier import Notifier, TelegramNotifier
+from bot.domain.analyzer import SignalAnalyzer
 from bot.domain.exchange_client import (
     BinanceExchangeClient,
     BybitExchangeClient,
@@ -10,7 +20,16 @@ from bot.domain.exchange_client import (
     InMemoryExchangeClient,
 )
 from bot.domain.execution_service import ExecutionService
+from bot.domain.models.exchange import Exchange
+from bot.domain.models.runtime import BacktestSettings, RuntimeMode
+from bot.domain.models.timeframe import Timeframe
 from bot.domain.orchestrator import Orchestrator, OrchestratorDependencies
+from bot.utils.datetime import parse_iso_datetime
+from bot.utils.logger import get_logger, setup_logging
+
+if TYPE_CHECKING:
+    from bot.domain.models.signal import Signal
+    from bot.domain.models.trade import Trade
 
 
 def run_live(dependencies: OrchestratorDependencies) -> Orchestrator:
@@ -24,17 +43,17 @@ def run_backtest(dependencies: OrchestratorDependencies, request: HistoricalRequ
     orchestrator.backfill(request)
 
 
-def create_exchange_client() -> ExchangeClient:
-    """Create an exchange client suitable for the current runtime."""
+def create_exchange_client(exchange: Exchange) -> ExchangeClient:
+    """Create an exchange client suitable for the selected exchange."""
 
-    if config.BINANCE_API_KEY and config.BINANCE_API_SECRET:
+    if exchange is Exchange.BINANCE and config.BINANCE_API_KEY and config.BINANCE_API_SECRET:
         return BinanceExchangeClient(
             api_key=config.BINANCE_API_KEY,
             api_secret=config.BINANCE_API_SECRET,
             base_url=config.BINANCE_API_URL,
             recv_window=config.BINANCE_RECV_WINDOW,
         )
-    if config.BYBIT_API_KEY and config.BYBIT_API_SECRET:
+    if exchange is Exchange.BYBIT and config.BYBIT_API_KEY and config.BYBIT_API_SECRET:
         return BybitExchangeClient(
             api_key=config.BYBIT_API_KEY,
             api_secret=config.BYBIT_API_SECRET,
@@ -45,8 +64,182 @@ def create_exchange_client() -> ExchangeClient:
     return InMemoryExchangeClient()
 
 
-def create_execution_service() -> ExecutionService:
-    """Factory that wires :class:`ExecutionService` for live trading."""
+def create_execution_service(exchange: Exchange) -> ExecutionService:
+    """Factory that wires :class:`ExecutionService` for the given exchange."""
 
-    exchange_client = create_exchange_client()
+    exchange_client = create_exchange_client(exchange)
     return ExecutionService(exchange_client)
+
+
+def create_market_data_loader() -> CcxtMarketDataLoader:
+    return CcxtMarketDataLoader()
+
+
+def create_live_stream(timeframe: Timeframe) -> WsLiveDataStream:
+    return WsLiveDataStream(timeframe=timeframe)
+
+
+def create_diary(base_path: Path | None = None) -> WorkbookDiary:
+    path = base_path or Path(os.getenv("BOT_DIARY_PATH", "var/diary"))
+    return WorkbookDiary(path=path)
+
+
+class _NullNotifier(Notifier):
+    """Fallback notifier that suppresses outbound notifications."""
+
+    def send_signal(self, signal: Signal) -> None:  # pragma: no cover - simple no-op
+        return None
+
+    def send_trade(self, trade: Trade) -> None:  # pragma: no cover - simple no-op
+        return None
+
+
+def create_notifier(mode: RuntimeMode) -> Notifier:
+    if mode is RuntimeMode.LIVE:
+        try:
+            return TelegramNotifier()
+        except ValueError as exc:  # pragma: no cover - configuration-dependent
+            get_logger(__name__).warning("Телеграм-уведомления отключены: %s", exc)
+    return _NullNotifier()
+
+
+def _create_ccxt_client(exchange: Exchange) -> object:
+    if exchange is Exchange.BINANCE:
+        params: dict[str, object] = {"enableRateLimit": True}
+        if config.BINANCE_API_KEY and config.BINANCE_API_SECRET:
+            params.update({"apiKey": config.BINANCE_API_KEY, "secret": config.BINANCE_API_SECRET})
+        return ccxt.binanceusdm(params)
+    if exchange is Exchange.BYBIT:
+        params: dict[str, object] = {
+            "enableRateLimit": True,
+            "options": {
+                "defaultType": "swap",
+                "defaultSubType": "linear",
+                "defaultSettle": "USDT",
+            },
+        }
+        if config.BYBIT_API_KEY and config.BYBIT_API_SECRET:
+            params.update({"apiKey": config.BYBIT_API_KEY, "secret": config.BYBIT_API_SECRET})
+        return ccxt.bybit(params)
+    raise ValueError(f"Unsupported exchange: {exchange}")
+
+
+def create_balance_provider(exchange: Exchange) -> CcxtBalanceProvider:
+    client = _create_ccxt_client(exchange)
+    return CcxtBalanceProvider(client)
+
+
+def create_orchestrator_dependencies(
+    exchange: Exchange, mode: RuntimeMode
+) -> OrchestratorDependencies:
+    primary_timeframe = config.DEFAULT_TIMEFRAMES[0]
+    market_loader = create_market_data_loader()
+    live_stream = create_live_stream(primary_timeframe)
+    diary = create_diary()
+    notifier = create_notifier(mode)
+    analyzer = SignalAnalyzer()
+    execution = create_execution_service(exchange)
+    balance_provider = create_balance_provider(exchange)
+    return OrchestratorDependencies(
+        market_loader=market_loader,
+        live_stream=live_stream,
+        diary=diary,
+        notifier=notifier,
+        analyzer=analyzer,
+        execution=execution,
+        balance_provider=balance_provider,
+    )
+
+
+def create_backtest_request(exchange: Exchange, settings: BacktestSettings) -> HistoricalRequest:
+    return HistoricalRequest(
+        exchange=exchange,
+        symbol=settings.symbol,
+        timeframe=settings.timeframe,
+        start=settings.start,
+        end=settings.end,
+        limit=settings.limit,
+    )
+
+
+def read_runtime_mode(env: Mapping[str, str]) -> RuntimeMode:
+    raw = env.get("BOT_MODE")
+    if raw is None:
+        return RuntimeMode.LIVE
+    try:
+        return RuntimeMode(raw.lower())
+    except ValueError as exc:
+        raise ValueError(f"Unsupported runtime mode: {raw}") from exc
+
+
+def read_exchange(env: Mapping[str, str]) -> Exchange:
+    raw = env.get("BOT_EXCHANGE")
+    if raw is None:
+        return Exchange.BINANCE
+    try:
+        return Exchange(raw.lower())
+    except ValueError as exc:
+        raise ValueError(f"Unsupported exchange: {raw}") from exc
+
+
+def read_backtest_settings(env: Mapping[str, str]) -> BacktestSettings:
+    symbol = env.get("BOT_BACKTEST_SYMBOL")
+    timeframe_raw = env.get("BOT_BACKTEST_TIMEFRAME")
+    start_raw = env.get("BOT_BACKTEST_START")
+    end_raw = env.get("BOT_BACKTEST_END")
+
+    missing = [
+        name
+        for name, value in {
+            "BOT_BACKTEST_SYMBOL": symbol,
+            "BOT_BACKTEST_TIMEFRAME": timeframe_raw,
+            "BOT_BACKTEST_START": start_raw,
+            "BOT_BACKTEST_END": end_raw,
+        }.items()
+        if not value
+    ]
+    if missing:
+        missing_vars = ", ".join(missing)
+        raise ValueError(f"Missing backtest configuration: {missing_vars}")
+
+    limit_raw = env.get("BOT_BACKTEST_LIMIT")
+    limit = int(limit_raw) if limit_raw else None
+    try:
+        timeframe = Timeframe((timeframe_raw or "").lower())
+    except ValueError as exc:
+        raise ValueError(f"Unsupported backtest timeframe: {timeframe_raw}") from exc
+
+    start = parse_iso_datetime(start_raw or "", timezone=config.TIMEZONE)
+    end = parse_iso_datetime(end_raw or "", timezone=config.TIMEZONE)
+
+    return BacktestSettings(
+        symbol=symbol or "",
+        timeframe=timeframe,
+        start=start,
+        end=end,
+        limit=limit,
+    )
+
+
+def run() -> None:
+    logger = setup_logging()
+    env = os.environ
+    mode = read_runtime_mode(env)
+    exchange = read_exchange(env)
+    logger.info(
+        "Инициализация режима %s для биржи %s", mode.value, exchange.value
+    )
+    dependencies = create_orchestrator_dependencies(exchange, mode)
+    if mode is RuntimeMode.LIVE:
+        run_live(dependencies)
+        return
+    if mode is RuntimeMode.BACKTEST:
+        settings = read_backtest_settings(env)
+        request = create_backtest_request(exchange, settings)
+        run_backtest(dependencies, request)
+        return
+    raise ValueError(f"Unsupported runtime mode: {mode}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    run()

--- a/bot/utils/datetime.py
+++ b/bot/utils/datetime.py
@@ -1,0 +1,18 @@
+"""Datetime parsing helpers."""
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+
+def parse_iso_datetime(value: str, *, timezone: ZoneInfo) -> datetime:
+    """Parse ISO 8601 datetime strings and normalize to ``timezone``.
+
+    ``value`` may omit timezone information or use ``Z`` suffix for UTC.
+    """
+
+    normalized = value.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone)
+    return parsed.astimezone(timezone)


### PR DESCRIPTION
## Summary
- move runtime runtime-specific types into a dedicated domain model module and add reusable ISO datetime parsing helper
- load runtime mode, exchange, and backtest settings inside the CLI entrypoint with stricter validation and updated dependency wiring

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68d9392b55648320bc082471cb9ff799