### PR TITLE
Extend backtest coverage window

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import os
-from datetime import timezone
+from datetime import timedelta, timezone
 from typing import Final
 from zoneinfo import ZoneInfo
 
@@ -47,6 +47,8 @@ AGGR_WINDOW_SEC = 15
 AGGR_IMBALANCE_THRESHOLD = 0.62
 
 SYMBOL_COOLDOWN_SEC = 3600
+
+BACKTEST_MIN_COVERAGE: Final[timedelta] = timedelta(days=30)
 
 LOG_TIME_FMT = '%H:%M:%S'
 

--- a/bot/data/loader.py
+++ b/bot/data/loader.py
@@ -215,6 +215,7 @@ class HistoricalRequest:
     start: datetime
     end: datetime
     limit: int | None = None
+    backtest: bool = False
 
 
 class MarketDataLoader:
@@ -270,7 +271,15 @@ class CcxtMarketDataLoader(MarketDataLoader):
         since = _to_millis(request.start)
         end_ts = _to_millis(request.end)
         limit = request.limit or 1000
-        cursor = since
+        min_start_ts: int | None = None
+        if request.backtest:
+            coverage_ms = int(config.BACKTEST_MIN_COVERAGE.total_seconds() * 1000)
+            min_start_ts = max(0, end_ts - coverage_ms)
+        effective_start_ts = min(since, min_start_ts) if min_start_ts is not None else since
+        effective_start = datetime.fromtimestamp(
+            effective_start_ts / 1000, tz=request.start.tzinfo
+        )
+        cursor = effective_start_ts
         bars_loaded = 0
 
         self._logger.info(
@@ -278,7 +287,7 @@ class CcxtMarketDataLoader(MarketDataLoader):
             request.exchange.value,
             request.symbol,
             timeframe,
-            request.start,
+            effective_start,
             request.end,
             limit,
         )

--- a/bot/main.py
+++ b/bot/main.py
@@ -159,6 +159,7 @@ def create_backtest_request(exchange: Exchange, settings: BacktestSettings) -> H
         start=settings.start,
         end=settings.end,
         limit=settings.limit,
+        backtest=True,
     )
 
 


### PR DESCRIPTION
## Summary
- add a configurable 30-day coverage window for backtests
- flag historical requests from backtests and extend CCXT loader start cursor accordingly
- update logging to reflect the effective fetch range

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d93f03094c8320892ecc42a5d5acc3