### PR TITLE
Update anomaly threshold references for LibreOffice compatibility

### DIFF
--- a/bot/data/diary.py
+++ b/bot/data/diary.py
@@ -132,7 +132,7 @@ class WorkbookDiaryBackend(DiaryBackend):
 
     # Mapping is used by formulas in the ``Anomalies`` sheet.
     _ANOMALY_THRESHOLD_CELL_MAP = {
-        name: f"Thresholds!$B${row_index}"
+        name: "'Thresholds'.$B$%d" % row_index
         for row_index, (_, name, _) in enumerate(_ANOMALY_THRESHOLD_LAYOUT, start=2)
     }
 
@@ -537,8 +537,8 @@ class WorkbookDiaryBackend(DiaryBackend):
                 label_cell.value = label
             if value_cell.value is None:
                 value_cell.value = (
-                    f"=IFERROR(LOOKUP(2,1/(Anomalies!${column_letter}:${column_letter}<>""),"
-                    f"Anomalies!${column_letter}:${column_letter}),Thresholds!$B$11)"
+                    f"=IFERROR(LOOKUP(2,1/('Anomalies'.${column_letter}<>\"\"),"
+                    f"'Anomalies'.${column_letter}),'Thresholds'.$B$11)"
                 )
 
 


### PR DESCRIPTION
## Summary
- switch anomaly threshold cell map to use LibreOffice-friendly `'Thresholds'.$B$<row>` references
- update summary LOOKUP formula to reference `'Anomalies'.$<column>` ranges and `'Thresholds'.$B$11`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da60eff3688320a4d5fca7bff23c00