### PR TITLE
Add exchange secrets wiring for API credentials

### DIFF
--- a/app.py
+++ b/app.py
@@ -172,18 +172,30 @@ class Application:
             resync=self._handle_resync,
         )
 
+    def _exchange_credentials(self) -> tuple[str | None, str | None]:
+        if CONFIG.general.exchange is ExchangeName.BINANCE:
+            return SECRETS.binance_api_key, SECRETS.binance_api_secret
+        if CONFIG.general.exchange is ExchangeName.BYBIT:
+            return SECRETS.bybit_api_key, SECRETS.bybit_api_secret
+        return None, None
+
     def _create_exchange_data(self, symbol: str) -> IExchangeData:
+        api_key, api_secret = self._exchange_credentials()
         if CONFIG.general.exchange is ExchangeName.BINANCE:
             return BinanceExchangeData(
                 symbol=symbol,
                 loop_interval_ms=CONFIG.general.loop_interval_ms,
                 log_writer=self._sink,
+                api_key=api_key,
+                api_secret=api_secret,
             )
         if CONFIG.general.exchange is ExchangeName.BYBIT:
             return BybitExchangeData(
                 symbol=symbol,
                 loop_interval_ms=CONFIG.general.loop_interval_ms,
                 log_writer=self._sink,
+                api_key=api_key,
+                api_secret=api_secret,
             )
         raise RuntimeError("unsupported exchange")
 
@@ -420,6 +432,7 @@ class Application:
 
     def _create_context(self, symbol: str) -> SymbolContext:
         exchange_data = self._create_exchange_data(symbol)
+        api_key, api_secret = self._exchange_credentials()
         context = SymbolContext(
             symbol=symbol,
             exchange_data=exchange_data,
@@ -429,7 +442,12 @@ class Application:
             trade_stream=exchange_data.stream_trades(),
             ticker_stream=exchange_data.stream_book_ticker(),
             filters=exchange_data.fetch_symbol_filters(),
-            trading_adapter=NoopTradingAdapter(self._exchange, symbol),
+            trading_adapter=NoopTradingAdapter(
+                self._exchange,
+                symbol,
+                api_key=api_key,
+                api_secret=api_secret,
+            ),
         )
         startup_timestamp = get_current_time()
         self._event_logger.log(

--- a/application/trading.py
+++ b/application/trading.py
@@ -1,15 +1,26 @@
 from __future__ import annotations
 
+from typing import Optional
+
 from domain.models import BalanceSource, Exchange, ExecutionReport, MarginMode, Side, StopTrigger
 from domain.trading_adapter import TradingAdapter
 from utils import get_current_time
 
 
 class NoopTradingAdapter(TradingAdapter):
-    def __init__(self, exchange: Exchange, symbol: str) -> None:
+    def __init__(
+        self,
+        exchange: Exchange,
+        symbol: str,
+        *,
+        api_key: Optional[str] = None,
+        api_secret: Optional[str] = None,
+    ) -> None:
         self._exchange = exchange
         self._symbol = symbol
         self._balance = 1000.0
+        self._api_key = api_key
+        self._api_secret = api_secret
 
     def get_balance(self, source: BalanceSource) -> float:
         return self._balance

--- a/config/models/secrets.py
+++ b/config/models/secrets.py
@@ -1,9 +1,14 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass(frozen=True)
 class Secrets:
     tg_bot_token: str
+    binance_api_key: Optional[str]
+    binance_api_secret: Optional[str]
+    bybit_api_key: Optional[str]
+    bybit_api_secret: Optional[str]
 
 
 __all__ = ["Secrets"]

--- a/config/secrets.py
+++ b/config/secrets.py
@@ -16,7 +16,23 @@ def _require_env(name: str) -> str:
     return stripped
 
 
-SECRETS: Final[Secrets] = Secrets(tg_bot_token=_require_env("TG_BOT_TOKEN"))
+def _optional_env(name: str) -> str | None:
+    value = os.getenv(name)
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    return stripped
+
+
+SECRETS: Final[Secrets] = Secrets(
+    tg_bot_token=_require_env("TG_BOT_TOKEN"),
+    binance_api_key=_optional_env("BINANCE_API_KEY"),
+    binance_api_secret=_optional_env("BINANCE_API_SECRET"),
+    bybit_api_key=_optional_env("BYBIT_API_KEY"),
+    bybit_api_secret=_optional_env("BYBIT_API_SECRET"),
+)
 
 
 __all__ = ["SECRETS"]

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -58,6 +58,8 @@ class BinanceExchangeData:
         reconnect_delay: float = 1.0,
         log_writer: Optional[Callable[[str], None]] = None,
         endpoints: Optional[BinanceEndpoints] = None,
+        api_key: Optional[str] = None,
+        api_secret: Optional[str] = None,
     ) -> None:
         self.symbol = symbol.upper()
         self._endpoints = endpoints or BinanceEndpoints()
@@ -70,6 +72,8 @@ class BinanceExchangeData:
         self._heartbeat_interval = self._silence_timeout / 2
         self._depth_last_update: Optional[int] = None
         self._lock = threading.Lock()
+        self._api_key = api_key
+        self._api_secret = api_secret
 
     def _rest_get(self, path: str, params: Optional[dict[str, Any]] = None) -> Any:
         params = params or {}

--- a/data/exchanges/bybit.py
+++ b/data/exchanges/bybit.py
@@ -109,6 +109,8 @@ class BybitExchangeData:
         reconnect_delay: float = 1.0,
         log_writer: Optional[Callable[[str], None]] = None,
         endpoints: Optional[BybitEndpoints] = None,
+        api_key: Optional[str] = None,
+        api_secret: Optional[str] = None,
     ) -> None:
         self.symbol = symbol.upper()
         self._endpoints = endpoints or BybitEndpoints()
@@ -121,6 +123,8 @@ class BybitExchangeData:
         self._heartbeat_interval = self._silence_timeout / 2
         self._depth_last_seq: Optional[int] = None
         self._lock = threading.Lock()
+        self._api_key = api_key
+        self._api_secret = api_secret
 
     def _rest_get(self, path: str, params: Optional[dict[str, Any]] = None) -> Any:
         params = params or {}


### PR DESCRIPTION
## Summary
- expand the secrets model to include Binance and Bybit API credentials and load them from the environment
- plumb the credentials through Binance/Bybit data sources and the trading adapter for future authenticated calls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e02c347f288320973358202eef1253