### PR TITLE
Enable live anomaly threshold optimization for live runs

### DIFF
--- a/bot/domain/analyzer.py
+++ b/bot/domain/analyzer.py
@@ -54,8 +54,13 @@ class AnalyzerSettings:
 class SignalAnalyzer:
     """Evaluates bars and produces strategy signals."""
 
-    def __init__(self) -> None:
-        self._settings = AnalyzerSettings()
+    def __init__(self, settings: AnalyzerSettings | None = None) -> None:
+        self._settings = settings or AnalyzerSettings()
+
+    def apply_settings(self, settings: AnalyzerSettings) -> None:
+        """Replace the analyzer thresholds with a new configuration."""
+
+        self._settings = settings
 
     def analyze_bar(
         self, bar: Bar, timestamp: Optional[datetime] = None

--- a/bot/domain/anomaly_bootstrapper.py
+++ b/bot/domain/anomaly_bootstrapper.py
@@ -12,7 +12,14 @@ from openpyxl import load_workbook
 from bot import config
 from bot.data.diary import AnomalyRow, WorkbookDiaryBackend
 from bot.data.loader import HistoricalRequest, MarketDataLoader
-from bot.domain.analyzer import SignalAnalyzer
+from bot.domain.analyzer import AnalyzerSettings, SignalAnalyzer
+from bot.domain.anomaly_optimizer import (
+    AnomalySample,
+    CandidateEvaluation,
+    ThresholdCandidate,
+    load_threshold_candidate,
+    optimize_thresholds,
+)
 from bot.domain.models.anomaly import Anomaly
 from bot.domain.models.bar import BarMetrics, BreakDirection
 from bot.domain.models.exchange import Exchange
@@ -35,6 +42,18 @@ class LoggedAnomaly:
     close: float
     volume: float
     metrics: BarMetrics
+
+
+@dataclass(frozen=True, slots=True)
+class BootstrapPreparationResult:
+    """Artifacts gathered while preparing the live anomalies log."""
+
+    anomalies: list[LoggedAnomaly]
+    samples: list[AnomalySample]
+    evaluation: CandidateEvaluation | None
+    candidate: ThresholdCandidate | None
+    settings: AnalyzerSettings | None
+    workbook_path: Path
 
 
 class AnomalyLiveBootstrapper:
@@ -78,6 +97,83 @@ class AnomalyLiveBootstrapper:
             )
         self._trim_outdated_rows()
         return self._parse_workbook()
+
+    def prepare(self) -> BootstrapPreparationResult:
+        """Synchronize the live workbook and derive optimized thresholds."""
+
+        anomalies = self.bootstrap()
+        samples = self._to_samples(anomalies)
+        evaluation: CandidateEvaluation | None = None
+        candidate: ThresholdCandidate | None = None
+        settings: AnalyzerSettings | None = None
+
+        if not samples:
+            self._logger.info(
+                "No anomaly samples available in %s; skipping optimization", self._live_path
+            )
+            return BootstrapPreparationResult(
+                anomalies=anomalies,
+                samples=samples,
+                evaluation=evaluation,
+                candidate=candidate,
+                settings=settings,
+                workbook_path=self._live_path,
+            )
+
+        try:
+            base_candidate = load_threshold_candidate(self._live_path)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self._logger.warning(
+                "Failed to load baseline thresholds from %s: %s",
+                self._live_path,
+                exc,
+            )
+            return BootstrapPreparationResult(
+                anomalies=anomalies,
+                samples=samples,
+                evaluation=evaluation,
+                candidate=candidate,
+                settings=settings,
+                workbook_path=self._live_path,
+            )
+
+        try:
+            grid_deltas = self._compute_grid_deltas(base_candidate)
+            evaluation = optimize_thresholds(
+                samples,
+                base_candidate,
+                grid_deltas=grid_deltas,
+            )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self._logger.warning(
+                "Threshold optimization failed using %d samples: %s",
+                len(samples),
+                exc,
+            )
+            return BootstrapPreparationResult(
+                anomalies=anomalies,
+                samples=samples,
+                evaluation=evaluation,
+                candidate=candidate,
+                settings=settings,
+                workbook_path=self._live_path,
+            )
+
+        candidate = evaluation.candidate
+        settings = self._candidate_to_settings(candidate)
+        self._logger.info(
+            "Optimized thresholds using %d anomaly samples; score %.2f",
+            len(samples),
+            evaluation.score,
+        )
+        return BootstrapPreparationResult(
+            anomalies=anomalies,
+            samples=samples,
+            evaluation=evaluation,
+            candidate=candidate,
+            settings=settings,
+            workbook_path=self._live_path,
+        )
 
     def _ensure_live_workbook(self) -> None:
         if self._live_path.exists():
@@ -301,6 +397,68 @@ class AnomalyLiveBootstrapper:
             )
             for anomaly in anomalies
         ]
+
+    @staticmethod
+    def _to_samples(anomalies: Iterable[LoggedAnomaly]) -> list[AnomalySample]:
+        return [
+            AnomalySample(
+                timestamp=anomaly.timestamp,
+                exchange=anomaly.exchange,
+                symbol=anomaly.symbol,
+                timeframe=anomaly.timeframe,
+                bar_id=anomaly.bar_id,
+                open=anomaly.open,
+                high=anomaly.high,
+                low=anomaly.low,
+                close=anomaly.close,
+                volume=anomaly.volume,
+                metrics=anomaly.metrics,
+            )
+            for anomaly in anomalies
+        ]
+
+    @staticmethod
+    def _candidate_to_settings(candidate: ThresholdCandidate) -> AnalyzerSettings:
+        return AnalyzerSettings(
+            min_green_move_pct=candidate.min_green_move_pct,
+            min_volume_spike=candidate.min_volume_spike,
+            min_anomaly_relative_volume=candidate.min_anomaly_relative_volume,
+            min_anomaly_atr_mult=candidate.min_anomaly_atr_mult,
+            min_anomaly_upper_wick_pct=candidate.min_anomaly_upper_wick_pct,
+            min_relative_volume=candidate.min_relative_volume,
+            max_relative_volume=candidate.max_relative_volume,
+            min_atr_mult=candidate.min_atr_mult,
+            min_pct_move=candidate.min_pct_move,
+            max_pct_move=candidate.max_pct_move,
+            max_upper_wick_pct=candidate.max_upper_wick_pct,
+            max_lower_wick_pct=candidate.max_lower_wick_pct,
+        )
+
+    @staticmethod
+    def _compute_grid_deltas(candidate: ThresholdCandidate) -> dict[str, float]:
+        adjustable_fields = [
+            "min_green_move_pct",
+            "min_volume_spike",
+            "min_anomaly_relative_volume",
+            "min_relative_volume",
+            "max_relative_volume",
+            "min_anomaly_atr_mult",
+            "min_atr_mult",
+            "min_pct_move",
+            "max_pct_move",
+            "min_anomaly_upper_wick_pct",
+            "max_upper_wick_pct",
+            "max_lower_wick_pct",
+            "min_rr",
+        ]
+        deltas: dict[str, float] = {}
+        for field in adjustable_fields:
+            baseline = getattr(candidate, field)
+            step = abs(baseline) * 0.1
+            if step <= 0:
+                step = 0.1
+            deltas[field] = step
+        return deltas
 
     @staticmethod
     def _parse_timestamp(value: object) -> datetime | None:

--- a/bot/main.py
+++ b/bot/main.py
@@ -14,6 +14,8 @@ from bot.data.exchange_utils import create_ccxt_client, fetch_linear_usdt_symbol
 from bot.data.loader import CcxtMarketDataLoader, HistoricalRequest, WsLiveDataStream
 from bot.data.notifier import Notifier, TelegramNotifier
 from bot.domain.analyzer import SignalAnalyzer
+from bot.domain.anomaly_bootstrapper import AnomalyLiveBootstrapper
+from bot.domain.anomaly_optimizer import write_threshold_candidate
 from bot.domain.exchange_client import (
     BinanceExchangeClient,
     BybitExchangeClient,
@@ -79,12 +81,20 @@ def create_live_stream(exchange: Exchange, timeframe: Timeframe) -> WsLiveDataSt
     return WsLiveDataStream(exchange=exchange, timeframe=timeframe)
 
 
-def create_diary(exchange: Exchange, base_path: Path | None = None) -> WorkbookDiary:
+def create_diary(
+    exchange: Exchange,
+    base_path: Path | None = None,
+    *,
+    anomalies_filename: str | None = None,
+) -> WorkbookDiary:
     base = Path(base_path) if base_path is not None else Path(
         os.getenv("BOT_DIARY_PATH", "var/diary")
     )
     path = base / exchange.value
-    return WorkbookDiary(path=path)
+    kwargs = {"path": path}
+    if anomalies_filename is not None:
+        kwargs["anomalies_filename"] = anomalies_filename
+    return WorkbookDiary(**kwargs)
 
 
 class _NullNotifier(Notifier):
@@ -114,22 +124,32 @@ def create_balance_provider(exchange: Exchange) -> CcxtBalanceProvider:
 def create_orchestrator_dependencies(
     exchange: Exchange,
     mode: RuntimeMode,
+    *,
     diary: WorkbookDiary | None = None,
+    analyzer: SignalAnalyzer | None = None,
+    market_loader: CcxtMarketDataLoader | None = None,
+    anomalies_filename: str | None = None,
 ) -> OrchestratorDependencies:
     primary_timeframe = config.DEFAULT_TIMEFRAMES[0]
-    market_loader = create_market_data_loader()
+    market_loader_instance = (
+        market_loader if market_loader is not None else create_market_data_loader()
+    )
     live_stream = create_live_stream(exchange, primary_timeframe)
-    diary_instance = diary if diary is not None else create_diary(exchange)
+    diary_instance = (
+        diary
+        if diary is not None
+        else create_diary(exchange, anomalies_filename=anomalies_filename)
+    )
     notifier = create_notifier(mode)
-    analyzer = SignalAnalyzer()
+    analyzer_instance = analyzer if analyzer is not None else SignalAnalyzer()
     execution = create_execution_service(exchange)
     balance_provider = create_balance_provider(exchange)
     return OrchestratorDependencies(
-        market_loader=market_loader,
+        market_loader=market_loader_instance,
         live_stream=live_stream,
         diary=diary_instance,
         notifier=notifier,
-        analyzer=analyzer,
+        analyzer=analyzer_instance,
         execution=execution,
         balance_provider=balance_provider,
         exchange=exchange,
@@ -144,7 +164,28 @@ def run() -> None:
         "Инициализация режима %s для биржи %s", mode.value, exchange.value
     )
     if mode is RuntimeMode.LIVE:
-        dependencies = create_orchestrator_dependencies(exchange, mode)
+        anomalies_filename = "anomalies_live.xlsx"
+        diary = create_diary(exchange, anomalies_filename=anomalies_filename)
+        market_loader = create_market_data_loader()
+        analyzer = SignalAnalyzer()
+        bootstrapper = AnomalyLiveBootstrapper(
+            exchange=exchange,
+            loader=market_loader,
+            analyzer=analyzer,
+            diary_root=diary.path,
+        )
+        preparation = bootstrapper.prepare()
+        if preparation.candidate is not None and preparation.settings is not None:
+            analyzer.apply_settings(preparation.settings)
+            write_threshold_candidate(preparation.workbook_path, preparation.candidate)
+        dependencies = create_orchestrator_dependencies(
+            exchange,
+            mode,
+            diary=diary,
+            analyzer=analyzer,
+            market_loader=market_loader,
+            anomalies_filename=anomalies_filename,
+        )
         try:
             run_live(dependencies)
         except KeyboardInterrupt:


### PR DESCRIPTION
## Summary
- allow SignalAnalyzer instances to accept externally supplied AnalyzerSettings
- extend the live anomaly bootstrapper to prepare optimized thresholds for anomalies_live.xlsx
- update orchestration wiring to use the live diary, apply optimized thresholds, and share dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcf95c46d4832080d7353164e69537