### PR TITLE
Limit live data handling to configured exchange

### DIFF
--- a/bot/data/loader.py
+++ b/bot/data/loader.py
@@ -346,10 +346,12 @@ class WsLiveDataStream(LiveDataStream):
     def __init__(
         self,
         *,
+        exchange: Exchange,
         timeframe: Timeframe,
         top_n: int = 50,
         logger=None,
     ) -> None:
+        self._exchange = exchange
         self._timeframe = timeframe
         self._top_n = top_n
         self._logger = logger or get_logger(__name__)
@@ -379,16 +381,30 @@ class WsLiveDataStream(LiveDataStream):
             if self._threads:
                 return
 
-            self._threads = [
-                threading.Thread(target=self._run_binance, name="binance-ws", daemon=True),
-                threading.Thread(target=self._run_bybit, name="bybit-ws", daemon=True),
-            ]
+            self._threads = []
+            if self._exchange is Exchange.BINANCE:
+                self._threads.append(
+                    threading.Thread(target=self._run_binance, name="binance-ws", daemon=True)
+                )
+            elif self._exchange is Exchange.BYBIT:
+                self._threads.append(
+                    threading.Thread(target=self._run_bybit, name="bybit-ws", daemon=True)
+                )
+            else:  # pragma: no cover - defensive branch for unsupported exchanges
+                self._logger.error(
+                    "Неизвестная биржа для подписки: %s", self._exchange.value
+                )
+                return
             for thread in self._threads:
                 thread.start()
-            self._logger.info("Запущены потоки подписки на Binance и Bybit")
+            self._logger.info(
+                "Запущен поток подписки на биржу %s", self._exchange.value
+            )
 
     def close(self) -> None:
-        self._logger.info("Останавливаем поток котировок")
+        self._logger.info(
+            "Останавливаем поток котировок для биржи %s", self._exchange.value
+        )
         self._stop_event.set()
         for app in list(self._apps):
             close = getattr(app, "close", None)

--- a/bot/domain/orchestrator.py
+++ b/bot/domain/orchestrator.py
@@ -15,6 +15,7 @@ from bot.utils.logger import get_logger
 from analyzer import SignalAnalyzer
 from execution_service import ExecutionService
 from models.bar import Bar, BreakDirection
+from models.exchange import Exchange
 from models.close_reason import CloseReason
 from models.signal import Signal
 from models.trade import Trade
@@ -65,6 +66,7 @@ class OrchestratorDependencies:
     analyzer: SignalAnalyzer
     execution: ExecutionService
     balance_provider: BalanceProvider
+    exchange: Exchange
 
 
 class Orchestrator:
@@ -72,6 +74,7 @@ class Orchestrator:
 
     def __init__(self, dependencies: OrchestratorDependencies) -> None:
         self._deps = dependencies
+        self._exchange = dependencies.exchange
         self._symbol_cooldown: dict[str, datetime] = {}
         self._latest_imbalance: dict[str, float] = {}
         self._symbols_above_threshold: set[str] = set()
@@ -82,7 +85,10 @@ class Orchestrator:
         self._logger = get_logger(__name__)
 
     def start(self) -> None:
-        self._logger.info("Запускаем оркестратор: подписываемся на поток баров")
+        self._logger.info(
+            "Запускаем оркестратор для биржи %s: подписываемся на поток баров",
+            self._exchange.value,
+        )
         self._deps.live_stream.subscribe(self._on_bar)
 
     def stop(self) -> None:
@@ -150,6 +156,14 @@ class Orchestrator:
 
     def _on_bar(self, event: LiveBarEvent) -> None:
         bar = event.bar
+        if bar.exchange is not self._exchange:
+            self._logger.debug(
+                "Пропускаем бар %s: биржа %s не соответствует %s",
+                bar.bar_id,
+                bar.exchange.value,
+                self._exchange.value,
+            )
+            return
         symbol_key = self._cooldown_key(bar)
         self._latest_imbalance[symbol_key] = event.imbalance
         if event.imbalance >= config.AGGR_IMBALANCE_THRESHOLD:
@@ -167,6 +181,14 @@ class Orchestrator:
         self._handle_bar(bar)
 
     def _handle_bar(self, bar: Bar, *, ignore_imbalance_checks: bool = False) -> None:
+        if bar.exchange is not self._exchange:
+            self._logger.debug(
+                "Пропускаем обработку бара %s: биржа %s не соответствует %s",
+                bar.bar_id,
+                bar.exchange.value,
+                self._exchange.value,
+            )
+            return
         symbol_key = self._cooldown_key(bar)
         trade_key = self._trade_key(bar.exchange.value, bar.symbol, bar.timeframe.value)
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -74,8 +74,8 @@ def create_market_data_loader() -> CcxtMarketDataLoader:
     return CcxtMarketDataLoader()
 
 
-def create_live_stream(timeframe: Timeframe) -> WsLiveDataStream:
-    return WsLiveDataStream(timeframe=timeframe)
+def create_live_stream(exchange: Exchange, timeframe: Timeframe) -> WsLiveDataStream:
+    return WsLiveDataStream(exchange=exchange, timeframe=timeframe)
 
 
 def create_diary(base_path: Path | None = None) -> WorkbookDiary:
@@ -112,7 +112,7 @@ def create_orchestrator_dependencies(
 ) -> OrchestratorDependencies:
     primary_timeframe = config.DEFAULT_TIMEFRAMES[0]
     market_loader = create_market_data_loader()
-    live_stream = create_live_stream(primary_timeframe)
+    live_stream = create_live_stream(exchange, primary_timeframe)
     diary = create_diary()
     notifier = create_notifier(mode)
     analyzer = SignalAnalyzer()
@@ -126,6 +126,7 @@ def create_orchestrator_dependencies(
         analyzer=analyzer,
         execution=execution,
         balance_provider=balance_provider,
+        exchange=exchange,
     )
 
 


### PR DESCRIPTION
## Summary
- extend the orchestrator dependencies with the configured exchange and ignore bars from other venues
- wire the selected exchange through the live data stream factory
- update the websocket stream to launch subscriptions only for the chosen exchange and improve related logging

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68d975736f6083208026cec24e2d1655