### PR TITLE
Add volume spike tracking to strategy focus logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import argparse
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import Dict, Iterable, Iterator, Optional, Sequence, Tuple, cast
+from collections import deque
+from typing import Deque, Dict, Iterable, Iterator, Optional, Sequence, Tuple, cast
 
 from config.config import CONFIG
 from config.models.balance_source import BalanceSource as ConfigBalanceSource
@@ -60,6 +61,47 @@ from application import FeedMonitor, GUARDS
 from application.market_scanner import MarketScanner
 from domain.trading_adapter import TradingAdapter
 
+class VolumeSpikeTracker:
+    def __init__(
+        self,
+        *,
+        window: timedelta = timedelta(seconds=30),
+        smoothing: float = 0.2,
+        min_samples: int = 20,
+    ) -> None:
+        self._window = window
+        self._smoothing = smoothing
+        self._min_samples = min_samples
+        self._entries: Deque[Tuple[datetime, float]] = deque()
+        self._total = 0.0
+        self._average = 0.0
+        self._samples = 0
+
+    def observe(self, timestamp: datetime, price: float, quantity: float) -> Tuple[float, float, float, bool]:
+        volume = abs(price * quantity)
+        self._entries.append((timestamp, volume))
+        self._total += volume
+        self._trim(timestamp)
+        current = max(self._total, 0.0)
+        baseline = self._average if self._average > 0.0 else current
+        ratio = current / baseline if baseline > 0.0 else 0.0
+        self._samples += 1
+        if self._samples == 1:
+            self._average = current
+        else:
+            alpha = self._smoothing
+            self._average = (1.0 - alpha) * self._average + alpha * current
+        ready = self._samples >= self._min_samples and self._average > 0.0
+        return current, self._average, ratio, ready
+
+    def _trim(self, now: datetime) -> None:
+        cutoff = now - self._window
+        while self._entries and self._entries[0][0] < cutoff:
+            _, volume = self._entries.popleft()
+            self._total -= volume
+        if self._total < 0.0:
+            self._total = 0.0
+
 
 @dataclass
 class SymbolContext:
@@ -81,6 +123,9 @@ class SymbolContext:
     balance: float = 0.0
     balance_updated_at: Optional[datetime] = None
     profile: TradingProfile = CONFIG.general.profile
+    volume_tracker: VolumeSpikeTracker = field(default_factory=VolumeSpikeTracker)
+    volume_ratio: float = 0.0
+    volume_spike: bool = False
 
 
 class TradingAdapterRouter(TradingAdapter):
@@ -371,6 +416,11 @@ class Application:
             trade = cast(Trade, event.data)
             if trade is not None:
                 context.last_trade_price = trade.price
+                _, _, ratio, ready = context.volume_tracker.observe(
+                    event.timestamp, trade.price, trade.quantity
+                )
+                context.volume_ratio = ratio
+                context.volume_spike = ready and ratio >= CONFIG.general.vol_spike_mult
 
     @staticmethod
     def _process_ticker_stream(context: SymbolContext) -> None:
@@ -442,6 +492,8 @@ class Application:
             opposite_wall_blocks=opposite_blocks,
             available_symbols=self._desired_symbols,
             feed_status=context.feed_monitor.snapshot(),
+            volume_ratio=context.volume_ratio,
+            volume_spike=context.volume_spike,
         )
 
     def _refresh_symbol_scan(self, timestamp: Optional[datetime] = None, *, force: bool = False) -> None:

--- a/domain/strategy/observation.py
+++ b/domain/strategy/observation.py
@@ -21,6 +21,8 @@ class MarketObservation:
     opposite_wall_blocks: bool
     available_symbols: Tuple[str, ...]
     feed_status: FeedStatus
+    volume_ratio: float
+    volume_spike: bool
 
     def __post_init__(self) -> None:
         ensure_current_timezone(self.timestamp)

--- a/domain/strategy/strategy.py
+++ b/domain/strategy/strategy.py
@@ -100,9 +100,23 @@ class Strategy:
         wall = observation.near_wall
         ratio = observation.pressure.imbalance_ratio
         if wall.side is Side.BID and ratio <= CONFIG.odr.focus_pre_odr_long:
-            self._focus_on_symbol(observation.symbol, Signal.LONG, wall, observation.timestamp)
+            if observation.volume_spike:
+                self._focus_on_symbol(
+                    observation.symbol,
+                    Signal.LONG,
+                    wall,
+                    observation.timestamp,
+                    observation.volume_ratio,
+                )
         elif wall.side is Side.ASK and ratio >= CONFIG.odr.focus_pre_odr_short:
-            self._focus_on_symbol(observation.symbol, Signal.SHORT, wall, observation.timestamp)
+            if observation.volume_spike:
+                self._focus_on_symbol(
+                    observation.symbol,
+                    Signal.SHORT,
+                    wall,
+                    observation.timestamp,
+                    observation.volume_ratio,
+                )
 
     def _handle_focused(self, observation: MarketObservation) -> None:
         if self._focus.current != observation.symbol:
@@ -110,7 +124,7 @@ class Strategy:
         pressure = observation.pressure
         wall = observation.near_wall
         timestamp = observation.timestamp
-        if pressure is not None and wall is not None:
+        if pressure is not None and wall is not None and observation.volume_spike:
             if self._focused_signal is Signal.LONG and wall.side is Side.BID:
                 if pressure.imbalance_ratio <= CONFIG.odr.focus_pre_odr_long:
                     self._last_focus_signal_at = timestamp
@@ -133,6 +147,8 @@ class Strategy:
         if pressure is None or wall is None:
             return
         if observation.opposite_wall_blocks:
+            return
+        if not observation.volume_spike:
             return
         if self._focused_signal is Signal.LONG and wall.side is Side.BID:
             if pressure.imbalance_ratio <= CONFIG.odr.odr_in_long:
@@ -187,7 +203,12 @@ class Strategy:
             self._wall_drop_since = None
 
     def _focus_on_symbol(
-        self, symbol: str, signal: Signal, wall: Wall, timestamp: datetime
+        self,
+        symbol: str,
+        signal: Signal,
+        wall: Wall,
+        timestamp: datetime,
+        volume_ratio: float,
     ) -> None:
         self._focus.focus(symbol, timestamp)
         self._state = StrategyState.FOCUSED
@@ -198,7 +219,8 @@ class Strategy:
         self._logger.log(
             (
                 f"{timestamp:%H:%M:%S} Аптик {symbol} {direction}. "
-                f"Стена {wall.price:g} объём {wall.notional:g}."
+                f"Стена {wall.price:g} объём {wall.notional:g}. "
+                f"Всплеск объёма x{volume_ratio:.2f}."
             ),
             timestamp,
         )


### PR DESCRIPTION
## Summary
- collect sliding window trade volume in each symbol context and detect spikes
- extend market observations with volume spike metadata
- require volume spikes to focus or enter positions and log the ratio for visibility

## Testing
- python -m py_compile app.py domain/strategy/observation.py domain/strategy/strategy.py

------
https://chatgpt.com/codex/tasks/task_e_68e0d0b413688320982991791c59fb6d