### PR TITLE
Remove docstrings from core modules

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -1,4 +1,3 @@
-"""Application configuration values."""
 from typing import Final
 
 from .models import (

--- a/config/models/__init__.py
+++ b/config/models/__init__.py
@@ -1,4 +1,3 @@
-"""Typed configuration models for the trading bot."""
 from .balance_source import BalanceSource
 from .config_model import Config
 from .exchange_name import ExchangeName

--- a/config/models/balance_source.py
+++ b/config/models/balance_source.py
@@ -1,10 +1,7 @@
-"""Enumeration for balance sources."""
 from enum import Enum
 
 
 class BalanceSource(str, Enum):
-    """Sources for balance retrieval."""
-
     AVAILABLE_BALANCE = "available_balance"
     WALLET_BALANCE = "wallet_balance"
 

--- a/config/models/config_model.py
+++ b/config/models/config_model.py
@@ -1,4 +1,3 @@
-"""Top-level configuration dataclass."""
 from dataclasses import dataclass
 
 from .focus_settings import FocusSettings

--- a/config/models/exchange_name.py
+++ b/config/models/exchange_name.py
@@ -1,10 +1,7 @@
-"""Enumeration of supported exchanges."""
 from enum import Enum
 
 
 class ExchangeName(str, Enum):
-    """Supported exchange identifiers."""
-
     BINANCE = "binance"
     BYBIT = "bybit"
 

--- a/config/models/focus_settings.py
+++ b/config/models/focus_settings.py
@@ -1,4 +1,3 @@
-"""Configuration model for focus settings."""
 from dataclasses import dataclass
 
 

--- a/config/models/funding_kill_switch_settings.py
+++ b/config/models/funding_kill_switch_settings.py
@@ -1,4 +1,3 @@
-"""Configuration model for funding kill switch settings."""
 from dataclasses import dataclass
 
 

--- a/config/models/general_settings.py
+++ b/config/models/general_settings.py
@@ -1,4 +1,3 @@
-"""Configuration model for general settings."""
 from dataclasses import dataclass
 
 from .exchange_name import ExchangeName

--- a/config/models/margin_mode.py
+++ b/config/models/margin_mode.py
@@ -1,10 +1,7 @@
-"""Enumeration for margin modes."""
 from enum import Enum
 
 
 class MarginMode(str, Enum):
-    """Margin mode options supported by the bot."""
-
     ISOLATED = "isolated"
     CROSS = "cross"
 

--- a/config/models/odr_settings.py
+++ b/config/models/odr_settings.py
@@ -1,4 +1,3 @@
-"""Configuration model for ODR settings."""
 from dataclasses import dataclass
 
 

--- a/config/models/position_settings.py
+++ b/config/models/position_settings.py
@@ -1,4 +1,3 @@
-"""Configuration model for position settings."""
 from dataclasses import dataclass
 
 from .balance_source import BalanceSource

--- a/config/models/secrets.py
+++ b/config/models/secrets.py
@@ -1,4 +1,3 @@
-"""Secrets configuration model."""
 from dataclasses import dataclass
 
 

--- a/config/models/stop_trigger.py
+++ b/config/models/stop_trigger.py
@@ -1,10 +1,7 @@
-"""Enumeration for stop trigger prices."""
 from enum import Enum
 
 
 class StopTrigger(str, Enum):
-    """Trigger prices supported for protective orders."""
-
     MARK_PRICE = "mark_price"
     LAST_PRICE = "last_price"
 

--- a/config/models/telegram_settings.py
+++ b/config/models/telegram_settings.py
@@ -1,4 +1,3 @@
-"""Configuration model for Telegram settings."""
 from dataclasses import dataclass
 from typing import Optional
 

--- a/config/models/trading_profile.py
+++ b/config/models/trading_profile.py
@@ -1,10 +1,7 @@
-"""Enumeration of trading profiles."""
 from enum import Enum
 
 
 class TradingProfile(str, Enum):
-    """Available trading profiles."""
-
     AUTO = "auto"
     TOP = "T"
     ALT = "A"

--- a/config/models/turnover_thresholds.py
+++ b/config/models/turnover_thresholds.py
@@ -1,4 +1,3 @@
-"""Configuration model for turnover thresholds."""
 from dataclasses import dataclass
 
 

--- a/config/models/wall_absolute_thresholds.py
+++ b/config/models/wall_absolute_thresholds.py
@@ -1,4 +1,3 @@
-"""Configuration model for absolute wall thresholds."""
 from dataclasses import dataclass
 
 

--- a/config/models/wall_settings.py
+++ b/config/models/wall_settings.py
@@ -1,4 +1,3 @@
-"""Configuration model for wall settings."""
 from dataclasses import dataclass
 
 from .wall_absolute_thresholds import WallAbsoluteThresholds

--- a/config/models/wall_shift_settings.py
+++ b/config/models/wall_shift_settings.py
@@ -1,4 +1,3 @@
-"""Configuration model for wall shift settings."""
 from dataclasses import dataclass
 
 

--- a/config/secrets.py
+++ b/config/secrets.py
@@ -1,5 +1,3 @@
-"""Secret values loaded from environment variables."""
-
 from __future__ import annotations
 
 import os

--- a/config/timezone.py
+++ b/config/timezone.py
@@ -1,5 +1,3 @@
-"""Timezone configuration used across the application."""
-
 from __future__ import annotations
 
 from typing import Final

--- a/data/__init__.py
+++ b/data/__init__.py
@@ -1,5 +1,3 @@
-"""Data layer modules for exchange interaction and integrations."""
-
 from .exchanges import (
     BestBidAsk,
     DepthStreamData,

--- a/data/exchanges/__init__.py
+++ b/data/exchanges/__init__.py
@@ -1,5 +1,3 @@
-"""Exchange data adapters exposed by the data layer."""
-
 from .base import (
     BestBidAsk,
     DepthStreamData,

--- a/data/exchanges/base/__init__.py
+++ b/data/exchanges/base/__init__.py
@@ -1,5 +1,3 @@
-"""Exchange base interfaces and streaming helpers."""
-
 from .best_bid_ask import BestBidAsk
 from .depth_stream_data import DepthStreamData
 from .exchange_data import IExchangeData

--- a/data/exchanges/base/best_bid_ask.py
+++ b/data/exchanges/base/best_bid_ask.py
@@ -1,13 +1,9 @@
-"""Best bid/ask quote snapshot emitted by exchanges."""
-
 from dataclasses import dataclass
 from datetime import datetime
 
 
 @dataclass(slots=True)
 class BestBidAsk:
-    """Best bid/ask quote snapshot emitted by exchanges."""
-
     exchange: str
     symbol: str
     bid_price: float

--- a/data/exchanges/base/depth_stream_data.py
+++ b/data/exchanges/base/depth_stream_data.py
@@ -1,5 +1,3 @@
-"""Type alias describing order book streaming payloads."""
-
 from typing import Union
 
 from domain.models import OrderBookSnapshot, OrderBookUpdate

--- a/data/exchanges/base/exchange_data.py
+++ b/data/exchanges/base/exchange_data.py
@@ -1,5 +1,3 @@
-"""Interface describing public data interactions with an exchange."""
-
 from typing import Iterator, Protocol
 
 from domain.models import Candle, OrderBookSnapshot, SymbolFilters, Trade
@@ -10,8 +8,6 @@ from .stream_event import StreamEvent
 
 
 class IExchangeData(Protocol):
-    """Interface describing public data interactions with an exchange."""
-
     def fetch_symbol_filters(self) -> SymbolFilters:
         ...
 

--- a/data/exchanges/base/exchange_logger.py
+++ b/data/exchanges/base/exchange_logger.py
@@ -1,5 +1,3 @@
-"""Simple logger producing `HH:MM:SS message` formatted strings."""
-
 from datetime import datetime, timezone
 from typing import Callable, Optional
 
@@ -7,8 +5,6 @@ from .resync_reason import ResyncReason
 
 
 class ExchangeLogger:
-    """Simple logger producing `HH:MM:SS message` formatted strings."""
-
     def __init__(
         self,
         name: str,

--- a/data/exchanges/base/exchange_trade.py
+++ b/data/exchanges/base/exchange_trade.py
@@ -1,13 +1,9 @@
-"""Interface describing trading specific interaction with an exchange."""
-
 from typing import Protocol
 
 from domain.models import BalanceSource, ExecutionReport, MarginMode, Side, StopTrigger
 
 
 class IExchangeTrade(Protocol):
-    """Interface describing trading specific interaction with an exchange."""
-
     def get_balance(self, source: BalanceSource) -> float:
         ...
 

--- a/data/exchanges/base/resync_reason.py
+++ b/data/exchanges/base/resync_reason.py
@@ -1,11 +1,7 @@
-"""Reasons that can trigger a resynchronisation of the stream."""
-
 from enum import Enum
 
 
 class ResyncReason(str, Enum):
-    """Reasons that can trigger a resynchronisation of the stream."""
-
     SEQUENCE_GAP = "пропуск последовательности"
     QUEUE_OVERFLOW = "переполнение очереди"
     SILENCE_TIMEOUT = "таймаут тишины"

--- a/data/exchanges/base/stream_buffer.py
+++ b/data/exchanges/base/stream_buffer.py
@@ -1,5 +1,3 @@
-"""Thread-safe queue wrapper with heartbeat and timeout handling."""
-
 from __future__ import annotations
 
 import queue
@@ -16,8 +14,6 @@ T = TypeVar("T")
 
 
 class StreamBuffer(Generic[T]):
-    """Thread-safe queue wrapper with heartbeat and timeout handling."""
-
     def __init__(
         self,
         name: str,

--- a/data/exchanges/base/stream_event.py
+++ b/data/exchanges/base/stream_event.py
@@ -1,5 +1,3 @@
-"""Wrapper describing data, heartbeat and resync events coming from streams."""
-
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Generic, Optional, TypeVar
@@ -12,8 +10,6 @@ T = TypeVar("T")
 
 @dataclass(frozen=True, slots=True)
 class StreamEvent(Generic[T]):
-    """Wrapper describing data, heartbeat and resync events coming from streams."""
-
     type: StreamEventType
     data: Optional[T] = None
     reason: Optional[ResyncReason] = None

--- a/data/exchanges/base/stream_event_type.py
+++ b/data/exchanges/base/stream_event_type.py
@@ -1,11 +1,7 @@
-"""Type of event yielded by a streaming iterator."""
-
 from enum import Enum
 
 
 class StreamEventType(str, Enum):
-    """Type of event yielded by a streaming iterator."""
-
     DATA = "data"
     SNAPSHOT = "snapshot"
     HEARTBEAT = "heartbeat"

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -1,5 +1,3 @@
-"""Binance exchange data adapter implementing REST and WebSocket flows."""
-
 from __future__ import annotations
 
 import json
@@ -38,8 +36,6 @@ class BinanceEndpoints:
 
 
 class BinanceExchangeData:
-    """Implementation of :class:`IExchangeData` for Binance Futures."""
-
     def __init__(
         self,
         symbol: str,

--- a/data/exchanges/bybit.py
+++ b/data/exchanges/bybit.py
@@ -1,5 +1,3 @@
-"""Bybit exchange data adapter with REST and streaming support."""
-
 from __future__ import annotations
 
 import json
@@ -78,8 +76,6 @@ class DepthEnvelope:
 
 
 class BybitExchangeData:
-    """Public data adapter for Bybit linear perpetual instruments."""
-
     def __init__(
         self,
         symbol: str,

--- a/data/logger.py
+++ b/data/logger.py
@@ -1,5 +1,3 @@
-"""Log writing utilities for the data layer."""
-
 from __future__ import annotations
 
 from typing import Callable, TextIO, TYPE_CHECKING
@@ -16,8 +14,6 @@ def _print_sink(message: str) -> None:
 
 
 def create_text_log_sink(stream: TextIO | None = None) -> LogSink:
-    """Create a simple text sink that writes log strings to the given stream."""
-
     if stream is None:
         return _print_sink
 
@@ -29,8 +25,6 @@ def create_text_log_sink(stream: TextIO | None = None) -> LogSink:
 
 
 def create_log_writer(sink: LogSink | None = None) -> LogLineWriter:
-    """Create a writer that emits log entries in the ``HH:MM:SS Message`` format."""
-
     text_sink = sink or _print_sink
 
     def _write(entry: LogLine) -> None:

--- a/data/telegram.py
+++ b/data/telegram.py
@@ -1,5 +1,3 @@
-"""Telegram messaging client."""
-
 from __future__ import annotations
 
 import json
@@ -13,8 +11,6 @@ from config.secrets import SECRETS
 
 @dataclass(slots=True)
 class TelegramClient:
-    """Minimal client for sending messages via Telegram Bot API."""
-
     token: str
     chat_id: Optional[int]
     silent: bool

--- a/domain/book.py
+++ b/domain/book.py
@@ -1,5 +1,3 @@
-"""In-memory order book representation with recent band tracking."""
-
 from __future__ import annotations
 
 from bisect import bisect_left
@@ -14,8 +12,6 @@ from .models._timezone import ensure_current_timezone
 
 @dataclass(slots=True)
 class _StoredLevel:
-    """Mutable storage for a single order book level."""
-
     price: float
     quantity: float
     notional: float
@@ -25,8 +21,6 @@ class _StoredLevel:
     max_quantity_seen: float
 
     def update(self, *, quantity: float, timestamp: datetime) -> None:
-        """Update statistics for the level with the latest values."""
-
         ensure_current_timezone(timestamp)
         self.quantity = quantity
         self.notional = self.price * quantity
@@ -37,8 +31,6 @@ class _StoredLevel:
             self.max_quantity_seen = quantity
 
     def to_dataclass(self) -> OrderBookLevel:
-        """Convert mutable storage back to an immutable domain model."""
-
         return OrderBookLevel(
             price=self.price,
             quantity=self.quantity,
@@ -52,16 +44,12 @@ class _StoredLevel:
 
 @dataclass(slots=True)
 class _RecentBandEntry:
-    """Single entry in the recent band ring buffer."""
-
     price: float
     level_index: int
     timestamp: datetime
 
 
 class RecentBand:
-    """Ring buffer tracking recently touched price levels."""
-
     __slots__ = (
         "_capacity",
         "_entries",
@@ -83,8 +71,6 @@ class RecentBand:
         return self._count
 
     def clear(self) -> None:
-        """Remove all entries from the ring buffer."""
-
         self._entries = [None] * self._capacity
         self._next = 0
         self._count = 0
@@ -92,8 +78,6 @@ class RecentBand:
         self._index_slots.clear()
 
     def _locate_price(self, price: float) -> Tuple[int, Optional[int]]:
-        """Return index buffer location and stored slot for the price."""
-
         index_pos = bisect_left(self._index_prices, price)
         if (
             index_pos < len(self._index_prices)
@@ -103,8 +87,6 @@ class RecentBand:
         return index_pos, None
 
     def _remove_from_index(self, price: float) -> Optional[int]:
-        """Remove price from index buffers and return previous slot if any."""
-
         index_pos, slot = self._locate_price(price)
         if slot is None:
             return None
@@ -113,8 +95,6 @@ class RecentBand:
         return slot
 
     def _store_in_index(self, price: float, slot: int) -> None:
-        """Insert or update slot reference for the provided price."""
-
         index_pos, existing_slot = self._locate_price(price)
         if existing_slot is None:
             self._index_prices.insert(index_pos, price)
@@ -123,8 +103,6 @@ class RecentBand:
             self._index_slots[index_pos] = slot
 
     def record(self, price: float, level_index: int, timestamp: datetime) -> None:
-        """Store the latest state for the provided price level."""
-
         if self._capacity == 0:
             return
         ensure_current_timezone(timestamp)
@@ -150,8 +128,6 @@ class RecentBand:
         self._count += 1
 
     def discard(self, price: float) -> None:
-        """Remove a price level from the recent band if it exists."""
-
         slot = self._remove_from_index(price)
         if slot is None:
             return
@@ -161,14 +137,10 @@ class RecentBand:
             self._count -= 1
 
     def contains(self, price: float) -> bool:
-        """Check if the price is currently tracked in the recent band."""
-
         _, slot = self._locate_price(price)
         return slot is not None
 
     def iter_newest_first(self) -> Iterator[_RecentBandEntry]:
-        """Iterate over entries starting from the newest one."""
-
         if self._capacity == 0 or self._count == 0:
             return
         remaining = self._count
@@ -183,8 +155,6 @@ class RecentBand:
             visited += 1
 
     def iter_oldest_first(self) -> Iterator[_RecentBandEntry]:
-        """Iterate over entries starting from the oldest one."""
-
         if self._capacity == 0 or self._count == 0:
             return
         remaining = self._count
@@ -199,8 +169,6 @@ class RecentBand:
             visited += 1
 
     def latest_level_index(self, price: float) -> Optional[int]:
-        """Return the last recorded position for the provided price."""
-
         _, slot = self._locate_price(price)
         if slot is None:
             return None
@@ -209,8 +177,6 @@ class RecentBand:
 
 
 class _BookSide:
-    """Order book side with sorted levels and recent band membership."""
-
     __slots__ = (
         "_side",
         "_levels",
@@ -284,8 +250,6 @@ class _BookSide:
         )
 
     def update_level(self, level: OrderBookLevel) -> None:
-        """Insert or update a single level based on an incremental event."""
-
         price = level.price
         if level.quantity <= 0:
             self.remove_level(price)
@@ -318,8 +282,6 @@ class _BookSide:
         self._recent_band.record(price, index, timestamp)
 
     def remove_level(self, price: float) -> None:
-        """Remove a level from the side if present."""
-
         _, index = self._locate_price(price)
         if index is None:
             return
@@ -330,8 +292,6 @@ class _BookSide:
         self._recent_band.discard(price)
 
     def replace_levels(self, levels: Iterable[OrderBookLevel]) -> None:
-        """Replace current side state with provided levels (snapshot)."""
-
         self._levels = []
         self._sort_keys = []
         self._index_prices = []
@@ -349,15 +309,11 @@ class _BookSide:
         return iter(self._levels)
 
     def iter_recent_levels(self) -> Iterator[_StoredLevel]:
-        """Yield levels that are currently inside the recent band."""
-
         for level in self._levels:
             if self._recent_band.contains(level.price):
                 yield level
 
     def find_nearest_wall(self, *, min_notional: float) -> Optional[_StoredLevel]:
-        """Return first level inside the recent band exceeding the threshold."""
-
         for level in self._levels:
             if not self._recent_band.contains(level.price):
                 continue
@@ -370,8 +326,6 @@ class _BookSide:
 
 
 class OrderBook:
-    """Aggregated bid/ask sides with helpers for recent band operations."""
-
     __slots__ = ("_bids", "_asks")
 
     def __init__(self, *, recent_band_capacity: int = 128) -> None:
@@ -387,29 +341,21 @@ class OrderBook:
         return self._asks
 
     def apply_snapshot(self, snapshot: OrderBookSnapshot) -> None:
-        """Reset the order book using a full snapshot."""
-
         self._bids.replace_levels(snapshot.bids)
         self._asks.replace_levels(snapshot.asks)
 
     def apply_update(self, update: OrderBookUpdate) -> None:
-        """Apply incremental changes to both sides of the order book."""
-
         for level in update.bids:
             self._bids.update_level(level)
         for level in update.asks:
             self._asks.update_level(level)
 
     def iter_recent_band(self, side: Side) -> Iterator[OrderBookLevel]:
-        """Iterate over levels inside the recent band for the requested side."""
-
         book_side = self._bids if side is Side.BID else self._asks
         for level in book_side.iter_recent_levels():
             yield level.to_dataclass()
 
     def find_nearest_wall(self, *, side: Side, min_notional: float) -> Optional[OrderBookLevel]:
-        """Return nearest wall candidate on provided side within recent band."""
-
         book_side = self._bids if side is Side.BID else self._asks
         level = book_side.find_nearest_wall(min_notional=min_notional)
         return None if level is None else level.to_dataclass()

--- a/domain/detectors.py
+++ b/domain/detectors.py
@@ -1,5 +1,3 @@
-"""Business logic for detecting pressure and wall conditions."""
-
 from __future__ import annotations
 
 from collections import deque
@@ -20,8 +18,6 @@ from utils import compute_odr_weight, get_current_time, median_filter_of_three
 
 
 def compute_odr(book: OrderBook, last_price: float, tick_size: float) -> Pressure:
-    """Compute order book pressure metrics using weighted levels."""
-
     bid_levels: Tuple[OrderBookLevel, ...] = _collect_levels(
         book.iter_recent_band(Side.BID),
         book.best_bid(),
@@ -43,16 +39,12 @@ def compute_odr(book: OrderBook, last_price: float, tick_size: float) -> Pressur
 
 
 def check_if_has_pressure(pressure: Pressure, want_long: bool) -> bool:
-    """Check if pressure conditions satisfy desired trade direction."""
-
     if want_long:
         return pressure.imbalance_ratio <= CONFIG.odr.odr_in_long
     return pressure.imbalance_ratio >= CONFIG.odr.odr_in_short
 
 
 def check_if_price_recent(level_price: float, recent_low: float, recent_high: float) -> bool:
-    """Return True if price stays within the recent traded band."""
-
     return recent_low <= level_price <= recent_high
 
 
@@ -64,8 +56,6 @@ def check_if_is_large_wall(
     persist_s: float,
     now: datetime,
 ) -> bool:
-    """Validate if an order book level qualifies as a large wall."""
-
     lifetime: timedelta = now - level.first_seen_at
     if lifetime < timedelta(seconds=persist_s):
         return False
@@ -77,8 +67,6 @@ def check_if_is_large_wall(
 
 
 def check_if_has_near_wall(book: OrderBook, side_stop: Side) -> Optional[Wall]:
-    """Return nearest significant wall on the stop side if present."""
-
     abs_threshold: float = _resolve_absolute_threshold(CONFIG.general.profile)
     level: Optional[OrderBookLevel] = book.find_nearest_wall(
         side=side_stop,
@@ -111,8 +99,6 @@ def check_if_has_near_wall(book: OrderBook, side_stop: Side) -> Optional[Wall]:
 
 
 def check_if_has_opposite_wall(book: OrderBook, side_move: Side, our_wall: Wall) -> bool:
-    """Determine if an opposing wall blocks the intended move."""
-
     opposite_side: Side = Side.ASK if side_move is Side.BID else Side.BID
     abs_threshold: float = _resolve_absolute_threshold(CONFIG.general.profile)
     level: Optional[OrderBookLevel] = book.find_nearest_wall(

--- a/domain/execution.py
+++ b/domain/execution.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-"""Order execution helpers coordinating trades with the adapter."""
-
 from typing import Callable, Optional, Tuple
 
 from config.config import CONFIG

--- a/domain/models/__init__.py
+++ b/domain/models/__init__.py
@@ -1,5 +1,3 @@
-"""Domain models exposed by the trading bot."""
-
 from .candle import Candle
 from .enums import BalanceSource, Exchange, MarginMode, Side, Signal, StopTrigger
 from .execution import ExecutionReport

--- a/domain/models/_timezone.py
+++ b/domain/models/_timezone.py
@@ -1,5 +1,3 @@
-"""Utilities for working with timezone-aware datetimes in domain models."""
-
 from __future__ import annotations
 
 from datetime import datetime
@@ -9,8 +7,6 @@ from config.timezone import BELGRADE_TIMEZONE
 
 
 def ensure_current_timezone(*values: datetime) -> None:
-    """Ensure that all provided datetimes use the configured timezone."""
-
     for value in values:
         if value.tzinfo is None:
             raise ValueError("datetime must be timezone-aware")

--- a/domain/models/candle.py
+++ b/domain/models/candle.py
@@ -1,5 +1,3 @@
-"""Models describing candlestick data."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -10,8 +8,6 @@ from ._timezone import ensure_current_timezone
 
 @dataclass(frozen=True, slots=True)
 class Candle:
-    """Single OHLCV candle aggregated over a fixed interval."""
-
     open_time: datetime
     close_time: datetime
     open_price: float

--- a/domain/models/enums.py
+++ b/domain/models/enums.py
@@ -1,48 +1,33 @@
-"""Enumerations shared across domain models."""
-
 from __future__ import annotations
-
 from enum import Enum
 
 
 class Exchange(str, Enum):
-    """Supported trading venues."""
-
     BINANCE = "binance"
     BYBIT = "bybit"
 
 
 class MarginMode(str, Enum):
-    """Account margin configuration."""
-
     ISOLATED = "isolated"
     CROSS = "cross"
 
 
 class BalanceSource(str, Enum):
-    """Different balance sources exposed by exchanges."""
-
     AVAILABLE = "available_balance"
     WALLET = "wallet_balance"
 
 
 class StopTrigger(str, Enum):
-    """Price reference used for stop orders."""
-
     MARK = "mark_price"
     LAST = "last_price"
 
 
 class Side(str, Enum):
-    """Order side or book direction."""
-
     BID = "bid"
     ASK = "ask"
 
 
 class Signal(str, Enum):
-    """Trading signal direction."""
-
     NONE = "none"
     LONG = "long"
     SHORT = "short"

--- a/domain/models/execution.py
+++ b/domain/models/execution.py
@@ -1,5 +1,3 @@
-"""Models related to order execution reporting."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -11,8 +9,6 @@ from .enums import Exchange, Side
 
 @dataclass(frozen=True, slots=True)
 class ExecutionReport:
-    """Execution result for a placed order."""
-
     exchange: Exchange
     symbol: str
     order_id: str

--- a/domain/models/log.py
+++ b/domain/models/log.py
@@ -1,5 +1,3 @@
-"""Models representing structured log entries."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -10,8 +8,6 @@ from ._timezone import ensure_current_timezone
 
 @dataclass(frozen=True, slots=True)
 class LogLine:
-    """Structured log line produced by the application."""
-
     timestamp: datetime
     message: str
     level: str

--- a/domain/models/order_book.py
+++ b/domain/models/order_book.py
@@ -1,5 +1,3 @@
-"""Order book related domain models."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -12,8 +10,6 @@ from .enums import Exchange
 
 @dataclass(frozen=True, slots=True)
 class OrderBookLevel:
-    """Represents a single price level in the order book."""
-
     price: float
     quantity: float
     notional: float
@@ -28,8 +24,6 @@ class OrderBookLevel:
 
 @dataclass(frozen=True, slots=True)
 class OrderBookSnapshot:
-    """Full snapshot of the order book provided by the exchange."""
-
     exchange: Exchange
     symbol: str
     last_update_id: int
@@ -43,8 +37,6 @@ class OrderBookSnapshot:
 
 @dataclass(frozen=True, slots=True)
 class OrderBookUpdate:
-    """Incremental order book update event."""
-
     exchange: Exchange
     symbol: str
     first_update_id: int

--- a/domain/models/position.py
+++ b/domain/models/position.py
@@ -1,5 +1,3 @@
-"""Models representing trading positions."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -11,8 +9,6 @@ from .enums import Exchange, MarginMode, Side
 
 @dataclass(frozen=True, slots=True)
 class Position:
-    """Open derivatives position tracked by the bot."""
-
     exchange: Exchange
     symbol: str
     side: Side

--- a/domain/models/pressure.py
+++ b/domain/models/pressure.py
@@ -1,5 +1,3 @@
-"""Models capturing order book pressure metrics."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -10,8 +8,6 @@ from ._timezone import ensure_current_timezone
 
 @dataclass(frozen=True, slots=True)
 class Pressure:
-    """Pressure metrics derived from the order book."""
-
     computed_at: datetime
     buy_pressure: float
     sell_pressure: float

--- a/domain/models/symbol.py
+++ b/domain/models/symbol.py
@@ -1,5 +1,3 @@
-"""Trading symbol configuration models."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -9,8 +7,6 @@ from .enums import Exchange
 
 @dataclass(frozen=True, slots=True)
 class SymbolFilters:
-    """Exchange-specific symbol filters and trading limits."""
-
     exchange: Exchange
     symbol: str
     base_asset: str

--- a/domain/models/trade.py
+++ b/domain/models/trade.py
@@ -1,5 +1,3 @@
-"""Models describing trade executions."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -11,8 +9,6 @@ from .enums import Exchange, Side
 
 @dataclass(frozen=True, slots=True)
 class Trade:
-    """Aggregated trade information received from the exchange."""
-
     trade_id: str
     exchange: Exchange
     symbol: str

--- a/domain/models/wall.py
+++ b/domain/models/wall.py
@@ -1,5 +1,3 @@
-"""Models describing large order book walls."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -11,8 +9,6 @@ from .enums import Exchange, Side
 
 @dataclass(frozen=True, slots=True)
 class Wall:
-    """Order book wall representation tracked by the strategy."""
-
     exchange: Exchange
     symbol: str
     side: Side

--- a/domain/strategy/__init__.py
+++ b/domain/strategy/__init__.py
@@ -1,5 +1,3 @@
-"""Strategy package exports."""
-
 from .event_logger import EventLogger
 from .focus import FocusController
 from .observation import MarketObservation

--- a/domain/strategy/event_logger.py
+++ b/domain/strategy/event_logger.py
@@ -1,5 +1,3 @@
-"""Event logging helper for the strategy."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -12,8 +10,6 @@ from .types import LogWriter
 
 @dataclass
 class EventLogger:
-    """Wrapper that records strategy events via the configured log writer."""
-
     write: LogWriter
 
     def log(self, message: str, timestamp: datetime) -> None:

--- a/domain/strategy/focus.py
+++ b/domain/strategy/focus.py
@@ -1,5 +1,3 @@
-"""Focus management for the strategy."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -12,8 +10,6 @@ from .types import DefocusHandler, FocusHandler
 
 @dataclass
 class FocusController:
-    """Controls which symbol the strategy is currently focused on."""
-
     focus_symbol: FocusHandler
     defocus_symbol: DefocusHandler
     logger: EventLogger

--- a/domain/strategy/observation.py
+++ b/domain/strategy/observation.py
@@ -1,5 +1,3 @@
-"""Market observation model used by the strategy."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -14,8 +12,6 @@ from .resync import FeedStatus
 
 @dataclass(frozen=True)
 class MarketObservation:
-    """Aggregated market data snapshot for the strategy decision loop."""
-
     timestamp: datetime
     symbol: str
     last_price: float

--- a/domain/strategy/position.py
+++ b/domain/strategy/position.py
@@ -1,5 +1,3 @@
-"""Position management helpers."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -13,8 +11,6 @@ from .types import PositionEntryHandler, PositionExitHandler, StopMoveHandler
 
 @dataclass
 class PositionController:
-    """Encapsulates position entry, exit, and stop management."""
-
     enter_position: PositionEntryHandler
     exit_position: PositionExitHandler
     move_stop: StopMoveHandler

--- a/domain/strategy/resync.py
+++ b/domain/strategy/resync.py
@@ -1,5 +1,3 @@
-"""Resynchronisation domain concepts."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -8,8 +6,6 @@ from typing import Optional
 
 
 class ResyncReason(str, Enum):
-    """Enumerates reasons that trigger an order book resynchronisation."""
-
     SEQUENCE_GAP = "пропуск последовательности"
     SILENCE = "тишина канала"
     BACKPRESSURE = "переполнение очереди"
@@ -17,15 +13,11 @@ class ResyncReason(str, Enum):
 
 @dataclass(frozen=True)
 class FeedStatus:
-    """Snapshot of the current feed health state."""
-
     has_sequence_gap: bool = False
     has_silence_timeout: bool = False
     has_queue_overflow: bool = False
 
     def resolve_reason(self) -> Optional[ResyncReason]:
-        """Return the first detected resync reason if any."""
-
         if self.has_sequence_gap:
             return ResyncReason.SEQUENCE_GAP
         if self.has_silence_timeout:

--- a/domain/strategy/state.py
+++ b/domain/strategy/state.py
@@ -1,13 +1,9 @@
-"""Strategy state definitions."""
-
 from __future__ import annotations
 
 from enum import Enum
 
 
 class StrategyState(str, Enum):
-    """Finite state machine states for the trading strategy."""
-
     SCANNING = "scanning"
     FOCUSED = "focused"
     IN_POSITION = "in_position"

--- a/domain/strategy/strategy.py
+++ b/domain/strategy/strategy.py
@@ -1,7 +1,4 @@
-"""Finite state machine implementing the uptick trading strategy."""
-
 from __future__ import annotations
-
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -21,7 +18,6 @@ from .types import ResyncHandler
 
 
 class Strategy:
-    """Coordinates market observations with position management actions."""
 
     def __init__(
         self,

--- a/domain/strategy/subscription.py
+++ b/domain/strategy/subscription.py
@@ -1,5 +1,3 @@
-"""Subscription management for the strategy."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -12,8 +10,6 @@ from .types import SubscriptionHandler
 
 @dataclass
 class SubscriptionManager:
-    """Keeps external data feed subscriptions in sync with strategy needs."""
-
     subscribe: SubscriptionHandler
     unsubscribe: SubscriptionHandler
     logger: EventLogger

--- a/domain/strategy/telegram.py
+++ b/domain/strategy/telegram.py
@@ -1,5 +1,3 @@
-"""Telegram notifications for the strategy."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -12,8 +10,6 @@ from .types import TelegramHandler
 
 @dataclass
 class TelegramNotifier:
-    """Sends strategy updates via Telegram."""
-
     send_message: TelegramHandler
 
     def notify_uptick(self, symbol: str, signal: Signal, timestamp: datetime) -> None:

--- a/domain/strategy/types.py
+++ b/domain/strategy/types.py
@@ -1,5 +1,3 @@
-"""Callable type aliases used by the strategy components."""
-
 from __future__ import annotations
 
 from typing import Callable

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,5 +1,3 @@
-"""Utility helpers used by the trading bot."""
-
 from .formatting import format_money, format_number
 from .mathx import (
     ceil_to_step,

--- a/utils/formatting.py
+++ b/utils/formatting.py
@@ -1,5 +1,3 @@
-"""Formatting helpers for logging numeric values."""
-
 from __future__ import annotations
 
 import math

--- a/utils/mathx.py
+++ b/utils/mathx.py
@@ -1,5 +1,3 @@
-"""Mathematical helpers for the trading domain."""
-
 from __future__ import annotations
 
 import math
@@ -7,8 +5,6 @@ from typing import Sequence, Tuple
 
 
 def median_filter_of_three(values: Sequence[float]) -> Tuple[float, ...]:
-    """Return a sequence smoothed by a median-of-three filter."""
-
     length: int = len(values)
     if length == 0:
         return ()
@@ -28,8 +24,6 @@ def median_filter_of_three(values: Sequence[float]) -> Tuple[float, ...]:
 
 
 def compute_odr_weight(price: float, reference_price: float, tick_size: float) -> float:
-    """Return a decay weight based on distance between two prices."""
-
     if tick_size <= 0.0:
         raise ValueError("tick_size must be positive")
     distance_ticks: float = abs(price - reference_price) / tick_size

--- a/utils/timez.py
+++ b/utils/timez.py
@@ -1,5 +1,3 @@
-"""Timezone-aware datetime helpers."""
-
 from __future__ import annotations
 
 import math
@@ -17,15 +15,11 @@ _MILLI_THRESHOLD: Decimal = Decimal("1000000000000")
 
 
 def get_current_time() -> datetime:
-    """Return the current time in the configured timezone."""
-
     current: datetime = datetime.now(BELGRADE_TIMEZONE)
     return current
 
 
 def from_exchange_timestamp(timestamp: NumberLike) -> datetime:
-    """Convert a raw exchange timestamp to a timezone-aware datetime."""
-
     seconds: Decimal = _normalize_to_seconds(timestamp)
     return datetime.fromtimestamp(float(seconds), BELGRADE_TIMEZONE)
 


### PR DESCRIPTION
## Summary
- remove module, class, and function docstrings throughout configuration, domain, data, and utility modules
- clean up surrounding whitespace and imports after docstring removal to keep linting happy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfdfcb813c8320ab9a6ee633e0c52e