### PR TITLE
Strip quoted values from env loader

### DIFF
--- a/config/env_loader.py
+++ b/config/env_loader.py
@@ -25,6 +25,12 @@ def load_env(path: Path = Path(".env")) -> None:
                 key = key.strip()
                 value = value.strip()
 
+                if len(value) >= 2 and (
+                    (value.startswith("\"") and value.endswith("\""))
+                    or (value.startswith("'") and value.endswith("'"))
+                ):
+                    value = value[1:-1]
+
                 if key:
                     os.environ.setdefault(key, value)
     except FileNotFoundError:


### PR DESCRIPTION
## Summary
- remove matching single or double quotes from values loaded via the env loader
- ensure secrets receive unwrapped values while keeping whitespace trimming and mismatched quote handling intact

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e10a64bb888320964f367e24928424