### PR TITLE
Document config model module

### DIFF
--- a/config/models/config_model.py
+++ b/config/models/config_model.py
@@ -1,3 +1,5 @@
+"""Aggregated configuration dataclass wiring domain settings."""
+
 from dataclasses import dataclass
 
 from .focus_settings import FocusSettings


### PR DESCRIPTION
## Summary
- add a module docstring that explains the purpose of the `Config` dataclass aggregator
- confirm the module explicitly imports `dataclass` for the decorator

## Testing
- python -m compileall config/models/config_model.py

------
https://chatgpt.com/codex/tasks/task_e_68e018d7053c8320955768fb4f161de6