### PR TITLE
Handle websocket restarts on silence timeouts

### DIFF
--- a/data/exchanges/base/stream_buffer.py
+++ b/data/exchanges/base/stream_buffer.py
@@ -30,6 +30,7 @@ class StreamBuffer(Generic[T]):
             heartbeat_interval if heartbeat_interval is not None else silence_timeout / 2
         )
         self._stop = Event()
+        self._restart_event = Event()
         now = time.monotonic()
         self._last_data = now
         self._last_heartbeat = now
@@ -45,6 +46,18 @@ class StreamBuffer(Generic[T]):
             except queue.Full:
                 self._drain()
                 self._queue.put_nowait(StreamEvent.stop())
+
+    def request_restart(self) -> None:
+        self._restart_event.set()
+
+    def consume_restart_request(self) -> bool:
+        if self._restart_event.is_set():
+            self._restart_event.clear()
+            return True
+        return False
+
+    def restart_requested(self) -> bool:
+        return self._restart_event.is_set()
 
     def push(self, event: StreamEvent[T]) -> None:
         if event.type in {StreamEventType.DATA, StreamEventType.SNAPSHOT}:
@@ -85,6 +98,7 @@ class StreamBuffer(Generic[T]):
                 now = time.monotonic()
                 if now - self._last_data >= self._silence_timeout:
                     self._last_data = now
+                    self.request_restart()
                     return StreamEvent.resync(
                         ResyncReason.SILENCE_TIMEOUT,
                         details=f"Стрим {self._name}: отсутствуют события {self._silence_timeout:.2f}с",

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -220,31 +220,76 @@ class BinanceExchangeData:
 
     def _run_depth_stream(self, buffer: StreamBuffer[DepthStreamData]) -> None:
         url = f"{self._endpoints.ws_base}/{self.symbol.lower()}@depth@100ms"
+        reconnect_after_silence = False
         while not buffer.stopped():
             ws: WebSocketClient | None = None
             try:
+                if reconnect_after_silence:
+                    self._logger.log(
+                        "Binance depth stream: перезапуск соединения после тайм-аута тишины"
+                    )
+                else:
+                    self._logger.log("Binance depth stream: открываем соединение")
                 ws, timeout_exception = self._connect_websocket(url)
                 ws.settimeout(self._ws_timeout)
+                if reconnect_after_silence:
+                    self._logger.log(
+                        "Binance depth stream: соединение успешно восстановлено"
+                    )
+                    reconnect_after_silence = False
                 while not buffer.stopped():
+                    if buffer.consume_restart_request():
+                        reconnect_after_silence = True
+                        self._logger.log(
+                            "Binance depth stream: получен запрос перезапуска от буфера"
+                        )
+                        break
                     try:
                         raw = ws.recv()
                     except timeout_exception:
+                        if buffer.consume_restart_request():
+                            reconnect_after_silence = True
+                            self._logger.log(
+                                "Binance depth stream: перезапуск по запросу буфера после тайм-аута ожидания"
+                            )
+                            break
                         buffer.push(StreamEvent.heartbeat())
                         continue
                     if not raw:
+                        if buffer.consume_restart_request():
+                            reconnect_after_silence = True
+                            self._logger.log(
+                                "Binance depth stream: перезапуск по запросу буфера после пустого сообщения"
+                            )
+                            break
                         continue
                     message = json.loads(raw)
                     self._handle_depth_message(message, buffer)
+                    if buffer.consume_restart_request():
+                        reconnect_after_silence = True
+                        self._logger.log(
+                            "Binance depth stream: перезапуск по запросу буфера после обработки сообщения"
+                        )
+                        break
             except Exception as exc:
-                buffer.push_resync(
-                    ResyncReason.CONNECTION_LOST,
-                    details=f"Binance depth stream: {exc}",
+                reason = (
+                    ResyncReason.SILENCE_TIMEOUT
+                    if reconnect_after_silence
+                    else ResyncReason.CONNECTION_LOST
                 )
-                self._logger.log_resync(
-                    ResyncReason.CONNECTION_LOST,
-                    details=f"Binance depth stream: {exc}",
-                )
-                time.sleep(self._reconnect_delay)
+                if reason == ResyncReason.SILENCE_TIMEOUT:
+                    details = (
+                        "Binance depth stream: не удалось переподключиться после тайм-аута тишины: "
+                        f"{exc}"
+                    )
+                    buffer.push_resync(reason, details)
+                    self._logger.log(details)
+                    time.sleep(self._reconnect_delay)
+                else:
+                    details = f"Binance depth stream: {exc}"
+                    buffer.push_resync(reason, details)
+                    self._logger.log_resync(reason, details)
+                    time.sleep(self._reconnect_delay)
             finally:
                 if ws is not None:
                     try:
@@ -365,28 +410,76 @@ class BinanceExchangeData:
         buffer: StreamBuffer[Any],
         name: str,
     ) -> None:
+        reconnect_after_silence = False
         while not buffer.stopped():
             ws: WebSocketClient | None = None
             try:
+                if reconnect_after_silence:
+                    self._logger.log(
+                        f"Binance {name} stream: перезапуск соединения после тайм-аута тишины"
+                    )
+                else:
+                    self._logger.log(f"Binance {name} stream: открываем соединение")
                 ws, timeout_exception = self._connect_websocket(url)
                 ws.settimeout(self._ws_timeout)
+                if reconnect_after_silence:
+                    self._logger.log(
+                        f"Binance {name} stream: соединение успешно восстановлено"
+                    )
+                    reconnect_after_silence = False
                 while not buffer.stopped():
+                    if buffer.consume_restart_request():
+                        reconnect_after_silence = True
+                        self._logger.log(
+                            f"Binance {name} stream: получен запрос перезапуска от буфера"
+                        )
+                        break
                     try:
                         raw = ws.recv()
                     except timeout_exception:
+                        if buffer.consume_restart_request():
+                            reconnect_after_silence = True
+                            self._logger.log(
+                                f"Binance {name} stream: перезапуск по запросу буфера после тайм-аута ожидания"
+                            )
+                            break
                         buffer.push(StreamEvent.heartbeat())
                         continue
                     if not raw:
+                        if buffer.consume_restart_request():
+                            reconnect_after_silence = True
+                            self._logger.log(
+                                f"Binance {name} stream: перезапуск по запросу буфера после пустого сообщения"
+                            )
+                            break
                         continue
                     message = json.loads(raw)
                     for payload in parser(message):
                         buffer.push_data(payload)
+                    if buffer.consume_restart_request():
+                        reconnect_after_silence = True
+                        self._logger.log(
+                            f"Binance {name} stream: перезапуск по запросу буфера после обработки сообщения"
+                        )
+                        break
             except Exception as exc:
-                buffer.push_resync(
-                    ResyncReason.CONNECTION_LOST,
-                    details=f"Binance {name} stream: {exc}",
+                reason = (
+                    ResyncReason.SILENCE_TIMEOUT
+                    if reconnect_after_silence
+                    else ResyncReason.CONNECTION_LOST
                 )
-                time.sleep(self._reconnect_delay)
+                if reason == ResyncReason.SILENCE_TIMEOUT:
+                    details = (
+                        f"Binance {name} stream: не удалось переподключиться после тайм-аута тишины: {exc}"
+                    )
+                    buffer.push_resync(reason, details)
+                    self._logger.log(details)
+                    time.sleep(self._reconnect_delay)
+                else:
+                    details = f"Binance {name} stream: {exc}"
+                    buffer.push_resync(reason, details)
+                    self._logger.log(details)
+                    time.sleep(self._reconnect_delay)
             finally:
                 if ws is not None:
                     try:

--- a/data/exchanges/bybit.py
+++ b/data/exchanges/bybit.py
@@ -284,37 +284,92 @@ class BybitExchangeData:
         url = self._endpoints.ws_base
         topic = f"orderbook.50.{self.symbol}"
         subscribe = json.dumps({"op": "subscribe", "args": [topic]})
+        reconnect_after_silence = False
         while not buffer.stopped():
             ws: WebSocketClient | None = None
             try:
+                if reconnect_after_silence:
+                    self._logger.log(
+                        "Bybit depth stream: перезапуск соединения после тайм-аута тишины"
+                    )
+                else:
+                    self._logger.log("Bybit depth stream: открываем соединение")
                 ws, timeout_exception = self._connect_websocket(url)
                 ws.settimeout(self._ws_timeout)
                 ws.send(subscribe)
+                if reconnect_after_silence:
+                    self._logger.log("Bybit depth stream: соединение успешно восстановлено")
+                    reconnect_after_silence = False
                 while not buffer.stopped():
+                    if buffer.consume_restart_request():
+                        reconnect_after_silence = True
+                        self._logger.log(
+                            "Bybit depth stream: получен запрос перезапуска от буфера"
+                        )
+                        break
                     try:
                         raw = ws.recv()
                     except timeout_exception:
+                        if buffer.consume_restart_request():
+                            reconnect_after_silence = True
+                            self._logger.log(
+                                "Bybit depth stream: перезапуск по запросу буфера после тайм-аута ожидания"
+                            )
+                            break
                         buffer.push(StreamEvent.heartbeat())
                         continue
                     if not raw:
+                        if buffer.consume_restart_request():
+                            reconnect_after_silence = True
+                            self._logger.log(
+                                "Bybit depth stream: перезапуск по запросу буфера после пустого сообщения"
+                            )
+                            break
                         continue
                     message = json.loads(raw)
                     if message.get("op") == "ping":
                         ws.send(json.dumps({"op": "pong", "req_id": message.get("req_id")}))
+                        if buffer.consume_restart_request():
+                            reconnect_after_silence = True
+                            self._logger.log(
+                                "Bybit depth stream: перезапуск по запросу буфера после ответа на ping"
+                            )
+                            break
                         continue
                     if message.get("topic") != topic:
+                        if buffer.consume_restart_request():
+                            reconnect_after_silence = True
+                            self._logger.log(
+                                "Bybit depth stream: перезапуск по запросу буфера при ожидании целевой темы"
+                            )
+                            break
                         continue
                     self._handle_depth_message(message, buffer)
+                    if buffer.consume_restart_request():
+                        reconnect_after_silence = True
+                        self._logger.log(
+                            "Bybit depth stream: перезапуск по запросу буфера после обработки сообщения"
+                        )
+                        break
             except Exception as exc:
-                buffer.push_resync(
-                    ResyncReason.CONNECTION_LOST,
-                    details=f"Bybit depth stream: {exc}",
+                reason = (
+                    ResyncReason.SILENCE_TIMEOUT
+                    if reconnect_after_silence
+                    else ResyncReason.CONNECTION_LOST
                 )
-                self._logger.log_resync(
-                    ResyncReason.CONNECTION_LOST,
-                    details=f"Bybit depth stream: {exc}",
-                )
-                time.sleep(self._reconnect_delay)
+                if reason == ResyncReason.SILENCE_TIMEOUT:
+                    details = (
+                        "Bybit depth stream: не удалось переподключиться после тайм-аута тишины: "
+                        f"{exc}"
+                    )
+                    buffer.push_resync(reason, details)
+                    self._logger.log(details)
+                    time.sleep(self._reconnect_delay)
+                else:
+                    details = f"Bybit depth stream: {exc}"
+                    buffer.push_resync(reason, details)
+                    self._logger.log_resync(reason, details)
+                    time.sleep(self._reconnect_delay)
             finally:
                 if ws is not None:
                     try:
@@ -538,34 +593,94 @@ class BybitExchangeData:
         subscribe: str,
     ) -> None:
         url = self._endpoints.ws_base
+        reconnect_after_silence = False
         while not buffer.stopped():
             ws: WebSocketClient | None = None
             try:
+                if reconnect_after_silence:
+                    self._logger.log(
+                        f"Bybit {name} stream: перезапуск соединения после тайм-аута тишины"
+                    )
+                else:
+                    self._logger.log(f"Bybit {name} stream: открываем соединение")
                 ws, timeout_exception = self._connect_websocket(url)
                 ws.settimeout(self._ws_timeout)
                 ws.send(subscribe)
+                if reconnect_after_silence:
+                    self._logger.log(
+                        f"Bybit {name} stream: соединение успешно восстановлено"
+                    )
+                    reconnect_after_silence = False
                 while not buffer.stopped():
+                    if buffer.consume_restart_request():
+                        reconnect_after_silence = True
+                        self._logger.log(
+                            f"Bybit {name} stream: получен запрос перезапуска от буфера"
+                        )
+                        break
                     try:
                         raw = ws.recv()
                     except timeout_exception:
+                        if buffer.consume_restart_request():
+                            reconnect_after_silence = True
+                            self._logger.log(
+                                f"Bybit {name} stream: перезапуск по запросу буфера после тайм-аута ожидания"
+                            )
+                            break
                         buffer.push(StreamEvent.heartbeat())
                         continue
                     if not raw:
+                        if buffer.consume_restart_request():
+                            reconnect_after_silence = True
+                            self._logger.log(
+                                f"Bybit {name} stream: перезапуск по запросу буфера после пустого сообщения"
+                            )
+                            break
                         continue
                     message = json.loads(raw)
                     if message.get("op") == "ping":
                         ws.send(json.dumps({"op": "pong", "req_id": message.get("req_id")}))
+                        if buffer.consume_restart_request():
+                            reconnect_after_silence = True
+                            self._logger.log(
+                                f"Bybit {name} stream: перезапуск по запросу буфера после ответа на ping"
+                            )
+                            break
                         continue
                     if message.get("topic") != topic:
+                        if buffer.consume_restart_request():
+                            reconnect_after_silence = True
+                            self._logger.log(
+                                f"Bybit {name} stream: перезапуск по запросу буфера при ожидании целевой темы"
+                            )
+                            break
                         continue
                     for payload in parser(message):
                         buffer.push_data(payload)
+                    if buffer.consume_restart_request():
+                        reconnect_after_silence = True
+                        self._logger.log(
+                            f"Bybit {name} stream: перезапуск по запросу буфера после обработки сообщения"
+                        )
+                        break
             except Exception as exc:
-                buffer.push_resync(
-                    ResyncReason.CONNECTION_LOST,
-                    details=f"Bybit {name} stream: {exc}",
+                reason = (
+                    ResyncReason.SILENCE_TIMEOUT
+                    if reconnect_after_silence
+                    else ResyncReason.CONNECTION_LOST
                 )
-                time.sleep(self._reconnect_delay)
+                if reason == ResyncReason.SILENCE_TIMEOUT:
+                    details = (
+                        f"Bybit {name} stream: не удалось переподключиться после тайм-аута тишины: {exc}"
+                    )
+                    buffer.push_resync(reason, details)
+                    self._logger.log(details)
+                    time.sleep(self._reconnect_delay)
+                else:
+                    details = f"Bybit {name} stream: {exc}"
+                    buffer.push_resync(reason, details)
+                    self._logger.log(details)
+                    time.sleep(self._reconnect_delay)
             finally:
                 if ws is not None:
                     try:


### PR DESCRIPTION
## Summary
- add a restart flag to StreamBuffer and raise it when silence timeouts are emitted
- teach Binance stream loops to close and reconnect websockets when a restart is requested and log the attempt results
- update Bybit stream workers to honour restart requests from the buffer and push SILENCE_TIMEOUT resyncs when reconnection fails

## Testing
- python -m compileall data/exchanges

------
https://chatgpt.com/codex/tasks/task_e_68e0e569e2388320ae572cab0ab268a8