### PR TITLE
Ensure workbook diary shuts down gracefully

### DIFF
--- a/bot/data/diary.py
+++ b/bot/data/diary.py
@@ -1,12 +1,16 @@
 """Workbook writers for signals and trades diaries."""
 from __future__ import annotations
 
+import atexit
+import signal
+import threading
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from queue import Empty, Queue
-from threading import Event, Thread
+from threading import Event, Lock, Thread
+from types import FrameType
 from typing import Callable, Iterable, Literal, Optional, Protocol, Union
 
 from openpyxl import Workbook, load_workbook
@@ -755,6 +759,13 @@ class WorkbookDiary:
     _worker: Thread = field(init=False, repr=False)
     _batch_size: int = field(init=False, repr=False)
     _flush_timeout: float = field(init=False, repr=False)
+    _close_lock: Lock = field(init=False, repr=False)
+    _closed: bool = field(default=False, init=False, repr=False)
+    _closing: bool = field(default=False, init=False, repr=False)
+    _previous_signal_handlers: dict[int, object] = field(init=False, repr=False)
+    _signal_handlers: dict[int, Callable[[int, FrameType | None], None]] = field(
+        init=False, repr=False
+    )
 
     def __post_init__(self) -> None:
         if self.backend is None:
@@ -766,8 +777,12 @@ class WorkbookDiary:
         self._flush_event = Event()
         self._flush_complete = Event()
         self._stop_event = Event()
+        self._close_lock = Lock()
         self._worker = Thread(target=self._worker_loop, name="WorkbookDiaryWorker", daemon=False)
         self._worker.start()
+        self._previous_signal_handlers = {}
+        self._signal_handlers = {}
+        self._register_shutdown_hooks()
 
     def append_signals(self, signals: Iterable[Signal]) -> None:
         rows = [self._signal_to_row(signal) for signal in signals]
@@ -783,24 +798,86 @@ class WorkbookDiary:
 
     def flush(self) -> None:
         self._raise_if_worker_failed()
-        if not self._worker.is_alive():
+        if self._closed:
+            return
+        worker = self._worker
+        if not worker.is_alive():
             return
         self._queue.join()
         self._flush_complete.clear()
         self._flush_event.set()
-        while self._worker.is_alive():
+        while worker.is_alive():
             if self._flush_complete.wait(timeout=self._flush_timeout):
                 break
         self._raise_if_worker_failed()
 
     def close(self) -> None:
+        if self._closed:
+            return
+        with self._close_lock:
+            if self._closed or self._closing:
+                return
+            self._closing = True
         try:
-            self.flush()
-        finally:
-            self._stop_event.set()
-            self._flush_event.set()
-            self._worker.join()
+            worker = self._worker
+            try:
+                self.flush()
+            finally:
+                self._stop_event.set()
+                self._flush_event.set()
+                if worker.is_alive() and worker is not threading.current_thread():
+                    worker.join()
             self._raise_if_worker_failed()
+        finally:
+            with self._close_lock:
+                self._closed = True
+                self._closing = False
+
+    def _register_shutdown_hooks(self) -> None:
+        atexit.register(self.close)
+        for signum in (getattr(signal, "SIGINT", None), getattr(signal, "SIGTERM", None)):
+            if signum is None:
+                continue
+            try:
+                previous = signal.getsignal(signum)
+            except (OSError, RuntimeError, ValueError):
+                continue
+            handler = self._make_signal_handler(signum)
+            try:
+                signal.signal(signum, handler)
+            except (OSError, RuntimeError, ValueError):
+                continue
+            self._previous_signal_handlers[signum] = previous
+            self._signal_handlers[signum] = handler
+
+    def _make_signal_handler(
+        self, signum: int
+    ) -> Callable[[int, FrameType | None], None]:
+        def handler(received: int, frame: FrameType | None) -> None:
+            try:
+                self.close()
+            finally:
+                previous = self._previous_signal_handlers.get(signum)
+                if callable(previous):
+                    previous(received, frame)
+                else:
+                    if previous in (signal.SIG_DFL, None):
+                        try:
+                            signal.signal(signum, signal.SIG_DFL)
+                        except (OSError, RuntimeError, ValueError):
+                            pass
+                        sigint = getattr(signal, "SIGINT", None)
+                        if sigint is not None and received == sigint:
+                            raise KeyboardInterrupt
+                        if hasattr(signal, "raise_signal"):
+                            signal.raise_signal(signum)
+                        else:
+                            raise SystemExit(0)
+                        return
+                    if previous is signal.SIG_IGN:
+                        return
+
+        return handler
 
     def _enqueue_rows(self, sheet_key: SheetKey, rows: Iterable[DiaryRow]) -> None:
         if not rows:

--- a/bot/domain/orchestrator.py
+++ b/bot/domain/orchestrator.py
@@ -93,7 +93,13 @@ class Orchestrator:
 
     def stop(self) -> None:
         self._logger.info("Останавливаем оркестратор и поток данных")
-        self._deps.live_stream.close()
+        try:
+            self._deps.live_stream.close()
+        finally:
+            try:
+                self._deps.diary.flush()
+            finally:
+                self._deps.diary.close()
 
     def backfill(self, request) -> None:  # type: ignore[no-untyped-def]
         self._logger.info(
@@ -104,68 +110,76 @@ class Orchestrator:
             request.start,
             request.end,
         )
-        simulated_trades: dict[str, SimulatedTrade] = {}
-        cooldown_registry: dict[str, datetime] = {}
-        last_bar: Bar | None = None
-        bars_processed = 0
-        signals_found = 0
-        trades_closed = 0
-        anomalies_found = 0
-        for bar in self._deps.market_loader.load(request):
-            last_bar = bar
-            bars_processed += 1
-            closed = self._update_simulated_trades(simulated_trades, bar)
-            if closed:
-                self._deps.diary.append_trades(closed)
-                trades_closed += len(closed)
+        try:
+            simulated_trades: dict[str, SimulatedTrade] = {}
+            cooldown_registry: dict[str, datetime] = {}
+            last_bar: Bar | None = None
+            bars_processed = 0
+            signals_found = 0
+            trades_closed = 0
+            anomalies_found = 0
+            for bar in self._deps.market_loader.load(request):
+                last_bar = bar
+                bars_processed += 1
+                closed = self._update_simulated_trades(simulated_trades, bar)
+                if closed:
+                    self._deps.diary.append_trades(closed)
+                    trades_closed += len(closed)
 
-            cooldown_key = self._backfill_cooldown_key(bar)
-            cooldown_until = cooldown_registry.get(cooldown_key)
-            if cooldown_until is not None:
-                if bar.close_time < cooldown_until:
+                cooldown_key = self._backfill_cooldown_key(bar)
+                cooldown_until = cooldown_registry.get(cooldown_key)
+                if cooldown_until is not None:
+                    if bar.close_time < cooldown_until:
+                        continue
+                    cooldown_registry.pop(cooldown_key, None)
+
+                signal, anomaly = self._deps.analyzer.analyze_bar(bar)
+
+                if anomaly is not None:
+                    self._deps.diary.append_anomalies([anomaly])
+                    anomalies_found += 1
+
+                if signal is None:
                     continue
-                cooldown_registry.pop(cooldown_key, None)
 
-            signal, anomaly = self._deps.analyzer.analyze_bar(bar)
+                expiry = bar.close_time + timedelta(seconds=config.SYMBOL_COOLDOWN_SEC)
+                current_expiry = cooldown_registry.get(cooldown_key)
+                if current_expiry is None or expiry > current_expiry:
+                    cooldown_registry[cooldown_key] = expiry
 
-            if anomaly is not None:
-                self._deps.diary.append_anomalies([anomaly])
-                anomalies_found += 1
+                self._deps.diary.append_signals([signal])
+                signals_found += 1
+                simulated_trade = SimulatedTrade(
+                    trade_id=f"backtest-{signal.signal_id}",
+                    signal=signal,
+                )
+                simulated_trades[simulated_trade.trade_id] = simulated_trade
 
-            if signal is None:
-                continue
+            if simulated_trades:
+                closing_timestamp = (
+                    last_bar.close_time
+                    if last_bar is not None
+                    else datetime.now(tz=config.TIMEZONE)
+                )
+                expired = [
+                    self._expire_simulated_trade(state, closing_timestamp)
+                    for state in simulated_trades.values()
+                ]
+                self._deps.diary.append_trades(expired)
+                trades_closed += len(expired)
 
-            expiry = bar.close_time + timedelta(seconds=config.SYMBOL_COOLDOWN_SEC)
-            current_expiry = cooldown_registry.get(cooldown_key)
-            if current_expiry is None or expiry > current_expiry:
-                cooldown_registry[cooldown_key] = expiry
-
-            self._deps.diary.append_signals([signal])
-            signals_found += 1
-            simulated_trade = SimulatedTrade(
-                trade_id=f"backtest-{signal.signal_id}",
-                signal=signal,
+            self._logger.info(
+                "Бэктест завершён: баров %s, аномалий %s, сигналов %s, закрытых сделок %s",
+                bars_processed,
+                anomalies_found,
+                signals_found,
+                trades_closed,
             )
-            simulated_trades[simulated_trade.trade_id] = simulated_trade
-
-        if simulated_trades:
-            closing_timestamp = (
-                last_bar.close_time if last_bar is not None else datetime.now(tz=config.TIMEZONE)
-            )
-            expired = [
-                self._expire_simulated_trade(state, closing_timestamp)
-                for state in simulated_trades.values()
-            ]
-            self._deps.diary.append_trades(expired)
-            trades_closed += len(expired)
-
-        self._logger.info(
-            "Бэктест завершён: баров %s, аномалий %s, сигналов %s, закрытых сделок %s",
-            bars_processed,
-            anomalies_found,
-            signals_found,
-            trades_closed
-        )
+        finally:
+            try:
+                self._deps.diary.flush()
+            finally:
+                self._deps.diary.close()
 
     def _on_bar(self, event: LiveBarEvent) -> None:
         bar = event.bar

--- a/bot/main.py
+++ b/bot/main.py
@@ -138,9 +138,14 @@ def run() -> None:
     logger.info(
         "Инициализация режима %s для биржи %s", mode.value, exchange.value
     )
-    dependencies = create_orchestrator_dependencies(exchange, mode)
     if mode is RuntimeMode.LIVE:
-        run_live(dependencies)
+        dependencies = create_orchestrator_dependencies(exchange, mode)
+        try:
+            run_live(dependencies)
+        except KeyboardInterrupt:
+            raise
+        finally:
+            dependencies.diary.close()
         return
     if mode is RuntimeMode.BACKTEST:
         end = datetime.datetime.now(tz=config.TIMEZONE)
@@ -164,6 +169,7 @@ def run() -> None:
         )
         for symbol in symbols:
             for timeframe in settings.timeframes:
+                dependencies = create_orchestrator_dependencies(exchange, mode)
                 request = HistoricalRequest(
                     exchange=exchange,
                     symbol=symbol,
@@ -173,7 +179,12 @@ def run() -> None:
                     limit=settings.limit,
                     backtest=True,
                 )
-                run_backtest(dependencies, request)
+                try:
+                    run_backtest(dependencies, request)
+                except KeyboardInterrupt:
+                    raise
+                finally:
+                    dependencies.diary.close()
         return
 
 


### PR DESCRIPTION
## Summary
- make `WorkbookDiary` shutdown-aware by adding idempotent `flush`/`close` logic plus atexit and signal handlers
- flush and close the diary during orchestrator shutdown paths to persist queued entries
- wrap the main entry points so live and backtest runs close their diaries even on KeyboardInterrupts

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68dbab5feb208320949aaad849045f33