### PR TITLE
Add stream subscription wrapper and manage stream lifecycle

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from collections import deque
-from typing import Deque, Dict, Iterable, Iterator, Optional, Sequence, Tuple, cast
+from typing import Deque, Dict, Iterable, Optional, Sequence, Tuple, cast
 
 from config.config import CONFIG
 from config.models.balance_source import BalanceSource as ConfigBalanceSource
@@ -25,6 +25,7 @@ from data.exchanges import (
     ResyncReason as StreamResyncReason,
     StreamEvent,
     StreamEventType,
+    StreamSubscription,
 )
 from data.logger import LogSink, create_log_writer, create_text_log_sink
 from data.telegram import TelegramClient
@@ -109,9 +110,9 @@ class SymbolContext:
     exchange_data: IExchangeData
     order_book: OrderBook
     feed_monitor: FeedMonitor
-    depth_stream: Iterator[StreamEvent[DepthStreamData]]
-    trade_stream: Iterator[StreamEvent[Trade]]
-    ticker_stream: Iterator[StreamEvent[BestBidAsk]]
+    depth_subscription: StreamSubscription[DepthStreamData]
+    trade_subscription: StreamSubscription[Trade]
+    ticker_subscription: StreamSubscription[BestBidAsk]
     filters: SymbolFilters
     trading_adapter: TradingAdapter
     next_funding_at: Optional[datetime] = None
@@ -308,10 +309,20 @@ class Application:
 
     def _unsubscribe_symbol(self, symbol: str) -> None:
         symbol = symbol.upper()
-        context = self._contexts.get(symbol)
+        context = self._contexts.pop(symbol, None)
         if context is None:
             return
         context.active = False
+        subscriptions = (
+            context.depth_subscription,
+            context.trade_subscription,
+            context.ticker_subscription,
+        )
+        for subscription in subscriptions:
+            try:
+                subscription.stop()
+            except Exception:
+                pass
         if self._focus_controller.current == symbol:
             timestamp = get_current_time()
             self._focus_controller.defocus(timestamp)
@@ -343,7 +354,7 @@ class Application:
 
     def _initialize_order_book(self, context: SymbolContext) -> None:
         while True:
-            event = next(context.depth_stream)
+            event = next(context.depth_subscription.events)
             if event.type is StreamEventType.SNAPSHOT:
                 snapshot = cast(OrderBookSnapshot, event.data)
                 if snapshot is None:
@@ -391,7 +402,7 @@ class Application:
         context.best_ask = None if ask_level is None else ask_level.price
 
     def _process_depth_stream(self, context: SymbolContext) -> None:
-        event = next(context.depth_stream)
+        event = next(context.depth_subscription.events)
         if event.type is StreamEventType.DATA:
             update = cast(OrderBookUpdate, event.data)
             if update is not None:
@@ -416,7 +427,7 @@ class Application:
 
     @staticmethod
     def _process_trade_stream(context: SymbolContext) -> None:
-        event = next(context.trade_stream)
+        event = next(context.trade_subscription.events)
         if event.type is StreamEventType.DATA:
             trade = cast(Trade, event.data)
             if trade is not None:
@@ -429,7 +440,7 @@ class Application:
 
     @staticmethod
     def _process_ticker_stream(context: SymbolContext) -> None:
-        event = next(context.ticker_stream)
+        event = next(context.ticker_subscription.events)
         if event.type is StreamEventType.DATA:
             ticker = cast(BestBidAsk, event.data)
             if ticker is not None:
@@ -556,9 +567,9 @@ class Application:
                 recent_band_volume_boost=CONFIG.general.recent_band_s_vol_boost,
             ),
             feed_monitor=FeedMonitor(),
-            depth_stream=exchange_data.stream_depth(),
-            trade_stream=exchange_data.stream_trades(),
-            ticker_stream=exchange_data.stream_book_ticker(),
+            depth_subscription=exchange_data.stream_depth(),
+            trade_subscription=exchange_data.stream_trades(),
+            ticker_subscription=exchange_data.stream_book_ticker(),
             filters=filters,
             trading_adapter=trading_adapter,
             profile=self._symbol_profiles.get(symbol, CONFIG.general.profile),

--- a/data/exchanges/__init__.py
+++ b/data/exchanges/__init__.py
@@ -8,6 +8,7 @@ from .base import (
     StreamBuffer,
     StreamEvent,
     StreamEventType,
+    StreamSubscription,
 )
 from .binance import BinanceExchangeData
 from .binance_trade import BinanceTradingAdapter
@@ -24,6 +25,7 @@ __all__ = [
     "StreamBuffer",
     "StreamEvent",
     "StreamEventType",
+    "StreamSubscription",
     "BinanceExchangeData",
     "BinanceTradingAdapter",
     "BybitExchangeData",

--- a/data/exchanges/base/__init__.py
+++ b/data/exchanges/base/__init__.py
@@ -1,6 +1,6 @@
 from .best_bid_ask import BestBidAsk
 from .depth_stream_data import DepthStreamData
-from .exchange_data import IExchangeData
+from .exchange_data import IExchangeData, StreamSubscription
 from .exchange_logger import ExchangeLogger
 from .exchange_trade import IExchangeTrade
 from .resync_reason import ResyncReason
@@ -18,4 +18,5 @@ __all__ = [
     "StreamBuffer",
     "StreamEvent",
     "StreamEventType",
+    "StreamSubscription",
 ]

--- a/data/exchanges/base/exchange_data.py
+++ b/data/exchanges/base/exchange_data.py
@@ -1,11 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Iterator, Optional, Protocol
+from threading import Thread
+from typing import Generic, Iterator, Optional, Protocol, TypeVar
 
 from domain.models import Candle, OrderBookSnapshot, SymbolFilters, Trade
 
 from .best_bid_ask import BestBidAsk
 from .depth_stream_data import DepthStreamData
+from .stream_buffer import StreamBuffer
 from .stream_event import StreamEvent
+
+
+T = TypeVar("T")
+
+
+@dataclass(slots=True)
+class StreamSubscription(Generic[T]):
+    events: Iterator[StreamEvent[T]]
+    _buffer: StreamBuffer[T]
+    _worker: Thread
+
+    def stop(self) -> None:
+        self._buffer.stop()
+        if self._worker.is_alive():
+            self._worker.join(timeout=1.0)
 
 
 class IExchangeData(Protocol):
@@ -15,20 +35,20 @@ class IExchangeData(Protocol):
     def fetch_orderbook_snapshot(self) -> OrderBookSnapshot:
         ...
 
-    def stream_depth(self) -> Iterator[StreamEvent[DepthStreamData]]:
+    def stream_depth(self) -> StreamSubscription[DepthStreamData]:
         ...
 
-    def stream_book_ticker(self) -> Iterator[StreamEvent[BestBidAsk]]:
+    def stream_book_ticker(self) -> StreamSubscription[BestBidAsk]:
         ...
 
-    def stream_trades(self) -> Iterator[StreamEvent[Trade]]:
+    def stream_trades(self) -> StreamSubscription[Trade]:
         ...
 
-    def stream_kline_1m(self) -> Iterator[StreamEvent[Candle]]:
+    def stream_kline_1m(self) -> StreamSubscription[Candle]:
         ...
 
     def fetch_next_funding_time(self) -> Optional[datetime]:
         ...
 
 
-__all__ = ["IExchangeData"]
+__all__ = ["IExchangeData", "StreamSubscription"]

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -30,6 +30,7 @@ from .base import (
     ResyncReason,
     StreamBuffer,
     StreamEvent,
+    StreamSubscription,
 )
 from utils.timez import from_exchange_timestamp, get_current_time
 
@@ -189,7 +190,7 @@ class BinanceExchangeData:
             next_funding += interval
         return next_funding
 
-    def stream_depth(self) -> Iterator[StreamEvent[DepthStreamData]]:
+    def stream_depth(self) -> StreamSubscription[DepthStreamData]:
         buffer: StreamBuffer[DepthStreamData] = StreamBuffer(
             name="depth",
             logger=self._logger,
@@ -206,12 +207,16 @@ class BinanceExchangeData:
             daemon=True,
         )
         worker.start()
-        try:
-            while True:
-                yield buffer.next()
-        finally:
-            buffer.stop()
-            worker.join(timeout=1.0)
+
+        def iterator() -> Iterator[StreamEvent[DepthStreamData]]:
+            try:
+                while True:
+                    yield buffer.next()
+            finally:
+                buffer.stop()
+                worker.join(timeout=1.0)
+
+        return StreamSubscription(events=iterator(), _buffer=buffer, _worker=worker)
 
     def _run_depth_stream(self, buffer: StreamBuffer[DepthStreamData]) -> None:
         url = f"{self._endpoints.ws_base}/{self.symbol.lower()}@depth@100ms"
@@ -301,21 +306,21 @@ class BinanceExchangeData:
             return
         buffer.push_snapshot(snapshot)
 
-    def stream_book_ticker(self) -> Iterator[StreamEvent[BestBidAsk]]:
+    def stream_book_ticker(self) -> StreamSubscription[BestBidAsk]:
         return self._run_simple_stream(
             name="book_ticker",
             url=f"{self._endpoints.ws_base}/{self.symbol.lower()}@bookTicker",
             parser=self._parse_book_ticker,
         )
 
-    def stream_trades(self) -> Iterator[StreamEvent[Trade]]:
+    def stream_trades(self) -> StreamSubscription[Trade]:
         return self._run_simple_stream(
             name="trades",
             url=f"{self._endpoints.ws_base}/{self.symbol.lower()}@aggTrade",
             parser=self._parse_trade,
         )
 
-    def stream_kline_1m(self) -> Iterator[StreamEvent[Candle]]:
+    def stream_kline_1m(self) -> StreamSubscription[Candle]:
         return self._run_simple_stream(
             name="kline_1m",
             url=f"{self._endpoints.ws_base}/{self.symbol.lower()}@kline_1m",
@@ -327,7 +332,7 @@ class BinanceExchangeData:
         name: str,
         url: str,
         parser: Callable[[dict[str, Any]], Iterable[Any]],
-    ) -> Iterator[StreamEvent[Any]]:
+    ) -> StreamSubscription[Any]:
         buffer: StreamBuffer[Any] = StreamBuffer(
             name=name,
             logger=self._logger,
@@ -342,12 +347,16 @@ class BinanceExchangeData:
             daemon=True,
         )
         worker.start()
-        try:
-            while True:
-                yield buffer.next()
-        finally:
-            buffer.stop()
-            worker.join(timeout=1.0)
+
+        def iterator() -> Iterator[StreamEvent[Any]]:
+            try:
+                while True:
+                    yield buffer.next()
+            finally:
+                buffer.stop()
+                worker.join(timeout=1.0)
+
+        return StreamSubscription(events=iterator(), _buffer=buffer, _worker=worker)
 
     def _stream_worker(
         self,

--- a/data/exchanges/bybit.py
+++ b/data/exchanges/bybit.py
@@ -41,6 +41,7 @@ from .base import (
     ResyncReason,
     StreamBuffer,
     StreamEvent,
+    StreamSubscription,
 )
 from utils.timez import from_exchange_timestamp, get_current_time
 
@@ -251,7 +252,7 @@ class BybitExchangeData:
                 candidate += interval
         return candidate
 
-    def stream_depth(self) -> Iterator[StreamEvent[DepthStreamData]]:
+    def stream_depth(self) -> StreamSubscription[DepthStreamData]:
         buffer: StreamBuffer[DepthStreamData] = StreamBuffer(
             name="depth",
             logger=self._logger,
@@ -268,12 +269,16 @@ class BybitExchangeData:
             daemon=True,
         )
         worker.start()
-        try:
-            while True:
-                yield buffer.next()
-        finally:
-            buffer.stop()
-            worker.join(timeout=1.0)
+
+        def iterator() -> Iterator[StreamEvent[DepthStreamData]]:
+            try:
+                while True:
+                    yield buffer.next()
+            finally:
+                buffer.stop()
+                worker.join(timeout=1.0)
+
+        return StreamSubscription(events=iterator(), _buffer=buffer, _worker=worker)
 
     def _run_depth_stream(self, buffer: StreamBuffer[DepthStreamData]) -> None:
         url = self._endpoints.ws_base
@@ -468,7 +473,7 @@ class BybitExchangeData:
             return
         buffer.push_snapshot(snapshot)
 
-    def stream_book_ticker(self) -> Iterator[StreamEvent[BestBidAsk]]:
+    def stream_book_ticker(self) -> StreamSubscription[BestBidAsk]:
         topic = f"tickers.{self.symbol}"
         return self._run_simple_stream(
             name="book_ticker",
@@ -476,7 +481,7 @@ class BybitExchangeData:
             parser=self._parse_ticker,
         )
 
-    def stream_trades(self) -> Iterator[StreamEvent[Trade]]:
+    def stream_trades(self) -> StreamSubscription[Trade]:
         topic = f"publicTrade.{self.symbol}"
         return self._run_simple_stream(
             name="trades",
@@ -484,7 +489,7 @@ class BybitExchangeData:
             parser=self._parse_trade,
         )
 
-    def stream_kline_1m(self) -> Iterator[StreamEvent[Candle]]:
+    def stream_kline_1m(self) -> StreamSubscription[Candle]:
         topic = f"kline.1.{self.symbol}"
         return self._run_simple_stream(
             name="kline_1m",
@@ -497,7 +502,7 @@ class BybitExchangeData:
         name: str,
         topic: str,
         parser: Callable[[dict[str, Any]], Iterable[Any]],
-    ) -> Iterator[StreamEvent[Any]]:
+    ) -> StreamSubscription[Any]:
         buffer: StreamBuffer[Any] = StreamBuffer(
             name=name,
             logger=self._logger,
@@ -513,12 +518,16 @@ class BybitExchangeData:
             daemon=True,
         )
         worker.start()
-        try:
-            while True:
-                yield buffer.next()
-        finally:
-            buffer.stop()
-            worker.join(timeout=1.0)
+
+        def iterator() -> Iterator[StreamEvent[Any]]:
+            try:
+                while True:
+                    yield buffer.next()
+            finally:
+                buffer.stop()
+                worker.join(timeout=1.0)
+
+        return StreamSubscription(events=iterator(), _buffer=buffer, _worker=worker)
 
     def _simple_worker(
         self,


### PR DESCRIPTION
## Summary
- add a StreamSubscription wrapper that exposes stream events alongside lifecycle management
- update Binance and Bybit exchange data streams to return StreamSubscription instances
- switch the application symbol context to use subscriptions and stop them during unsubscribe

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0df375278832090db59537fa0b6fc