### PR TITLE
Rename timezone helper to avoid city naming

### DIFF
--- a/domain/detectors.py
+++ b/domain/detectors.py
@@ -1,0 +1,225 @@
+"""Business logic for detecting pressure and wall conditions."""
+
+from __future__ import annotations
+
+from collections import deque
+from datetime import datetime, timedelta
+from statistics import median
+from typing import Deque, Iterable, Optional, Sequence, Tuple
+
+from config.config import CONFIG
+from config.models.trading_profile import TradingProfile
+from config.models.wall_absolute_thresholds import WallAbsoluteThresholds
+
+from .book import OrderBook
+from .models.enums import Exchange, Side
+from .models.order_book import OrderBookLevel
+from .models.pressure import Pressure
+from .models.wall import Wall
+from utils import get_current_time, median_filter_of_three, price_weight
+
+
+def compute_odr(book: OrderBook, last_price: float, tick_size: float) -> Pressure:
+    """Compute order book pressure metrics using weighted levels."""
+
+    bid_levels: Tuple[OrderBookLevel, ...] = _collect_levels(
+        book.iter_recent_band(Side.BID),
+        book.best_bid(),
+    )
+    ask_levels: Tuple[OrderBookLevel, ...] = _collect_levels(
+        book.iter_recent_band(Side.ASK),
+        book.best_ask(),
+    )
+    buy_pressure: float = _sum_side_pressure(bid_levels, last_price, tick_size)
+    sell_pressure: float = _sum_side_pressure(ask_levels, last_price, tick_size)
+    raw_ratio: float = _compute_ratio(sell_pressure, buy_pressure)
+    smoothed_ratio: float = _smooth_ratio(raw_ratio)
+    return Pressure(
+        computed_at=get_current_time(),
+        buy_pressure=buy_pressure,
+        sell_pressure=sell_pressure,
+        imbalance_ratio=smoothed_ratio,
+    )
+
+
+def check_if_has_pressure(pressure: Pressure, want_long: bool) -> bool:
+    """Check if pressure conditions satisfy desired trade direction."""
+
+    if want_long:
+        return pressure.imbalance_ratio <= CONFIG.odr.odr_in_long
+    return pressure.imbalance_ratio >= CONFIG.odr.odr_in_short
+
+
+def check_if_price_recent(level_price: float, recent_low: float, recent_high: float) -> bool:
+    """Return True if price stays within the recent traded band."""
+
+    return recent_low <= level_price <= recent_high
+
+
+def check_if_is_large_wall(
+    level: OrderBookLevel,
+    abs_usd_min: float,
+    rel_mult_min: float,
+    median_level_qty: float,
+    persist_s: float,
+    now: datetime,
+) -> bool:
+    """Validate if an order book level qualifies as a large wall."""
+
+    lifetime: timedelta = now - level.first_seen_at
+    if lifetime < timedelta(seconds=persist_s):
+        return False
+    if level.notional < abs_usd_min:
+        return False
+    if median_level_qty > 0.0 and level.quantity < median_level_qty * rel_mult_min:
+        return False
+    return True
+
+
+def check_if_has_near_wall(book: OrderBook, side_stop: Side) -> Optional[Wall]:
+    """Return nearest significant wall on the stop side if present."""
+
+    abs_threshold: float = _resolve_absolute_threshold(CONFIG.general.profile)
+    level: Optional[OrderBookLevel] = book.find_nearest_wall(
+        side=side_stop,
+        min_notional=abs_threshold,
+    )
+    if level is None:
+        return None
+    now: datetime = get_current_time()
+    persist_s: float = _resolve_persist(CONFIG.general.profile)
+    median_qty: float = _compute_median_quantity(book.iter_recent_band(side_stop))
+    if not check_if_is_large_wall(
+        level,
+        abs_threshold,
+        CONFIG.walls.relative_multiplier,
+        median_qty,
+        persist_s,
+        now,
+    ):
+        return None
+    return Wall(
+        exchange=_resolve_exchange(),
+        symbol="",
+        side=side_stop,
+        price=level.price,
+        quantity=level.quantity,
+        notional=level.notional,
+        first_seen_at=level.first_seen_at,
+        last_seen_at=level.last_update_at,
+    )
+
+
+def check_if_has_opposite_wall(book: OrderBook, side_move: Side, our_wall: Wall) -> bool:
+    """Determine if an opposing wall blocks the intended move."""
+
+    opposite_side: Side = Side.ASK if side_move is Side.BID else Side.BID
+    abs_threshold: float = _resolve_absolute_threshold(CONFIG.general.profile)
+    level: Optional[OrderBookLevel] = book.find_nearest_wall(
+        side=opposite_side,
+        min_notional=abs_threshold,
+    )
+    if level is None:
+        return False
+    now: datetime = get_current_time()
+    persist_s: float = _resolve_persist(CONFIG.general.profile)
+    median_qty: float = _compute_median_quantity(book.iter_recent_band(opposite_side))
+    if not check_if_is_large_wall(
+        level,
+        abs_threshold,
+        CONFIG.walls.relative_multiplier,
+        median_qty,
+        persist_s,
+        now,
+    ):
+        return False
+    return level.notional >= our_wall.notional
+
+
+def _collect_levels(
+    levels: Iterable[OrderBookLevel],
+    fallback: Optional[OrderBookLevel],
+) -> Tuple[OrderBookLevel, ...]:
+    collected: Tuple[OrderBookLevel, ...] = tuple(levels)
+    if collected:
+        return collected
+    return () if fallback is None else (fallback,)
+
+
+def _sum_side_pressure(
+    levels: Sequence[OrderBookLevel],
+    last_price: float,
+    tick_size: float,
+) -> float:
+    contributions: list[float] = [
+        price_weight(level.price, last_price, tick_size) * level.notional for level in levels
+    ]
+    smoothed: Tuple[float, ...] = median_filter_of_three(contributions)
+    return float(sum(smoothed))
+
+
+def _compute_ratio(sell_pressure: float, buy_pressure: float) -> float:
+    if buy_pressure <= 0.0:
+        return float("inf") if sell_pressure > 0.0 else 1.0
+    return sell_pressure / buy_pressure
+
+
+_ODR_HISTORY: Deque[float] = deque(maxlen=max(1, CONFIG.general.odr_smooth_samples))
+
+
+def _smooth_ratio(raw_ratio: float) -> float:
+    maxlen: int = CONFIG.general.odr_smooth_samples
+    if maxlen <= 1:
+        return raw_ratio
+    if _ODR_HISTORY.maxlen != maxlen:
+        _resize_history(maxlen)
+    _ODR_HISTORY.append(raw_ratio)
+    return median(_ODR_HISTORY)
+
+
+def _resize_history(maxlen: int) -> None:
+    global _ODR_HISTORY
+    history: Deque[float] = deque(_ODR_HISTORY, maxlen=maxlen)
+    _ODR_HISTORY = history
+
+
+def _compute_median_quantity(levels: Iterable[OrderBookLevel]) -> float:
+    quantities: Tuple[float, ...] = tuple(level.quantity for level in levels)
+    if not quantities:
+        return 0.0
+    return float(median(quantities))
+
+
+def _resolve_absolute_threshold(profile: TradingProfile) -> float:
+    thresholds: WallAbsoluteThresholds = CONFIG.walls.absolute
+    if profile is TradingProfile.TOP:
+        return float(thresholds.top_usd)
+    if profile is TradingProfile.ALT:
+        return float(thresholds.alt_usd)
+    if profile is TradingProfile.LISTING:
+        return float(thresholds.listing_usd)
+    return float(thresholds.top_usd)
+
+
+def _resolve_persist(profile: TradingProfile) -> float:
+    if profile is TradingProfile.TOP:
+        return CONFIG.walls.persist_s_top
+    if profile is TradingProfile.ALT:
+        return CONFIG.walls.persist_s_alt
+    if profile is TradingProfile.LISTING:
+        return CONFIG.walls.persist_s_listing
+    return CONFIG.walls.persist_s_top
+
+
+def _resolve_exchange() -> Exchange:
+    return Exchange(CONFIG.general.exchange.value)
+
+
+__all__ = [
+    "compute_odr",
+    "check_if_has_pressure",
+    "check_if_price_recent",
+    "check_if_is_large_wall",
+    "check_if_has_near_wall",
+    "check_if_has_opposite_wall",
+]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,10 @@
+"""Utility helpers used by the trading bot."""
+
+from .mathx import median_filter_of_three, price_weight
+from .timez import get_current_time
+
+__all__ = [
+    "median_filter_of_three",
+    "price_weight",
+    "get_current_time",
+]

--- a/utils/mathx.py
+++ b/utils/mathx.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Mathematical helpers for the trading domain."""
+
+from typing import Sequence, Tuple
+
+
+def median_filter_of_three(values: Sequence[float]) -> Tuple[float, ...]:
+    """Apply a median-of-three filter to the provided sequence."""
+
+    length: int = len(values)
+    if length == 0:
+        return ()
+    if length < 3:
+        return tuple(values)
+    smoothed: list[float] = [values[0]]
+    for index in range(1, length - 1):
+        window: Tuple[float, float, float] = (
+            float(values[index - 1]),
+            float(values[index]),
+            float(values[index + 1]),
+        )
+        sorted_window: list[float] = sorted(window)
+        smoothed.append(sorted_window[1])
+    smoothed.append(float(values[-1]))
+    return tuple(smoothed)
+
+
+def price_weight(price: float, reference_price: float, tick_size: float) -> float:
+    """Return distance weight for a level using reciprocal tick distance."""
+
+    if tick_size <= 0:
+        raise ValueError("tick_size must be positive")
+    ticks: float = abs(price - reference_price) / tick_size
+    return 1.0 / (1.0 + ticks)
+
+
+__all__ = ["median_filter_of_three", "price_weight"]

--- a/utils/timez.py
+++ b/utils/timez.py
@@ -1,0 +1,15 @@
+"""Timezone-aware datetime helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from config.timezone import BELGRADE_TIMEZONE
+
+
+def get_current_time() -> datetime:
+    current: datetime = datetime.now(BELGRADE_TIMEZONE)
+    return current
+
+
+__all__ = ["get_current_time"]


### PR DESCRIPTION
## Summary
- rename the timezone helper to `get_current_time` so it no longer embeds the city name
- update domain detectors and utility exports to rely on the renamed helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfb02c18b88320869e61f6b00cf090