### PR TITLE
Fix named range sheet references

### DIFF
--- a/bot/data/diary.py
+++ b/bot/data/diary.py
@@ -669,7 +669,8 @@ class WorkbookDiaryBackend(DiaryBackend):
     def _set_named_range(workbook: Workbook, *, name: str, sheet_title: str, column_letter: str, row: int) -> None:
         """Ensure a workbook defined name points at the requested cell."""
 
-        attr_text = f"{sheet_title}.${column_letter.upper()}${row}"
+        escaped_sheet_title = sheet_title.replace("'", "''")
+        attr_text = f"'{escaped_sheet_title}'!${column_letter.upper()}${row}"
         if name in workbook.defined_names:
             del workbook.defined_names[name]
         workbook.defined_names[name] = DefinedName(name=name, attr_text=attr_text)


### PR DESCRIPTION
## Summary
- ensure defined names use Excel-style sheet references when updating workbook named ranges

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbb6b10c508320ab2d010959417dc2