### PR TITLE
Remove legacy domain models monolith

### DIFF
--- a/config/timezone.py
+++ b/config/timezone.py
@@ -1,0 +1,10 @@
+"""Timezone configuration used across the application."""
+
+from __future__ import annotations
+
+from typing import Final
+from zoneinfo import ZoneInfo
+
+BELGRADE_TIMEZONE: Final[ZoneInfo] = ZoneInfo("Europe/Belgrade")
+
+__all__ = ["BELGRADE_TIMEZONE"]

--- a/domain/models/__init__.py
+++ b/domain/models/__init__.py
@@ -1,0 +1,32 @@
+"""Domain models exposed by the trading bot."""
+
+from .candle import Candle
+from .enums import BalanceSource, Exchange, MarginMode, Side, Signal, StopTrigger
+from .execution import ExecutionReport
+from .log import LogLine
+from .order_book import OrderBookLevel, OrderBookSnapshot, OrderBookUpdate
+from .position import Position
+from .pressure import Pressure
+from .symbol import SymbolFilters
+from .trade import Trade
+from .wall import Wall
+
+__all__ = [
+    "BalanceSource",
+    "Exchange",
+    "MarginMode",
+    "Side",
+    "Signal",
+    "StopTrigger",
+    "SymbolFilters",
+    "Candle",
+    "Trade",
+    "OrderBookLevel",
+    "OrderBookSnapshot",
+    "OrderBookUpdate",
+    "Wall",
+    "Pressure",
+    "Position",
+    "ExecutionReport",
+    "LogLine",
+]

--- a/domain/models/_timezone.py
+++ b/domain/models/_timezone.py
@@ -1,0 +1,24 @@
+"""Utilities for working with timezone-aware datetimes in domain models."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from config.timezone import BELGRADE_TIMEZONE
+
+
+def ensure_belgrade_timezone(*values: datetime) -> None:
+    """Ensure that all provided datetimes use the Europe/Belgrade timezone."""
+
+    for value in values:
+        if value.tzinfo is None:
+            raise ValueError("datetime must be timezone-aware")
+        tz_key = getattr(value.tzinfo, "key", None)
+        if tz_key is None:
+            if value.tzinfo != BELGRADE_TIMEZONE:
+                raise ValueError("datetime must use Europe/Belgrade timezone")
+        elif tz_key != BELGRADE_TIMEZONE.key:
+            raise ValueError("datetime must use Europe/Belgrade timezone")
+
+
+__all__ = ["ensure_belgrade_timezone"]

--- a/domain/models/candle.py
+++ b/domain/models/candle.py
@@ -1,0 +1,28 @@
+"""Models describing candlestick data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from ._timezone import ensure_belgrade_timezone
+
+
+@dataclass(frozen=True, slots=True)
+class Candle:
+    """Single OHLCV candle aggregated over a fixed interval."""
+
+    open_time: datetime
+    close_time: datetime
+    open_price: float
+    high_price: float
+    low_price: float
+    close_price: float
+    volume: float
+    quote_volume: float
+
+    def __post_init__(self) -> None:
+        ensure_belgrade_timezone(self.open_time, self.close_time)
+
+
+__all__ = ["Candle"]

--- a/domain/models/enums.py
+++ b/domain/models/enums.py
@@ -1,0 +1,58 @@
+"""Enumerations shared across domain models."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Exchange(str, Enum):
+    """Supported trading venues."""
+
+    BINANCE = "binance"
+    BYBIT = "bybit"
+
+
+class MarginMode(str, Enum):
+    """Account margin configuration."""
+
+    ISOLATED = "isolated"
+    CROSS = "cross"
+
+
+class BalanceSource(str, Enum):
+    """Different balance sources exposed by exchanges."""
+
+    AVAILABLE = "available_balance"
+    WALLET = "wallet_balance"
+
+
+class StopTrigger(str, Enum):
+    """Price reference used for stop orders."""
+
+    MARK = "mark_price"
+    LAST = "last_price"
+
+
+class Side(str, Enum):
+    """Order side or book direction."""
+
+    BID = "bid"
+    ASK = "ask"
+
+
+class Signal(str, Enum):
+    """Trading signal direction."""
+
+    NONE = "none"
+    LONG = "long"
+    SHORT = "short"
+
+
+__all__ = [
+    "Exchange",
+    "MarginMode",
+    "BalanceSource",
+    "StopTrigger",
+    "Side",
+    "Signal",
+]

--- a/domain/models/execution.py
+++ b/domain/models/execution.py
@@ -1,0 +1,31 @@
+"""Models related to order execution reporting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from ._timezone import ensure_belgrade_timezone
+from .enums import Exchange, Side
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionReport:
+    """Execution result for a placed order."""
+
+    exchange: Exchange
+    symbol: str
+    order_id: str
+    side: Side
+    price: float
+    quantity: float
+    executed_qty: float
+    status: str
+    commission: float
+    executed_at: datetime
+
+    def __post_init__(self) -> None:
+        ensure_belgrade_timezone(self.executed_at)
+
+
+__all__ = ["ExecutionReport"]

--- a/domain/models/log.py
+++ b/domain/models/log.py
@@ -1,0 +1,23 @@
+"""Models representing structured log entries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from ._timezone import ensure_belgrade_timezone
+
+
+@dataclass(frozen=True, slots=True)
+class LogLine:
+    """Structured log line produced by the application."""
+
+    timestamp: datetime
+    message: str
+    level: str
+
+    def __post_init__(self) -> None:
+        ensure_belgrade_timezone(self.timestamp)
+
+
+__all__ = ["LogLine"]

--- a/domain/models/order_book.py
+++ b/domain/models/order_book.py
@@ -1,0 +1,64 @@
+"""Order book related domain models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Tuple
+
+from ._timezone import ensure_belgrade_timezone
+from .enums import Exchange
+
+
+@dataclass(frozen=True, slots=True)
+class OrderBookLevel:
+    """Represents a single price level in the order book."""
+
+    price: float
+    quantity: float
+    notional: float
+    first_seen_at: datetime
+    last_update_at: datetime
+    min_quantity_seen: float
+    max_quantity_seen: float
+
+    def __post_init__(self) -> None:
+        ensure_belgrade_timezone(self.first_seen_at, self.last_update_at)
+
+
+@dataclass(frozen=True, slots=True)
+class OrderBookSnapshot:
+    """Full snapshot of the order book provided by the exchange."""
+
+    exchange: Exchange
+    symbol: str
+    last_update_id: int
+    bids: Tuple[OrderBookLevel, ...]
+    asks: Tuple[OrderBookLevel, ...]
+    received_at: datetime
+
+    def __post_init__(self) -> None:
+        ensure_belgrade_timezone(self.received_at)
+
+
+@dataclass(frozen=True, slots=True)
+class OrderBookUpdate:
+    """Incremental order book update event."""
+
+    exchange: Exchange
+    symbol: str
+    first_update_id: int
+    last_update_id: int
+    bids: Tuple[OrderBookLevel, ...]
+    asks: Tuple[OrderBookLevel, ...]
+    event_time: datetime
+
+    def __post_init__(self) -> None:
+        ensure_belgrade_timezone(self.event_time)
+
+
+__all__ = [
+    "OrderBookLevel",
+    "OrderBookSnapshot",
+    "OrderBookUpdate",
+]

--- a/domain/models/position.py
+++ b/domain/models/position.py
@@ -1,0 +1,31 @@
+"""Models representing trading positions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from ._timezone import ensure_belgrade_timezone
+from .enums import Exchange, MarginMode, Side
+
+
+@dataclass(frozen=True, slots=True)
+class Position:
+    """Open derivatives position tracked by the bot."""
+
+    exchange: Exchange
+    symbol: str
+    side: Side
+    entry_price: float
+    quantity: float
+    leverage: int
+    margin_mode: MarginMode
+    unrealized_pnl: float
+    opened_at: datetime
+    updated_at: datetime
+
+    def __post_init__(self) -> None:
+        ensure_belgrade_timezone(self.opened_at, self.updated_at)
+
+
+__all__ = ["Position"]

--- a/domain/models/pressure.py
+++ b/domain/models/pressure.py
@@ -1,0 +1,24 @@
+"""Models capturing order book pressure metrics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from ._timezone import ensure_belgrade_timezone
+
+
+@dataclass(frozen=True, slots=True)
+class Pressure:
+    """Pressure metrics derived from the order book."""
+
+    computed_at: datetime
+    buy_pressure: float
+    sell_pressure: float
+    imbalance_ratio: float
+
+    def __post_init__(self) -> None:
+        ensure_belgrade_timezone(self.computed_at)
+
+
+__all__ = ["Pressure"]

--- a/domain/models/symbol.py
+++ b/domain/models/symbol.py
@@ -1,0 +1,27 @@
+"""Trading symbol configuration models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .enums import Exchange
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolFilters:
+    """Exchange-specific symbol filters and trading limits."""
+
+    exchange: Exchange
+    symbol: str
+    base_asset: str
+    quote_asset: str
+    price_tick_size: float
+    quantity_step_size: float
+    min_price: float
+    max_price: float
+    min_qty: float
+    max_qty: float
+    min_notional: float
+
+
+__all__ = ["SymbolFilters"]

--- a/domain/models/trade.py
+++ b/domain/models/trade.py
@@ -1,0 +1,28 @@
+"""Models describing trade executions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from ._timezone import ensure_belgrade_timezone
+from .enums import Exchange, Side
+
+
+@dataclass(frozen=True, slots=True)
+class Trade:
+    """Aggregated trade information received from the exchange."""
+
+    trade_id: str
+    exchange: Exchange
+    symbol: str
+    executed_at: datetime
+    price: float
+    quantity: float
+    side: Side
+
+    def __post_init__(self) -> None:
+        ensure_belgrade_timezone(self.executed_at)
+
+
+__all__ = ["Trade"]

--- a/domain/models/wall.py
+++ b/domain/models/wall.py
@@ -1,0 +1,29 @@
+"""Models describing large order book walls."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from ._timezone import ensure_belgrade_timezone
+from .enums import Exchange, Side
+
+
+@dataclass(frozen=True, slots=True)
+class Wall:
+    """Order book wall representation tracked by the strategy."""
+
+    exchange: Exchange
+    symbol: str
+    side: Side
+    price: float
+    quantity: float
+    notional: float
+    first_seen_at: datetime
+    last_seen_at: datetime
+
+    def __post_init__(self) -> None:
+        ensure_belgrade_timezone(self.first_seen_at, self.last_seen_at)
+
+
+__all__ = ["Wall"]


### PR DESCRIPTION
## Summary
- remove the deprecated monolithic `domain/models.py` now that models live in dedicated modules
- add a shared timezone validation helper to enforce Europe/Belgrade datetimes in each domain dataclass
- restore timezone enforcement and enum value consistency across the modularized domain models

## Testing
- `python -m compileall domain/models`


------
https://chatgpt.com/codex/tasks/task_e_68dfaa49462c83209eea8b1d5ab5c778