### PR TITLE
Refactor config models into dedicated modules

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -1,0 +1,88 @@
+"""Application configuration values."""
+from typing import Final
+
+from .models import (
+    BalanceSource,
+    Config,
+    ExchangeName,
+    FocusSettings,
+    FundingKillSwitchSettings,
+    GeneralSettings,
+    MarginMode,
+    OdrSettings,
+    PositionSettings,
+    StopTrigger,
+    TelegramSettings,
+    TradingProfile,
+    TurnoverThresholds,
+    WallAbsoluteThresholds,
+    WallSettings,
+    WallShiftSettings,
+)
+
+CONFIG: Final[Config] = Config(
+    general=GeneralSettings(
+        exchange=ExchangeName.BINANCE,
+        profile=TradingProfile.AUTO,
+        loop_interval_ms=100,
+        odr_smooth_samples=3,
+        recent_band_s=5,
+        recent_band_s_vol_boost=8,
+        vol_spike_mult=2.0,
+    ),
+    turnover=TurnoverThresholds(
+        top_usd=700_000,
+        alt_usd=120_000,
+        listing_usd=250_000,
+        market_scan_interval_s=30,
+    ),
+    odr=OdrSettings(
+        odr_in_short=3.1,
+        odr_in_long=0.322,
+        odr_neutral_low=0.70,
+        odr_neutral_high=1.45,
+        odr_neutral_hold_ms=800,
+        focus_pre_odr_short=2.0,
+        focus_pre_odr_long=0.50,
+    ),
+    walls=WallSettings(
+        absolute=WallAbsoluteThresholds(
+            top_usd=600_000,
+            alt_usd=120_000,
+            listing_usd=200_000,
+        ),
+        relative_multiplier=3.5,
+        persist_s_top=2.0,
+        persist_s_alt=2.0,
+        persist_s_listing=3.0,
+    ),
+    wall_shift=WallShiftSettings(
+        shift_min_ticks=1,
+        shift_hold_s=0.8,
+        vanish_drop=0.50,
+        vanish_grace_ms=600,
+    ),
+    position=PositionSettings(
+        position_fraction=0.10,
+        position_min_usdt=10,
+        balance_refresh_h=1,
+        balance_source=BalanceSource.AVAILABLE_BALANCE,
+        margin_mode=MarginMode.ISOLATED,
+        leverage=10,
+        stop_trigger=StopTrigger.MARK_PRICE,
+    ),
+    focus=FocusSettings(defocus_timeout_s=30),
+    funding_ks=FundingKillSwitchSettings(
+        funding_block_s=30,
+        max_stops_per_min=3,
+        max_drawdown_frac=0.005,
+        block_min=5,
+    ),
+    telegram=TelegramSettings(
+        chat_id=None,
+        silent=False,
+        uptick_cooldown_min=5,
+    ),
+)
+
+__all__ = ["CONFIG"]

--- a/config/models/__init__.py
+++ b/config/models/__init__.py
@@ -1,0 +1,36 @@
+"""Typed configuration models for the trading bot."""
+from .balance_source import BalanceSource
+from .config_model import Config
+from .exchange_name import ExchangeName
+from .focus_settings import FocusSettings
+from .funding_kill_switch_settings import FundingKillSwitchSettings
+from .general_settings import GeneralSettings
+from .margin_mode import MarginMode
+from .odr_settings import OdrSettings
+from .position_settings import PositionSettings
+from .stop_trigger import StopTrigger
+from .telegram_settings import TelegramSettings
+from .trading_profile import TradingProfile
+from .turnover_thresholds import TurnoverThresholds
+from .wall_absolute_thresholds import WallAbsoluteThresholds
+from .wall_settings import WallSettings
+from .wall_shift_settings import WallShiftSettings
+
+__all__ = [
+    "BalanceSource",
+    "Config",
+    "ExchangeName",
+    "FocusSettings",
+    "FundingKillSwitchSettings",
+    "GeneralSettings",
+    "MarginMode",
+    "OdrSettings",
+    "PositionSettings",
+    "StopTrigger",
+    "TelegramSettings",
+    "TradingProfile",
+    "TurnoverThresholds",
+    "WallAbsoluteThresholds",
+    "WallSettings",
+    "WallShiftSettings",
+]

--- a/config/models/balance_source.py
+++ b/config/models/balance_source.py
@@ -1,0 +1,12 @@
+"""Enumeration for balance sources."""
+from enum import Enum
+
+
+class BalanceSource(str, Enum):
+    """Sources for balance retrieval."""
+
+    AVAILABLE_BALANCE = "available_balance"
+    WALLET_BALANCE = "wallet_balance"
+
+
+__all__ = ["BalanceSource"]

--- a/config/models/config_model.py
+++ b/config/models/config_model.py
@@ -1,0 +1,28 @@
+"""Top-level configuration dataclass."""
+from dataclasses import dataclass
+
+from .focus_settings import FocusSettings
+from .funding_kill_switch_settings import FundingKillSwitchSettings
+from .general_settings import GeneralSettings
+from .odr_settings import OdrSettings
+from .position_settings import PositionSettings
+from .telegram_settings import TelegramSettings
+from .turnover_thresholds import TurnoverThresholds
+from .wall_settings import WallSettings
+from .wall_shift_settings import WallShiftSettings
+
+
+@dataclass(frozen=True)
+class Config:
+    general: GeneralSettings
+    turnover: TurnoverThresholds
+    odr: OdrSettings
+    walls: WallSettings
+    wall_shift: WallShiftSettings
+    position: PositionSettings
+    focus: FocusSettings
+    funding_ks: FundingKillSwitchSettings
+    telegram: TelegramSettings
+
+
+__all__ = ["Config"]

--- a/config/models/exchange_name.py
+++ b/config/models/exchange_name.py
@@ -1,0 +1,12 @@
+"""Enumeration of supported exchanges."""
+from enum import Enum
+
+
+class ExchangeName(str, Enum):
+    """Supported exchange identifiers."""
+
+    BINANCE = "binance"
+    BYBIT = "bybit"
+
+
+__all__ = ["ExchangeName"]

--- a/config/models/focus_settings.py
+++ b/config/models/focus_settings.py
@@ -1,0 +1,10 @@
+"""Configuration model for focus settings."""
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FocusSettings:
+    defocus_timeout_s: int
+
+
+__all__ = ["FocusSettings"]

--- a/config/models/funding_kill_switch_settings.py
+++ b/config/models/funding_kill_switch_settings.py
@@ -1,0 +1,13 @@
+"""Configuration model for funding kill switch settings."""
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FundingKillSwitchSettings:
+    funding_block_s: int
+    max_stops_per_min: int
+    max_drawdown_frac: float
+    block_min: int
+
+
+__all__ = ["FundingKillSwitchSettings"]

--- a/config/models/general_settings.py
+++ b/config/models/general_settings.py
@@ -1,0 +1,19 @@
+"""Configuration model for general settings."""
+from dataclasses import dataclass
+
+from .exchange_name import ExchangeName
+from .trading_profile import TradingProfile
+
+
+@dataclass(frozen=True)
+class GeneralSettings:
+    exchange: ExchangeName
+    profile: TradingProfile
+    loop_interval_ms: int
+    odr_smooth_samples: int
+    recent_band_s: int
+    recent_band_s_vol_boost: int
+    vol_spike_mult: float
+
+
+__all__ = ["GeneralSettings"]

--- a/config/models/margin_mode.py
+++ b/config/models/margin_mode.py
@@ -1,0 +1,12 @@
+"""Enumeration for margin modes."""
+from enum import Enum
+
+
+class MarginMode(str, Enum):
+    """Margin mode options supported by the bot."""
+
+    ISOLATED = "isolated"
+    CROSS = "cross"
+
+
+__all__ = ["MarginMode"]

--- a/config/models/odr_settings.py
+++ b/config/models/odr_settings.py
@@ -1,0 +1,16 @@
+"""Configuration model for ODR settings."""
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class OdrSettings:
+    odr_in_short: float
+    odr_in_long: float
+    odr_neutral_low: float
+    odr_neutral_high: float
+    odr_neutral_hold_ms: int
+    focus_pre_odr_short: float
+    focus_pre_odr_long: float
+
+
+__all__ = ["OdrSettings"]

--- a/config/models/position_settings.py
+++ b/config/models/position_settings.py
@@ -1,0 +1,20 @@
+"""Configuration model for position settings."""
+from dataclasses import dataclass
+
+from .balance_source import BalanceSource
+from .margin_mode import MarginMode
+from .stop_trigger import StopTrigger
+
+
+@dataclass(frozen=True)
+class PositionSettings:
+    position_fraction: float
+    position_min_usdt: int
+    balance_refresh_h: int
+    balance_source: BalanceSource
+    margin_mode: MarginMode
+    leverage: int
+    stop_trigger: StopTrigger
+
+
+__all__ = ["PositionSettings"]

--- a/config/models/stop_trigger.py
+++ b/config/models/stop_trigger.py
@@ -1,0 +1,12 @@
+"""Enumeration for stop trigger prices."""
+from enum import Enum
+
+
+class StopTrigger(str, Enum):
+    """Trigger prices supported for protective orders."""
+
+    MARK_PRICE = "mark_price"
+    LAST_PRICE = "last_price"
+
+
+__all__ = ["StopTrigger"]

--- a/config/models/telegram_settings.py
+++ b/config/models/telegram_settings.py
@@ -1,0 +1,13 @@
+"""Configuration model for Telegram settings."""
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class TelegramSettings:
+    chat_id: Optional[int]
+    silent: bool
+    uptick_cooldown_min: int
+
+
+__all__ = ["TelegramSettings"]

--- a/config/models/trading_profile.py
+++ b/config/models/trading_profile.py
@@ -1,0 +1,14 @@
+"""Enumeration of trading profiles."""
+from enum import Enum
+
+
+class TradingProfile(str, Enum):
+    """Available trading profiles."""
+
+    AUTO = "auto"
+    TOP = "T"
+    ALT = "A"
+    LISTING = "L"
+
+
+__all__ = ["TradingProfile"]

--- a/config/models/turnover_thresholds.py
+++ b/config/models/turnover_thresholds.py
@@ -1,0 +1,13 @@
+"""Configuration model for turnover thresholds."""
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TurnoverThresholds:
+    top_usd: int
+    alt_usd: int
+    listing_usd: int
+    market_scan_interval_s: int
+
+
+__all__ = ["TurnoverThresholds"]

--- a/config/models/wall_absolute_thresholds.py
+++ b/config/models/wall_absolute_thresholds.py
@@ -1,0 +1,12 @@
+"""Configuration model for absolute wall thresholds."""
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class WallAbsoluteThresholds:
+    top_usd: int
+    alt_usd: int
+    listing_usd: int
+
+
+__all__ = ["WallAbsoluteThresholds"]

--- a/config/models/wall_settings.py
+++ b/config/models/wall_settings.py
@@ -1,0 +1,16 @@
+"""Configuration model for wall settings."""
+from dataclasses import dataclass
+
+from .wall_absolute_thresholds import WallAbsoluteThresholds
+
+
+@dataclass(frozen=True)
+class WallSettings:
+    absolute: WallAbsoluteThresholds
+    relative_multiplier: float
+    persist_s_top: float
+    persist_s_alt: float
+    persist_s_listing: float
+
+
+__all__ = ["WallSettings"]

--- a/config/models/wall_shift_settings.py
+++ b/config/models/wall_shift_settings.py
@@ -1,0 +1,13 @@
+"""Configuration model for wall shift settings."""
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class WallShiftSettings:
+    shift_min_ticks: int
+    shift_hold_s: float
+    vanish_drop: float
+    vanish_grace_ms: int
+
+
+__all__ = ["WallShiftSettings"]


### PR DESCRIPTION
## Summary
- relocate every configuration enum and dataclass into dedicated modules under config/models
- update config/config.py to only assemble the CONFIG instance from the typed models
- remove the unused secrets loader in favour of direct environment access

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfa619cd6c832082063135f7e40a6e