### PR TITLE
Fix long-side aggression detection threshold

### DIFF
--- a/bot/domain/orchestrator.py
+++ b/bot/domain/orchestrator.py
@@ -327,7 +327,7 @@ class Orchestrator:
 
         aggression_detected = False
         if last_imbalance is not None:
-            if trade.side.is_long and last_imbalance <= -config.AGGR_IMBALANCE_THRESHOLD:
+            if trade.side.is_long and (1 - last_imbalance) >= config.AGGR_IMBALANCE_THRESHOLD:
                 aggression_detected = True
             elif trade.side.is_short and last_imbalance >= config.AGGR_IMBALANCE_THRESHOLD:
                 aggression_detected = True


### PR DESCRIPTION
## Summary
- update the long aggression check to use the sell-side share (1 - imbalance) instead of an unattainable negative imbalance

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9466eb1bc832092518a323483e90d