### PR TITLE
Add drop-oldest overflow handling for ticker streams

### DIFF
--- a/app.py
+++ b/app.py
@@ -477,13 +477,16 @@ class Application:
             events = [primary]
             events.extend(buffer.drain_pending())
         processed = False
+        latest_ticker: BestBidAsk | None = None
         for event in events:
             processed = True
             if event.type is StreamEventType.DATA:
                 ticker = cast(BestBidAsk, event.data)
                 if ticker is not None:
-                    context.best_bid = ticker.bid_price
-                    context.best_ask = ticker.ask_price
+                    latest_ticker = ticker
+        if latest_ticker is not None:
+            context.best_bid = latest_ticker.bid_price
+            context.best_ask = latest_ticker.ask_price
         return processed
 
     @staticmethod

--- a/data/exchanges/base/stream_buffer.py
+++ b/data/exchanges/base/stream_buffer.py
@@ -21,6 +21,7 @@ class StreamBuffer(Generic[T]):
         silence_timeout: float,
         heartbeat_interval: Optional[float] = None,
         maxsize: int = 1024,
+        drop_oldest_on_overflow: bool = False,
     ) -> None:
         self._name = name
         self._logger = logger
@@ -29,6 +30,7 @@ class StreamBuffer(Generic[T]):
         self._heartbeat_interval = (
             heartbeat_interval if heartbeat_interval is not None else silence_timeout / 2
         )
+        self._drop_oldest_on_overflow = drop_oldest_on_overflow
         self._stop = Event()
         self._restart_event = Event()
         now = time.monotonic()
@@ -65,6 +67,17 @@ class StreamBuffer(Generic[T]):
         try:
             self._queue.put_nowait(event)
         except queue.Full:
+            if self._drop_oldest_on_overflow:
+                try:
+                    self._queue.get_nowait()
+                except queue.Empty:
+                    pass
+                else:
+                    try:
+                        self._queue.put_nowait(event)
+                        return
+                    except queue.Full:
+                        pass
             self._logger.log_resync(
                 ResyncReason.QUEUE_OVERFLOW,
                 details=f"Стрим {self._name}: очередь переполнена",

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -502,6 +502,7 @@ class BinanceExchangeData:
             name="book_ticker",
             url=f"{self._endpoints.ws_base}/{self.symbol.lower()}@bookTicker",
             parser=self._parse_book_ticker,
+            drop_oldest_on_overflow=True,
         )
 
     def stream_trades(self) -> StreamSubscription[Trade]:
@@ -523,6 +524,8 @@ class BinanceExchangeData:
         name: str,
         url: str,
         parser: Callable[[dict[str, Any]], Iterable[Any]],
+        *,
+        drop_oldest_on_overflow: bool = False,
     ) -> StreamSubscription[Any]:
         silence_timeout = self._silence_timeout
         heartbeat_interval = self._heartbeat_interval
@@ -532,6 +535,7 @@ class BinanceExchangeData:
             logger=self._logger,
             silence_timeout=silence_timeout,
             heartbeat_interval=heartbeat_interval,
+            drop_oldest_on_overflow=drop_oldest_on_overflow,
         )
 
         worker = threading.Thread(

--- a/data/exchanges/bybit.py
+++ b/data/exchanges/bybit.py
@@ -547,6 +547,7 @@ class BybitExchangeData:
             name="book_ticker",
             topic=topic,
             parser=self._parse_ticker,
+            drop_oldest_on_overflow=True,
         )
 
     def stream_trades(self) -> StreamSubscription[Trade]:
@@ -570,6 +571,8 @@ class BybitExchangeData:
         name: str,
         topic: str,
         parser: Callable[[dict[str, Any]], Iterable[Any]],
+        *,
+        drop_oldest_on_overflow: bool = False,
     ) -> StreamSubscription[Any]:
         silence_timeout = self._silence_timeout
         heartbeat_interval = self._heartbeat_interval
@@ -579,6 +582,7 @@ class BybitExchangeData:
             logger=self._logger,
             silence_timeout=silence_timeout,
             heartbeat_interval=heartbeat_interval,
+            drop_oldest_on_overflow=drop_oldest_on_overflow,
         )
         subscribe = json.dumps({"op": "subscribe", "args": [topic]})
 


### PR DESCRIPTION
## Summary
- extend StreamBuffer with an option to drop the oldest event instead of triggering a resync when full
- enable the new overflow handling for Binance and Bybit book ticker streams while keeping other streams unchanged
- ensure Application processing uses the freshest ticker update after draining buffered events

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e118a571d88320b92fb2930388cc8b