### PR TITLE
Add resilient network retries

### DIFF
--- a/application/market_scanner.py
+++ b/application/market_scanner.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import json
+import socket
+import time
 from typing import Callable, Iterable, Optional, Sequence, Tuple
 from urllib import parse
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
+from http.client import RemoteDisconnected
 
 from config.models.exchange_name import ExchangeName
 from config.models.trading_profile import TradingProfile
@@ -18,12 +22,18 @@ class MarketScanner:
         thresholds: TurnoverThresholds,
         *,
         timeout: float = 5.0,
+        retries: int = 3,
+        retry_delay: float = 0.5,
+        retry_backoff: float = 2.0,
         log: Optional[Callable[[str], None]] = None,
     ) -> None:
         self._exchange = exchange
         self._profile = profile
         self._thresholds = thresholds
         self._timeout = timeout
+        self._retries = max(0, int(retries))
+        self._retry_delay = max(0.0, float(retry_delay))
+        self._retry_backoff = max(1.0, float(retry_backoff))
         self._log = log
         self._last_symbols: Tuple[str, ...] = ()
 
@@ -46,9 +56,7 @@ class MarketScanner:
     def _scan_binance(self) -> Tuple[str, ...]:
         url = "https://fapi.binance.com/fapi/v1/ticker/24hr"
         request = Request(url, method="GET", headers={"User-Agent": "mtf-trend/1.0"})
-        with urlopen(request, timeout=self._timeout) as response:
-            payload = response.read().decode("utf-8")
-        data = json.loads(payload)
+        data = self._request_json(request)
         entries = ((item.get("symbol", ""), item.get("quoteVolume", "0")) for item in data)
         return self._filter_and_sort(entries)
 
@@ -56,9 +64,7 @@ class MarketScanner:
         params = parse.urlencode({"category": "linear"})
         url = f"https://api.bybit.com/v5/market/tickers?{params}"
         request = Request(url, method="GET", headers={"User-Agent": "mtf-trend/1.0"})
-        with urlopen(request, timeout=self._timeout) as response:
-            payload = response.read().decode("utf-8")
-        data = json.loads(payload)
+        data = self._request_json(request)
         if str(data.get("retCode")) not in {"0", "OK"}:
             raise RuntimeError(f"unexpected bybit response code: {data.get('retCode')}")
         result = data.get("result") or {}
@@ -71,6 +77,30 @@ class MarketScanner:
             for row in entries
         )
         return self._filter_and_sort(rows)
+
+    def _request_json(self, request: Request) -> dict[str, object] | list[object]:
+        retries_remaining = self._retries
+        delay = self._retry_delay
+        while True:
+            try:
+                with urlopen(request, timeout=self._timeout) as response:
+                    payload = response.read().decode("utf-8")
+                return json.loads(payload)
+            except HTTPError:
+                raise
+            except (
+                URLError,
+                RemoteDisconnected,
+                TimeoutError,
+                socket.timeout,
+                ConnectionError,
+            ):
+                if retries_remaining <= 0:
+                    raise
+                if delay > 0.0:
+                    time.sleep(delay)
+                retries_remaining -= 1
+                delay *= self._retry_backoff
 
     def _filter_and_sort(self, entries: Iterable[Tuple[object, object]]) -> Tuple[str, ...]:
         threshold = self._resolve_threshold()

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import json
+import socket
 import threading
 import time
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Callable, Iterable, Iterator, Optional, Protocol
 from urllib import parse
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
+from http.client import RemoteDisconnected
 
 from domain.models import (
     Candle,
@@ -54,6 +57,9 @@ class BinanceExchangeData:
         loop_interval_ms: int = 100,
         depth_limit: int = 200,
         rest_timeout: float = 5.0,
+        rest_retries: int = 3,
+        rest_retry_delay: float = 0.5,
+        rest_retry_backoff: float = 2.0,
         ws_timeout: float = 10.0,
         reconnect_delay: float = 1.0,
         log_writer: Optional[Callable[[str], None]] = None,
@@ -64,6 +70,9 @@ class BinanceExchangeData:
         self.symbol = symbol.upper()
         self._endpoints = endpoints or BinanceEndpoints()
         self._rest_timeout = rest_timeout
+        self._rest_retries = max(0, int(rest_retries))
+        self._rest_retry_delay = max(0.0, float(rest_retry_delay))
+        self._rest_retry_backoff = max(1.0, float(rest_retry_backoff))
         self._ws_timeout = ws_timeout
         self._reconnect_delay = reconnect_delay
         self._depth_limit = depth_limit
@@ -82,9 +91,31 @@ class BinanceExchangeData:
         if query:
             url = f"{url}?{query}"
         req = Request(url, method="GET", headers={"User-Agent": "mtf-trend/1.0"})
-        with urlopen(req, timeout=self._rest_timeout) as resp:
-            payload = resp.read().decode("utf-8")
-        return json.loads(payload)
+        return self._execute_rest_request(req)
+
+    def _execute_rest_request(self, request: Request) -> Any:
+        retries_remaining = self._rest_retries
+        delay = self._rest_retry_delay
+        while True:
+            try:
+                with urlopen(request, timeout=self._rest_timeout) as resp:
+                    payload = resp.read().decode("utf-8")
+                return json.loads(payload)
+            except HTTPError:
+                raise
+            except (
+                URLError,
+                RemoteDisconnected,
+                TimeoutError,
+                socket.timeout,
+                ConnectionError,
+            ):
+                if retries_remaining <= 0:
+                    raise
+                if delay > 0.0:
+                    time.sleep(delay)
+                retries_remaining -= 1
+                delay *= self._rest_retry_backoff
 
     def fetch_symbol_filters(self) -> SymbolFilters:
         data = self._rest_get("/fapi/v1/exchangeInfo", {"symbol": self.symbol})

--- a/data/exchanges/binance_trade.py
+++ b/data/exchanges/binance_trade.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import socket
 import time
 from dataclasses import dataclass
+from http.client import RemoteDisconnected
 from typing import Any, Mapping, Optional
 from urllib import parse
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from domain.models import BalanceSource, Exchange, ExecutionReport, MarginMode, Side, StopTrigger
@@ -38,6 +40,9 @@ class BinanceTradingAdapter(TradingAdapter):
         recv_window: int = 5_000,
         timeout: float = 10.0,
         endpoints: Optional[BinanceTradeEndpoints] = None,
+        max_retries: int = 3,
+        retry_delay: float = 0.5,
+        retry_backoff: float = 2.0,
     ) -> None:
         if not api_key or not api_secret:
             raise ValueError("Binance trading adapter requires API credentials")
@@ -48,6 +53,9 @@ class BinanceTradingAdapter(TradingAdapter):
         self._recv_window = recv_window
         self._timeout = timeout
         self._endpoints = endpoints or BinanceTradeEndpoints()
+        self._max_retries = max(0, int(max_retries))
+        self._retry_delay = max(0.0, float(retry_delay))
+        self._retry_backoff = max(1.0, float(retry_backoff))
 
     def get_balance(self, source: BalanceSource) -> float:
         response = self._signed_request("GET", "/fapi/v2/balance")
@@ -174,12 +182,7 @@ class BinanceTradingAdapter(TradingAdapter):
                 "X-MBX-APIKEY": self._api_key,
             },
         )
-        try:
-            with urlopen(request, timeout=self._timeout) as response:
-                raw = response.read().decode("utf-8")
-        except HTTPError as error:
-            payload = error.read().decode("utf-8")
-            raise self._translate_error(payload, status_code=error.code)
+        raw = self._perform_request(request)
         data = json.loads(raw)
         if isinstance(data, Mapping) and "code" in data and data.get("code") not in (0, 200):
             raise BinanceAPIError(
@@ -187,6 +190,43 @@ class BinanceTradingAdapter(TradingAdapter):
                 code=int(data.get("code", 0)),
             )
         return data
+
+    def _perform_request(self, request: Request) -> str:
+        retries_remaining = self._max_retries
+        delay = self._retry_delay
+        while True:
+            try:
+                with urlopen(request, timeout=self._timeout) as response:
+                    return response.read().decode("utf-8")
+            except HTTPError as error:
+                payload = error.read().decode("utf-8")
+                raise self._translate_error(payload, status_code=error.code)
+            except (
+                URLError,
+                RemoteDisconnected,
+                TimeoutError,
+                socket.timeout,
+                ConnectionError,
+            ) as error:
+                if retries_remaining <= 0:
+                    message = self._format_network_error(error)
+                    raise BinanceAPIError(message, code=None) from error
+                if delay > 0.0:
+                    time.sleep(delay)
+                retries_remaining -= 1
+                delay *= self._retry_backoff
+
+    @staticmethod
+    def _format_network_error(error: BaseException) -> str:
+        reason = getattr(error, "reason", None)
+        if isinstance(reason, Exception):
+            text = str(reason)
+        elif reason is not None:
+            text = str(reason)
+        else:
+            text = str(error)
+        text = (text or "").strip() or error.__class__.__name__
+        return f"Connection error: {text}"
 
     @staticmethod
     def _translate_error(payload: str, *, status_code: Optional[int] = None) -> BinanceAPIError:

--- a/data/exchanges/bybit.py
+++ b/data/exchanges/bybit.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import json
+import socket
 import threading
 import time
 from dataclasses import dataclass
 from datetime import datetime
+from http.client import RemoteDisconnected
 from typing import (
     Any,
     Callable,
@@ -18,6 +20,7 @@ from typing import (
     cast,
 )
 from urllib import parse
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from domain.models import (
@@ -105,6 +108,9 @@ class BybitExchangeData:
         loop_interval_ms: int = 100,
         depth_limit: int = 200,
         rest_timeout: float = 5.0,
+        rest_retries: int = 3,
+        rest_retry_delay: float = 0.5,
+        rest_retry_backoff: float = 2.0,
         ws_timeout: float = 10.0,
         reconnect_delay: float = 1.0,
         log_writer: Optional[Callable[[str], None]] = None,
@@ -115,6 +121,9 @@ class BybitExchangeData:
         self.symbol = symbol.upper()
         self._endpoints = endpoints or BybitEndpoints()
         self._rest_timeout = rest_timeout
+        self._rest_retries = max(0, int(rest_retries))
+        self._rest_retry_delay = max(0.0, float(rest_retry_delay))
+        self._rest_retry_backoff = max(1.0, float(rest_retry_backoff))
         self._ws_timeout = ws_timeout
         self._reconnect_delay = reconnect_delay
         self._depth_limit = depth_limit
@@ -133,12 +142,34 @@ class BybitExchangeData:
         if query:
             url = f"{url}?{query}"
         req = Request(url, method="GET", headers={"User-Agent": "mtf-trend/1.0"})
-        with urlopen(req, timeout=self._rest_timeout) as resp:
-            payload = resp.read().decode("utf-8")
-        data = json.loads(payload)
+        data = self._execute_rest_request(req)
         if data.get("retCode") not in (0, None):
             raise RuntimeError(f"Bybit API error: {data.get('retMsg')}")
         return data
+
+    def _execute_rest_request(self, request: Request) -> Any:
+        retries_remaining = self._rest_retries
+        delay = self._rest_retry_delay
+        while True:
+            try:
+                with urlopen(request, timeout=self._rest_timeout) as resp:
+                    payload = resp.read().decode("utf-8")
+                return json.loads(payload)
+            except HTTPError:
+                raise
+            except (
+                URLError,
+                RemoteDisconnected,
+                TimeoutError,
+                socket.timeout,
+                ConnectionError,
+            ):
+                if retries_remaining <= 0:
+                    raise
+                if delay > 0.0:
+                    time.sleep(delay)
+                retries_remaining -= 1
+                delay *= self._rest_retry_backoff
 
     def fetch_symbol_filters(self) -> SymbolFilters:
         data = self._rest_get(

--- a/data/exchanges/bybit_trade.py
+++ b/data/exchanges/bybit_trade.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import socket
 import time
 from dataclasses import dataclass
+from http.client import RemoteDisconnected
 from typing import Any, Mapping, Optional
 from urllib import parse
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from domain.models import BalanceSource, Exchange, ExecutionReport, MarginMode, Side, StopTrigger
@@ -38,6 +40,9 @@ class BybitTradingAdapter(TradingAdapter):
         recv_window: int = 5_000,
         timeout: float = 10.0,
         endpoints: Optional[BybitTradeEndpoints] = None,
+        max_retries: int = 3,
+        retry_delay: float = 0.5,
+        retry_backoff: float = 2.0,
     ) -> None:
         if not api_key or not api_secret:
             raise ValueError("Bybit trading adapter requires API credentials")
@@ -49,6 +54,9 @@ class BybitTradingAdapter(TradingAdapter):
         self._timeout = timeout
         self._endpoints = endpoints or BybitTradeEndpoints()
         self._category = "linear"
+        self._max_retries = max(0, int(max_retries))
+        self._retry_delay = max(0.0, float(retry_delay))
+        self._retry_backoff = max(1.0, float(retry_backoff))
 
     def get_balance(self, source: BalanceSource) -> float:
         params = {
@@ -246,12 +254,7 @@ class BybitTradingAdapter(TradingAdapter):
         }
         data_bytes = body.encode("utf-8") if body else None
         request = Request(url, data=data_bytes, headers=headers, method=method)
-        try:
-            with urlopen(request, timeout=self._timeout) as response:
-                payload = response.read().decode("utf-8")
-        except HTTPError as error:
-            payload = error.read().decode("utf-8")
-            raise self._translate_error(payload, status_code=error.code)
+        payload = self._perform_request(request)
         data = json.loads(payload)
         if isinstance(data, Mapping) and int(data.get("retCode", 0)) != 0:
             raise BybitAPIError(
@@ -259,6 +262,43 @@ class BybitTradingAdapter(TradingAdapter):
                 code=int(data.get("retCode", 0)),
             )
         return data
+
+    def _perform_request(self, request: Request) -> str:
+        retries_remaining = self._max_retries
+        delay = self._retry_delay
+        while True:
+            try:
+                with urlopen(request, timeout=self._timeout) as response:
+                    return response.read().decode("utf-8")
+            except HTTPError as error:
+                payload = error.read().decode("utf-8")
+                raise self._translate_error(payload, status_code=error.code)
+            except (
+                URLError,
+                RemoteDisconnected,
+                TimeoutError,
+                socket.timeout,
+                ConnectionError,
+            ) as error:
+                if retries_remaining <= 0:
+                    message = self._format_network_error(error)
+                    raise BybitAPIError(message, code=None) from error
+                if delay > 0.0:
+                    time.sleep(delay)
+                retries_remaining -= 1
+                delay *= self._retry_backoff
+
+    @staticmethod
+    def _format_network_error(error: BaseException) -> str:
+        reason = getattr(error, "reason", None)
+        if isinstance(reason, Exception):
+            text = str(reason)
+        elif reason is not None:
+            text = str(reason)
+        else:
+            text = str(error)
+        text = (text or "").strip() or error.__class__.__name__
+        return f"Connection error: {text}"
 
     @staticmethod
     def _translate_error(payload: str, *, status_code: Optional[int] = None) -> BybitAPIError:

--- a/data/telegram.py
+++ b/data/telegram.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import json
+import socket
+import time
 from dataclasses import dataclass
 from typing import Optional
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
+from http.client import RemoteDisconnected
 
 from config.models import TelegramSettings
 from config.secrets import SECRETS
@@ -15,6 +19,9 @@ class TelegramClient:
     chat_id: Optional[int]
     silent: bool
     request_timeout: float = 10.0
+    max_retries: int = 3
+    retry_delay: float = 0.5
+    retry_backoff: float = 2.0
 
     def send_message(self, message: str) -> None:
         if self.chat_id is None:
@@ -33,8 +40,28 @@ class TelegramClient:
             headers={"Content-Type": "application/json"},
             method="POST",
         )
-        with urlopen(request, timeout=self.request_timeout):
-            pass
+        retries_remaining = self.max_retries
+        delay = max(0.0, float(self.retry_delay))
+        backoff = max(1.0, float(self.retry_backoff))
+        while True:
+            try:
+                with urlopen(request, timeout=self.request_timeout):
+                    return
+            except HTTPError:
+                raise
+            except (
+                URLError,
+                RemoteDisconnected,
+                TimeoutError,
+                socket.timeout,
+                ConnectionError,
+            ):
+                if retries_remaining <= 0:
+                    raise
+                if delay > 0.0:
+                    time.sleep(delay)
+                retries_remaining -= 1
+                delay *= backoff
 
 
 def create_client(settings: TelegramSettings) -> TelegramClient:


### PR DESCRIPTION
## Summary
- add configurable retry with exponential backoff to Binance and Bybit trading adapters
- harden exchange data REST helpers and the market scanner with retryable requests
- make the Telegram notifier resilient to transient connection failures

## Testing
- python -m compileall application/market_scanner.py data/exchanges/binance.py data/exchanges/binance_trade.py data/exchanges/bybit.py data/exchanges/bybit_trade.py data/telegram.py

------
https://chatgpt.com/codex/tasks/task_e_68e0c4e00ba08320bf2cdb638407cfd7