### PR TITLE
Ensure exchange data uses configured timezone

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from typing import Optional, Sequence, Tuple, cast
 from config.config import CONFIG
 from config.models.exchange_name import ExchangeName
 from config.secrets import SECRETS
-from config.timezone import BELGRADE_TIMEZONE
+from config.timezone import CURRENT_TIMEZONE
 from data.exchanges import (
     BestBidAsk,
     BinanceExchangeData,
@@ -150,7 +150,7 @@ class Application:
     def _handle_resync(self, reason: StrategyResyncReason) -> None:
         snapshot = self._exchange_data.fetch_orderbook_snapshot()
         self._apply_snapshot(snapshot)
-        timestamp = snapshot.received_at.astimezone(BELGRADE_TIMEZONE)
+        timestamp = snapshot.received_at.astimezone(CURRENT_TIMEZONE)
         self._feed_monitor.clear()
         self._strategy.complete_resync(timestamp)
 

--- a/config/timezone.py
+++ b/config/timezone.py
@@ -3,6 +3,6 @@ from __future__ import annotations
 from typing import Final
 from zoneinfo import ZoneInfo
 
-BELGRADE_TIMEZONE: Final[ZoneInfo] = ZoneInfo("Europe/Belgrade")
+CURRENT_TIMEZONE: Final[ZoneInfo] = ZoneInfo("Europe/Belgrade")
 
-__all__ = ["BELGRADE_TIMEZONE"]
+__all__ = ["CURRENT_TIMEZONE"]

--- a/data/exchanges/base/exchange_logger.py
+++ b/data/exchanges/base/exchange_logger.py
@@ -1,7 +1,8 @@
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Callable, Optional
 
 from .resync_reason import ResyncReason
+from utils.timez import get_current_time
 
 
 class ExchangeLogger:
@@ -14,7 +15,7 @@ class ExchangeLogger:
         self._writer = writer
 
     def log(self, message: str) -> None:
-        timestamp = datetime.now(timezone.utc).astimezone()
+        timestamp = get_current_time().astimezone()
         formatted = f"{timestamp:%H:%M:%S} {message}"
         if self._writer:
             self._writer(formatted)

--- a/data/exchanges/base/stream_event.py
+++ b/data/exchanges/base/stream_event.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Generic, Optional, TypeVar
 
 from .resync_reason import ResyncReason
 from .stream_event_type import StreamEventType
+from utils.timez import get_current_time
 
 T = TypeVar("T")
 
@@ -14,7 +15,7 @@ class StreamEvent(Generic[T]):
     data: Optional[T] = None
     reason: Optional[ResyncReason] = None
     details: Optional[str] = None
-    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    timestamp: datetime = field(default_factory=get_current_time)
 
     @classmethod
     def data_event(cls, payload: T) -> "StreamEvent[T]":

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -4,7 +4,7 @@ import json
 import threading
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Callable, Iterable, Iterator, Optional, Protocol
 from urllib import parse
 from urllib.request import Request, urlopen
@@ -28,6 +28,7 @@ from .base import (
     StreamBuffer,
     StreamEvent,
 )
+from utils.timez import from_exchange_timestamp, get_current_time
 
 
 @dataclass(slots=True)
@@ -111,7 +112,7 @@ class BinanceExchangeData:
             {"symbol": self.symbol, "limit": self._depth_limit},
         )
         last_update_id = int(data["lastUpdateId"])
-        now = datetime.now(timezone.utc)
+        now = get_current_time()
         bids = tuple(
             self._build_level(float(price), float(qty), now)
             for price, qty in data.get("bids", [])
@@ -199,7 +200,7 @@ class BinanceExchangeData:
         first_update = int(message.get("U", 0))
         last_update = int(message.get("u", 0))
         prev_update = int(message.get("pu", first_update - 1))
-        event_time = datetime.fromtimestamp(message.get("E", 0) / 1000.0, tz=timezone.utc)
+        event_time = from_exchange_timestamp(message.get("E", 0) / 1000.0)
 
         with self._lock:
             expected = None if self._depth_last_update is None else self._depth_last_update + 1
@@ -378,7 +379,7 @@ class BinanceExchangeData:
     def _parse_book_ticker(self, message: dict[str, Any]) -> Iterable[BestBidAsk]:
         if message.get("s") != self.symbol:
             return ()
-        event_time = datetime.fromtimestamp(message.get("E", 0) / 1000.0, tz=timezone.utc)
+        event_time = from_exchange_timestamp(message.get("E", 0) / 1000.0)
         return (
             BestBidAsk(
                 exchange=Exchange.BINANCE.value,
@@ -394,7 +395,7 @@ class BinanceExchangeData:
     def _parse_trade(self, message: dict[str, Any]) -> Iterable[Trade]:
         if message.get("s") != self.symbol:
             return ()
-        event_time = datetime.fromtimestamp(message.get("T", 0) / 1000.0, tz=timezone.utc)
+        event_time = from_exchange_timestamp(message.get("T", 0) / 1000.0)
         side = Side.ASK if message.get("m", False) else Side.BID
         return (
             Trade(
@@ -414,8 +415,8 @@ class BinanceExchangeData:
         payload = message.get("k") or {}
         if payload.get("s") != self.symbol:
             return ()
-        open_time = datetime.fromtimestamp(payload.get("t", 0) / 1000.0, tz=timezone.utc)
-        close_time = datetime.fromtimestamp(payload.get("T", 0) / 1000.0, tz=timezone.utc)
+        open_time = from_exchange_timestamp(payload.get("t", 0) / 1000.0)
+        close_time = from_exchange_timestamp(payload.get("T", 0) / 1000.0)
         return (
             Candle(
                 open_time=open_time,

--- a/data/exchanges/bybit.py
+++ b/data/exchanges/bybit.py
@@ -4,7 +4,7 @@ import json
 import threading
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import (
     Any,
     Callable,
@@ -38,6 +38,7 @@ from .base import (
     StreamBuffer,
     StreamEvent,
 )
+from utils.timez import from_exchange_timestamp, get_current_time
 
 
 @dataclass(slots=True)
@@ -169,7 +170,7 @@ class BybitExchangeData:
         bids_raw = result.get("b") or result.get("bids") or []
         asks_raw = result.get("a") or result.get("asks") or []
         seq = int(result.get("u") or result.get("seq") or 0)
-        now = datetime.now(timezone.utc)
+        now = get_current_time()
         bids = tuple(
             self._build_level(price, quantity, now)
             for price, quantity in self._normalize_levels(bids_raw)
@@ -326,7 +327,7 @@ class BybitExchangeData:
             message.get("ts"),
             payload.get("ts"),
         )
-        event_time = datetime.fromtimestamp(timestamp_ms / 1000.0, tz=timezone.utc)
+        event_time = from_exchange_timestamp(timestamp_ms / 1000.0)
         return DepthEnvelope(
             payload=payload,
             sequence=sequence,
@@ -626,9 +627,8 @@ class BybitExchangeData:
             entries = list(data)
         results: list[BestBidAsk] = []
         for payload in entries:
-            event_time = datetime.fromtimestamp(
-                (payload.get("ts") or message.get("ts") or 0) / 1000.0,
-                tz=timezone.utc,
+            event_time = from_exchange_timestamp(
+                (payload.get("ts") or message.get("ts") or 0) / 1000.0
             )
             results.append(
                 BestBidAsk(
@@ -651,7 +651,7 @@ class BybitExchangeData:
             entries = list(data)
         trades: list[Trade] = []
         for payload in entries:
-            event_time = datetime.fromtimestamp(payload.get("T", 0) / 1000.0, tz=timezone.utc)
+            event_time = from_exchange_timestamp(payload.get("T", 0) / 1000.0)
             side_value = payload.get("S") or payload.get("side")
             side = Side.BID if str(side_value).lower() in ("buy", "bid", "true") else Side.ASK
             trades.append(
@@ -677,8 +677,8 @@ class BybitExchangeData:
         for payload in entries:
             open_raw = payload.get("start") or payload.get("t") or payload.get("openTime") or 0
             close_raw = payload.get("end") or payload.get("T") or payload.get("closeTime") or 0
-            open_time = datetime.fromtimestamp(open_raw / 1000.0, tz=timezone.utc)
-            close_time = datetime.fromtimestamp(close_raw / 1000.0, tz=timezone.utc)
+            open_time = from_exchange_timestamp(open_raw / 1000.0)
+            close_time = from_exchange_timestamp(close_raw / 1000.0)
             candles.append(
                 Candle(
                     open_time=open_time,

--- a/domain/models/_timezone.py
+++ b/domain/models/_timezone.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-from config.timezone import BELGRADE_TIMEZONE
+from config.timezone import CURRENT_TIMEZONE
 
 
 def ensure_current_timezone(*values: datetime) -> None:
@@ -13,11 +13,15 @@ def ensure_current_timezone(*values: datetime) -> None:
         tzinfo = value.tzinfo
         match tzinfo:
             case ZoneInfo(key=key):
-                if key != BELGRADE_TIMEZONE.key:
-                    raise ValueError("datetime must use Europe/Belgrade timezone")
+                if key != CURRENT_TIMEZONE.key:
+                    raise ValueError(
+                        f"datetime must use {CURRENT_TIMEZONE.key} timezone"
+                    )
             case _:
-                if tzinfo != BELGRADE_TIMEZONE:
-                    raise ValueError("datetime must use Europe/Belgrade timezone")
+                if tzinfo != CURRENT_TIMEZONE:
+                    raise ValueError(
+                        f"datetime must use {CURRENT_TIMEZONE.key} timezone"
+                    )
 
 
 __all__ = ["ensure_current_timezone"]

--- a/utils/timez.py
+++ b/utils/timez.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from decimal import Decimal, DecimalException
 from typing import Union
 
-from config.timezone import BELGRADE_TIMEZONE
+from config.timezone import CURRENT_TIMEZONE
 
 NumberLike = Union[int, float, str, Decimal]
 
@@ -15,13 +15,13 @@ _MILLI_THRESHOLD: Decimal = Decimal("1000000000000")
 
 
 def get_current_time() -> datetime:
-    current: datetime = datetime.now(BELGRADE_TIMEZONE)
+    current: datetime = datetime.now(CURRENT_TIMEZONE)
     return current
 
 
 def from_exchange_timestamp(timestamp: NumberLike) -> datetime:
     seconds: Decimal = _normalize_to_seconds(timestamp)
-    return datetime.fromtimestamp(float(seconds), BELGRADE_TIMEZONE)
+    return datetime.fromtimestamp(float(seconds), CURRENT_TIMEZONE)
 
 
 def _normalize_to_seconds(timestamp: NumberLike) -> Decimal:


### PR DESCRIPTION
## Summary
- rename the timezone constant to CURRENT_TIMEZONE
- update exchange adapters and helpers to produce timezone-aware datetimes in the configured zone
- use shared helpers for current time and timestamp conversion across exchange logging and stream events

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e01554442c8320b0e0754519f9dbcd