### PR TITLE
Handle silence restarts without premature resync events

### DIFF
--- a/data/exchanges/base/stream_buffer.py
+++ b/data/exchanges/base/stream_buffer.py
@@ -99,10 +99,8 @@ class StreamBuffer(Generic[T]):
                 if now - self._last_data >= self._silence_timeout:
                     self._last_data = now
                     self.request_restart()
-                    return StreamEvent.resync(
-                        ResyncReason.SILENCE_TIMEOUT,
-                        details=f"Стрим {self._name}: отсутствуют события {self._silence_timeout:.2f}с",
-                    )
+                    self._last_heartbeat = now
+                    return StreamEvent.heartbeat()
                 if now - self._last_heartbeat >= self._heartbeat_interval:
                     self._last_heartbeat = now
                     return StreamEvent.heartbeat()


### PR DESCRIPTION
## Summary
- adjust stream buffer silence handling to request a reconnect but only emit a heartbeat until reconnection fails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0e99c0aac8320b5803f37c4261366