### PR TITLE
Return neutral imbalance when no prints are aggregated

### DIFF
--- a/bot/utils/prints_aggregator.py
+++ b/bot/utils/prints_aggregator.py
@@ -34,7 +34,7 @@ class PrintsAggregator:
         reference_time = now or datetime.now(tz=config.UTC)
         self._drop_expired(reference_time)
         if self._total_qty == 0:
-            return 0.0
+            return 0.5
         return self._buy_qty / self._total_qty
 
     def clear(self) -> None:


### PR DESCRIPTION
## Summary
- return a neutral imbalance when no aggressive prints are accumulated so symbols are not flagged as sellers without trades

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d949b509988320884c604a3e540c64