### PR TITLE
Add funding window handling and next funding lookup

### DIFF
--- a/app.py
+++ b/app.py
@@ -114,6 +114,9 @@ class SymbolContext:
     ticker_stream: Iterator[StreamEvent[BestBidAsk]]
     filters: SymbolFilters
     trading_adapter: TradingAdapter
+    next_funding_at: Optional[datetime] = None
+    next_funding_updated_at: Optional[datetime] = None
+    funding_block_logged: bool = False
     last_update_id: Optional[int] = None
     last_trade_price: Optional[float] = None
     best_bid: Optional[float] = None
@@ -231,6 +234,8 @@ class Application:
             max_drawdown=ks_settings.max_drawdown_frac,
             position_fraction=CONFIG.position.position_fraction,
         )
+        self._funding_block_window = timedelta(seconds=ks_settings.funding_block_s)
+        self._funding_refresh_interval = timedelta(minutes=5)
         self._strategy = Strategy(
             subscriptions=self._subscription_manager,
             focus=self._focus_controller,
@@ -578,6 +583,7 @@ class Application:
         )
         self._update_context_balance(context)
         self._initialize_order_book(context)
+        self._refresh_context_funding(context, force=True)
         return context
 
     def _create_trading_adapter(self, symbol: str, filters: SymbolFilters) -> TradingAdapter:
@@ -617,6 +623,91 @@ class Application:
             timestamp,
         )
 
+    def _refresh_context_funding(
+        self,
+        context: SymbolContext,
+        *,
+        force: bool = False,
+    ) -> None:
+        now = get_current_time()
+        needs_refresh = force
+        if not needs_refresh:
+            if context.next_funding_updated_at is None:
+                needs_refresh = True
+            elif context.next_funding_at is None:
+                needs_refresh = (
+                    now - context.next_funding_updated_at
+                    >= self._funding_refresh_interval
+                )
+            else:
+                if now - context.next_funding_updated_at >= self._funding_refresh_interval:
+                    needs_refresh = True
+                elif now > context.next_funding_at + self._funding_block_window:
+                    needs_refresh = True
+        if not needs_refresh:
+            return
+        try:
+            next_funding = context.exchange_data.fetch_next_funding_time()
+        except Exception as exc:
+            self._event_logger.log(
+                f"Не удалось обновить время фандинга для {context.symbol}: {exc}",
+                now,
+            )
+            context.next_funding_updated_at = now
+            return
+        previous = context.next_funding_at
+        context.next_funding_at = next_funding
+        context.next_funding_updated_at = now
+        context.funding_block_logged = False
+        if next_funding is None:
+            if previous is not None:
+                self._event_logger.log(
+                    f"Следующее время фандинга для {context.symbol} недоступно.",
+                    now,
+                )
+            return
+        if previous is None or next_funding != previous:
+            localized = next_funding.astimezone(CURRENT_TIMEZONE)
+            self._event_logger.log(
+                (
+                    f"Следующее время фандинга для {context.symbol}: "
+                    f"{localized:%Y-%m-%d %H:%M:%S %Z}."
+                ),
+                now,
+            )
+
+    def _handle_funding_window(self, context: SymbolContext, timestamp: datetime) -> None:
+        window = self._funding_block_window
+        if window <= timedelta(0):
+            return
+        next_funding = context.next_funding_at
+        if next_funding is None:
+            if context.funding_block_logged:
+                context.funding_block_logged = False
+            return
+        start = next_funding - window
+        end = next_funding + window
+        if start <= timestamp <= end:
+            self._kill_switch.handle_funding(next_funding)
+            if not context.funding_block_logged:
+                blocked_until = self._kill_switch.blocked_until()
+                funding_local = next_funding.astimezone(CURRENT_TIMEZONE)
+                if blocked_until is not None:
+                    block_local = blocked_until.astimezone(CURRENT_TIMEZONE)
+                    message = (
+                        f"{context.symbol}: блокировка из-за фандинга до "
+                        f"{block_local:%H:%M:%S %Z}. Фандинг в {funding_local:%H:%M:%S %Z}."
+                    )
+                else:
+                    message = (
+                        f"{context.symbol}: блокировка из-за фандинга. "
+                        f"Фандинг в {funding_local:%H:%M:%S %Z}."
+                    )
+                self._event_logger.log(message, timestamp)
+                context.funding_block_logged = True
+        elif context.funding_block_logged and timestamp > end:
+            context.funding_block_logged = False
+
     def _refresh_balances(self, *, force: bool = False) -> None:
         if not self._contexts:
             return
@@ -645,6 +736,9 @@ class Application:
             for context in self._iter_active_contexts():
                 self._current_symbol = context.symbol
                 self._ensure_cycle_logged(context)
+                self._refresh_context_funding(context)
+                now = get_current_time()
+                self._handle_funding_window(context, now)
                 self._process_depth_stream(context)
                 self._process_trade_stream(context)
                 self._process_ticker_stream(context)

--- a/data/exchanges/base/exchange_data.py
+++ b/data/exchanges/base/exchange_data.py
@@ -1,4 +1,5 @@
-from typing import Iterator, Protocol
+from datetime import datetime
+from typing import Iterator, Optional, Protocol
 
 from domain.models import Candle, OrderBookSnapshot, SymbolFilters, Trade
 
@@ -24,6 +25,9 @@ class IExchangeData(Protocol):
         ...
 
     def stream_kline_1m(self) -> Iterator[StreamEvent[Candle]]:
+        ...
+
+    def fetch_next_funding_time(self) -> Optional[datetime]:
         ...
 
 

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -5,7 +5,7 @@ import socket
 import threading
 import time
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Callable, Iterable, Iterator, Optional, Protocol
 from urllib import parse
 from urllib.error import HTTPError, URLError
@@ -167,6 +167,27 @@ class BinanceExchangeData:
         with self._lock:
             self._depth_last_update = last_update_id
         return snapshot
+
+    def fetch_next_funding_time(self) -> Optional[datetime]:
+        response = self._rest_get(
+            "/fapi/v1/fundingRate",
+            {"symbol": self.symbol, "limit": 1},
+        )
+        if not response:
+            return None
+        entry = response[0]
+        funding_time_raw = entry.get("fundingTime")
+        if funding_time_raw is None:
+            return None
+        last_funding = from_exchange_timestamp(funding_time_raw)
+        interval = timedelta(hours=8)
+        if interval <= timedelta(0):
+            return None
+        next_funding = last_funding + interval
+        now = get_current_time()
+        while next_funding <= now:
+            next_funding += interval
+        return next_funding
 
     def stream_depth(self) -> Iterator[StreamEvent[DepthStreamData]]:
         buffer: StreamBuffer[DepthStreamData] = StreamBuffer(

--- a/data/exchanges/bybit.py
+++ b/data/exchanges/bybit.py
@@ -5,7 +5,7 @@ import socket
 import threading
 import time
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from http.client import RemoteDisconnected
 from typing import (
     Any,
@@ -226,6 +226,30 @@ class BybitExchangeData:
         with self._lock:
             self._depth_last_seq = seq
         return snapshot
+
+    def fetch_next_funding_time(self) -> Optional[datetime]:
+        response = self._rest_get(
+            "/v5/market/funding/history",
+            {"category": "linear", "symbol": self.symbol, "limit": 1},
+        )
+        result = response.get("result") if isinstance(response, dict) else None
+        records = [] if result is None else result.get("list") or []
+        if not records:
+            return None
+        entry = records[0]
+        next_funding_raw = entry.get("nextFundingTime") or entry.get("fundingRateTimestamp")
+        if next_funding_raw is None:
+            return None
+        candidate = from_exchange_timestamp(next_funding_raw)
+        interval = timedelta(hours=8)
+        if interval <= timedelta(0):
+            return None
+        now = get_current_time()
+        if candidate <= now:
+            candidate += interval
+            while candidate <= now:
+                candidate += interval
+        return candidate
 
     def stream_depth(self) -> Iterator[StreamEvent[DepthStreamData]]:
         buffer: StreamBuffer[DepthStreamData] = StreamBuffer(

--- a/domain/strategy/kill_switch.py
+++ b/domain/strategy/kill_switch.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from typing import Deque, Optional
 
 from .event_logger import EventLogger
+from utils import get_current_time
 
 
 @dataclass
@@ -22,17 +23,24 @@ class KillSwitch:
     _stop_events: Deque[datetime] = field(default_factory=deque)
     _equity: float = 1.0
     _peak_equity: float = 1.0
+    _funding_event_at: Optional[datetime] = None
+    _block_reason: Optional[str] = None
 
     def is_blocked(self, timestamp: datetime) -> bool:
         if self._block_until is None:
             return False
         if timestamp >= self._block_until:
             self._block_until = None
+            self._block_reason = None
+            self._funding_event_at = None
             return False
         return True
 
     def blocked_until(self) -> Optional[datetime]:
         return self._block_until
+
+    def block_reason(self) -> Optional[str]:
+        return self._block_reason
 
     def record_entry(self, timestamp: datetime) -> None:
         self._purge_stops(timestamp)
@@ -53,7 +61,42 @@ class KillSwitch:
         if self._block_until is None or block_until > self._block_until:
             self._block_until = block_until
         self._last_block_at = timestamp
+        self._block_reason = "ожидание после ресинка"
+        self._funding_event_at = None
         self.logger.log("Блокировка торгов: ожидание после ресинка.", timestamp)
+
+    def handle_funding(self, funding_time: datetime) -> None:
+        if self.funding_block <= timedelta(0):
+            return
+        now = get_current_time()
+        start = funding_time - self.funding_block
+        end = funding_time + self.funding_block
+        if now < start or now > end:
+            return
+        if (
+            self._funding_event_at == funding_time
+            and self._block_until is not None
+            and self._block_until >= end
+        ):
+            return
+        if self._block_until is None or self._block_until < end:
+            self._block_until = end
+            update_reason = True
+        else:
+            update_reason = self._block_reason in (None, "окно фандинга")
+        self._last_block_at = now
+        self._funding_event_at = funding_time
+        if update_reason:
+            self._block_reason = "окно фандинга"
+        funding_str = funding_time.strftime("%Y-%m-%d %H:%M:%S %Z")
+        release = (self._block_until or end).strftime("%Y-%m-%d %H:%M:%S %Z")
+        self.logger.log(
+            (
+                "Блокировка торгов: окно фандинга."
+                f" Фандинг в {funding_str}, блокировка до {release}."
+            ),
+            now,
+        )
 
     def _purge_stops(self, timestamp: datetime) -> None:
         if self.stop_interval <= timedelta(0):
@@ -84,6 +127,8 @@ class KillSwitch:
         if self._block_until is None or block_until > self._block_until:
             self._block_until = block_until
         self._last_block_at = timestamp
+        self._block_reason = reason
+        self._funding_event_at = None
         self.logger.log(f"Блокировка торгов: {reason}.", timestamp)
 
 

--- a/domain/strategy/strategy.py
+++ b/domain/strategy/strategy.py
@@ -273,11 +273,16 @@ class Strategy:
             return
         if self._safety.is_blocked(timestamp):
             blocked_until = self._safety.blocked_until()
+            reason = self._safety.block_reason()
             if blocked_until is not None:
-                self._logger.log(
-                    f"Вход в {symbol} заблокирован до {blocked_until:%H:%M:%S}.",
-                    timestamp,
-                )
+                message = f"Вход в {symbol} заблокирован до {blocked_until:%H:%M:%S}"
+            else:
+                message = f"Вход в {symbol} заблокирован"
+            if reason:
+                message = f"{message} ({reason})."
+            else:
+                message = f"{message}."
+            self._logger.log(message, timestamp)
             return
         self._position.enter(symbol, signal, wall, timestamp)
         self._safety.record_entry(timestamp)


### PR DESCRIPTION
## Summary
- add a next funding timestamp accessor to the exchange data protocol with Binance and Bybit implementations
- track the next funding time inside each symbol context, refreshing it periodically and invoking the funding kill switch when entering the configurable window
- extend the kill switch to manage funding-driven blocks and surface the reason when strategy entries are skipped

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e0d8819df08320ad8e3879dbd3c332