### PR TITLE
Adjust anomaly LibreOffice formulas

### DIFF
--- a/bot/data/diary.py
+++ b/bot/data/diary.py
@@ -388,25 +388,25 @@ class WorkbookDiaryBackend(DiaryBackend):
         )
         long_filter_formula = (
             f"=AND("
-            f"L{row_index}>={threshold_cells['min_relative_volume']},"
-            f"L{row_index}<={threshold_cells['max_relative_volume']},"
-            f"M{row_index}>{threshold_cells['min_atr_mult']},"
-            f"K{row_index}>={threshold_cells['min_pct_move']},"
-            f"K{row_index}<={threshold_cells['max_pct_move']},"
-            f"N{row_index}<{threshold_cells['max_upper_wick_pct']},"
-            f"P{row_index}<{threshold_cells['max_lower_wick_pct']},"
+            f"L{row_index}>={threshold_cells['min_relative_volume']};"
+            f"L{row_index}<={threshold_cells['max_relative_volume']};"
+            f"M{row_index}>{threshold_cells['min_atr_mult']};"
+            f"K{row_index}>={threshold_cells['min_pct_move']};"
+            f"K{row_index}<={threshold_cells['max_pct_move']};"
+            f"N{row_index}<{threshold_cells['max_upper_wick_pct']};"
+            f"P{row_index}<{threshold_cells['max_lower_wick_pct']};"
             f"X{row_index}>={threshold_cells['min_rr']}"
             f")"
         )
         short_filter_formula = (
             f"=AND("
-            f"OR(L{row_index}<{threshold_cells['min_relative_volume']},"
-            f"L{row_index}>{threshold_cells['max_relative_volume']}),"
-            f"M{row_index}<{threshold_cells['min_atr_mult']},"
-            f"OR(K{row_index}>{threshold_cells['max_pct_move']},"
-            f"K{row_index}<{threshold_cells['min_pct_move']}),"
-            f"N{row_index}<{threshold_cells['max_upper_wick_pct']},"
-            f"P{row_index}<{threshold_cells['max_lower_wick_pct']},"
+            f"OR(L{row_index}<{threshold_cells['min_relative_volume']};"
+            f"L{row_index}>{threshold_cells['max_relative_volume']});"
+            f"M{row_index}<{threshold_cells['min_atr_mult']};"
+            f"OR(K{row_index}>{threshold_cells['max_pct_move']};"
+            f"K{row_index}<{threshold_cells['min_pct_move']});"
+            f"N{row_index}<{threshold_cells['max_upper_wick_pct']};"
+            f"P{row_index}<{threshold_cells['max_lower_wick_pct']};"
             f"Y{row_index}>={threshold_cells['min_rr']}"
             f")"
         )
@@ -425,14 +425,14 @@ class WorkbookDiaryBackend(DiaryBackend):
             f"(I{row_index}-G{row_index})/I{row_index}*100,0)))"
         )
         long_equity_formula = (
-            f"=IF(ISNUMBER(AD{row_index-1}),"
-            f"IF($Z{row_index},AD{row_index-1}*(1+{threshold_cells['position_fraction']}*AB{row_index}/100),AD{row_index-1}),"
-            f"IF($Z{row_index},{threshold_cells['initial_deposit']}*(1+{threshold_cells['position_fraction']}*AB{row_index}/100),{threshold_cells['initial_deposit']}))"
+            f"=IF(ISNUMBER(AD{row_index-1});"
+            f"IF($Z{row_index};AD{row_index-1}*(1+{threshold_cells['position_fraction']}*AB{row_index}/100);AD{row_index-1});"
+            f"IF($Z{row_index};{threshold_cells['initial_deposit']}*(1+{threshold_cells['position_fraction']}*AB{row_index}/100);{threshold_cells['initial_deposit']}))"
         )
         short_equity_formula = (
-            f"=IF(ISNUMBER(AE{row_index-1}),"
-            f"IF($AA{row_index},AE{row_index-1}*(1+{threshold_cells['position_fraction']}*AC{row_index}/100),AE{row_index-1}),"
-            f"IF($AA{row_index},{threshold_cells['initial_deposit']}*(1+{threshold_cells['position_fraction']}*AC{row_index}/100),{threshold_cells['initial_deposit']}))"
+            f"=IF(ISNUMBER(AE{row_index-1});"
+            f"IF($AA{row_index};AE{row_index-1}*(1+{threshold_cells['position_fraction']}*AC{row_index}/100);AE{row_index-1});"
+            f"IF($AA{row_index};{threshold_cells['initial_deposit']}*(1+{threshold_cells['position_fraction']}*AC{row_index}/100);{threshold_cells['initial_deposit']}))"
         )
         return [
             self._format_dt(row.timestamp),


### PR DESCRIPTION
## Summary
- update anomaly filter formulas to use semicolons between arguments for LibreOffice compatibility
- update long and short equity formulas to use semicolon-separated IF arguments for LibreOffice

## Testing
- python - <<'PY'
from datetime import datetime
from bot.data.diary import WorkbookDiaryBackend, AnomalyRow
from bot.domain.models.bar import BarMetrics, BreakDirection
from bot.domain.models.anomaly import AnomalyThresholdSnapshot
from bot.domain.models.exchange import Exchange
from bot.domain.models.timeframe import Timeframe

backend = object.__new__(WorkbookDiaryBackend)
metrics = BarMetrics(
    pct_move=1.0,
    relative_volume=2.0,
    atr_mult=3.0,
    upper_wick_pct=4.0,
    body_pct=5.0,
    lower_wick_pct=6.0,
    pct_to_low_break=7.0,
    pct_to_high_break=8.0,
    break_direction=BreakDirection.HIGH_FIRST,
)
thresholds = AnomalyThresholdSnapshot(
    min_green_move_pct=1.5,
    min_volume_spike=2.5,
    min_relative_volume=3.5,
    min_atr_mult=4.5,
)
row = AnomalyRow(
    timestamp=datetime(2024, 1, 1),
    exchange=Exchange.BINANCE,
    symbol='BTCUSDT',
    timeframe=Timeframe.M15,
    bar_id='bar123',
    open=100.0,
    high=110.0,
    low=90.0,
    close=105.0,
    volume=1000.0,
    metrics=metrics,
    thresholds=thresholds,
)
values = backend._anomaly_values(row, 2)
for idx in range(25, 31):
    print(idx, values[idx])
PY

------
https://chatgpt.com/codex/tasks/task_e_68da6be8e1288320ba70ebb29494de07