### PR TITLE
Implement Binance and Bybit trading adapters

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,7 +14,9 @@ from config.timezone import CURRENT_TIMEZONE
 from data.exchanges import (
     BestBidAsk,
     BinanceExchangeData,
+    BinanceTradingAdapter,
     BybitExchangeData,
+    BybitTradingAdapter,
     DepthStreamData,
     IExchangeData,
     ResyncReason as StreamResyncReason,
@@ -51,7 +53,7 @@ from domain.strategy import (
 from domain.strategy.resync import ResyncReason as StrategyResyncReason
 from domain.strategy.state import StrategyState
 from utils import get_current_time
-from application import FeedMonitor, GUARDS, NoopTradingAdapter
+from application import FeedMonitor, GUARDS
 from application.market_scanner import MarketScanner
 from domain.trading_adapter import TradingAdapter
 
@@ -66,7 +68,7 @@ class SymbolContext:
     trade_stream: Iterator[StreamEvent[Trade]]
     ticker_stream: Iterator[StreamEvent[BestBidAsk]]
     filters: SymbolFilters
-    trading_adapter: NoopTradingAdapter
+    trading_adapter: TradingAdapter
     last_update_id: Optional[int] = None
     last_trade_price: Optional[float] = None
     best_bid: Optional[float] = None
@@ -83,7 +85,7 @@ class TradingAdapterRouter(TradingAdapter):
     def set_current_symbol(self, symbol: str) -> None:
         self._current_symbol = symbol.upper()
 
-    def _resolve(self) -> NoopTradingAdapter:
+    def _resolve(self) -> TradingAdapter:
         if self._current_symbol is None:
             raise RuntimeError("trading symbol is not selected")
         context = self._contexts.get(self._current_symbol)
@@ -438,7 +440,8 @@ class Application:
 
     def _create_context(self, symbol: str) -> SymbolContext:
         exchange_data = self._create_exchange_data(symbol)
-        api_key, api_secret = self._exchange_credentials()
+        filters = exchange_data.fetch_symbol_filters()
+        trading_adapter = self._create_trading_adapter(symbol, filters)
         context = SymbolContext(
             symbol=symbol,
             exchange_data=exchange_data,
@@ -447,13 +450,8 @@ class Application:
             depth_stream=exchange_data.stream_depth(),
             trade_stream=exchange_data.stream_trades(),
             ticker_stream=exchange_data.stream_book_ticker(),
-            filters=exchange_data.fetch_symbol_filters(),
-            trading_adapter=NoopTradingAdapter(
-                self._exchange,
-                symbol,
-                api_key=api_key,
-                api_secret=api_secret,
-            ),
+            filters=filters,
+            trading_adapter=trading_adapter,
         )
         startup_timestamp = get_current_time()
         self._event_logger.log(
@@ -476,6 +474,26 @@ class Application:
         )
         self._initialize_order_book(context)
         return context
+
+    def _create_trading_adapter(self, symbol: str, filters: SymbolFilters) -> TradingAdapter:
+        api_key, api_secret = self._exchange_credentials()
+        if not api_key or not api_secret:
+            raise RuntimeError("API credentials are required for trading operations")
+        if self._exchange is Exchange.BINANCE:
+            return BinanceTradingAdapter(
+                symbol=symbol,
+                quote_asset=filters.quote_asset,
+                api_key=api_key,
+                api_secret=api_secret,
+            )
+        if self._exchange is Exchange.BYBIT:
+            return BybitTradingAdapter(
+                symbol=symbol,
+                settle_coin=filters.quote_asset,
+                api_key=api_key,
+                api_secret=api_secret,
+            )
+        raise RuntimeError("unsupported exchange")
 
     def _log_scanner_message(self, message: str) -> None:
         timestamp = get_current_time()

--- a/data/exchanges/__init__.py
+++ b/data/exchanges/__init__.py
@@ -10,7 +10,9 @@ from .base import (
     StreamEventType,
 )
 from .binance import BinanceExchangeData
+from .binance_trade import BinanceTradingAdapter
 from .bybit import BybitExchangeData
+from .bybit_trade import BybitTradingAdapter
 
 __all__ = [
     "BestBidAsk",
@@ -23,5 +25,7 @@ __all__ = [
     "StreamEvent",
     "StreamEventType",
     "BinanceExchangeData",
+    "BinanceTradingAdapter",
     "BybitExchangeData",
+    "BybitTradingAdapter",
 ]

--- a/data/exchanges/binance_trade.py
+++ b/data/exchanges/binance_trade.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+from urllib import parse
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from domain.models import BalanceSource, Exchange, ExecutionReport, MarginMode, Side, StopTrigger
+from domain.trading_adapter import TradingAdapter
+from utils.timez import from_exchange_timestamp, get_current_time
+
+
+class BinanceAPIError(RuntimeError):
+    def __init__(self, message: str, *, code: Optional[int] = None, status_code: Optional[int] = None) -> None:
+        self.code = code
+        self.status_code = status_code
+        super().__init__(message)
+
+
+@dataclass(slots=True)
+class BinanceTradeEndpoints:
+    rest_base: str = "https://fapi.binance.com"
+
+
+class BinanceTradingAdapter(TradingAdapter):
+    def __init__(
+        self,
+        symbol: str,
+        quote_asset: str,
+        *,
+        api_key: Optional[str],
+        api_secret: Optional[str],
+        recv_window: int = 5_000,
+        timeout: float = 10.0,
+        endpoints: Optional[BinanceTradeEndpoints] = None,
+    ) -> None:
+        if not api_key or not api_secret:
+            raise ValueError("Binance trading adapter requires API credentials")
+        self._symbol = symbol.upper()
+        self._quote_asset = quote_asset.upper()
+        self._api_key = api_key
+        self._api_secret = api_secret.encode("utf-8")
+        self._recv_window = recv_window
+        self._timeout = timeout
+        self._endpoints = endpoints or BinanceTradeEndpoints()
+
+    def get_balance(self, source: BalanceSource) -> float:
+        response = self._signed_request("GET", "/fapi/v2/balance")
+        if not isinstance(response, list):
+            raise BinanceAPIError("Unexpected balance payload", code=None)
+        for entry in response:
+            if not isinstance(entry, Mapping):
+                continue
+            if entry.get("asset", "").upper() != self._quote_asset:
+                continue
+            if source is BalanceSource.AVAILABLE:
+                return float(entry.get("availableBalance", 0.0))
+            if source is BalanceSource.WALLET:
+                return float(entry.get("walletBalance", 0.0))
+        raise BinanceAPIError(
+            f"Balance for asset {self._quote_asset} not found",
+            code=None,
+        )
+
+    def set_leverage(self, leverage: int, margin_mode: MarginMode) -> None:
+        margin_type = "ISOLATED" if margin_mode is MarginMode.ISOLATED else "CROSSED"
+        try:
+            self._signed_request(
+                "POST",
+                "/fapi/v1/marginType",
+                {
+                    "symbol": self._symbol,
+                    "marginType": margin_type,
+                },
+            )
+        except BinanceAPIError as error:
+            # -4046 means the margin type is already set – ignore silently
+            if error.code != -4046:
+                raise
+        self._signed_request(
+            "POST",
+            "/fapi/v1/leverage",
+            {
+                "symbol": self._symbol,
+                "leverage": leverage,
+            },
+        )
+
+    def place_market(
+        self,
+        side: Side,
+        quantity: float,
+        *,
+        reason: Optional[str] = None,
+    ) -> ExecutionReport:
+        params: dict[str, Any] = {
+            "symbol": self._symbol,
+            "side": self._map_side(side),
+            "type": "MARKET",
+            "quantity": self._format_decimal(quantity),
+        }
+        client_id = self._build_client_id(reason)
+        if client_id:
+            params["newClientOrderId"] = client_id
+        payload = self._signed_request("POST", "/fapi/v1/order", params)
+        return self._build_execution_report(payload, side)
+
+    def place_stop_market(
+        self,
+        side: Side,
+        stop_price: float,
+        quantity: float,
+        trigger: StopTrigger,
+    ) -> None:
+        working_type = "MARK_PRICE" if trigger is StopTrigger.MARK else "CONTRACT_PRICE"
+        params: dict[str, Any] = {
+            "symbol": self._symbol,
+            "side": self._map_side(side),
+            "type": "STOP_MARKET",
+            "stopPrice": self._format_decimal(stop_price),
+            "quantity": self._format_decimal(quantity),
+            "workingType": working_type,
+            "timeInForce": "GTC",
+        }
+        self._signed_request("POST", "/fapi/v1/order", params)
+
+    def _build_execution_report(self, payload: Mapping[str, Any], side: Side) -> ExecutionReport:
+        order_id = str(payload.get("orderId", ""))
+        price = float(payload.get("avgPrice") or payload.get("price") or 0.0)
+        quantity = float(payload.get("origQty", 0.0))
+        executed_qty = float(payload.get("executedQty", quantity))
+        status = str(payload.get("status", "UNKNOWN")).lower()
+        update_time = payload.get("updateTime") or payload.get("transactTime")
+        if update_time:
+            executed_at = from_exchange_timestamp(float(update_time) / 1000.0)
+        else:
+            executed_at = get_current_time()
+        return ExecutionReport(
+            exchange=Exchange.BINANCE,
+            symbol=self._symbol,
+            order_id=order_id,
+            side=side,
+            price=price,
+            quantity=quantity,
+            executed_qty=executed_qty,
+            status=status,
+            commission=float(payload.get("cumQuote", 0.0)),
+            executed_at=executed_at,
+        )
+
+    def _signed_request(
+        self,
+        method: str,
+        path: str,
+        params: Optional[Mapping[str, Any]] = None,
+    ) -> Any:
+        params = dict(params or {})
+        params.setdefault("timestamp", int(time.time() * 1000))
+        params.setdefault("recvWindow", self._recv_window)
+        query = parse.urlencode(params)
+        signature = hmac.new(self._api_secret, query.encode("utf-8"), hashlib.sha256).hexdigest()
+        signed_query = f"{query}&signature={signature}"
+        url = f"{self._endpoints.rest_base}{path}?{signed_query}"
+        request = Request(
+            url,
+            method=method.upper(),
+            headers={
+                "User-Agent": "mtf-trend/1.0",
+                "X-MBX-APIKEY": self._api_key,
+            },
+        )
+        try:
+            with urlopen(request, timeout=self._timeout) as response:
+                raw = response.read().decode("utf-8")
+        except HTTPError as error:
+            payload = error.read().decode("utf-8")
+            raise self._translate_error(payload, status_code=error.code)
+        data = json.loads(raw)
+        if isinstance(data, Mapping) and "code" in data and data.get("code") not in (0, 200):
+            raise BinanceAPIError(
+                str(data.get("msg", "unknown error")),
+                code=int(data.get("code", 0)),
+            )
+        return data
+
+    @staticmethod
+    def _translate_error(payload: str, *, status_code: Optional[int] = None) -> BinanceAPIError:
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            return BinanceAPIError(payload or "HTTP error", status_code=status_code)
+        message = str(data.get("msg", "HTTP error"))
+        code = data.get("code")
+        if code is not None:
+            try:
+                parsed_code = int(code)
+            except (TypeError, ValueError):
+                parsed_code = None
+        else:
+            parsed_code = None
+        return BinanceAPIError(message, code=parsed_code, status_code=status_code)
+
+    @staticmethod
+    def _map_side(side: Side) -> str:
+        if side is Side.BID:
+            return "BUY"
+        if side is Side.ASK:
+            return "SELL"
+        raise ValueError("Unsupported side")
+
+    @staticmethod
+    def _format_decimal(value: float) -> str:
+        text = format(value, "f")
+        if "e" in text or "E" in text:
+            text = f"{value:.8f}"
+        return text.rstrip("0").rstrip(".") or "0"
+
+    @staticmethod
+    def _build_client_id(reason: Optional[str]) -> Optional[str]:
+        if not reason:
+            return None
+        sanitized = "".join(ch for ch in reason if ch.isalnum() or ch in {"-", "_"})
+        return sanitized[:32] or None
+
+
+__all__ = ["BinanceTradingAdapter", "BinanceTradeEndpoints", "BinanceAPIError"]
+

--- a/data/exchanges/bybit_trade.py
+++ b/data/exchanges/bybit_trade.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+from urllib import parse
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from domain.models import BalanceSource, Exchange, ExecutionReport, MarginMode, Side, StopTrigger
+from domain.trading_adapter import TradingAdapter
+from utils.timez import from_exchange_timestamp, get_current_time
+
+
+class BybitAPIError(RuntimeError):
+    def __init__(self, message: str, *, code: Optional[int] = None, status_code: Optional[int] = None) -> None:
+        self.code = code
+        self.status_code = status_code
+        super().__init__(message)
+
+
+@dataclass(slots=True)
+class BybitTradeEndpoints:
+    rest_base: str = "https://api.bybit.com"
+
+
+class BybitTradingAdapter(TradingAdapter):
+    def __init__(
+        self,
+        symbol: str,
+        settle_coin: str,
+        *,
+        api_key: Optional[str],
+        api_secret: Optional[str],
+        recv_window: int = 5_000,
+        timeout: float = 10.0,
+        endpoints: Optional[BybitTradeEndpoints] = None,
+    ) -> None:
+        if not api_key or not api_secret:
+            raise ValueError("Bybit trading adapter requires API credentials")
+        self._symbol = symbol.upper()
+        self._settle_coin = settle_coin.upper()
+        self._api_key = api_key
+        self._api_secret = api_secret.encode("utf-8")
+        self._recv_window = recv_window
+        self._timeout = timeout
+        self._endpoints = endpoints or BybitTradeEndpoints()
+        self._category = "linear"
+
+    def get_balance(self, source: BalanceSource) -> float:
+        params = {
+            "accountType": "UNIFIED",
+            "coin": self._settle_coin,
+        }
+        data = self._signed_request("GET", "/v5/account/wallet-balance", params)
+        result = data.get("result", {}) if isinstance(data, Mapping) else {}
+        for account in result.get("list", []):
+            if not isinstance(account, Mapping):
+                continue
+            for coin in account.get("coin", []):
+                if not isinstance(coin, Mapping):
+                    continue
+                if coin.get("coin", "").upper() != self._settle_coin:
+                    continue
+                if source is BalanceSource.AVAILABLE:
+                    return float(coin.get("availableToWithdraw", 0.0))
+                if source is BalanceSource.WALLET:
+                    return float(coin.get("walletBalance", 0.0))
+        raise BybitAPIError(
+            f"Balance for asset {self._settle_coin} not found",
+            code=None,
+        )
+
+    def set_leverage(self, leverage: int, margin_mode: MarginMode) -> None:
+        trade_mode = 1 if margin_mode is MarginMode.ISOLATED else 0
+        body = {
+            "category": self._category,
+            "symbol": self._symbol,
+            "tradeMode": trade_mode,
+        }
+        if trade_mode == 1:
+            body["buyLeverage"] = str(leverage)
+            body["sellLeverage"] = str(leverage)
+        self._signed_request("POST", "/v5/position/switch-isolated", body)
+        self._signed_request(
+            "POST",
+            "/v5/position/set-leverage",
+            {
+                "category": self._category,
+                "symbol": self._symbol,
+                "buyLeverage": str(leverage),
+                "sellLeverage": str(leverage),
+            },
+        )
+
+    def place_market(
+        self,
+        side: Side,
+        quantity: float,
+        *,
+        reason: Optional[str] = None,
+    ) -> ExecutionReport:
+        body: dict[str, Any] = {
+            "category": self._category,
+            "symbol": self._symbol,
+            "side": self._map_side(side),
+            "orderType": "Market",
+            "qty": self._format_decimal(quantity),
+            "timeInForce": "IOC",
+        }
+        client_id = self._build_client_id(reason)
+        if client_id:
+            body["orderLinkId"] = client_id
+        data = self._signed_request("POST", "/v5/order/create", body)
+        result = data.get("result", {}) if isinstance(data, Mapping) else {}
+        order_id = str(result.get("orderId", ""))
+        return self._fetch_execution_report(order_id, side, quantity)
+
+    def place_stop_market(
+        self,
+        side: Side,
+        stop_price: float,
+        quantity: float,
+        trigger: StopTrigger,
+    ) -> None:
+        trigger_by = "MarkPrice" if trigger is StopTrigger.MARK else "LastPrice"
+        body: dict[str, Any] = {
+            "category": self._category,
+            "symbol": self._symbol,
+            "side": self._map_side(side),
+            "orderType": "Market",
+            "qty": self._format_decimal(quantity),
+            "triggerPrice": self._format_decimal(stop_price),
+            "triggerBy": trigger_by,
+            "timeInForce": "GTC",
+            "reduceOnly": True,
+        }
+        self._signed_request("POST", "/v5/order/create", body)
+
+    def _fetch_execution_report(
+        self,
+        order_id: str,
+        side: Side,
+        requested_qty: float,
+    ) -> ExecutionReport:
+        if not order_id:
+            executed_at = get_current_time()
+            return ExecutionReport(
+                exchange=Exchange.BYBIT,
+                symbol=self._symbol,
+                order_id="",
+                side=side,
+                price=0.0,
+                quantity=requested_qty,
+                executed_qty=0.0,
+                status="unknown",
+                commission=0.0,
+                executed_at=executed_at,
+            )
+        params = {
+            "category": self._category,
+            "orderId": order_id,
+        }
+        data = self._signed_request("GET", "/v5/execution/list", params)
+        result = data.get("result", {}) if isinstance(data, Mapping) else {}
+        executions = [
+            exec_item
+            for exec_item in result.get("list", [])
+            if isinstance(exec_item, Mapping)
+        ]
+        if not executions:
+            executed_at = get_current_time()
+            return ExecutionReport(
+                exchange=Exchange.BYBIT,
+                symbol=self._symbol,
+                order_id=order_id,
+                side=side,
+                price=0.0,
+                quantity=requested_qty,
+                executed_qty=0.0,
+                status="unknown",
+                commission=0.0,
+                executed_at=executed_at,
+            )
+        total_qty = sum(float(item.get("execQty", 0.0)) for item in executions)
+        if total_qty <= 0.0:
+            executed_price = 0.0
+        else:
+            total_notional = sum(
+                float(item.get("execQty", 0.0)) * float(item.get("execPrice", 0.0))
+                for item in executions
+            )
+            executed_price = total_notional / total_qty
+        commission = sum(float(item.get("execFee", 0.0)) for item in executions)
+        last_exec = executions[-1]
+        status = str(last_exec.get("orderStatus", "Filled")).lower()
+        exec_time_raw = last_exec.get("execTime")
+        if exec_time_raw is None:
+            executed_at = get_current_time()
+        else:
+            executed_at = from_exchange_timestamp(float(exec_time_raw) / 1000.0)
+        quantity = float(last_exec.get("orderQty", requested_qty))
+        return ExecutionReport(
+            exchange=Exchange.BYBIT,
+            symbol=self._symbol,
+            order_id=order_id,
+            side=side,
+            price=executed_price,
+            quantity=quantity,
+            executed_qty=total_qty,
+            status=status,
+            commission=commission,
+            executed_at=executed_at,
+        )
+
+    def _signed_request(
+        self,
+        method: str,
+        path: str,
+        params: Optional[Mapping[str, Any]] = None,
+    ) -> Mapping[str, Any] | list[Any]:
+        method = method.upper()
+        params = dict(params or {})
+        timestamp = int(time.time() * 1000)
+        recv_window = self._recv_window
+        url = f"{self._endpoints.rest_base}{path}"
+        body = ""
+        query = ""
+        if method == "GET" and params:
+            query = self._encode_query(params)
+            url = f"{url}?{query}"
+        elif method in {"POST", "DELETE"}:
+            body = json.dumps(params, separators=(",", ":")) if params else "{}"
+        sign_target = f"{timestamp}{self._api_key}{recv_window}{body or query}"
+        signature = hmac.new(self._api_secret, sign_target.encode("utf-8"), hashlib.sha256).hexdigest()
+        headers = {
+            "User-Agent": "mtf-trend/1.0",
+            "Content-Type": "application/json",
+            "X-BAPI-API-KEY": self._api_key,
+            "X-BAPI-TIMESTAMP": str(timestamp),
+            "X-BAPI-RECV-WINDOW": str(recv_window),
+            "X-BAPI-SIGN": signature,
+        }
+        data_bytes = body.encode("utf-8") if body else None
+        request = Request(url, data=data_bytes, headers=headers, method=method)
+        try:
+            with urlopen(request, timeout=self._timeout) as response:
+                payload = response.read().decode("utf-8")
+        except HTTPError as error:
+            payload = error.read().decode("utf-8")
+            raise self._translate_error(payload, status_code=error.code)
+        data = json.loads(payload)
+        if isinstance(data, Mapping) and int(data.get("retCode", 0)) != 0:
+            raise BybitAPIError(
+                str(data.get("retMsg", "unknown error")),
+                code=int(data.get("retCode", 0)),
+            )
+        return data
+
+    @staticmethod
+    def _translate_error(payload: str, *, status_code: Optional[int] = None) -> BybitAPIError:
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            return BybitAPIError(payload or "HTTP error", status_code=status_code)
+        message = str(data.get("retMsg", "HTTP error"))
+        code = data.get("retCode")
+        if code is not None:
+            try:
+                parsed_code = int(code)
+            except (TypeError, ValueError):
+                parsed_code = None
+        else:
+            parsed_code = None
+        return BybitAPIError(message, code=parsed_code, status_code=status_code)
+
+    @staticmethod
+    def _encode_query(params: Mapping[str, Any]) -> str:
+        ordered = sorted((str(key), str(params[key])) for key in params)
+        return parse.urlencode(ordered)
+
+    @staticmethod
+    def _map_side(side: Side) -> str:
+        if side is Side.BID:
+            return "Buy"
+        if side is Side.ASK:
+            return "Sell"
+        raise ValueError("Unsupported side")
+
+    @staticmethod
+    def _format_decimal(value: float) -> str:
+        text = format(value, "f")
+        if "e" in text or "E" in text:
+            text = f"{value:.8f}"
+        return text.rstrip("0").rstrip(".") or "0"
+
+    @staticmethod
+    def _build_client_id(reason: Optional[str]) -> Optional[str]:
+        if not reason:
+            return None
+        sanitized = "".join(ch for ch in reason if ch.isalnum() or ch in {"-", "_"})
+        return sanitized[:36] or None
+
+
+__all__ = ["BybitTradingAdapter", "BybitTradeEndpoints", "BybitAPIError"]
+


### PR DESCRIPTION
## Summary
- add dedicated Binance and Bybit trading adapters that perform signed REST calls for balances and orders
- create exchange-specific trading adapters when building a symbol context and require API credentials
- update the trading adapter router to work with the new adapters

## Testing
- python -m compileall app.py data/exchanges/binance_trade.py data/exchanges/bybit_trade.py

------
https://chatgpt.com/codex/tasks/task_e_68e031768a208320b66ac7f2e9041a76