### PR TITLE
Prevent recreating existing diary workbooks

### DIFF
--- a/bot/data/diary.py
+++ b/bot/data/diary.py
@@ -272,15 +272,16 @@ class WorkbookDiaryBackend(DiaryBackend):
                     workbook.save(path)
             finally:
                 workbook.close()
-
-        workbook = Workbook()
-        try:
-            sheet = workbook.active
-            sheet.title = sheet_name
-            sheet.append(headers)
-            workbook.save(path)
-        finally:
-            workbook.close()
+            return
+        else:
+            workbook = Workbook()
+            try:
+                sheet = workbook.active
+                sheet.title = sheet_name
+                sheet.append(headers)
+                workbook.save(path)
+            finally:
+                workbook.close()
 
     @staticmethod
     def _needs_header(sheet) -> bool:  # type: ignore[no-any-unimported]


### PR DESCRIPTION
## Summary
- avoid creating a new workbook when an existing diary file is updated
- only create a workbook and add headers when the file is missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da43a3664883208ce631cd0be12323