### PR TITLE
Add future annotations import to config

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Final
 
 from .models import (


### PR DESCRIPTION
## Summary
- add `from __future__ import annotations` to `config/config.py` so the configuration module can use forward references cleanly alongside the existing `Final` annotation

## Testing
- python -m compileall config/config.py

------
https://chatgpt.com/codex/tasks/task_e_68e018e57ea48320b1ec6ebac8433f99