### PR TITLE
Maintain per-book ODR smoothing history

### DIFF
--- a/app.py
+++ b/app.py
@@ -366,6 +366,7 @@ class Application:
                 context.last_update_id = None
 
     def _apply_snapshot(self, context: SymbolContext, snapshot: OrderBookSnapshot) -> None:
+        context.order_book.reset_odr_history()
         context.order_book.apply_snapshot(snapshot)
         context.last_update_id = snapshot.last_update_id
         self._update_best_from_book(context)
@@ -584,6 +585,7 @@ class Application:
             trading_adapter=trading_adapter,
             profile=self._symbol_profiles.get(symbol, CONFIG.general.profile),
         )
+        context.order_book.reset_odr_history()
         startup_timestamp = get_current_time()
         self._event_logger.log(
             f"Старт бота для {symbol} на {self._exchange.value}.",

--- a/domain/book.py
+++ b/domain/book.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from bisect import bisect_left
+from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Iterable, Iterator, List, Optional, Tuple
+from statistics import median
+from typing import Deque, Iterable, Iterator, List, Optional, Tuple
 
+from config.config import CONFIG
 from models.enums import Side
 from models.order_book import OrderBookLevel, OrderBookSnapshot, OrderBookUpdate
 from models.timezone import ensure_current_timezone
@@ -403,7 +406,7 @@ class _BookSide:
 
 
 class OrderBook:
-    __slots__ = ("_bids", "_asks")
+    __slots__ = ("_bids", "_asks", "_odr_history")
 
     def __init__(
         self,
@@ -428,6 +431,9 @@ class OrderBook:
             recent_band_capacity=base_capacity,
             recent_band_window_s=recent_band_window_s,
             recent_band_volume_boost=recent_band_volume_boost,
+        )
+        self._odr_history: Deque[float] = deque(
+            maxlen=max(1, CONFIG.general.odr_smooth_samples)
         )
 
     @property
@@ -471,6 +477,22 @@ class OrderBook:
         except StopIteration:
             return None
         return level.to_dataclass()
+
+    def update_odr_history(self, raw_ratio: float) -> float:
+        maxlen = max(1, CONFIG.general.odr_smooth_samples)
+        history = self._odr_history
+        if history.maxlen != maxlen:
+            history = deque(history, maxlen=maxlen)
+            self._odr_history = history
+        if maxlen <= 1:
+            history.clear()
+            history.append(raw_ratio)
+            return raw_ratio
+        history.append(raw_ratio)
+        return float(median(history))
+
+    def reset_odr_history(self) -> None:
+        self._odr_history = deque(maxlen=max(1, CONFIG.general.odr_smooth_samples))
 
 
 __all__ = [

--- a/domain/detectors.py
+++ b/domain/detectors.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from collections import deque
 from datetime import datetime, timedelta
 from statistics import median
-from typing import Deque, Iterable, Optional, Sequence, Tuple
+from typing import Iterable, Optional, Sequence, Tuple
 
 from config.config import CONFIG
 from config.models.trading_profile import TradingProfile
@@ -29,7 +28,7 @@ def compute_odr(book: OrderBook, last_price: float, tick_size: float) -> Pressur
     buy_pressure: float = _sum_side_pressure(bid_levels, last_price, tick_size)
     sell_pressure: float = _sum_side_pressure(ask_levels, last_price, tick_size)
     raw_ratio: float = _compute_ratio(sell_pressure, buy_pressure)
-    smoothed_ratio: float = _smooth_ratio(raw_ratio)
+    smoothed_ratio: float = book.update_odr_history(raw_ratio)
     return Pressure(
         computed_at=get_current_time(),
         buy_pressure=buy_pressure,
@@ -158,25 +157,6 @@ def _compute_ratio(sell_pressure: float, buy_pressure: float) -> float:
     if buy_pressure <= 0.0:
         return float("inf") if sell_pressure > 0.0 else 1.0
     return sell_pressure / buy_pressure
-
-
-_ODR_HISTORY: Deque[float] = deque(maxlen=max(1, CONFIG.general.odr_smooth_samples))
-
-
-def _smooth_ratio(raw_ratio: float) -> float:
-    maxlen: int = CONFIG.general.odr_smooth_samples
-    if maxlen <= 1:
-        return raw_ratio
-    if _ODR_HISTORY.maxlen != maxlen:
-        _resize_history(maxlen)
-    _ODR_HISTORY.append(raw_ratio)
-    return median(_ODR_HISTORY)
-
-
-def _resize_history(maxlen: int) -> None:
-    global _ODR_HISTORY
-    history: Deque[float] = deque(_ODR_HISTORY, maxlen=maxlen)
-    _ODR_HISTORY = history
 
 
 def _compute_median_quantity(levels: Iterable[OrderBookLevel]) -> float:


### PR DESCRIPTION
## Summary
- add an ODR history buffer to each order book and expose helpers to maintain it
- update ODR computation to smooth ratios via the owning book instead of a global buffer
- reset ODR smoothing state whenever a context is created or a snapshot is applied

## Testing
- python -m compileall domain app.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f2700afc8320ac0754803d2bb568