### PR TITLE
Handle symbol profiles from market scanner

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from typing import Dict, Iterable, Iterator, Optional, Sequence, Tuple, cast
 from config.config import CONFIG
 from config.models.balance_source import BalanceSource as ConfigBalanceSource
 from config.models.exchange_name import ExchangeName
+from config.models.trading_profile import TradingProfile
 from config.secrets import SECRETS
 from config.timezone import CURRENT_TIMEZONE
 from data.exchanges import (
@@ -79,6 +80,7 @@ class SymbolContext:
     cycle_started: bool = False
     balance: float = 0.0
     balance_updated_at: Optional[datetime] = None
+    profile: TradingProfile = CONFIG.general.profile
 
 
 class TradingAdapterRouter(TradingAdapter):
@@ -131,6 +133,7 @@ class Application:
         self._event_logger = EventLogger(write=self._log_writer)
         self._focused_symbol: Optional[str] = None
         self._desired_symbols: Tuple[str, ...] = ()
+        self._symbol_profiles: Dict[str, TradingProfile] = {}
         self._telegram_client = TelegramClient(
             token=SECRETS.tg_bot_token,
             chat_id=CONFIG.telegram.chat_id,
@@ -400,8 +403,8 @@ class Application:
         )
 
     def _choose_wall(self, context: SymbolContext) -> Optional[Wall]:
-        bid_wall = check_if_has_near_wall(context.order_book, Side.BID)
-        ask_wall = check_if_has_near_wall(context.order_book, Side.ASK)
+        bid_wall = check_if_has_near_wall(context.order_book, Side.BID, context.profile)
+        ask_wall = check_if_has_near_wall(context.order_book, Side.ASK, context.profile)
         candidate: Optional[Wall] = None
         if bid_wall is not None and ask_wall is not None:
             candidate = bid_wall if bid_wall.notional >= ask_wall.notional else ask_wall
@@ -423,7 +426,12 @@ class Application:
         opposite_blocks = False
         if wall is not None:
             move_side = Side.ASK if wall.side is Side.BID else Side.BID
-            opposite_blocks = check_if_has_opposite_wall(context.order_book, move_side, wall)
+            opposite_blocks = check_if_has_opposite_wall(
+                context.order_book,
+                move_side,
+                wall,
+                context.profile,
+            )
         return MarketObservation(
             timestamp=get_current_time(),
             symbol=context.symbol,
@@ -441,8 +449,14 @@ class Application:
         if not force and self._last_scan_at is not None:
             if timestamp - self._last_scan_at < self._scanner_interval:
                 return
-        symbols = self._scanner.scan()
+        scan_result = self._scanner.scan()
+        self._symbol_profiles = {symbol: profile for symbol, profile in scan_result}
+        symbols = tuple(symbol for symbol, _ in scan_result)
         self._desired_symbols = symbols
+        for symbol, profile in self._symbol_profiles.items():
+            context = self._contexts.get(symbol)
+            if context is not None:
+                context.profile = profile
         self._subscription_manager.update(symbols, timestamp)
         self._last_scan_at = timestamp
 
@@ -489,6 +503,7 @@ class Application:
             ticker_stream=exchange_data.stream_book_ticker(),
             filters=filters,
             trading_adapter=trading_adapter,
+            profile=self._symbol_profiles.get(symbol, CONFIG.general.profile),
         )
         startup_timestamp = get_current_time()
         self._event_logger.log(

--- a/application/market_scanner.py
+++ b/application/market_scanner.py
@@ -35,9 +35,9 @@ class MarketScanner:
         self._retry_delay = max(0.0, float(retry_delay))
         self._retry_backoff = max(1.0, float(retry_backoff))
         self._log = log
-        self._last_symbols: Tuple[str, ...] = ()
+        self._last_symbols: Tuple[Tuple[str, TradingProfile], ...] = ()
 
-    def scan(self) -> Tuple[str, ...]:
+    def scan(self) -> Tuple[Tuple[str, TradingProfile], ...]:
         try:
             if self._exchange is ExchangeName.BINANCE:
                 symbols = self._scan_binance()
@@ -53,14 +53,14 @@ class MarketScanner:
                 self._log(f"ошибка сканера: {exc}")
             return self._last_symbols
 
-    def _scan_binance(self) -> Tuple[str, ...]:
+    def _scan_binance(self) -> Tuple[Tuple[str, TradingProfile], ...]:
         url = "https://fapi.binance.com/fapi/v1/ticker/24hr"
         request = Request(url, method="GET", headers={"User-Agent": "mtf-trend/1.0"})
         data = self._request_json(request)
         entries = ((item.get("symbol", ""), item.get("quoteVolume", "0")) for item in data)
         return self._filter_and_sort(entries)
 
-    def _scan_bybit(self) -> Tuple[str, ...]:
+    def _scan_bybit(self) -> Tuple[Tuple[str, TradingProfile], ...]:
         params = parse.urlencode({"category": "linear"})
         url = f"https://api.bybit.com/v5/market/tickers?{params}"
         request = Request(url, method="GET", headers={"User-Agent": "mtf-trend/1.0"})
@@ -102,7 +102,9 @@ class MarketScanner:
                 retries_remaining -= 1
                 delay *= self._retry_backoff
 
-    def _filter_and_sort(self, entries: Iterable[Tuple[object, object]]) -> Tuple[str, ...]:
+    def _filter_and_sort(
+        self, entries: Iterable[Tuple[object, object]]
+    ) -> Tuple[Tuple[str, TradingProfile], ...]:
         threshold = self._resolve_threshold()
         pairs: list[Tuple[str, float]] = []
         for raw_symbol, raw_turnover in entries:
@@ -116,10 +118,14 @@ class MarketScanner:
             if turnover >= threshold:
                 pairs.append((symbol, turnover))
         pairs.sort(key=lambda item: item[1], reverse=True)
-        return tuple(symbol for symbol, _ in pairs)
+        if self._profile is TradingProfile.AUTO:
+            return tuple((symbol, self._classify_turnover(turnover)) for symbol, turnover in pairs)
+        return tuple((symbol, self._profile) for symbol, _ in pairs)
 
     def _resolve_threshold(self) -> float:
         thresholds = self._thresholds
+        if self._profile is TradingProfile.AUTO:
+            return float(min(thresholds.top_usd, thresholds.alt_usd, thresholds.listing_usd))
         if self._profile is TradingProfile.TOP:
             return float(thresholds.top_usd)
         if self._profile is TradingProfile.ALT:
@@ -127,6 +133,14 @@ class MarketScanner:
         if self._profile is TradingProfile.LISTING:
             return float(thresholds.listing_usd)
         return float(thresholds.top_usd)
+
+    def _classify_turnover(self, turnover: float) -> TradingProfile:
+        thresholds = self._thresholds
+        if turnover >= float(thresholds.top_usd):
+            return TradingProfile.TOP
+        if turnover >= float(thresholds.alt_usd):
+            return TradingProfile.ALT
+        return TradingProfile.LISTING
 
 
 __all__ = ["MarketScanner"]

--- a/domain/detectors.py
+++ b/domain/detectors.py
@@ -66,8 +66,12 @@ def check_if_is_large_wall(
     return True
 
 
-def check_if_has_near_wall(book: OrderBook, side_stop: Side) -> Optional[Wall]:
-    abs_threshold: float = _resolve_absolute_threshold(CONFIG.general.profile)
+def check_if_has_near_wall(
+    book: OrderBook,
+    side_stop: Side,
+    profile: TradingProfile,
+) -> Optional[Wall]:
+    abs_threshold: float = _resolve_absolute_threshold(profile)
     level: Optional[OrderBookLevel] = book.find_nearest_wall(
         side=side_stop,
         min_notional=abs_threshold,
@@ -75,7 +79,7 @@ def check_if_has_near_wall(book: OrderBook, side_stop: Side) -> Optional[Wall]:
     if level is None:
         return None
     now: datetime = get_current_time()
-    persist_s: float = _resolve_persist(CONFIG.general.profile)
+    persist_s: float = _resolve_persist(profile)
     median_qty: float = _compute_median_quantity(book.iter_recent_band(side_stop))
     if not check_if_is_large_wall(
         level,
@@ -98,9 +102,14 @@ def check_if_has_near_wall(book: OrderBook, side_stop: Side) -> Optional[Wall]:
     )
 
 
-def check_if_has_opposite_wall(book: OrderBook, side_move: Side, our_wall: Wall) -> bool:
+def check_if_has_opposite_wall(
+    book: OrderBook,
+    side_move: Side,
+    our_wall: Wall,
+    profile: TradingProfile,
+) -> bool:
     opposite_side: Side = Side.ASK if side_move is Side.BID else Side.BID
-    abs_threshold: float = _resolve_absolute_threshold(CONFIG.general.profile)
+    abs_threshold: float = _resolve_absolute_threshold(profile)
     level: Optional[OrderBookLevel] = book.find_nearest_wall(
         side=opposite_side,
         min_notional=abs_threshold,
@@ -108,7 +117,7 @@ def check_if_has_opposite_wall(book: OrderBook, side_move: Side, our_wall: Wall)
     if level is None:
         return False
     now: datetime = get_current_time()
-    persist_s: float = _resolve_persist(CONFIG.general.profile)
+    persist_s: float = _resolve_persist(profile)
     median_qty: float = _compute_median_quantity(book.iter_recent_band(opposite_side))
     if not check_if_is_large_wall(
         level,


### PR DESCRIPTION
## Summary
- update the market scanner to classify symbols by turnover when using the AUTO profile and return category information
- store the actual profile for each symbol in the application context and pass it to wall detectors
- allow wall detectors to operate on symbol-specific profiles rather than the global configuration

## Testing
- python -m compileall app.py application domain

------
https://chatgpt.com/codex/tasks/task_e_68e0cf7423a083209348e16f92675b04