### PR TITLE
Load .env variables before initializing secrets

### DIFF
--- a/config/env_loader.py
+++ b/config/env_loader.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def load_env(path: Path = Path(".env")) -> None:
+    """Load key-value pairs from a dotenv file into the environment.
+
+    The loader skips empty lines and comments and does not overwrite values
+    that are already present in the environment.
+    """
+
+    try:
+        with path.open("r", encoding="utf-8") as env_file:
+            for raw_line in env_file:
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+
+                if "=" not in line:
+                    continue
+
+                key, value = line.split("=", 1)
+                key = key.strip()
+                value = value.strip()
+
+                if key:
+                    os.environ.setdefault(key, value)
+    except FileNotFoundError:
+        return

--- a/config/secrets.py
+++ b/config/secrets.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import os
 from typing import Final
 
+from config.env_loader import load_env
+
 from config.models.secrets import Secrets
+
+load_env()
 
 
 def _require_env(name: str) -> str:


### PR DESCRIPTION
## Summary
- add a reusable utility for loading key-value pairs from a .env file into os.environ
- invoke the loader during secrets initialization so the environment is populated before accessing required keys

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0fcc546c88320a7451ef65903c684