### PR TITLE
Preserve baseline threshold precision when writing

### DIFF
--- a/bot/domain/anomaly_optimizer.py
+++ b/bot/domain/anomaly_optimizer.py
@@ -158,6 +158,20 @@ THRESHOLD_GRID_METADATA: dict[str, GridFieldMetadata] = {
     "min_rr": _bounded_metadata(step=0.5, minimum=0.0, maximum=3.0),
 }
 
+# These fields mirror the baseline-only thresholds in
+# ``AnomalyLiveBootstrapper._compute_grid_deltas``. They are not adjusted during
+# grid exploration and should retain their original precision when written back
+# to the workbook.
+BASELINE_THRESHOLD_FIELDS: frozenset[str] = frozenset(
+    {
+        "min_green_move_pct",
+        "min_volume_spike",
+        "min_anomaly_relative_volume",
+        "min_anomaly_upper_wick_pct",
+        "min_anomaly_atr_mult",
+    }
+)
+
 
 def _apply_grid_constraints(field: str, value: float) -> float:
     metadata = THRESHOLD_GRID_METADATA.get(field)
@@ -723,9 +737,11 @@ def write_threshold_candidate(workbook_path: Path, candidate: ThresholdCandidate
             if named_range not in layout_index:
                 continue
             row_index = layout_index[named_range]
-            sheet.cell(row=row_index, column=2).value = _quantize_threshold(
-                getattr(candidate, field)
-            )
+            value = getattr(candidate, field)
+            if field not in BASELINE_THRESHOLD_FIELDS:
+                value = _apply_grid_constraints(field, value)
+                value = _quantize_threshold(value)
+            sheet.cell(row=row_index, column=2).value = value
 
         workbook.save(workbook_path)
     finally:

--- a/tests/test_anomaly_optimizer.py
+++ b/tests/test_anomaly_optimizer.py
@@ -73,7 +73,10 @@ from bot.domain.anomaly_optimizer import (
     AnomalySample,
     ThresholdCandidate,
     evaluate_candidate,
+    write_threshold_candidate,
 )
+from bot.data.diary import WorkbookDiaryBackend
+import pytest
 from pytest import approx
 from bot.domain.models.bar import BarMetrics, BreakDirection
 from bot.domain.models.exchange import Exchange
@@ -137,3 +140,106 @@ def test_evaluate_candidate_scales_returns_by_equity() -> None:
     assert evaluation.long_final_equity == approx(1_102.5)
     assert evaluation.score == approx(102.5)
     assert evaluation.average_trade_return_pct == approx(51.25)
+
+
+class _WorkbookStub:
+    def __init__(self) -> None:
+        self._sheet = _SheetStub()
+        self.saved_path: Path | None = None
+        self.closed = False
+
+    @property
+    def sheetnames(self) -> list[str]:
+        return ["thresholds"]
+
+    def __getitem__(self, key: str) -> "_SheetStub":
+        if key != "thresholds":
+            raise KeyError(key)
+        return self._sheet
+
+    def save(self, path: Path) -> None:
+        self.saved_path = path
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _SheetStub:
+    def __init__(self) -> None:
+        self._cells: dict[tuple[int, int], _CellStub] = {}
+
+    def cell(self, row: int, column: int) -> "_CellStub":
+        key = (row, column)
+        if key not in self._cells:
+            self._cells[key] = _CellStub()
+        return self._cells[key]
+
+
+class _CellStub:
+    def __init__(self) -> None:
+        self.value: float | None = None
+
+
+def test_write_threshold_candidate_preserves_precision(monkeypatch, tmp_path) -> None:
+    workbook = _WorkbookStub()
+    monkeypatch.setattr(
+        "bot.domain.anomaly_optimizer.load_workbook", lambda _path: workbook
+    )
+
+    workbook_path = tmp_path / "anomalies.xlsx"
+    candidate = ThresholdCandidate(
+        min_green_move_pct=3.456,
+        min_volume_spike=7.891,
+        min_anomaly_relative_volume=11.111,
+        min_relative_volume=5.432,
+        max_relative_volume=250.0,
+        min_anomaly_atr_mult=2.345,
+        min_atr_mult=3.876,
+        min_pct_move=4.321,
+        max_pct_move=34.789,
+        min_anomaly_upper_wick_pct=6.789,
+        max_upper_wick_pct=133.333,
+        max_lower_wick_pct=83.333,
+        min_rr=1.234,
+        initial_deposit=1_234.56,
+        position_fraction=0.333,
+    )
+
+    write_threshold_candidate(workbook_path, candidate)
+
+    layout_index = {
+        name: row_index
+        for row_index, (_, name, _) in enumerate(
+            WorkbookDiaryBackend._ANOMALY_THRESHOLD_LAYOUT, start=2
+        )
+    }
+    sheet = workbook["thresholds"]
+
+    # Baseline thresholds retain their original precision.
+    baseline_row = layout_index["thresholds_min_green_move_pct"]
+    assert sheet.cell(row=baseline_row, column=2).value == pytest.approx(
+        candidate.min_green_move_pct
+    )
+    anomaly_volume_row = layout_index["thresholds_min_anomaly_relative_volume"]
+    assert sheet.cell(row=anomaly_volume_row, column=2).value == pytest.approx(
+        candidate.min_anomaly_relative_volume
+    )
+
+    # Adjustable thresholds are clamped and quantized to their grid metadata.
+    min_rel_row = layout_index["thresholds_min_relative_volume"]
+    assert sheet.cell(row=min_rel_row, column=2).value == pytest.approx(5.0)
+    max_rel_row = layout_index["thresholds_max_relative_volume"]
+    assert sheet.cell(row=max_rel_row, column=2).value == pytest.approx(200.0)
+    max_upper_row = layout_index["thresholds_max_upper_wick_pct"]
+    assert sheet.cell(row=max_upper_row, column=2).value == pytest.approx(100.0)
+    max_lower_row = layout_index["thresholds_max_lower_wick_pct"]
+    assert sheet.cell(row=max_lower_row, column=2).value == pytest.approx(80.0)
+    min_rr_row = layout_index["thresholds_min_rr"]
+    assert sheet.cell(row=min_rr_row, column=2).value == pytest.approx(1.0)
+
+    # Non-grid fields continue to be quantized.
+    deposit_row = layout_index["thresholds_initial_deposit"]
+    assert sheet.cell(row=deposit_row, column=2).value == pytest.approx(1_234.6)
+
+    assert workbook.saved_path == workbook_path
+    assert workbook.closed


### PR DESCRIPTION
## Summary
- avoid quantizing baseline-only anomaly thresholds so workbook values keep their full precision
- continue clamping adjustable thresholds to the configured grid before quantizing
- add a regression test that exercises workbook writes with baseline and adjustable fields

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd3ce808f88320a6f78baab9ca398e