### PR TITLE
Implement Telegram client and refine uptick notifications

### DIFF
--- a/config/models/__init__.py
+++ b/config/models/__init__.py
@@ -15,6 +15,7 @@ from .turnover_thresholds import TurnoverThresholds
 from .wall_absolute_thresholds import WallAbsoluteThresholds
 from .wall_settings import WallSettings
 from .wall_shift_settings import WallShiftSettings
+from .secrets import Secrets
 
 __all__ = [
     "BalanceSource",
@@ -29,6 +30,7 @@ __all__ = [
     "StopTrigger",
     "TelegramSettings",
     "TradingProfile",
+    "Secrets",
     "TurnoverThresholds",
     "WallAbsoluteThresholds",
     "WallSettings",

--- a/config/models/secrets.py
+++ b/config/models/secrets.py
@@ -1,0 +1,10 @@
+"""Secrets configuration model."""
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Secrets:
+    tg_bot_token: str
+
+
+__all__ = ["Secrets"]

--- a/config/secrets.py
+++ b/config/secrets.py
@@ -1,0 +1,24 @@
+"""Secret values loaded from environment variables."""
+
+from __future__ import annotations
+
+import os
+from typing import Final
+
+from .models.secrets import Secrets
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name)
+    if value is None:
+        raise ValueError(f"Environment variable {name} is required")
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError(f"Environment variable {name} must not be empty")
+    return stripped
+
+
+SECRETS: Final[Secrets] = Secrets(tg_bot_token=_require_env("TG_BOT_TOKEN"))
+
+
+__all__ = ["SECRETS"]

--- a/data/telegram.py
+++ b/data/telegram.py
@@ -1,0 +1,52 @@
+"""Telegram messaging client."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Optional
+from urllib.request import Request, urlopen
+
+from config.models import TelegramSettings
+from config.secrets import SECRETS
+
+
+@dataclass(slots=True)
+class TelegramClient:
+    """Minimal client for sending messages via Telegram Bot API."""
+
+    token: str
+    chat_id: Optional[int]
+    silent: bool
+    request_timeout: float = 10.0
+
+    def send_message(self, message: str) -> None:
+        if self.chat_id is None:
+            return
+        if not message:
+            return
+        payload = {
+            "chat_id": self.chat_id,
+            "text": message,
+            "disable_notification": self.silent,
+        }
+        data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        request = Request(
+            url=f"https://api.telegram.org/bot{self.token}/sendMessage",
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urlopen(request, timeout=self.request_timeout):
+            pass
+
+
+def create_client(settings: TelegramSettings) -> TelegramClient:
+    return TelegramClient(
+        token=SECRETS.tg_bot_token,
+        chat_id=settings.chat_id,
+        silent=settings.silent,
+    )
+
+
+__all__ = ["TelegramClient", "create_client"]

--- a/domain/strategy/strategy.py
+++ b/domain/strategy/strategy.py
@@ -46,6 +46,9 @@ class Strategy:
         self._last_scan_at: Optional[datetime] = None
         self._last_focus_signal_at: Optional[datetime] = None
         self._last_uptick_at: Optional[datetime] = None
+        self._last_trade_at: Optional[datetime] = None
+        self._last_stop_move_at: Optional[datetime] = None
+        self._last_uptick_loss_at: Optional[datetime] = None
         self._position_symbol: Optional[str] = None
         self._position_signal = Signal.NONE
         self._position_wall: Optional[Wall] = None
@@ -121,6 +124,7 @@ class Strategy:
             self._focused_signal = Signal.NONE
             self._focused_wall = None
             self._state = StrategyState.SCANNING
+            self._last_uptick_loss_at = timestamp
             return
         if pressure is None or wall is None:
             return
@@ -176,7 +180,23 @@ class Strategy:
         cooldown = timedelta(minutes=CONFIG.telegram.uptick_cooldown_min)
         if self._last_uptick_at is None:
             return True
-        return timestamp - self._last_uptick_at >= cooldown
+        if timestamp - self._last_uptick_at >= cooldown:
+            return True
+        return self._has_recent_activity(timestamp, cooldown)
+
+    def _has_recent_activity(self, timestamp: datetime, window: timedelta) -> bool:
+        lower_bound = timestamp - window
+        if self._last_uptick_at is not None and self._last_uptick_at > lower_bound:
+            lower_bound = self._last_uptick_at
+        events = (
+            self._last_trade_at,
+            self._last_stop_move_at,
+            self._last_uptick_loss_at,
+        )
+        for moment in events:
+            if moment is not None and lower_bound <= moment <= timestamp:
+                return True
+        return False
 
     def _should_defocus(self, timestamp: datetime) -> bool:
         if self._last_focus_signal_at is None:
@@ -189,6 +209,7 @@ class Strategy:
         if signal is Signal.NONE:
             return
         self._position.enter(symbol, signal, wall, timestamp)
+        self._last_trade_at = timestamp
         self._notifier.notify_entry(symbol, signal, timestamp)
         self._state = StrategyState.IN_POSITION
         self._position_symbol = symbol
@@ -204,6 +225,7 @@ class Strategy:
         if symbol is None:
             return
         self._position.exit(symbol, reason, timestamp)
+        self._last_trade_at = timestamp
         self._notifier.notify_exit(symbol, reason, timestamp)
         self._state = StrategyState.SCANNING
         self._position_symbol = None
@@ -282,6 +304,7 @@ class Strategy:
         if self._position_symbol is None:
             return
         self._position.adjust_stop(self._position_symbol, wall.price, timestamp)
+        self._last_stop_move_at = timestamp
         self._position_wall = wall
         self._shift_candidate_price = None
         self._shift_candidate_since = None


### PR DESCRIPTION
## Summary
- add a secrets dataclass and loader for the Telegram bot token
- implement a Telegram client that uses the loaded secrets and runtime settings
- refine the uptick notification cooldown to account for recent trading activity and stop moves

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dfd29ba82c83208e745f70e69ca941