### PR TITLE
Add anomaly threshold summary metrics

### DIFF
--- a/bot/data/diary.py
+++ b/bot/data/diary.py
@@ -717,18 +717,66 @@ class WorkbookDiaryBackend(DiaryBackend):
         short_equity_column_letter = get_column_letter(
             self._ANOMALIES_HEADERS.index("short_equity_pct") + 1
         )
+        long_pnl_column_letter = get_column_letter(
+            self._ANOMALIES_HEADERS.index("long_pnl_pct") + 1
+        )
+        short_pnl_column_letter = get_column_letter(
+            self._ANOMALIES_HEADERS.index("short_pnl_pct") + 1
+        )
+        long_trade_executed_column_letter = get_column_letter(
+            self._ANOMALIES_HEADERS.index("long_trade_executed") + 1
+        )
+        short_trade_executed_column_letter = get_column_letter(
+            self._ANOMALIES_HEADERS.index("short_trade_executed") + 1
+        )
+
+        def _column_range(column_letter: str) -> str:
+            return f"anomalies!${column_letter.upper()}$2:${column_letter.upper()}$1048576"
+
+        long_equity_range = _column_range(long_equity_column_letter)
+        short_equity_range = _column_range(short_equity_column_letter)
+        long_pnl_range = _column_range(long_pnl_column_letter)
+        short_pnl_range = _column_range(short_pnl_column_letter)
+        long_trade_executed_range = _column_range(long_trade_executed_column_letter)
+        short_trade_executed_range = _column_range(short_trade_executed_column_letter)
 
         # The summary formulas below depend on the columns used in the ``anomalies``
-        # sheet. We specifically read ``long_equity_pct`` and ``short_equity_pct``
-        # columns, so changes to ``_ANOMALIES_HEADERS`` that move these fields must
-        # also update the calculated column letters above.
-        for offset, (label, column_letter) in enumerate(
+        # sheet. We read several columns, so changes to ``_ANOMALIES_HEADERS`` that
+        # move these fields must also update the calculated column letters above.
+        summary_rows = [
+            ("Итог лонг", f"=AVERAGE({long_equity_range})"),
+            ("Итог шорт", f"=AVERAGE({short_equity_range})"),
             (
-                ("Итог лонг", long_equity_column_letter),
-                ("Итог шорт", short_equity_column_letter),
+                "Выигрыши лонг",
+                f"=COUNTIFS({long_trade_executed_range},TRUE,{long_pnl_range},\">0\")",
             ),
-            start=0,
-        ):
+            (
+                "Проигрыши лонг",
+                f"=COUNTIFS({long_trade_executed_range},TRUE,{long_pnl_range},\"<0\")",
+            ),
+            (
+                "Winrate лонг",
+                f"=IFERROR(COUNTIFS({long_trade_executed_range},TRUE,{long_pnl_range},\">0\")/"
+                f"(COUNTIFS({long_trade_executed_range},TRUE,{long_pnl_range},\">0\")+"
+                f"COUNTIFS({long_trade_executed_range},TRUE,{long_pnl_range},\"<0\")),0)",
+            ),
+            (
+                "Выигрыши шорт",
+                f"=COUNTIFS({short_trade_executed_range},TRUE,{short_pnl_range},\">0\")",
+            ),
+            (
+                "Проигрыши шорт",
+                f"=COUNTIFS({short_trade_executed_range},TRUE,{short_pnl_range},\"<0\")",
+            ),
+            (
+                "Winrate шорт",
+                f"=IFERROR(COUNTIFS({short_trade_executed_range},TRUE,{short_pnl_range},\">0\")/"
+                f"(COUNTIFS({short_trade_executed_range},TRUE,{short_pnl_range},\">0\")+"
+                f"COUNTIFS({short_trade_executed_range},TRUE,{short_pnl_range},\"<0\")),0)",
+            ),
+        ]
+
+        for offset, (label, formula) in enumerate(summary_rows, start=0):
             row_index = summary_row_start + offset
             label_cell = sheet.cell(row=row_index, column=1)
             value_cell = sheet.cell(row=row_index, column=2)
@@ -736,10 +784,7 @@ class WorkbookDiaryBackend(DiaryBackend):
             if label_cell.value is None:
                 label_cell.value = label
             if value_cell.value is None:
-                column_range = (
-                    f"anomalies!${column_letter.upper()}$2:${column_letter.upper()}$1048576"
-                )
-                value_cell.value = f"=AVERAGE({column_range})"
+                value_cell.value = formula
 
 
 @dataclass(slots=True)

--- a/tests/test_diary_formulas.py
+++ b/tests/test_diary_formulas.py
@@ -216,13 +216,59 @@ def test_anomaly_threshold_summary_formulas_cover_full_column() -> None:
     short_column_letter = _column_letter_from_index(
         backend._ANOMALIES_HEADERS.index("short_equity_pct") + 1
     )
+    long_pnl_column_letter = _column_letter_from_index(
+        backend._ANOMALIES_HEADERS.index("long_pnl_pct") + 1
+    )
+    short_pnl_column_letter = _column_letter_from_index(
+        backend._ANOMALIES_HEADERS.index("short_pnl_pct") + 1
+    )
+    long_trade_executed_letter = _column_letter_from_index(
+        backend._ANOMALIES_HEADERS.index("long_trade_executed") + 1
+    )
+    short_trade_executed_letter = _column_letter_from_index(
+        backend._ANOMALIES_HEADERS.index("short_trade_executed") + 1
+    )
 
     long_value_cell = sheet.cell(row=summary_row_start, column=2)
     short_value_cell = sheet.cell(row=summary_row_start + 1, column=2)
+    long_wins_cell = sheet.cell(row=summary_row_start + 2, column=2)
+    long_losses_cell = sheet.cell(row=summary_row_start + 3, column=2)
+    long_winrate_cell = sheet.cell(row=summary_row_start + 4, column=2)
+    short_wins_cell = sheet.cell(row=summary_row_start + 5, column=2)
+    short_losses_cell = sheet.cell(row=summary_row_start + 6, column=2)
+    short_winrate_cell = sheet.cell(row=summary_row_start + 7, column=2)
 
-    assert long_value_cell.value == (
-        f"=AVERAGE(anomalies!${long_column_letter}$2:${long_column_letter}$1048576)"
+    def _column_range(column_letter: str) -> str:
+        return f"anomalies!${column_letter}$2:${column_letter}$1048576"
+
+    long_equity_range = _column_range(long_column_letter)
+    short_equity_range = _column_range(short_column_letter)
+    long_pnl_range = _column_range(long_pnl_column_letter)
+    short_pnl_range = _column_range(short_pnl_column_letter)
+    long_trade_executed_range = _column_range(long_trade_executed_letter)
+    short_trade_executed_range = _column_range(short_trade_executed_letter)
+
+    assert long_value_cell.value == f"=AVERAGE({long_equity_range})"
+    assert short_value_cell.value == f"=AVERAGE({short_equity_range})"
+    assert long_wins_cell.value == (
+        f"=COUNTIFS({long_trade_executed_range},TRUE,{long_pnl_range},\">0\")"
     )
-    assert short_value_cell.value == (
-        f"=AVERAGE(anomalies!${short_column_letter}$2:${short_column_letter}$1048576)"
+    assert long_losses_cell.value == (
+        f"=COUNTIFS({long_trade_executed_range},TRUE,{long_pnl_range},\"<0\")"
+    )
+    assert long_winrate_cell.value == (
+        f"=IFERROR(COUNTIFS({long_trade_executed_range},TRUE,{long_pnl_range},\">0\")/"
+        f"(COUNTIFS({long_trade_executed_range},TRUE,{long_pnl_range},\">0\")+"
+        f"COUNTIFS({long_trade_executed_range},TRUE,{long_pnl_range},\"<0\")),0)"
+    )
+    assert short_wins_cell.value == (
+        f"=COUNTIFS({short_trade_executed_range},TRUE,{short_pnl_range},\">0\")"
+    )
+    assert short_losses_cell.value == (
+        f"=COUNTIFS({short_trade_executed_range},TRUE,{short_pnl_range},\"<0\")"
+    )
+    assert short_winrate_cell.value == (
+        f"=IFERROR(COUNTIFS({short_trade_executed_range},TRUE,{short_pnl_range},\">0\")/"
+        f"(COUNTIFS({short_trade_executed_range},TRUE,{short_pnl_range},\">0\")+"
+        f"COUNTIFS({short_trade_executed_range},TRUE,{short_pnl_range},\"<0\")),0)"
     )


### PR DESCRIPTION
## Summary
- compute the anomalies sheet column letters for PnL and execution metrics
- add long and short win/loss counts and winrate formulas to the thresholds summary
- update the unit test to cover the new summary formulas

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbbb1d2aec8320a535650436c8c4dd