### PR TITLE
Increase websocket silence timeout configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -261,6 +261,7 @@ class Application:
             return BinanceExchangeData(
                 symbol=symbol,
                 loop_interval_ms=CONFIG.general.loop_interval_ms,
+                silence_timeout_ms=CONFIG.general.ws_silence_timeout_ms,
                 log_writer=self._sink,
                 api_key=api_key,
                 api_secret=api_secret,
@@ -269,6 +270,7 @@ class Application:
             return BybitExchangeData(
                 symbol=symbol,
                 loop_interval_ms=CONFIG.general.loop_interval_ms,
+                silence_timeout_ms=CONFIG.general.ws_silence_timeout_ms,
                 log_writer=self._sink,
                 api_key=api_key,
                 api_secret=api_secret,

--- a/config/config.py
+++ b/config/config.py
@@ -26,6 +26,7 @@ CONFIG: Final[Config] = Config(
         exchange=ExchangeName.BINANCE,
         profile=TradingProfile.AUTO,
         loop_interval_ms=100,
+        ws_silence_timeout_ms=1500,
         odr_smooth_samples=3,
         recent_band_s=5,
         recent_band_s_vol_boost=8,

--- a/config/models/general_settings.py
+++ b/config/models/general_settings.py
@@ -9,6 +9,7 @@ class GeneralSettings:
     exchange: ExchangeName
     profile: TradingProfile
     loop_interval_ms: int
+    ws_silence_timeout_ms: int
     odr_smooth_samples: int
     recent_band_s: int
     recent_band_s_vol_boost: int

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -51,6 +51,7 @@ class WebSocketClient(Protocol):
 
 
 BINANCE_ALLOWED_DEPTH_LIMITS: frozenset[int] = frozenset({5, 10, 20, 50, 100, 500, 1000})
+MIN_STREAM_SILENCE_TIMEOUT_MS = 1500.0
 
 
 class BinanceExchangeData:
@@ -69,6 +70,7 @@ class BinanceExchangeData:
         endpoints: Optional[BinanceEndpoints] = None,
         api_key: Optional[str] = None,
         api_secret: Optional[str] = None,
+        silence_timeout_ms: float | None = None,
     ) -> None:
         self.symbol = symbol.upper()
         self._endpoints = endpoints or BinanceEndpoints()
@@ -80,8 +82,15 @@ class BinanceExchangeData:
         self._reconnect_delay = reconnect_delay
         self._logger = ExchangeLogger(f"Binance:{self.symbol}", log_writer)
         self._depth_limit = self._normalize_depth_limit(depth_limit)
-        self._silence_timeout = max(0.1, (loop_interval_ms * 5) / 1000.0)
-        self._heartbeat_interval = self._silence_timeout / 2
+        if silence_timeout_ms is not None:
+            effective_silence_timeout_ms = max(
+                float(silence_timeout_ms),
+                MIN_STREAM_SILENCE_TIMEOUT_MS,
+            )
+        else:
+            effective_silence_timeout_ms = MIN_STREAM_SILENCE_TIMEOUT_MS
+        self._silence_timeout = max(0.1, effective_silence_timeout_ms / 1000.0)
+        self._heartbeat_interval = max(self._silence_timeout / 2, 0.1)
         self._depth_last_update: Optional[int] = None
         self._depth_buffered_messages: list[dict[str, Any]] = []
         self._depth_allow_skip = False
@@ -219,11 +228,14 @@ class BinanceExchangeData:
         return next_funding
 
     def stream_depth(self) -> StreamSubscription[DepthStreamData]:
+        silence_timeout = self._silence_timeout
+        heartbeat_interval = self._heartbeat_interval
+
         buffer: StreamBuffer[DepthStreamData] = StreamBuffer(
             name="depth",
             logger=self._logger,
-            silence_timeout=self._silence_timeout,
-            heartbeat_interval=self._heartbeat_interval,
+            silence_timeout=silence_timeout,
+            heartbeat_interval=heartbeat_interval,
         )
 
         worker = threading.Thread(
@@ -512,11 +524,14 @@ class BinanceExchangeData:
         url: str,
         parser: Callable[[dict[str, Any]], Iterable[Any]],
     ) -> StreamSubscription[Any]:
+        silence_timeout = self._silence_timeout
+        heartbeat_interval = self._heartbeat_interval
+
         buffer: StreamBuffer[Any] = StreamBuffer(
             name=name,
             logger=self._logger,
-            silence_timeout=self._silence_timeout,
-            heartbeat_interval=self._heartbeat_interval,
+            silence_timeout=silence_timeout,
+            heartbeat_interval=heartbeat_interval,
         )
 
         worker = threading.Thread(

--- a/data/exchanges/bybit.py
+++ b/data/exchanges/bybit.py
@@ -101,6 +101,9 @@ class WebSocketClient(Protocol):
     def settimeout(self, timeout: float) -> None: ...
 
 
+MIN_STREAM_SILENCE_TIMEOUT_MS = 1500.0
+
+
 class BybitExchangeData:
     def __init__(
         self,
@@ -117,6 +120,7 @@ class BybitExchangeData:
         endpoints: Optional[BybitEndpoints] = None,
         api_key: Optional[str] = None,
         api_secret: Optional[str] = None,
+        silence_timeout_ms: float | None = None,
     ) -> None:
         self.symbol = symbol.upper()
         self._endpoints = endpoints or BybitEndpoints()
@@ -128,8 +132,15 @@ class BybitExchangeData:
         self._reconnect_delay = reconnect_delay
         self._depth_limit = depth_limit
         self._logger = ExchangeLogger(f"Bybit:{self.symbol}", log_writer)
-        self._silence_timeout = max(0.1, (loop_interval_ms * 5) / 1000.0)
-        self._heartbeat_interval = self._silence_timeout / 2
+        if silence_timeout_ms is not None:
+            effective_silence_timeout_ms = max(
+                float(silence_timeout_ms),
+                MIN_STREAM_SILENCE_TIMEOUT_MS,
+            )
+        else:
+            effective_silence_timeout_ms = MIN_STREAM_SILENCE_TIMEOUT_MS
+        self._silence_timeout = max(0.1, effective_silence_timeout_ms / 1000.0)
+        self._heartbeat_interval = max(self._silence_timeout / 2, 0.1)
         self._depth_last_seq: Optional[int] = None
         self._lock = threading.Lock()
         self._api_key = api_key
@@ -252,11 +263,14 @@ class BybitExchangeData:
         return candidate
 
     def stream_depth(self) -> StreamSubscription[DepthStreamData]:
+        silence_timeout = self._silence_timeout
+        heartbeat_interval = self._heartbeat_interval
+
         buffer: StreamBuffer[DepthStreamData] = StreamBuffer(
             name="depth",
             logger=self._logger,
-            silence_timeout=self._silence_timeout,
-            heartbeat_interval=self._heartbeat_interval,
+            silence_timeout=silence_timeout,
+            heartbeat_interval=heartbeat_interval,
         )
         initial_snapshot = self.fetch_orderbook_snapshot()
         buffer.push_snapshot(initial_snapshot)
@@ -557,11 +571,14 @@ class BybitExchangeData:
         topic: str,
         parser: Callable[[dict[str, Any]], Iterable[Any]],
     ) -> StreamSubscription[Any]:
+        silence_timeout = self._silence_timeout
+        heartbeat_interval = self._heartbeat_interval
+
         buffer: StreamBuffer[Any] = StreamBuffer(
             name=name,
             logger=self._logger,
-            silence_timeout=self._silence_timeout,
-            heartbeat_interval=self._heartbeat_interval,
+            silence_timeout=silence_timeout,
+            heartbeat_interval=heartbeat_interval,
         )
         subscribe = json.dumps({"op": "subscribe", "args": [topic]})
 


### PR DESCRIPTION
## Summary
- add a configurable `ws_silence_timeout_ms` option to general settings and pass it when building exchange data
- ensure Binance and Bybit exchange data apply a minimum 1.5s silence timeout and reuse the derived heartbeat interval when creating stream buffers

## Testing
- python -m compileall app.py data/exchanges/binance.py data/exchanges/bybit.py config

------
https://chatgpt.com/codex/tasks/task_e_68e11737eab08320b11ad15e848a9c62