### PR TITLE
Increase Binance trade stream buffer

### DIFF
--- a/data/exchanges/base/stream_buffer.py
+++ b/data/exchanges/base/stream_buffer.py
@@ -20,12 +20,13 @@ class StreamBuffer(Generic[T]):
         logger: ExchangeLogger,
         silence_timeout: float,
         heartbeat_interval: Optional[float] = None,
-        maxsize: int = 1024,
+        maxsize: int | None = None,
         drop_oldest_on_overflow: bool = False,
     ) -> None:
         self._name = name
         self._logger = logger
-        self._queue: "queue.Queue[StreamEvent[T]]" = queue.Queue(maxsize)
+        queue_size = 1024 if maxsize is None else int(maxsize)
+        self._queue: "queue.Queue[StreamEvent[T]]" = queue.Queue(queue_size)
         self._silence_timeout = silence_timeout
         self._heartbeat_interval = (
             heartbeat_interval if heartbeat_interval is not None else silence_timeout / 2

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -518,6 +518,8 @@ class BinanceExchangeData:
             name="trades",
             url=f"{self._endpoints.ws_base}/{self.symbol.lower()}@aggTrade",
             parser=self._parse_trade,
+            drop_oldest_on_overflow=True,
+            maxsize=4096,
         )
 
     def stream_kline_1m(self) -> StreamSubscription[Candle]:
@@ -534,6 +536,7 @@ class BinanceExchangeData:
         parser: Callable[[dict[str, Any]], Iterable[Any]],
         *,
         drop_oldest_on_overflow: bool = False,
+        maxsize: int | None = None,
     ) -> StreamSubscription[Any]:
         silence_timeout = self._silence_timeout
         heartbeat_interval = self._heartbeat_interval
@@ -543,6 +546,7 @@ class BinanceExchangeData:
             logger=self._logger,
             silence_timeout=silence_timeout,
             heartbeat_interval=heartbeat_interval,
+            maxsize=maxsize,
             drop_oldest_on_overflow=drop_oldest_on_overflow,
         )
 


### PR DESCRIPTION
## Summary
- allow configuring the StreamBuffer queue size so streams can override capacity when needed
- increase the Binance trades stream buffer size and enable dropping the oldest event to reduce overflow risk

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e11deb0a308320ae46f1420146f916