### PR TITLE
Add lifecycle logs for uptick flow

### DIFF
--- a/app.py
+++ b/app.py
@@ -79,10 +79,28 @@ class Application:
             logger=self._event_logger,
         )
         self._exchange = Exchange(CONFIG.general.exchange.value)
+        startup_timestamp = get_current_time()
+        self._event_logger.log(
+            f"{startup_timestamp:%H:%M:%S} Старт бота для {self._symbol} на {self._exchange.value}.",
+            startup_timestamp,
+        )
         self._exchange_data = self._create_exchange_data()
         self._filters = self._exchange_data.fetch_symbol_filters()
+        filters_timestamp = get_current_time()
+        self._event_logger.log(
+            (
+                f"{filters_timestamp:%H:%M:%S} Получены фильтры {self._symbol}: "
+                f"шаг цены {self._filters.price_tick_size:g}."
+            ),
+            filters_timestamp,
+        )
         self._trading_adapter = NoopTradingAdapter(self._exchange, self._symbol)
         initialize_account(self._trading_adapter)
+        account_timestamp = get_current_time()
+        self._event_logger.log(
+            f"{account_timestamp:%H:%M:%S} Торговый адаптер инициализирован для {self._symbol}.",
+            account_timestamp,
+        )
         entry, exit_, move_stop = create_execution_handlers(
             self._trading_adapter,
             self._provide_filters,
@@ -171,6 +189,14 @@ class Application:
         self._order_book.apply_snapshot(snapshot)
         self._last_update_id = snapshot.last_update_id
         self._update_best_from_book()
+        timestamp = snapshot.received_at
+        self._event_logger.log(
+            (
+                f"{timestamp:%H:%M:%S} Снимок стакана применён. "
+                f"ID {snapshot.last_update_id}."
+            ),
+            timestamp,
+        )
 
     def _apply_update(self, update: OrderBookUpdate) -> None:
         if self._last_update_id is None:
@@ -208,6 +234,15 @@ class Application:
         elif event.type is StreamEventType.RESYNC and event.reason is not None:
             self._feed_monitor.flag(event.reason)
             self._last_update_id = None
+            timestamp = event.timestamp.astimezone(CURRENT_TIMEZONE)
+            details = f" {event.details}." if event.details else ""
+            self._event_logger.log(
+                (
+                    f"{timestamp:%H:%M:%S} Поток стакана требует ресинк: "
+                    f"{event.reason.value}.{details}"
+                ),
+                timestamp,
+            )
 
     def _process_trade_stream(self) -> None:
         event = next(self._trade_stream)
@@ -282,6 +317,11 @@ class Application:
 
     def run(self) -> None:
         interval = CONFIG.general.loop_interval_ms / 1000.0
+        start_timestamp = get_current_time()
+        self._event_logger.log(
+            f"{start_timestamp:%H:%M:%S} Запущен цикл обработки для {self._symbol}.",
+            start_timestamp,
+        )
         while True:
             self._process_depth_stream()
             self._process_trade_stream()

--- a/domain/strategy/strategy.py
+++ b/domain/strategy/strategy.py
@@ -116,6 +116,10 @@ class Strategy:
                     self._last_focus_signal_at = timestamp
                     self._focused_wall = wall
         if self._should_defocus(timestamp):
+            self._logger.log(
+                f"{timestamp:%H:%M:%S} Аптик {observation.symbol} потерян: таймаут сигнала.",
+                timestamp,
+            )
             self._focus.defocus(timestamp)
             self._focused_signal = Signal.NONE
             self._focused_wall = None
@@ -168,6 +172,14 @@ class Strategy:
         self._focused_signal = signal
         self._focused_wall = wall
         self._last_focus_signal_at = timestamp
+        direction = "лонг" if signal is Signal.LONG else "шорт"
+        self._logger.log(
+            (
+                f"{timestamp:%H:%M:%S} Аптик {symbol} {direction}. "
+                f"Стена {wall.price:g} объём {wall.notional:g}."
+            ),
+            timestamp,
+        )
         if self._should_notify_uptick(timestamp):
             self._notifier.notify_uptick(symbol, signal, timestamp)
             self._last_uptick_at = timestamp


### PR DESCRIPTION
## Summary
- log application startup, snapshot handling, and resync triggers to trace lifecycle stages
- record uptick detection and loss events in the strategy for clearer signal tracking

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e01bc1c24c8320acd538fa801f4664