### PR TITLE
Adjust Binance depth limit default

### DIFF
--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -59,7 +59,7 @@ class BinanceExchangeData:
         self,
         symbol: str,
         loop_interval_ms: int = 100,
-        depth_limit: int = 200,
+        depth_limit: int = 500,
         rest_timeout: float = 5.0,
         rest_retries: int = 3,
         rest_retry_delay: float = 0.5,


### PR DESCRIPTION
## Summary
- set the Binance exchange data default depth limit to a Binance-supported value to avoid unsupported limit warnings

## Testing
- python - <<'PY'
from data.exchanges.binance import BinanceExchangeData

BinanceExchangeData(symbol="BTCUSDT")
PY

------
https://chatgpt.com/codex/tasks/task_e_68e11d064b988320b3f68d625559f657