### PR TITLE
Normalize centralized log timestamp formatting

### DIFF
--- a/app.py
+++ b/app.py
@@ -356,7 +356,7 @@ class Application:
         timestamp = snapshot.received_at
         self._event_logger.log(
             (
-                f"{timestamp:%H:%M:%S} Снимок стакана {context.symbol} применён. "
+                f"Снимок стакана {context.symbol} применён. "
                 f"ID {snapshot.last_update_id}."
             ),
             timestamp,
@@ -403,7 +403,7 @@ class Application:
             details = f" {event.details}." if event.details else ""
             self._event_logger.log(
                 (
-                    f"{timestamp:%H:%M:%S} Поток стакана {context.symbol} требует ресинк: "
+                    f"Поток стакана {context.symbol} требует ресинк: "
                     f"{event.reason.value}.{details}"
                 ),
                 timestamp,
@@ -533,7 +533,7 @@ class Application:
             return
         timestamp = get_current_time()
         self._event_logger.log(
-            f"{timestamp:%H:%M:%S} Запущен цикл обработки для {context.symbol}.",
+            f"Запущен цикл обработки для {context.symbol}.",
             timestamp,
         )
         context.cycle_started = True
@@ -559,13 +559,13 @@ class Application:
         )
         startup_timestamp = get_current_time()
         self._event_logger.log(
-            f"{startup_timestamp:%H:%M:%S} Старт бота для {symbol} на {self._exchange.value}.",
+            f"Старт бота для {symbol} на {self._exchange.value}.",
             startup_timestamp,
         )
         filters_timestamp = get_current_time()
         self._event_logger.log(
             (
-                f"{filters_timestamp:%H:%M:%S} Получены фильтры {symbol}: "
+                f"Получены фильтры {symbol}: "
                 f"шаг цены {context.filters.price_tick_size:g}."
             ),
             filters_timestamp,
@@ -573,7 +573,7 @@ class Application:
         initialize_account(context.trading_adapter)
         account_timestamp = get_current_time()
         self._event_logger.log(
-            f"{account_timestamp:%H:%M:%S} Торговый адаптер инициализирован для {symbol}.",
+            f"Торговый адаптер инициализирован для {symbol}.",
             account_timestamp,
         )
         self._update_context_balance(context)
@@ -603,7 +603,7 @@ class Application:
     def _log_scanner_message(self, message: str) -> None:
         timestamp = get_current_time()
         self._event_logger.log(
-            f"{timestamp:%H:%M:%S} Сканер рынка: {message}",
+            f"Сканер рынка: {message}",
             timestamp,
         )
 
@@ -613,7 +613,7 @@ class Application:
         context.balance = balance
         context.balance_updated_at = timestamp
         self._event_logger.log(
-            f"{timestamp:%H:%M:%S} Баланс {context.symbol} обновлён: {balance:g}.",
+            f"Баланс {context.symbol} обновлён: {balance:g}.",
             timestamp,
         )
 

--- a/data/logger.py
+++ b/data/logger.py
@@ -27,9 +27,18 @@ def create_text_log_sink(stream: TextIO | None = None) -> LogSink:
 def create_log_writer(sink: LogSink | None = None) -> LogLineWriter:
     text_sink = sink or _print_sink
 
+    def _strip_prefix(message: str) -> str:
+        stripped = message.strip()
+        if len(stripped) >= 9 and stripped[2] == ":" and stripped[5] == ":":
+            if stripped[:2].isdigit() and stripped[3:5].isdigit() and stripped[6:8].isdigit():
+                if stripped[8] == " ":
+                    return stripped[9:]
+        return stripped
+
     def _write(entry: LogLine) -> None:
         timestamp = entry.timestamp.astimezone()
-        text_sink(f"{timestamp:%H:%M:%S} {entry.message}")
+        message = _strip_prefix(entry.message)
+        text_sink(f"{timestamp:%H:%M:%S} {message}")
 
     return _write
 

--- a/domain/strategy/focus.py
+++ b/domain/strategy/focus.py
@@ -21,7 +21,7 @@ class FocusController:
         if self._current is not None:
             self.defocus(timestamp)
         self.focus_symbol(symbol)
-        self.logger.log(f"{timestamp:%H:%M:%S} Фокус на {symbol}.", timestamp)
+        self.logger.log(f"Фокус на {symbol}.", timestamp)
         self._current = symbol
 
     def defocus(self, timestamp: datetime) -> None:
@@ -29,7 +29,7 @@ class FocusController:
             return
         current = self._current
         self.defocus_symbol()
-        self.logger.log(f"{timestamp:%H:%M:%S} Дефокус со {current}.", timestamp)
+        self.logger.log(f"Дефокус со {current}.", timestamp)
         self._current = None
 
     @property

--- a/domain/strategy/kill_switch.py
+++ b/domain/strategy/kill_switch.py
@@ -53,10 +53,7 @@ class KillSwitch:
         if self._block_until is None or block_until > self._block_until:
             self._block_until = block_until
         self._last_block_at = timestamp
-        self.logger.log(
-            f"{timestamp:%H:%M:%S} Блокировка торгов: ожидание после ресинка.",
-            timestamp,
-        )
+        self.logger.log("Блокировка торгов: ожидание после ресинка.", timestamp)
 
     def _purge_stops(self, timestamp: datetime) -> None:
         if self.stop_interval <= timedelta(0):
@@ -87,10 +84,7 @@ class KillSwitch:
         if self._block_until is None or block_until > self._block_until:
             self._block_until = block_until
         self._last_block_at = timestamp
-        self.logger.log(
-            f"{timestamp:%H:%M:%S} Блокировка торгов: {reason}.",
-            timestamp,
-        )
+        self.logger.log(f"Блокировка торгов: {reason}.", timestamp)
 
 
 __all__ = ["KillSwitch"]

--- a/domain/strategy/position.py
+++ b/domain/strategy/position.py
@@ -20,21 +20,17 @@ class PositionController:
         self.enter_position(symbol, signal, wall)
         direction = "лонг" if signal is Signal.LONG else "шорт"
         self.logger.log(
-            f"{timestamp:%H:%M:%S} Вход {direction} {symbol} по стене {wall.price:g}.",
+            f"Вход {direction} {symbol} по стене {wall.price:g}.",
             timestamp,
         )
 
     def exit(self, symbol: str, reason: str, timestamp: datetime) -> None:
         self.exit_position(symbol, reason)
-        self.logger.log(
-            f"{timestamp:%H:%M:%S} Выход {symbol}. Причина: {reason}.", timestamp
-        )
+        self.logger.log(f"Выход {symbol}. Причина: {reason}.", timestamp)
 
     def adjust_stop(self, symbol: str, price: float, timestamp: datetime) -> None:
         self.move_stop(symbol, price)
-        self.logger.log(
-            f"{timestamp:%H:%M:%S} Перенос стопа {symbol} на {price:g}.", timestamp
-        )
+        self.logger.log(f"Перенос стопа {symbol} на {price:g}.", timestamp)
 
 
 __all__ = ["PositionController"]

--- a/domain/strategy/strategy.py
+++ b/domain/strategy/strategy.py
@@ -83,7 +83,7 @@ class Strategy:
     def complete_resync(self, timestamp: datetime) -> StrategyState:
         if self._state is not StrategyState.RESYNC:
             return self._state
-        self._logger.log(f"{timestamp:%H:%M:%S} Ресинк завершён.", timestamp)
+        self._logger.log("Ресинк завершён.", timestamp)
         self._state = self._previous_state
         self._resync_reason = None
         return self._state
@@ -136,7 +136,7 @@ class Strategy:
                     self._focused_wall = wall
         if self._should_defocus(timestamp):
             self._logger.log(
-                f"{timestamp:%H:%M:%S} Аптик {symbol} потерян: таймаут сигнала.",
+                f"Аптик {symbol} потерян: таймаут сигнала.",
                 timestamp,
             )
             self._focus.defocus(timestamp)
@@ -219,7 +219,7 @@ class Strategy:
         direction = "лонг" if signal is Signal.LONG else "шорт"
         self._logger.log(
             (
-                f"{timestamp:%H:%M:%S} Аптик {symbol} {direction}. "
+                f"Аптик {symbol} {direction}. "
                 f"Стена {wall.price:g} объём {wall.notional:g}. "
                 f"Всплеск объёма x{volume_ratio:.2f}."
             ),
@@ -275,10 +275,7 @@ class Strategy:
             blocked_until = self._safety.blocked_until()
             if blocked_until is not None:
                 self._logger.log(
-                    (
-                        f"{timestamp:%H:%M:%S} Вход в {symbol} заблокирован до "
-                        f"{blocked_until:%H:%M:%S}."
-                    ),
+                    f"Вход в {symbol} заблокирован до {blocked_until:%H:%M:%S}.",
                     timestamp,
                 )
             return
@@ -406,7 +403,7 @@ class Strategy:
         self._state = StrategyState.RESYNC
         self._resync_reason = reason
         self._logger.log(
-            f"{timestamp:%H:%M:%S} Ресинк книги. Причина: {reason.value}.", timestamp
+            f"Ресинк книги. Причина: {reason.value}.", timestamp
         )
         self._track_resync_summary(timestamp)
         self._safety.handle_resync(timestamp)
@@ -417,7 +414,7 @@ class Strategy:
         elapsed = timestamp - self._resync_summary_start
         if elapsed >= timedelta(hours=1):
             self._logger.log(
-                f"{timestamp:%H:%M:%S} Ресинков за час: {self._resync_summary_count}.",
+                f"Ресинков за час: {self._resync_summary_count}.",
                 timestamp,
             )
             self._resync_summary_start = timestamp

--- a/domain/strategy/subscription.py
+++ b/domain/strategy/subscription.py
@@ -20,10 +20,10 @@ class SubscriptionManager:
         removals = self._compute_removals(symbols)
         for symbol in additions:
             self.subscribe(symbol)
-            self.logger.log(f"{timestamp:%H:%M:%S} Подписка на {symbol}.", timestamp)
+            self.logger.log(f"Подписка на {symbol}.", timestamp)
         for symbol in removals:
             self.unsubscribe(symbol)
-            self.logger.log(f"{timestamp:%H:%M:%S} Отписка от {symbol}.", timestamp)
+            self.logger.log(f"Отписка от {symbol}.", timestamp)
         self._active = tuple(symbols)
 
     def _compute_additions(self, symbols: Tuple[str, ...]) -> Tuple[str, ...]:


### PR DESCRIPTION
## Summary
- update the log writer to strip any pre-existing timestamp and consistently emit `ЧЧ:ММ:СС` formatted lines
- adjust strategy and application log messages to rely on centralized timestamp formatting instead of embedding time prefixes

## Testing
- python -m compileall app.py data domain

------
https://chatgpt.com/codex/tasks/task_e_68e0d4bc5e3883208948c0f27186668a