### PR TITLE
Add strategy kill switch to enforce funding safeguards

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,6 +44,7 @@ from domain.models import (
 from domain.strategy import (
     EventLogger,
     FocusController,
+    KillSwitch,
     MarketObservation,
     PositionController,
     Strategy,
@@ -165,6 +166,16 @@ class Application:
             move_stop=move_stop,
             logger=self._event_logger,
         )
+        ks_settings = CONFIG.funding_ks
+        self._kill_switch = KillSwitch(
+            logger=self._event_logger,
+            funding_block=timedelta(seconds=ks_settings.funding_block_s),
+            block_duration=timedelta(minutes=ks_settings.block_min),
+            stop_interval=timedelta(minutes=1),
+            max_stops=ks_settings.max_stops_per_min,
+            max_drawdown=ks_settings.max_drawdown_frac,
+            position_fraction=CONFIG.position.position_fraction,
+        )
         self._strategy = Strategy(
             subscriptions=self._subscription_manager,
             focus=self._focus_controller,
@@ -172,6 +183,7 @@ class Application:
             notifier=self._telegram_notifier,
             logger=self._event_logger,
             resync=self._handle_resync,
+            safety=self._kill_switch,
         )
 
     @staticmethod

--- a/domain/strategy/__init__.py
+++ b/domain/strategy/__init__.py
@@ -1,5 +1,6 @@
 from .event_logger import EventLogger
 from .focus import FocusController
+from .kill_switch import KillSwitch
 from .observation import MarketObservation
 from .position import PositionController
 from .resync import FeedStatus, ResyncReason
@@ -22,6 +23,7 @@ from .types import (
 __all__ = [
     "EventLogger",
     "FocusController",
+    "KillSwitch",
     "MarketObservation",
     "PositionController",
     "FeedStatus",

--- a/domain/strategy/kill_switch.py
+++ b/domain/strategy/kill_switch.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Deque, Optional
+
+from .event_logger import EventLogger
+
+
+@dataclass
+class KillSwitch:
+    logger: EventLogger
+    funding_block: timedelta
+    block_duration: timedelta
+    stop_interval: timedelta
+    max_stops: int
+    max_drawdown: float
+    position_fraction: float
+    _block_until: Optional[datetime] = None
+    _last_block_at: Optional[datetime] = None
+    _stop_events: Deque[datetime] = field(default_factory=deque)
+    _equity: float = 1.0
+    _peak_equity: float = 1.0
+
+    def is_blocked(self, timestamp: datetime) -> bool:
+        if self._block_until is None:
+            return False
+        if timestamp >= self._block_until:
+            self._block_until = None
+            return False
+        return True
+
+    def blocked_until(self) -> Optional[datetime]:
+        return self._block_until
+
+    def record_entry(self, timestamp: datetime) -> None:
+        self._purge_stops(timestamp)
+
+    def record_exit(self, timestamp: datetime, is_stop: bool, pnl_fraction: float) -> None:
+        if is_stop and self.max_stops > 0:
+            self._stop_events.append(timestamp)
+            self._purge_stops(timestamp)
+            if len(self._stop_events) > self.max_stops:
+                self._trigger_block("Частые стопы", timestamp)
+        if pnl_fraction < 0.0:
+            self._update_drawdown(pnl_fraction, timestamp)
+
+    def handle_resync(self, timestamp: datetime) -> None:
+        if self.funding_block <= timedelta(0):
+            return
+        block_until = timestamp + self.funding_block
+        if self._block_until is None or block_until > self._block_until:
+            self._block_until = block_until
+        self._last_block_at = timestamp
+        self.logger.log(
+            f"{timestamp:%H:%M:%S} Блокировка торгов: ожидание после ресинка.",
+            timestamp,
+        )
+
+    def _purge_stops(self, timestamp: datetime) -> None:
+        if self.stop_interval <= timedelta(0):
+            return
+        cutoff = timestamp - self.stop_interval
+        while self._stop_events and self._stop_events[0] < cutoff:
+            self._stop_events.popleft()
+
+    def _update_drawdown(self, pnl_fraction: float, timestamp: datetime) -> None:
+        change = 1.0 + pnl_fraction * self.position_fraction
+        if change <= 0.0:
+            self._equity = 0.0
+        else:
+            self._equity *= change
+        if self._equity > self._peak_equity:
+            self._peak_equity = self._equity
+            return
+        if self._peak_equity <= 0.0:
+            return
+        drawdown = (self._peak_equity - self._equity) / self._peak_equity
+        if drawdown >= self.max_drawdown > 0.0:
+            self._trigger_block("Просадка превысила лимит", timestamp)
+
+    def _trigger_block(self, reason: str, timestamp: datetime) -> None:
+        if self.block_duration <= timedelta(0):
+            return
+        block_until = timestamp + self.block_duration
+        if self._block_until is None or block_until > self._block_until:
+            self._block_until = block_until
+        self._last_block_at = timestamp
+        self.logger.log(
+            f"{timestamp:%H:%M:%S} Блокировка торгов: {reason}.",
+            timestamp,
+        )
+
+
+__all__ = ["KillSwitch"]

--- a/domain/strategy/strategy.py
+++ b/domain/strategy/strategy.py
@@ -8,6 +8,7 @@ from domain.models import Pressure, Signal, Side, Wall
 
 from .event_logger import EventLogger
 from .focus import FocusController
+from .kill_switch import KillSwitch
 from .observation import MarketObservation
 from .position import PositionController
 from .resync import ResyncReason
@@ -28,6 +29,7 @@ class Strategy:
         notifier: TelegramNotifier,
         logger: EventLogger,
         resync: ResyncHandler,
+        safety: KillSwitch,
     ) -> None:
         self._subscriptions = subscriptions
         self._focus = focus
@@ -35,6 +37,7 @@ class Strategy:
         self._notifier = notifier
         self._logger = logger
         self._resync = resync
+        self._safety = safety
         self._state = StrategyState.SCANNING
         self._previous_state = StrategyState.SCANNING
         self._focused_signal = Signal.NONE
@@ -48,6 +51,7 @@ class Strategy:
         self._position_symbol: Optional[str] = None
         self._position_signal = Signal.NONE
         self._position_wall: Optional[Wall] = None
+        self._position_entry_price: Optional[float] = None
         self._odr_neutral_since: Optional[datetime] = None
         self._wall_drop_since: Optional[datetime] = None
         self._shift_candidate_price: Optional[float] = None
@@ -132,10 +136,20 @@ class Strategy:
             return
         if self._focused_signal is Signal.LONG and wall.side is Side.BID:
             if pressure.imbalance_ratio <= CONFIG.odr.odr_in_long:
-                self._enter_position(observation.symbol, wall, timestamp)
+                self._enter_position(
+                    observation.symbol,
+                    wall,
+                    timestamp,
+                    observation.last_price,
+                )
         elif self._focused_signal is Signal.SHORT and wall.side is Side.ASK:
             if pressure.imbalance_ratio >= CONFIG.odr.odr_in_short:
-                self._enter_position(observation.symbol, wall, timestamp)
+                self._enter_position(
+                    observation.symbol,
+                    wall,
+                    timestamp,
+                    observation.last_price,
+                )
 
     def _handle_in_position(self, observation: MarketObservation) -> None:
         if self._position_symbol != observation.symbol:
@@ -150,7 +164,11 @@ class Strategy:
         if self._odr_neutral_since is not None:
             hold = timedelta(milliseconds=CONFIG.odr.odr_neutral_hold_ms)
             if timestamp - self._odr_neutral_since >= hold:
-                self._exit_position("ODR нейтрален", timestamp)
+                self._exit_position(
+                    "ODR нейтрален",
+                    timestamp,
+                    observation.last_price,
+                )
                 return
         wall = observation.near_wall
         if wall is not None:
@@ -160,7 +178,11 @@ class Strategy:
             if self._wall_drop_since is None:
                 self._wall_drop_since = timestamp
             elif timestamp - self._wall_drop_since >= grace:
-                self._exit_position("Стена исчезла", timestamp)
+                self._exit_position(
+                    "Стена исчезла",
+                    timestamp,
+                    observation.last_price,
+                )
         else:
             self._wall_drop_since = None
 
@@ -212,33 +234,56 @@ class Strategy:
         timeout = timedelta(seconds=CONFIG.focus.defocus_timeout_s)
         return timestamp - self._last_focus_signal_at >= timeout
 
-    def _enter_position(self, symbol: str, wall: Wall, timestamp: datetime) -> None:
+    def _enter_position(
+        self,
+        symbol: str,
+        wall: Wall,
+        timestamp: datetime,
+        last_price: float,
+    ) -> None:
         signal = self._focused_signal
         if signal is Signal.NONE:
             return
+        if self._safety.is_blocked(timestamp):
+            blocked_until = self._safety.blocked_until()
+            if blocked_until is not None:
+                self._logger.log(
+                    (
+                        f"{timestamp:%H:%M:%S} Вход в {symbol} заблокирован до "
+                        f"{blocked_until:%H:%M:%S}."
+                    ),
+                    timestamp,
+                )
+            return
         self._position.enter(symbol, signal, wall, timestamp)
+        self._safety.record_entry(timestamp)
         self._last_trade_at = timestamp
         self._notifier.notify_entry(symbol, signal, timestamp)
         self._state = StrategyState.IN_POSITION
         self._position_symbol = symbol
         self._position_signal = signal
         self._position_wall = wall
+        self._position_entry_price = last_price if last_price > 0.0 else None
         self._odr_neutral_since = None
         self._wall_drop_since = None
         self._shift_candidate_price = None
         self._shift_candidate_since = None
 
-    def _exit_position(self, reason: str, timestamp: datetime) -> None:
+    def _exit_position(self, reason: str, timestamp: datetime, price: float) -> None:
         symbol = self._position_symbol
         if symbol is None:
             return
         self._position.exit(symbol, reason, timestamp)
+        pnl_fraction = self._compute_pnl_fraction(price)
+        is_stop = "стоп" in reason.lower() or "stop" in reason.lower()
+        self._safety.record_exit(timestamp, is_stop, pnl_fraction)
         self._last_trade_at = timestamp
         self._notifier.notify_exit(symbol, reason, timestamp)
         self._state = StrategyState.SCANNING
         self._position_symbol = None
         self._position_signal = Signal.NONE
         self._position_wall = None
+        self._position_entry_price = None
         self._odr_neutral_since = None
         self._wall_drop_since = None
         self._shift_candidate_price = None
@@ -335,6 +380,7 @@ class Strategy:
             f"{timestamp:%H:%M:%S} Ресинк книги. Причина: {reason.value}.", timestamp
         )
         self._track_resync_summary(timestamp)
+        self._safety.handle_resync(timestamp)
 
     def _track_resync_summary(self, timestamp: datetime) -> None:
         if self._resync_summary_start is None:
@@ -348,6 +394,19 @@ class Strategy:
             self._resync_summary_start = timestamp
             self._resync_summary_count = 0
         self._resync_summary_count += 1
+
+    def _compute_pnl_fraction(self, exit_price: float) -> float:
+        entry_price = self._position_entry_price
+        signal = self._position_signal
+        if entry_price is None or entry_price <= 0.0:
+            return 0.0
+        if exit_price <= 0.0:
+            return 0.0
+        if signal is Signal.LONG:
+            return (exit_price - entry_price) / entry_price
+        if signal is Signal.SHORT:
+            return (entry_price - exit_price) / entry_price
+        return 0.0
 
 
 __all__ = ["Strategy"]


### PR DESCRIPTION
## Summary
- add a strategy kill switch component that tracks funding block windows, stop density, and drawdown thresholds
- integrate the kill switch into the strategy flow so entries are suppressed while blocked and trade performance feeds the safeguards
- wire the kill switch into application startup using the funding kill switch configuration values

## Testing
- python -m compileall domain/strategy app.py

------
https://chatgpt.com/codex/tasks/task_e_68e032efa4048320858832eb82f0bd91