### PR TITLE
Require explicit BOT_MODE and BOT_EXCHANGE configuration

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -165,7 +165,7 @@ def create_backtest_request(exchange: Exchange, settings: BacktestSettings) -> H
 def read_runtime_mode(env: Mapping[str, str]) -> RuntimeMode:
     raw = env.get("BOT_MODE")
     if raw is None:
-        return RuntimeMode.LIVE
+        raise ValueError("Missing runtime mode: set the BOT_MODE environment variable")
     try:
         return RuntimeMode(raw.lower())
     except ValueError as exc:
@@ -175,7 +175,7 @@ def read_runtime_mode(env: Mapping[str, str]) -> RuntimeMode:
 def read_exchange(env: Mapping[str, str]) -> Exchange:
     raw = env.get("BOT_EXCHANGE")
     if raw is None:
-        return Exchange.BINANCE
+        raise ValueError("Missing exchange: set the BOT_EXCHANGE environment variable")
     try:
         return Exchange(raw.lower())
     except ValueError as exc:


### PR DESCRIPTION
## Summary
- raise clear errors when BOT_MODE or BOT_EXCHANGE are not provided

## Testing
- python -m compileall bot/main.py

------
https://chatgpt.com/codex/tasks/task_e_68d95994286883208ffa69feaa65a868