### PR TITLE
Handle floating point residue in prints aggregator

### DIFF
--- a/bot/utils/prints_aggregator.py
+++ b/bot/utils/prints_aggregator.py
@@ -1,12 +1,16 @@
 """Aggregates aggressive trade prints to compute imbalances."""
 from __future__ import annotations
 
+import math
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Deque
 
 from bot import config
+
+
+_EPSILON = 1e-9
 
 
 @dataclass(slots=True)
@@ -33,9 +37,10 @@ class PrintsAggregator:
     def imbalance(self, now: datetime | None = None) -> float:
         reference_time = now or datetime.now(tz=config.UTC)
         self._drop_expired(reference_time)
-        if self._total_qty == 0:
+        if math.isclose(self._total_qty, 0.0, abs_tol=_EPSILON):
             return 0.5
-        return self._buy_qty / self._total_qty
+        ratio = self._buy_qty / self._total_qty
+        return min(max(ratio, 0.0), 1.0)
 
     def clear(self) -> None:
         self._prints.clear()
@@ -49,3 +54,7 @@ class PrintsAggregator:
             self._total_qty -= expired.quantity
             if expired.is_buy:
                 self._buy_qty -= expired.quantity
+        if math.isclose(self._total_qty, 0.0, abs_tol=_EPSILON):
+            self._total_qty = 0.0
+        if math.isclose(self._buy_qty, 0.0, abs_tol=_EPSILON):
+            self._buy_qty = 0.0


### PR DESCRIPTION
## Summary
- treat near-zero total quantity as zero when computing imbalance
- clamp aggregated totals after dropping expired prints to avoid rounding residue
- bound the imbalance ratio to the [0, 1] interval to guard against numerical drift

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d94cb53eac8320a77ed34e56026f36