### PR TITLE
Implement math, time, and formatting helpers

### DIFF
--- a/domain/detectors.py
+++ b/domain/detectors.py
@@ -16,7 +16,7 @@ from .models.enums import Exchange, Side
 from .models.order_book import OrderBookLevel
 from .models.pressure import Pressure
 from .models.wall import Wall
-from utils import get_current_time, median_filter_of_three, price_weight
+from utils import compute_odr_weight, median_filter_of_three, now_belgrade
 
 
 def compute_odr(book: OrderBook, last_price: float, tick_size: float) -> Pressure:
@@ -35,7 +35,7 @@ def compute_odr(book: OrderBook, last_price: float, tick_size: float) -> Pressur
     raw_ratio: float = _compute_ratio(sell_pressure, buy_pressure)
     smoothed_ratio: float = _smooth_ratio(raw_ratio)
     return Pressure(
-        computed_at=get_current_time(),
+        computed_at=now_belgrade(),
         buy_pressure=buy_pressure,
         sell_pressure=sell_pressure,
         imbalance_ratio=smoothed_ratio,
@@ -86,7 +86,7 @@ def check_if_has_near_wall(book: OrderBook, side_stop: Side) -> Optional[Wall]:
     )
     if level is None:
         return None
-    now: datetime = get_current_time()
+    now: datetime = now_belgrade()
     persist_s: float = _resolve_persist(CONFIG.general.profile)
     median_qty: float = _compute_median_quantity(book.iter_recent_band(side_stop))
     if not check_if_is_large_wall(
@@ -121,7 +121,7 @@ def check_if_has_opposite_wall(book: OrderBook, side_move: Side, our_wall: Wall)
     )
     if level is None:
         return False
-    now: datetime = get_current_time()
+    now: datetime = now_belgrade()
     persist_s: float = _resolve_persist(CONFIG.general.profile)
     median_qty: float = _compute_median_quantity(book.iter_recent_band(opposite_side))
     if not check_if_is_large_wall(
@@ -152,7 +152,8 @@ def _sum_side_pressure(
     tick_size: float,
 ) -> float:
     contributions: list[float] = [
-        price_weight(level.price, last_price, tick_size) * level.notional for level in levels
+        compute_odr_weight(level.price, last_price, tick_size) * level.notional
+        for level in levels
     ]
     smoothed: Tuple[float, ...] = median_filter_of_three(contributions)
     return float(sum(smoothed))

--- a/domain/detectors.py
+++ b/domain/detectors.py
@@ -16,7 +16,7 @@ from .models.enums import Exchange, Side
 from .models.order_book import OrderBookLevel
 from .models.pressure import Pressure
 from .models.wall import Wall
-from utils import compute_odr_weight, median_filter_of_three, now_belgrade
+from utils import compute_odr_weight, get_current_time, median_filter_of_three
 
 
 def compute_odr(book: OrderBook, last_price: float, tick_size: float) -> Pressure:
@@ -35,7 +35,7 @@ def compute_odr(book: OrderBook, last_price: float, tick_size: float) -> Pressur
     raw_ratio: float = _compute_ratio(sell_pressure, buy_pressure)
     smoothed_ratio: float = _smooth_ratio(raw_ratio)
     return Pressure(
-        computed_at=now_belgrade(),
+        computed_at=get_current_time(),
         buy_pressure=buy_pressure,
         sell_pressure=sell_pressure,
         imbalance_ratio=smoothed_ratio,
@@ -86,7 +86,7 @@ def check_if_has_near_wall(book: OrderBook, side_stop: Side) -> Optional[Wall]:
     )
     if level is None:
         return None
-    now: datetime = now_belgrade()
+    now: datetime = get_current_time()
     persist_s: float = _resolve_persist(CONFIG.general.profile)
     median_qty: float = _compute_median_quantity(book.iter_recent_band(side_stop))
     if not check_if_is_large_wall(
@@ -121,7 +121,7 @@ def check_if_has_opposite_wall(book: OrderBook, side_move: Side, our_wall: Wall)
     )
     if level is None:
         return False
-    now: datetime = now_belgrade()
+    now: datetime = get_current_time()
     persist_s: float = _resolve_persist(CONFIG.general.profile)
     median_qty: float = _compute_median_quantity(book.iter_recent_band(opposite_side))
     if not check_if_is_large_wall(

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -9,7 +9,7 @@ from .mathx import (
     median_filter_of_three,
     round_to_step,
 )
-from .timez import from_exchange_timestamp, get_current_time, now_belgrade
+from .timez import from_exchange_timestamp, get_current_time
 
 __all__ = [
     "ceil_to_step",
@@ -19,7 +19,6 @@ __all__ = [
     "format_money",
     "format_number",
     "median_filter_of_three",
-    "now_belgrade",
     "get_current_time",
     "round_to_step",
     "from_exchange_timestamp",

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,10 +1,25 @@
 """Utility helpers used by the trading bot."""
 
-from .mathx import median_filter_of_three, price_weight
-from .timez import get_current_time
+from .formatting import format_money, format_number
+from .mathx import (
+    ceil_to_step,
+    compute_odr_weight,
+    compute_position_size,
+    floor_to_step,
+    median_filter_of_three,
+    round_to_step,
+)
+from .timez import from_exchange_timestamp, now_belgrade
 
 __all__ = [
+    "ceil_to_step",
+    "compute_odr_weight",
+    "compute_position_size",
+    "floor_to_step",
+    "format_money",
+    "format_number",
     "median_filter_of_three",
-    "price_weight",
-    "get_current_time",
+    "now_belgrade",
+    "round_to_step",
+    "from_exchange_timestamp",
 ]

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -9,7 +9,7 @@ from .mathx import (
     median_filter_of_three,
     round_to_step,
 )
-from .timez import from_exchange_timestamp, now_belgrade
+from .timez import from_exchange_timestamp, get_current_time, now_belgrade
 
 __all__ = [
     "ceil_to_step",
@@ -20,6 +20,7 @@ __all__ = [
     "format_number",
     "median_filter_of_three",
     "now_belgrade",
+    "get_current_time",
     "round_to_step",
     "from_exchange_timestamp",
 ]

--- a/utils/formatting.py
+++ b/utils/formatting.py
@@ -1,0 +1,32 @@
+"""Formatting helpers for logging numeric values."""
+
+from __future__ import annotations
+
+import math
+from decimal import Decimal, ROUND_HALF_UP
+
+
+def format_number(value: float, decimals: int = 4) -> str:
+    if decimals < 0:
+        raise ValueError("decimals must be non-negative")
+    if math.isnan(value) or math.isinf(value):
+        raise ValueError("value must be a finite number")
+    quantize_pattern: str = "1" if decimals == 0 else f"1.{'0' * decimals}"
+    decimal_value: Decimal = Decimal(str(value)).quantize(
+        Decimal(quantize_pattern), rounding=ROUND_HALF_UP
+    )
+    if decimal_value == 0:
+        return "0"
+    formatted: str = format(decimal_value, "f")
+    if decimals > 0:
+        formatted = formatted.rstrip("0").rstrip(".")
+    return formatted
+
+
+def format_money(value: float, currency: str = "USDT", decimals: int = 2) -> str:
+    formatted_amount: str = format_number(value, decimals)
+    return f"{formatted_amount} {currency}"
+
+
+__all__ = ["format_number", "format_money"]
+

--- a/utils/mathx.py
+++ b/utils/mathx.py
@@ -1,20 +1,20 @@
-from __future__ import annotations
-
 """Mathematical helpers for the trading domain."""
+
+from __future__ import annotations
 
 import math
 from typing import Sequence, Tuple
 
 
 def median_filter_of_three(values: Sequence[float]) -> Tuple[float, ...]:
-    """Apply a median-of-three filter to the provided sequence."""
+    """Return a sequence smoothed by a median-of-three filter."""
 
     length: int = len(values)
     if length == 0:
         return ()
     if length < 3:
-        return tuple(values)
-    smoothed: list[float] = [values[0]]
+        return tuple(float(value) for value in values)
+    smoothed: list[float] = [float(values[0])]
     for index in range(1, length - 1):
         window: Tuple[float, float, float] = (
             float(values[index - 1]),
@@ -27,13 +27,13 @@ def median_filter_of_three(values: Sequence[float]) -> Tuple[float, ...]:
     return tuple(smoothed)
 
 
-def price_weight(price: float, reference_price: float, tick_size: float) -> float:
-    """Return distance weight for a level using reciprocal tick distance."""
+def compute_odr_weight(price: float, reference_price: float, tick_size: float) -> float:
+    """Return a decay weight based on distance between two prices."""
 
-    if tick_size <= 0:
+    if tick_size <= 0.0:
         raise ValueError("tick_size must be positive")
-    ticks: float = abs(price - reference_price) / tick_size
-    return 1.0 / (1.0 + ticks)
+    distance_ticks: float = abs(price - reference_price) / tick_size
+    return 1.0 / (1.0 + distance_ticks)
 
 
 def floor_to_step(value: float, step: float) -> float:
@@ -52,6 +52,17 @@ def ceil_to_step(value: float, step: float) -> float:
     return ceiled * step
 
 
+def round_to_step(value: float, step: float) -> float:
+    if step <= 0.0:
+        raise ValueError("step must be positive")
+    scaled: float = value / step
+    if scaled >= 0.0:
+        rounded: float = math.floor(scaled + 0.5)
+    else:
+        rounded = math.ceil(scaled - 0.5)
+    return rounded * step
+
+
 def compute_position_size(
     balance: float,
     fraction: float,
@@ -63,7 +74,15 @@ def compute_position_size(
         raise ValueError("price must be positive")
     if step <= 0.0:
         raise ValueError("step must be positive")
+    if fraction < 0.0:
+        raise ValueError("fraction must be non-negative")
+    if minimum_notional < 0.0:
+        raise ValueError("minimum_notional must be non-negative")
+    if balance <= 0.0:
+        return 0.0
     target_notional: float = max(balance * fraction, minimum_notional)
+    if target_notional <= 0.0:
+        return 0.0
     raw_quantity: float = target_notional / price
     if raw_quantity <= 0.0:
         return 0.0
@@ -72,8 +91,9 @@ def compute_position_size(
 
 __all__ = [
     "median_filter_of_three",
-    "price_weight",
+    "compute_odr_weight",
     "floor_to_step",
     "ceil_to_step",
+    "round_to_step",
     "compute_position_size",
 ]

--- a/utils/timez.py
+++ b/utils/timez.py
@@ -2,14 +2,72 @@
 
 from __future__ import annotations
 
+import math
 from datetime import datetime
+from decimal import Decimal, DecimalException
+from typing import Union
 
 from config.timezone import BELGRADE_TIMEZONE
 
+NumberLike = Union[int, float, str]
 
-def get_current_time() -> datetime:
+_NANO_THRESHOLD: Decimal = Decimal("1000000000000000000")
+_MICRO_THRESHOLD: Decimal = Decimal("1000000000000000")
+_MILLI_THRESHOLD: Decimal = Decimal("1000000000000")
+
+
+def now_belgrade() -> datetime:
+    """Return the current time in the Europe/Belgrade timezone."""
+
     current: datetime = datetime.now(BELGRADE_TIMEZONE)
     return current
 
 
-__all__ = ["get_current_time"]
+def from_exchange_timestamp(timestamp: NumberLike) -> datetime:
+    """Convert a raw exchange timestamp to a timezone-aware datetime."""
+
+    seconds: Decimal = _normalize_to_seconds(timestamp)
+    return datetime.fromtimestamp(float(seconds), BELGRADE_TIMEZONE)
+
+
+def _normalize_to_seconds(timestamp: NumberLike) -> Decimal:
+    value: Decimal = _coerce_to_decimal(timestamp)
+    absolute: Decimal = abs(value)
+    if absolute == 0:
+        return Decimal(0)
+    if absolute >= _NANO_THRESHOLD:
+        return value / Decimal(1_000_000_000)
+    if absolute >= _MICRO_THRESHOLD:
+        return value / Decimal(1_000_000)
+    if absolute >= _MILLI_THRESHOLD:
+        return value / Decimal(1_000)
+    return value
+
+
+def _coerce_to_decimal(timestamp: NumberLike) -> Decimal:
+    if isinstance(timestamp, str):
+        stripped: str = timestamp.strip()
+        if not stripped:
+            raise ValueError("timestamp string must not be empty")
+        try:
+            decimal_value: Decimal = Decimal(stripped)
+        except (ArithmeticError, DecimalException, ValueError) as error:
+            raise ValueError("timestamp string must contain a numeric value") from error
+        _validate_decimal(decimal_value)
+        return decimal_value
+    if isinstance(timestamp, int):
+        return Decimal(timestamp)
+    if isinstance(timestamp, float):
+        if math.isnan(timestamp) or math.isinf(timestamp):
+            raise ValueError("timestamp must be a finite number")
+        return Decimal(str(timestamp))
+    raise TypeError("timestamp must be int, float, or str")
+
+
+def _validate_decimal(value: Decimal) -> None:
+    if value.is_nan() or value.is_infinite():
+        raise ValueError("timestamp must be a finite number")
+
+
+__all__ = ["NumberLike", "now_belgrade", "from_exchange_timestamp"]
+

--- a/utils/timez.py
+++ b/utils/timez.py
@@ -9,7 +9,7 @@ from typing import Union
 
 from config.timezone import BELGRADE_TIMEZONE
 
-NumberLike = Union[int, float, str]
+NumberLike = Union[int, float, str, Decimal]
 
 _NANO_THRESHOLD: Decimal = Decimal("1000000000000000000")
 _MICRO_THRESHOLD: Decimal = Decimal("1000000000000000")
@@ -67,7 +67,10 @@ def _coerce_to_decimal(timestamp: NumberLike) -> Decimal:
         if math.isnan(timestamp) or math.isinf(timestamp):
             raise ValueError("timestamp must be a finite number")
         return Decimal(str(timestamp))
-    raise TypeError("timestamp must be int, float, or str")
+    if isinstance(timestamp, Decimal):
+        _validate_decimal(timestamp)
+        return timestamp
+    raise TypeError("timestamp must be int, float, str, or Decimal")
 
 
 def _validate_decimal(value: Decimal) -> None:
@@ -75,5 +78,10 @@ def _validate_decimal(value: Decimal) -> None:
         raise ValueError("timestamp must be a finite number")
 
 
-__all__ = ["NumberLike", "now_belgrade", "get_current_time", "from_exchange_timestamp"]
+__all__ = [
+    "NumberLike",
+    "now_belgrade",
+    "get_current_time",
+    "from_exchange_timestamp",
+]
 

--- a/utils/timez.py
+++ b/utils/timez.py
@@ -23,6 +23,12 @@ def now_belgrade() -> datetime:
     return current
 
 
+def get_current_time() -> datetime:
+    """Return the current Europe/Belgrade time for legacy callers."""
+
+    return now_belgrade()
+
+
 def from_exchange_timestamp(timestamp: NumberLike) -> datetime:
     """Convert a raw exchange timestamp to a timezone-aware datetime."""
 
@@ -69,5 +75,5 @@ def _validate_decimal(value: Decimal) -> None:
         raise ValueError("timestamp must be a finite number")
 
 
-__all__ = ["NumberLike", "now_belgrade", "from_exchange_timestamp"]
+__all__ = ["NumberLike", "now_belgrade", "get_current_time", "from_exchange_timestamp"]
 

--- a/utils/timez.py
+++ b/utils/timez.py
@@ -16,17 +16,11 @@ _MICRO_THRESHOLD: Decimal = Decimal("1000000000000000")
 _MILLI_THRESHOLD: Decimal = Decimal("1000000000000")
 
 
-def now_belgrade() -> datetime:
-    """Return the current time in the Europe/Belgrade timezone."""
+def get_current_time() -> datetime:
+    """Return the current time in the configured timezone."""
 
     current: datetime = datetime.now(BELGRADE_TIMEZONE)
     return current
-
-
-def get_current_time() -> datetime:
-    """Return the current Europe/Belgrade time for legacy callers."""
-
-    return now_belgrade()
 
 
 def from_exchange_timestamp(timestamp: NumberLike) -> datetime:
@@ -78,10 +72,5 @@ def _validate_decimal(value: Decimal) -> None:
         raise ValueError("timestamp must be a finite number")
 
 
-__all__ = [
-    "NumberLike",
-    "now_belgrade",
-    "get_current_time",
-    "from_exchange_timestamp",
-]
+__all__ = ["NumberLike", "get_current_time", "from_exchange_timestamp"]
 


### PR DESCRIPTION
## Summary
- extend math utilities with ODR weighting, rounding helpers, and stricter position sizing rules
- add timezone helpers for Belgrade timestamps and expose exchange timestamp conversion
- introduce logging-oriented numeric formatting helpers and export new utilities via the utils package
- update pressure detector logic to rely on the new helpers

## Testing
- python -m compileall utils domain

------
https://chatgpt.com/codex/tasks/task_e_68dfbd11e08c83208ed5e95324cfd91b