### PR TITLE
Adjust diary lifecycle handling for backtests

### DIFF
--- a/bot/domain/orchestrator.py
+++ b/bot/domain/orchestrator.py
@@ -118,79 +118,73 @@ class Orchestrator:
             request.start,
             request.end,
         )
-        try:
-            simulated_trades: dict[str, SimulatedTrade] = {}
-            cooldown_registry: dict[str, datetime] = {}
-            last_bar: Bar | None = None
-            bars_processed = 0
-            signals_found = 0
-            trades_closed = 0
-            anomalies_found = 0
-            for bar in self._deps.market_loader.load(request):
-                last_bar = bar
-                bars_processed += 1
-                closed = self._update_simulated_trades(simulated_trades, bar)
-                if closed:
-                    self._deps.diary.append_trades(closed)
-                    trades_closed += len(closed)
+        simulated_trades: dict[str, SimulatedTrade] = {}
+        cooldown_registry: dict[str, datetime] = {}
+        last_bar: Bar | None = None
+        bars_processed = 0
+        signals_found = 0
+        trades_closed = 0
+        anomalies_found = 0
+        for bar in self._deps.market_loader.load(request):
+            last_bar = bar
+            bars_processed += 1
+            closed = self._update_simulated_trades(simulated_trades, bar)
+            if closed:
+                self._deps.diary.append_trades(closed)
+                trades_closed += len(closed)
 
-                cooldown_key = self._backfill_cooldown_key(bar)
-                cooldown_until = cooldown_registry.get(cooldown_key)
-                if cooldown_until is not None:
-                    if bar.close_time < cooldown_until:
-                        continue
-                    cooldown_registry.pop(cooldown_key, None)
-
-                if not self._should_analyze_bar(bar):
+            cooldown_key = self._backfill_cooldown_key(bar)
+            cooldown_until = cooldown_registry.get(cooldown_key)
+            if cooldown_until is not None:
+                if bar.close_time < cooldown_until:
                     continue
+                cooldown_registry.pop(cooldown_key, None)
 
-                signal, anomaly = self._deps.analyzer.analyze_bar(bar)
+            if not self._should_analyze_bar(bar):
+                continue
 
-                if anomaly is not None:
-                    self._deps.diary.append_anomalies([anomaly])
-                    anomalies_found += 1
+            signal, anomaly = self._deps.analyzer.analyze_bar(bar)
 
-                if signal is None:
-                    continue
+            if anomaly is not None:
+                self._deps.diary.append_anomalies([anomaly])
+                anomalies_found += 1
 
-                expiry = bar.close_time + timedelta(seconds=config.SYMBOL_COOLDOWN_SEC)
-                current_expiry = cooldown_registry.get(cooldown_key)
-                if current_expiry is None or expiry > current_expiry:
-                    cooldown_registry[cooldown_key] = expiry
+            if signal is None:
+                continue
 
-                self._deps.diary.append_signals([signal])
-                signals_found += 1
-                simulated_trade = SimulatedTrade(
-                    trade_id=f"backtest-{signal.signal_id}",
-                    signal=signal,
-                )
-                simulated_trades[simulated_trade.trade_id] = simulated_trade
+            expiry = bar.close_time + timedelta(seconds=config.SYMBOL_COOLDOWN_SEC)
+            current_expiry = cooldown_registry.get(cooldown_key)
+            if current_expiry is None or expiry > current_expiry:
+                cooldown_registry[cooldown_key] = expiry
 
-            if simulated_trades:
-                closing_timestamp = (
-                    last_bar.close_time
-                    if last_bar is not None
-                    else datetime.now(tz=config.TIMEZONE)
-                )
-                expired = [
-                    self._expire_simulated_trade(state, closing_timestamp)
-                    for state in simulated_trades.values()
-                ]
-                self._deps.diary.append_trades(expired)
-                trades_closed += len(expired)
-
-            self._logger.info(
-                "Бэктест завершён: баров %s, аномалий %s, сигналов %s, закрытых сделок %s",
-                bars_processed,
-                anomalies_found,
-                signals_found,
-                trades_closed,
+            self._deps.diary.append_signals([signal])
+            signals_found += 1
+            simulated_trade = SimulatedTrade(
+                trade_id=f"backtest-{signal.signal_id}",
+                signal=signal,
             )
-        finally:
-            try:
-                self._deps.diary.flush()
-            finally:
-                self._deps.diary.close()
+            simulated_trades[simulated_trade.trade_id] = simulated_trade
+
+        if simulated_trades:
+            closing_timestamp = (
+                last_bar.close_time
+                if last_bar is not None
+                else datetime.now(tz=config.TIMEZONE)
+            )
+            expired = [
+                self._expire_simulated_trade(state, closing_timestamp)
+                for state in simulated_trades.values()
+            ]
+            self._deps.diary.append_trades(expired)
+            trades_closed += len(expired)
+
+        self._logger.info(
+            "Бэктест завершён: баров %s, аномалий %s, сигналов %s, закрытых сделок %s",
+            bars_processed,
+            anomalies_found,
+            signals_found,
+            trades_closed,
+        )
 
     def _on_bar(self, event: LiveBarEvent) -> None:
         bar = event.bar

--- a/bot/main.py
+++ b/bot/main.py
@@ -112,12 +112,14 @@ def create_balance_provider(exchange: Exchange) -> CcxtBalanceProvider:
 
 
 def create_orchestrator_dependencies(
-    exchange: Exchange, mode: RuntimeMode
+    exchange: Exchange,
+    mode: RuntimeMode,
+    diary: WorkbookDiary | None = None,
 ) -> OrchestratorDependencies:
     primary_timeframe = config.DEFAULT_TIMEFRAMES[0]
     market_loader = create_market_data_loader()
     live_stream = create_live_stream(exchange, primary_timeframe)
-    diary = create_diary(exchange)
+    diary_instance = diary if diary is not None else create_diary(exchange)
     notifier = create_notifier(mode)
     analyzer = SignalAnalyzer()
     execution = create_execution_service(exchange)
@@ -125,7 +127,7 @@ def create_orchestrator_dependencies(
     return OrchestratorDependencies(
         market_loader=market_loader,
         live_stream=live_stream,
-        diary=diary,
+        diary=diary_instance,
         notifier=notifier,
         analyzer=analyzer,
         execution=execution,
@@ -170,24 +172,25 @@ def run() -> None:
             len(symbols),
             len(settings.timeframes),
         )
-        for symbol in symbols:
-            for timeframe in settings.timeframes:
-                dependencies = create_orchestrator_dependencies(exchange, mode)
-                request = HistoricalRequest(
-                    exchange=exchange,
-                    symbol=symbol,
-                    timeframe=timeframe,
-                    start=settings.start,
-                    end=settings.end,
-                    limit=settings.limit,
-                    backtest=True,
-                )
-                try:
+        diary = create_diary(exchange)
+        try:
+            for symbol in symbols:
+                for timeframe in settings.timeframes:
+                    dependencies = create_orchestrator_dependencies(
+                        exchange, mode, diary=diary
+                    )
+                    request = HistoricalRequest(
+                        exchange=exchange,
+                        symbol=symbol,
+                        timeframe=timeframe,
+                        start=settings.start,
+                        end=settings.end,
+                        limit=settings.limit,
+                        backtest=True,
+                    )
                     run_backtest(dependencies, request)
-                except KeyboardInterrupt:
-                    raise
-                finally:
-                    dependencies.diary.close()
+        finally:
+            diary.close()
         return
 
 


### PR DESCRIPTION
## Summary
- stop forcibly flushing and closing the diary from the orchestrator backfill
- allow orchestrator dependencies to reuse an externally managed diary instance
- share a single workbook diary across backtests and close it once after completion

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dccdc594ec8320a69d2800cfa00d36