### PR TITLE
Refine wall handling in market observation

### DIFF
--- a/app.py
+++ b/app.py
@@ -468,34 +468,42 @@ class Application:
             last_seen_at=wall.last_seen_at,
         )
 
-    def _choose_wall(self, context: SymbolContext) -> Optional[Wall]:
-        bid_wall = check_if_has_near_wall(context.order_book, Side.BID, context.profile)
-        ask_wall = check_if_has_near_wall(context.order_book, Side.ASK, context.profile)
-        candidate: Optional[Wall] = None
-        if bid_wall is not None and ask_wall is not None:
-            candidate = bid_wall if bid_wall.notional >= ask_wall.notional else ask_wall
-        elif bid_wall is not None:
-            candidate = bid_wall
-        elif ask_wall is not None:
-            candidate = ask_wall
-        if candidate is None:
-            return None
-        return self._assign_symbol(context, candidate)
-
     def _build_observation(self, context: SymbolContext) -> MarketObservation:
         last_price = self._resolve_last_price(context)
         tick_size = context.filters.price_tick_size
         pressure = None
         if last_price > 0.0 and tick_size > 0.0:
             pressure = compute_odr(context.order_book, last_price, tick_size)
-        wall = self._choose_wall(context)
-        opposite_blocks = False
-        if wall is not None:
-            move_side = Side.ASK if wall.side is Side.BID else Side.BID
-            opposite_blocks = check_if_has_opposite_wall(
+        bid_wall_candidate = check_if_has_near_wall(
+            context.order_book, Side.BID, context.profile
+        )
+        ask_wall_candidate = check_if_has_near_wall(
+            context.order_book, Side.ASK, context.profile
+        )
+        bid_wall = (
+            self._assign_symbol(context, bid_wall_candidate)
+            if bid_wall_candidate is not None
+            else None
+        )
+        ask_wall = (
+            self._assign_symbol(context, ask_wall_candidate)
+            if ask_wall_candidate is not None
+            else None
+        )
+        bid_opposite_blocks = False
+        if bid_wall is not None:
+            bid_opposite_blocks = check_if_has_opposite_wall(
                 context.order_book,
-                move_side,
-                wall,
+                Side.ASK,
+                bid_wall,
+                context.profile,
+            )
+        ask_opposite_blocks = False
+        if ask_wall is not None:
+            ask_opposite_blocks = check_if_has_opposite_wall(
+                context.order_book,
+                Side.BID,
+                ask_wall,
                 context.profile,
             )
         return MarketObservation(
@@ -504,8 +512,10 @@ class Application:
             last_price=last_price,
             tick_size=tick_size,
             pressure=pressure,
-            near_wall=wall,
-            opposite_wall_blocks=opposite_blocks,
+            bid_wall=bid_wall,
+            ask_wall=ask_wall,
+            bid_opposite_wall_blocks=bid_opposite_blocks,
+            ask_opposite_wall_blocks=ask_opposite_blocks,
             available_symbols=self._desired_symbols,
             feed_status=context.feed_monitor.snapshot(),
             volume_ratio=context.volume_ratio,

--- a/domain/strategy/observation.py
+++ b/domain/strategy/observation.py
@@ -17,8 +17,10 @@ class MarketObservation:
     last_price: float
     tick_size: float
     pressure: Optional[Pressure]
-    near_wall: Optional[Wall]
-    opposite_wall_blocks: bool
+    bid_wall: Optional[Wall]
+    ask_wall: Optional[Wall]
+    bid_opposite_wall_blocks: bool
+    ask_opposite_wall_blocks: bool
     available_symbols: Tuple[str, ...]
     feed_status: FeedStatus
     volume_ratio: float

--- a/domain/strategy/strategy.py
+++ b/domain/strategy/strategy.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from config.config import CONFIG
 
-from domain.models import Pressure, Signal, Side, Wall
+from domain.models import Pressure, Signal, Wall
 
 from .event_logger import EventLogger
 from .focus import FocusController
@@ -95,42 +95,51 @@ class Strategy:
             self._last_scan_at = observation.timestamp
 
     def _handle_scanning(self, observation: MarketObservation) -> None:
-        if observation.pressure is None or observation.near_wall is None:
+        if observation.pressure is None:
             return
-        wall = observation.near_wall
+        wall: Optional[Wall] = None
         ratio = observation.pressure.imbalance_ratio
-        if wall.side is Side.BID and ratio <= CONFIG.odr.focus_pre_odr_long:
-            if observation.volume_spike:
-                self._focus_on_symbol(
-                    observation.symbol,
-                    Signal.LONG,
-                    wall,
-                    observation.timestamp,
-                    observation.volume_ratio,
-                )
-        elif wall.side is Side.ASK and ratio >= CONFIG.odr.focus_pre_odr_short:
-            if observation.volume_spike:
-                self._focus_on_symbol(
-                    observation.symbol,
-                    Signal.SHORT,
-                    wall,
-                    observation.timestamp,
-                    observation.volume_ratio,
-                )
+        signal: Signal
+        if ratio <= CONFIG.odr.focus_pre_odr_long:
+            wall = observation.bid_wall
+            signal = Signal.LONG
+        elif ratio >= CONFIG.odr.focus_pre_odr_short:
+            wall = observation.ask_wall
+            signal = Signal.SHORT
+        else:
+            return
+        if wall is None or not observation.volume_spike:
+            return
+        self._focus_on_symbol(
+            observation.symbol,
+            signal,
+            wall,
+            observation.timestamp,
+            observation.volume_ratio,
+        )
 
     def _handle_focused(self, observation: MarketObservation) -> None:
         symbol = observation.symbol
         if self._focus.current != symbol:
             return
         pressure = observation.pressure
-        wall = observation.near_wall
+        wall: Optional[Wall]
+        opposite_blocks = False
+        if self._focused_signal is Signal.LONG:
+            wall = observation.bid_wall
+            opposite_blocks = observation.bid_opposite_wall_blocks
+        elif self._focused_signal is Signal.SHORT:
+            wall = observation.ask_wall
+            opposite_blocks = observation.ask_opposite_wall_blocks
+        else:
+            wall = None
         timestamp = observation.timestamp
         if pressure is not None and wall is not None and observation.volume_spike:
-            if self._focused_signal is Signal.LONG and wall.side is Side.BID:
+            if self._focused_signal is Signal.LONG:
                 if pressure.imbalance_ratio <= CONFIG.odr.focus_pre_odr_long:
                     self._last_focus_signal_at = timestamp
                     self._focused_wall = wall
-            elif self._focused_signal is Signal.SHORT and wall.side is Side.ASK:
+            elif self._focused_signal is Signal.SHORT:
                 if pressure.imbalance_ratio >= CONFIG.odr.focus_pre_odr_short:
                     self._last_focus_signal_at = timestamp
                     self._focused_wall = wall
@@ -147,11 +156,11 @@ class Strategy:
             return
         if pressure is None or wall is None:
             return
-        if observation.opposite_wall_blocks:
+        if opposite_blocks:
             return
         if not observation.volume_spike:
             return
-        if self._focused_signal is Signal.LONG and wall.side is Side.BID:
+        if self._focused_signal is Signal.LONG:
             if pressure.imbalance_ratio <= CONFIG.odr.odr_in_long:
                 self._enter_position(
                     observation.symbol,
@@ -159,7 +168,7 @@ class Strategy:
                     timestamp,
                     observation.last_price,
                 )
-        elif self._focused_signal is Signal.SHORT and wall.side is Side.ASK:
+        elif self._focused_signal is Signal.SHORT:
             if pressure.imbalance_ratio >= CONFIG.odr.odr_in_short:
                 self._enter_position(
                     observation.symbol,
@@ -187,7 +196,12 @@ class Strategy:
                     observation.last_price,
                 )
                 return
-        wall = observation.near_wall
+        if self._position_signal is Signal.LONG:
+            wall = observation.bid_wall
+        elif self._position_signal is Signal.SHORT:
+            wall = observation.ask_wall
+        else:
+            wall = None
         if wall is not None:
             self._consider_wall_shift(wall, observation.tick_size, timestamp)
         if self._detect_wall_drop(wall, observation.tick_size):


### PR DESCRIPTION
## Summary
- capture bid and ask walls separately when building observations and compute their opposite wall blockers
- extend MarketObservation with explicit bid/ask wall fields and update Strategy logic to consume them per signal side

## Testing
- python -m compileall app.py domain/strategy

------
https://chatgpt.com/codex/tasks/task_e_68e0ebbb47f48320b125ecc68d6dbd37