### PR TITLE
Propagate exit reason to trading adapter

### DIFF
--- a/application/trading.py
+++ b/application/trading.py
@@ -17,8 +17,17 @@ class NoopTradingAdapter(TradingAdapter):
     def set_leverage(self, leverage: int, margin_mode: MarginMode) -> None:
         return
 
-    def place_market(self, side: Side, quantity: float) -> ExecutionReport:
+    def place_market(
+        self,
+        side: Side,
+        quantity: float,
+        *,
+        reason: str | None = None,
+    ) -> ExecutionReport:
         executed_at = get_current_time()
+        if reason:
+            # Preserve exit reason context for observability during development.
+            print(f"[noop] market order reason: {reason}")
         return ExecutionReport(
             exchange=self._exchange,
             symbol=self._symbol,

--- a/data/exchanges/base/exchange_trade.py
+++ b/data/exchanges/base/exchange_trade.py
@@ -1,4 +1,4 @@
-from typing import Protocol
+from typing import Optional, Protocol
 
 from domain.models import BalanceSource, ExecutionReport, MarginMode, Side, StopTrigger
 
@@ -10,7 +10,13 @@ class IExchangeTrade(Protocol):
     def set_leverage(self, leverage: int, margin_mode: MarginMode) -> None:
         ...
 
-    def place_market(self, side: Side, quantity: float) -> ExecutionReport:
+    def place_market(
+        self,
+        side: Side,
+        quantity: float,
+        *,
+        reason: Optional[str] = None,
+    ) -> ExecutionReport:
         ...
 
     def place_stop_market(

--- a/domain/execution.py
+++ b/domain/execution.py
@@ -82,7 +82,7 @@ def create_execution_handlers(
             current_quantity = 0.0
             return
         side: Side = _signal_to_exit_side(current_signal)
-        trading.place_market(side, current_quantity)
+        trading.place_market(side, current_quantity, reason=reason)
         current_symbol = None
         current_signal = Signal.NONE
         current_quantity = 0.0

--- a/domain/trading_adapter.py
+++ b/domain/trading_adapter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Optional, Protocol
 
 from domain.models import BalanceSource, ExecutionReport, MarginMode, Side, StopTrigger
 
@@ -12,7 +12,13 @@ class TradingAdapter(Protocol):
     def set_leverage(self, leverage: int, margin_mode: MarginMode) -> None:
         ...
 
-    def place_market(self, side: Side, quantity: float) -> ExecutionReport:
+    def place_market(
+        self,
+        side: Side,
+        quantity: float,
+        *,
+        reason: Optional[str] = None,
+    ) -> ExecutionReport:
         ...
 
     def place_stop_market(


### PR DESCRIPTION
## Summary
- add an optional `reason` note to the `place_market` contract so adapters can record exit context
- wire the exit handler to forward its reason when flattening a position
- surface the note in the noop adapter for basic observability

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0244e53d8832080e82927be9a94cb