### PR TITLE
Fix equity scaling in anomaly optimizer

### DIFF
--- a/bot/domain/anomaly_optimizer.py
+++ b/bot/domain/anomaly_optimizer.py
@@ -1,0 +1,499 @@
+"""Threshold optimization utilities for anomaly backtests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime
+from itertools import product
+from pathlib import Path
+from random import Random
+from typing import Sequence
+
+from openpyxl import load_workbook
+
+from bot.data.diary import WorkbookDiaryBackend
+from bot.domain.models.bar import BarMetrics, BreakDirection
+from bot.domain.models.exchange import Exchange
+from bot.domain.models.timeframe import Timeframe
+
+
+@dataclass(frozen=True, slots=True)
+class AnomalySample:
+    """Parsed anomaly row with the information required for optimization."""
+
+    timestamp: datetime
+    exchange: Exchange
+    symbol: str
+    timeframe: Timeframe
+    bar_id: str
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+    metrics: BarMetrics
+
+    @property
+    def break_direction(self) -> BreakDirection:
+        return self.metrics.break_direction
+
+
+@dataclass(frozen=True, slots=True)
+class ThresholdCandidate:
+    """Collection of thresholds used for evaluating workbook anomalies."""
+
+    min_green_move_pct: float
+    min_volume_spike: float
+    min_anomaly_relative_volume: float
+    min_relative_volume: float
+    max_relative_volume: float
+    min_anomaly_atr_mult: float
+    min_atr_mult: float
+    min_pct_move: float
+    max_pct_move: float
+    min_anomaly_upper_wick_pct: float
+    max_upper_wick_pct: float
+    max_lower_wick_pct: float
+    min_rr: float
+    initial_deposit: float
+    position_fraction: float
+
+    def updated(self, **changes: float) -> "ThresholdCandidate":
+        """Return a copy with one or more values replaced."""
+
+        return replace(self, **changes)
+
+
+@dataclass(frozen=True, slots=True)
+class TradeEvaluation:
+    """Result of evaluating a single anomaly for one trade direction."""
+
+    filters: dict[str, bool]
+    filters_pass: bool
+    trade_executed: bool
+    rr: float | None
+    pnl_pct: float | None
+    equity: float
+
+
+@dataclass(frozen=True, slots=True)
+class AnomalyEvaluation:
+    """Long/short results for a specific anomaly sample."""
+
+    sample: AnomalySample
+    long: TradeEvaluation
+    short: TradeEvaluation
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateEvaluation:
+    """Aggregated metrics describing a threshold candidate."""
+
+    candidate: ThresholdCandidate
+    evaluations: list[AnomalyEvaluation]
+    executed_trades: int
+    average_trade_return_pct: float
+    score: float
+    long_final_equity: float
+    short_final_equity: float
+
+
+_ANOMALIES_SHEET = "anomalies"
+_THRESHOLDS_SHEET = "thresholds"
+
+_THRESHOLD_FIELD_TO_NAME = {
+    "min_green_move_pct": "thresholds_min_green_move_pct",
+    "min_volume_spike": "thresholds_min_volume_spike",
+    "min_anomaly_relative_volume": "thresholds_min_anomaly_relative_volume",
+    "min_relative_volume": "thresholds_min_relative_volume",
+    "max_relative_volume": "thresholds_max_relative_volume",
+    "min_anomaly_atr_mult": "thresholds_min_anomaly_atr_mult",
+    "min_atr_mult": "thresholds_min_atr_mult",
+    "min_pct_move": "thresholds_min_pct_move",
+    "max_pct_move": "thresholds_max_pct_move",
+    "min_anomaly_upper_wick_pct": "thresholds_min_anomaly_upper_wick_pct",
+    "max_upper_wick_pct": "thresholds_max_upper_wick_pct",
+    "max_lower_wick_pct": "thresholds_max_lower_wick_pct",
+    "min_rr": "thresholds_min_rr",
+    "initial_deposit": "thresholds_initial_deposit",
+    "position_fraction": "thresholds_position_fraction",
+}
+
+
+def parse_anomaly_samples(workbook_path: Path) -> list[AnomalySample]:
+    """Load anomaly samples from a workbook for offline optimization."""
+
+    workbook = load_workbook(workbook_path, data_only=True)
+    try:
+        try:
+            sheet = workbook[_ANOMALIES_SHEET]
+        except KeyError:
+            sheet = workbook.active
+        header = [cell.value for cell in sheet[1]]
+        index = {str(name): position for position, name in enumerate(header)}
+        required = [
+            "timestamp",
+            "exchange",
+            "symbol",
+            "timeframe",
+            "bar_id",
+            "open",
+            "high",
+            "low",
+            "close",
+            "volume",
+            "metrics_pct_move",
+            "metrics_relative_volume",
+            "metrics_atr_mult",
+            "metrics_upper_wick_pct",
+            "metrics_body_pct",
+            "metrics_lower_wick_pct",
+            "metrics_pct_to_low_break",
+            "metrics_pct_to_high_break",
+            "metrics_break_direction",
+        ]
+        for column in required:
+            if column not in index:
+                raise KeyError(f"Missing '{column}' column in anomalies workbook")
+
+        samples: list[AnomalySample] = []
+        for row in sheet.iter_rows(min_row=2, values_only=True):
+            timestamp = row[index["timestamp"]]
+            if not isinstance(timestamp, datetime):
+                continue
+            exchange_value = row[index["exchange"]]
+            symbol = row[index["symbol"]]
+            timeframe_value = row[index["timeframe"]]
+            bar_id = row[index["bar_id"]]
+            if exchange_value is None or symbol is None or timeframe_value is None or bar_id is None:
+                continue
+            open_price = _float(row[index["open"]])
+            high_price = _float(row[index["high"]])
+            low_price = _float(row[index["low"]])
+            close_price = _float(row[index["close"]])
+            volume = _float(row[index["volume"]])
+            pct_move = _float(row[index["metrics_pct_move"]])
+            relative_volume = _float(row[index["metrics_relative_volume"]])
+            atr_mult = _float(row[index["metrics_atr_mult"]])
+            upper_wick_pct = _float(row[index["metrics_upper_wick_pct"]])
+            body_pct = _float(row[index["metrics_body_pct"]])
+            lower_wick_pct = _float(row[index["metrics_lower_wick_pct"]])
+            pct_to_low_break = _float(row[index["metrics_pct_to_low_break"]])
+            pct_to_high_break = _float(row[index["metrics_pct_to_high_break"]])
+            break_direction_value = row[index["metrics_break_direction"]]
+
+            try:
+                exchange = exchange_value if isinstance(exchange_value, Exchange) else Exchange(str(exchange_value))
+                timeframe = timeframe_value if isinstance(timeframe_value, Timeframe) else Timeframe(str(timeframe_value))
+            except ValueError:
+                continue
+
+            try:
+                break_direction = BreakDirection[str(break_direction_value)]
+            except Exception:
+                break_direction = BreakDirection.NONE
+
+            metrics = BarMetrics(
+                pct_move=pct_move,
+                relative_volume=relative_volume,
+                atr_mult=atr_mult,
+                upper_wick_pct=upper_wick_pct,
+                body_pct=body_pct,
+                lower_wick_pct=lower_wick_pct,
+                pct_to_low_break=pct_to_low_break,
+                pct_to_high_break=pct_to_high_break,
+                break_direction=break_direction,
+            )
+
+            samples.append(
+                AnomalySample(
+                    timestamp=timestamp,
+                    exchange=exchange,
+                    symbol=str(symbol),
+                    timeframe=timeframe,
+                    bar_id=str(bar_id),
+                    open=open_price,
+                    high=high_price,
+                    low=low_price,
+                    close=close_price,
+                    volume=volume,
+                    metrics=metrics,
+                )
+            )
+
+        return samples
+    finally:
+        workbook.close()
+
+
+def load_threshold_candidate(workbook_path: Path) -> ThresholdCandidate:
+    """Read the baseline threshold configuration from the workbook."""
+
+    workbook = load_workbook(workbook_path, data_only=True)
+    try:
+        if _THRESHOLDS_SHEET not in workbook.sheetnames:
+            raise KeyError("Workbook is missing the 'thresholds' sheet")
+        sheet = workbook[_THRESHOLDS_SHEET]
+
+        layout = list(WorkbookDiaryBackend._ANOMALY_THRESHOLD_LAYOUT)
+        lookup = {name: value for _, name, value in layout}
+        layout_index = {name: row_index for row_index, (_, name, _) in enumerate(layout, start=2)}
+        values: dict[str, float] = {}
+        for field, named_range in _THRESHOLD_FIELD_TO_NAME.items():
+            try:
+                defined_name = workbook.defined_names[named_range]
+                destinations = list(defined_name.destinations)
+            except KeyError:
+                destinations = []
+            cell_value = None
+            for sheet_name, cell_address in destinations:
+                if sheet_name == sheet.title:
+                    cell_value = sheet[cell_address].value
+                    break
+            if cell_value is None:
+                # Fallback to defaults from the layout when no value is set yet.
+                if named_range in layout_index:
+                    cell_value = sheet.cell(row=layout_index[named_range], column=2).value
+            if cell_value is None:
+                cell_value = lookup.get(named_range)
+            values[field] = float(cell_value)
+
+        return ThresholdCandidate(**values)
+    finally:
+        workbook.close()
+
+
+def evaluate_candidate(
+    samples: Sequence[AnomalySample],
+    candidate: ThresholdCandidate,
+) -> CandidateEvaluation:
+    """Evaluate filters and PnL metrics for a threshold candidate."""
+
+    evaluations: list[AnomalyEvaluation] = []
+    executed_returns: list[float] = []
+
+    long_equity = candidate.initial_deposit
+    short_equity = candidate.initial_deposit
+
+    for sample in samples:
+        metrics = sample.metrics
+
+        long_filters = {
+            "green_move": metrics.pct_move >= candidate.min_green_move_pct,
+            "volume_spike": metrics.relative_volume >= candidate.min_volume_spike,
+            "anomaly_relative_volume": metrics.relative_volume >= candidate.min_anomaly_relative_volume,
+            "relative_volume_min": metrics.relative_volume >= candidate.min_relative_volume,
+            "relative_volume_max": metrics.relative_volume <= candidate.max_relative_volume,
+            "anomaly_atr": metrics.atr_mult >= candidate.min_anomaly_atr_mult,
+            "atr": metrics.atr_mult > candidate.min_atr_mult,
+            "pct_move_min": metrics.pct_move >= candidate.min_pct_move,
+            "pct_move_max": metrics.pct_move <= candidate.max_pct_move,
+            "upper_wick": metrics.upper_wick_pct < candidate.max_upper_wick_pct,
+            "lower_wick": metrics.lower_wick_pct < candidate.max_lower_wick_pct,
+        }
+        long_rr = _compute_rr(sample.close, sample.high, sample.low, long=True)
+        long_filters["rr"] = long_rr is not None and long_rr > candidate.min_rr
+        long_filters_pass = all(long_filters.values())
+        long_trade_executed = long_filters_pass
+        long_pnl_pct = (
+            _compute_long_pnl(sample)
+            if long_trade_executed and sample.close != 0
+            else None
+        )
+        if long_trade_executed and long_pnl_pct is not None:
+            prev_long_equity = long_equity
+            long_equity = prev_long_equity * (
+                1 + candidate.position_fraction * long_pnl_pct / 100
+            )
+            profit_delta = (
+                prev_long_equity * candidate.position_fraction * long_pnl_pct / 100
+            )
+            executed_returns.append(profit_delta)
+        long_evaluation = TradeEvaluation(
+            filters=long_filters,
+            filters_pass=long_filters_pass,
+            trade_executed=long_trade_executed,
+            rr=long_rr,
+            pnl_pct=long_pnl_pct,
+            equity=long_equity,
+        )
+
+        short_filters = {
+            "green_move": metrics.pct_move >= candidate.min_green_move_pct,
+            "volume_spike": metrics.relative_volume >= candidate.min_volume_spike,
+            "anomaly_relative_volume": metrics.relative_volume >= candidate.min_anomaly_relative_volume,
+            "relative_volume": (
+                metrics.relative_volume < candidate.min_relative_volume
+                or metrics.relative_volume > candidate.max_relative_volume
+            ),
+            "anomaly_atr": metrics.atr_mult >= candidate.min_anomaly_atr_mult,
+            "atr": metrics.atr_mult < candidate.min_atr_mult,
+            "pct_move": (
+                metrics.pct_move > candidate.max_pct_move
+                or metrics.pct_move < candidate.min_pct_move
+            ),
+            "upper_wick": metrics.upper_wick_pct < candidate.max_upper_wick_pct,
+            "lower_wick": metrics.lower_wick_pct < candidate.max_lower_wick_pct,
+        }
+        short_rr = _compute_rr(sample.close, sample.high, sample.low, long=False)
+        short_filters["rr"] = short_rr is not None and short_rr >= candidate.min_rr
+        short_filters_pass = all(short_filters.values())
+        short_trade_executed = short_filters_pass
+        short_pnl_pct = (
+            _compute_short_pnl(sample)
+            if short_trade_executed and sample.close != 0
+            else None
+        )
+        if short_trade_executed and short_pnl_pct is not None:
+            prev_short_equity = short_equity
+            short_equity = prev_short_equity * (
+                1 + candidate.position_fraction * short_pnl_pct / 100
+            )
+            profit_delta = (
+                prev_short_equity * candidate.position_fraction * short_pnl_pct / 100
+            )
+            executed_returns.append(profit_delta)
+        short_evaluation = TradeEvaluation(
+            filters=short_filters,
+            filters_pass=short_filters_pass,
+            trade_executed=short_trade_executed,
+            rr=short_rr,
+            pnl_pct=short_pnl_pct,
+            equity=short_equity,
+        )
+
+        evaluations.append(
+            AnomalyEvaluation(sample=sample, long=long_evaluation, short=short_evaluation)
+        )
+
+    executed_trades = len(executed_returns)
+    average_return_pct = sum(executed_returns) / executed_trades if executed_trades else 0.0
+    score = average_return_pct * executed_trades if executed_trades else 0.0
+
+    return CandidateEvaluation(
+        candidate=candidate,
+        evaluations=evaluations,
+        executed_trades=executed_trades,
+        average_trade_return_pct=average_return_pct,
+        score=score,
+        long_final_equity=long_equity,
+        short_final_equity=short_equity,
+    )
+
+
+def optimize_thresholds(
+    samples: Sequence[AnomalySample],
+    base_candidate: ThresholdCandidate,
+    *,
+    grid_deltas: dict[str, float],
+    random_iterations: int = 50,
+    random_scale: float = 0.5,
+    rng: Random | None = None,
+) -> CandidateEvaluation:
+    """Run a coarse grid search followed by random perturbations."""
+
+    rng = rng or Random()
+    best_evaluation = evaluate_candidate(samples, base_candidate)
+
+    fields = list(grid_deltas.keys())
+    offsets = [-1, 0, 1]
+
+    for combination in product(offsets, repeat=len(fields)):
+        if all(offset == 0 for offset in combination):
+            continue
+        updates = {}
+        for field, offset in zip(fields, combination):
+            baseline = getattr(base_candidate, field)
+            delta = grid_deltas[field] * offset
+            updates[field] = _ensure_non_negative(baseline + delta)
+        candidate = base_candidate.updated(**updates)
+        evaluation = evaluate_candidate(samples, candidate)
+        if evaluation.score > best_evaluation.score:
+            best_evaluation = evaluation
+
+    for _ in range(random_iterations):
+        updates = {}
+        for field, delta in grid_deltas.items():
+            baseline = getattr(best_evaluation.candidate, field)
+            span = delta * random_scale
+            updates[field] = _ensure_non_negative(baseline + rng.uniform(-span, span))
+        candidate = best_evaluation.candidate.updated(**updates)
+        evaluation = evaluate_candidate(samples, candidate)
+        if evaluation.score > best_evaluation.score:
+            best_evaluation = evaluation
+
+    return best_evaluation
+
+
+def write_threshold_candidate(workbook_path: Path, candidate: ThresholdCandidate) -> None:
+    """Persist the selected candidate back into the workbook."""
+
+    workbook = load_workbook(workbook_path)
+    try:
+        if _THRESHOLDS_SHEET not in workbook.sheetnames:
+            raise KeyError("Workbook is missing the 'thresholds' sheet")
+        sheet = workbook[_THRESHOLDS_SHEET]
+
+        layout_index = {
+            name: row_index
+            for row_index, (_, name, _) in enumerate(
+                WorkbookDiaryBackend._ANOMALY_THRESHOLD_LAYOUT, start=2
+            )
+        }
+
+        for field, named_range in _THRESHOLD_FIELD_TO_NAME.items():
+            if named_range not in layout_index:
+                continue
+            row_index = layout_index[named_range]
+            sheet.cell(row=row_index, column=2).value = getattr(candidate, field)
+
+        workbook.save(workbook_path)
+    finally:
+        workbook.close()
+
+
+def _compute_rr(close: float, high: float, low: float, *, long: bool) -> float | None:
+    if close == 0:
+        return None
+    if long:
+        risk = close - low
+        reward = high - close
+    else:
+        risk = high - close
+        reward = close - low
+    if risk <= 0:
+        return None
+    return reward / risk
+
+
+def _compute_long_pnl(sample: AnomalySample) -> float | None:
+    close = sample.close
+    if close == 0:
+        return None
+    direction = sample.break_direction
+    if direction is BreakDirection.HIGH_FIRST:
+        return (sample.high - close) / close * 100
+    if direction in (BreakDirection.LOW_FIRST, BreakDirection.BOTH):
+        return (sample.low - close) / close * 100
+    return 0.0
+
+
+def _compute_short_pnl(sample: AnomalySample) -> float | None:
+    close = sample.close
+    if close == 0:
+        return None
+    direction = sample.break_direction
+    if direction is BreakDirection.LOW_FIRST:
+        return (close - sample.low) / close * 100
+    if direction in (BreakDirection.HIGH_FIRST, BreakDirection.BOTH):
+        return (close - sample.high) / close * 100
+    return 0.0
+
+
+def _ensure_non_negative(value: float) -> float:
+    return value if value >= 0 else 0.0
+
+
+def _float(value: object) -> float:
+    return float(value) if value is not None else 0.0
+

--- a/tests/test_anomaly_optimizer.py
+++ b/tests/test_anomaly_optimizer.py
@@ -1,0 +1,139 @@
+from datetime import datetime
+from pathlib import Path
+import sys
+import types
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+openpyxl_module = types.ModuleType("openpyxl")
+workbook_module = types.ModuleType("openpyxl.workbook")
+defined_name_module = types.ModuleType("openpyxl.workbook.defined_name")
+
+
+class Workbook:  # pragma: no cover - simple stub
+    ...
+
+
+def load_workbook(*_args, **_kwargs):  # pragma: no cover - simple stub
+    raise NotImplementedError("Workbook access is not required for this test")
+
+
+class DefinedName:  # pragma: no cover - simple stub
+    def __init__(self, name: str, attr_text: str) -> None:
+        self.name = name
+        self.attr_text = attr_text
+
+
+defined_name_module.DefinedName = DefinedName
+workbook_module.defined_name = defined_name_module
+
+utils_module = types.ModuleType("openpyxl.utils")
+cell_module = types.ModuleType("openpyxl.utils.cell")
+
+
+def get_column_letter(index: int) -> str:  # pragma: no cover - copied stub
+    letters = []
+    while index:
+        index, remainder = divmod(index - 1, 26)
+        letters.append(chr(ord("A") + remainder))
+    return "".join(reversed(letters))
+
+
+cell_module.get_column_letter = get_column_letter
+utils_module.cell = cell_module
+
+worksheet_module = types.ModuleType("openpyxl.worksheet")
+worksheet_worksheet_module = types.ModuleType("openpyxl.worksheet.worksheet")
+
+
+class Worksheet:  # pragma: no cover - simple stub
+    ...
+
+
+worksheet_worksheet_module.Worksheet = Worksheet
+worksheet_module.worksheet = worksheet_worksheet_module
+
+openpyxl_module.Workbook = Workbook
+openpyxl_module.load_workbook = load_workbook
+openpyxl_module.workbook = workbook_module
+openpyxl_module.utils = utils_module
+openpyxl_module.worksheet = worksheet_module
+
+sys.modules.setdefault("openpyxl", openpyxl_module)
+sys.modules.setdefault("openpyxl.workbook", workbook_module)
+sys.modules.setdefault("openpyxl.workbook.defined_name", defined_name_module)
+sys.modules.setdefault("openpyxl.utils", utils_module)
+sys.modules.setdefault("openpyxl.utils.cell", cell_module)
+sys.modules.setdefault("openpyxl.worksheet", worksheet_module)
+sys.modules.setdefault("openpyxl.worksheet.worksheet", worksheet_worksheet_module)
+
+from bot.domain.anomaly_optimizer import (
+    AnomalySample,
+    ThresholdCandidate,
+    evaluate_candidate,
+)
+from pytest import approx
+from bot.domain.models.bar import BarMetrics, BreakDirection
+from bot.domain.models.exchange import Exchange
+from bot.domain.models.timeframe import Timeframe
+
+
+def _sample(*, break_direction: BreakDirection) -> AnomalySample:
+    metrics = BarMetrics(
+        pct_move=5.0,
+        relative_volume=3.0,
+        atr_mult=2.0,
+        upper_wick_pct=1.0,
+        body_pct=1.0,
+        lower_wick_pct=1.0,
+        pct_to_low_break=0.0,
+        pct_to_high_break=0.0,
+        break_direction=break_direction,
+    )
+    return AnomalySample(
+        timestamp=datetime(2024, 1, 1),
+        exchange=Exchange.BINANCE,
+        symbol="BTCUSDT",
+        timeframe=Timeframe.M15,
+        bar_id="bar",
+        open=100.0,
+        high=110.0,
+        low=95.0,
+        close=100.0,
+        volume=1_000.0,
+        metrics=metrics,
+    )
+
+
+def _candidate() -> ThresholdCandidate:
+    return ThresholdCandidate(
+        min_green_move_pct=0.0,
+        min_volume_spike=0.0,
+        min_anomaly_relative_volume=0.0,
+        min_relative_volume=1.0,
+        max_relative_volume=10.0,
+        min_anomaly_atr_mult=0.0,
+        min_atr_mult=0.0,
+        min_pct_move=0.0,
+        max_pct_move=10.0,
+        min_anomaly_upper_wick_pct=0.0,
+        max_upper_wick_pct=10.0,
+        max_lower_wick_pct=10.0,
+        min_rr=0.0,
+        initial_deposit=1_000.0,
+        position_fraction=0.5,
+    )
+
+
+def test_evaluate_candidate_scales_returns_by_equity() -> None:
+    samples = [_sample(break_direction=BreakDirection.HIGH_FIRST) for _ in range(2)]
+    candidate = _candidate()
+
+    evaluation = evaluate_candidate(samples, candidate)
+
+    assert evaluation.executed_trades == 2
+    assert evaluation.long_final_equity == approx(1_102.5)
+    assert evaluation.score == approx(102.5)
+    assert evaluation.average_trade_return_pct == approx(51.25)


### PR DESCRIPTION
## Summary
- update the anomaly optimizer to record equity-scaled profit deltas for both long and short trades
- add a focused unit test with an openpyxl stub to verify compounding-aware scoring

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcecf60ec0832095e45cbfae1809a6