### PR TITLE
Refine turnover thresholds for auto profile

### DIFF
--- a/app.py
+++ b/app.py
@@ -507,12 +507,13 @@ class Application:
             if timestamp - self._last_scan_at < self._scanner_interval:
                 return
         scan_result = self._scanner.scan()
-        self._symbol_profiles = {symbol: profile for symbol, profile in scan_result}
-        symbols = tuple(symbol for symbol, _ in scan_result)
+        profile_by_symbol = {symbol: profile for symbol, profile in scan_result}
+        self._symbol_profiles = profile_by_symbol
+        symbols = tuple(profile_by_symbol.keys())
         self._desired_symbols = symbols
-        for symbol, profile in self._symbol_profiles.items():
-            context = self._contexts.get(symbol)
-            if context is not None:
+        for symbol, context in self._contexts.items():
+            profile = profile_by_symbol.get(symbol)
+            if profile is not None:
                 context.profile = profile
         self._subscription_manager.update(symbols, timestamp)
         self._last_scan_at = timestamp

--- a/application/market_scanner.py
+++ b/application/market_scanner.py
@@ -125,7 +125,15 @@ class MarketScanner:
     def _resolve_threshold(self) -> float:
         thresholds = self._thresholds
         if self._profile is TradingProfile.AUTO:
-            return float(min(thresholds.top_usd, thresholds.alt_usd, thresholds.listing_usd))
+            values = (
+                float(thresholds.top_usd),
+                float(thresholds.listing_usd),
+                float(thresholds.alt_usd),
+            )
+            positives = [value for value in values if value > 0.0]
+            if not positives:
+                return 0.0
+            return min(positives)
         if self._profile is TradingProfile.TOP:
             return float(thresholds.top_usd)
         if self._profile is TradingProfile.ALT:
@@ -136,9 +144,14 @@ class MarketScanner:
 
     def _classify_turnover(self, turnover: float) -> TradingProfile:
         thresholds = self._thresholds
-        if turnover >= float(thresholds.top_usd):
+        top_threshold = float(thresholds.top_usd)
+        listing_threshold = float(thresholds.listing_usd)
+        alt_threshold = float(thresholds.alt_usd)
+        if turnover >= top_threshold:
             return TradingProfile.TOP
-        if turnover >= float(thresholds.alt_usd):
+        if turnover >= listing_threshold:
+            return TradingProfile.LISTING
+        if turnover >= alt_threshold:
             return TradingProfile.ALT
         return TradingProfile.LISTING
 


### PR DESCRIPTION
## Summary
- ensure auto mode filtering uses the lowest positive turnover threshold
- update turnover classification to check TOP, LISTING, then ALT so listing bands are reachable
- propagate refreshed symbol profiles to existing contexts when scans run

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0db5aa76c832097c51783be839e50