### PR TITLE
Adjust anomaly threshold summary averages

### DIFF
--- a/bot/data/diary.py
+++ b/bot/data/diary.py
@@ -744,8 +744,14 @@ class WorkbookDiaryBackend(DiaryBackend):
         # sheet. We read several columns, so changes to ``_ANOMALIES_HEADERS`` that
         # move these fields must also update the calculated column letters above.
         summary_rows = [
-            ("Итог лонг", f"=AVERAGE({long_equity_range})"),
-            ("Итог шорт", f"=AVERAGE({short_equity_range})"),
+            (
+                "Средний результат лонг",
+                f"=AVERAGE({long_equity_range})-thresholds_initial_deposit",
+            ),
+            (
+                "Средний результат шорт",
+                f"=AVERAGE({short_equity_range})-thresholds_initial_deposit",
+            ),
             (
                 "Выигрыши лонг",
                 f"=COUNTIFS({long_trade_executed_range},TRUE,{long_pnl_range},\">0\")",

--- a/tests/test_diary_formulas.py
+++ b/tests/test_diary_formulas.py
@@ -248,8 +248,12 @@ def test_anomaly_threshold_summary_formulas_cover_full_column() -> None:
     long_trade_executed_range = _column_range(long_trade_executed_letter)
     short_trade_executed_range = _column_range(short_trade_executed_letter)
 
-    assert long_value_cell.value == f"=AVERAGE({long_equity_range})"
-    assert short_value_cell.value == f"=AVERAGE({short_equity_range})"
+    assert long_value_cell.value == (
+        f"=AVERAGE({long_equity_range})-thresholds_initial_deposit"
+    )
+    assert short_value_cell.value == (
+        f"=AVERAGE({short_equity_range})-thresholds_initial_deposit"
+    )
     assert long_wins_cell.value == (
         f"=COUNTIFS({long_trade_executed_range},TRUE,{long_pnl_range},\">0\")"
     )


### PR DESCRIPTION
## Summary
- rename the anomaly threshold sheet average labels to clarify long and short results
- subtract the thresholds_initial_deposit named range in the long/short average formulas and update tests

## Testing
- pytest tests/test_diary_formulas.py

------
https://chatgpt.com/codex/tasks/task_e_68dbbc5852348320a41aa9d2027b2e3a