### PR TITLE
Add pooled Binance stream handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ import time
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import Deque, Dict, Iterable, Optional, Sequence, Tuple, cast
+from typing import Any, Deque, Dict, Iterable, Optional, Sequence, Tuple, cast
 
 from application import FeedMonitor, GUARDS
 from application.market_scanner import MarketScanner
@@ -309,6 +309,13 @@ class Application:
         context.active = True
         context.cycle_started = False
 
+    @staticmethod
+    def _stop_stream_subscription(subscription: StreamSubscription[Any]) -> None:
+        try:
+            subscription.stop()
+        except Exception:
+            pass
+
     def _unsubscribe_symbol(self, symbol: str) -> None:
         symbol = symbol.upper()
         context = self._contexts.pop(symbol, None)
@@ -321,10 +328,7 @@ class Application:
             context.ticker_subscription,
         )
         for subscription in subscriptions:
-            try:
-                subscription.stop()
-            except Exception:
-                pass
+            self._stop_stream_subscription(subscription)
         if self._focus_controller.current == symbol:
             timestamp = get_current_time()
             self._focus_controller.defocus(timestamp)

--- a/data/exchanges/base/exchange_data.py
+++ b/data/exchanges/base/exchange_data.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from threading import Thread
-from typing import Generic, Iterator, Optional, Protocol, TypeVar
+from typing import Callable, Generic, Iterator, Optional, Protocol, TypeVar
 
 from domain.models import Candle, OrderBookSnapshot, SymbolFilters, Trade
 from .best_bid_ask import BestBidAsk
@@ -18,11 +18,17 @@ T = TypeVar("T")
 class StreamSubscription(Generic[T]):
     events: Iterator[StreamEvent[T]]
     _buffer: StreamBuffer[T]
-    _worker: Thread
+    _stopper: Optional[Callable[[], None]] = None
+    _worker: Optional[Thread] = None
 
     def stop(self) -> None:
         self._buffer.stop()
-        if self._worker.is_alive():
+        if self._stopper is not None:
+            try:
+                self._stopper()
+            except Exception:
+                pass
+        if self._worker is not None and self._worker.is_alive():
             self._worker.join(timeout=1.0)
 
 

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -7,7 +7,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from http.client import RemoteDisconnected
-from typing import Any, Callable, Iterable, Iterator, Optional, Protocol
+from typing import Any, Callable, ClassVar, Iterable, Iterator, Optional, Protocol
 from urllib import parse
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
@@ -32,6 +32,7 @@ from .base import (
     StreamEvent,
     StreamSubscription,
 )
+from .binance_stream_pool import BinanceStreamPool
 
 
 @dataclass(slots=True)
@@ -55,6 +56,9 @@ MIN_STREAM_SILENCE_TIMEOUT_MS = 1500.0
 
 
 class BinanceExchangeData:
+    _pool_lock: ClassVar[threading.Lock] = threading.Lock()
+    _shared_stream_pool: ClassVar[BinanceStreamPool | None] = None
+
     def __init__(
         self,
         symbol: str,
@@ -81,6 +85,12 @@ class BinanceExchangeData:
         self._ws_timeout = ws_timeout
         self._reconnect_delay = reconnect_delay
         self._logger = ExchangeLogger(f"Binance:{self.symbol}", log_writer)
+        self._stream_pool = self._get_stream_pool(
+            endpoints=self._endpoints,
+            ws_timeout=self._ws_timeout,
+            reconnect_delay=self._reconnect_delay,
+            log_writer=log_writer,
+        )
         self._depth_limit = self._normalize_depth_limit(depth_limit)
         if silence_timeout_ms is not None:
             effective_silence_timeout_ms = max(
@@ -123,6 +133,25 @@ class BinanceExchangeData:
             f"Binance depth limit {requested_limit} is unsupported, using {normalized} instead"
         )
         return normalized
+
+    @classmethod
+    def _get_stream_pool(
+        cls,
+        *,
+        endpoints: BinanceEndpoints,
+        ws_timeout: float,
+        reconnect_delay: float,
+        log_writer: Optional[Callable[[str], None]],
+    ) -> BinanceStreamPool:
+        with cls._pool_lock:
+            if cls._shared_stream_pool is None:
+                cls._shared_stream_pool = BinanceStreamPool(
+                    endpoints_ws_base=endpoints.ws_base,
+                    ws_timeout=ws_timeout,
+                    reconnect_delay=reconnect_delay,
+                    log_writer=log_writer,
+                )
+            return cls._shared_stream_pool
 
     def _rest_get(self, path: str, params: Optional[dict[str, Any]] = None) -> Any:
         params = params or {}
@@ -237,14 +266,23 @@ class BinanceExchangeData:
             silence_timeout=silence_timeout,
             heartbeat_interval=heartbeat_interval,
         )
+        self._reset_depth_state()
 
-        worker = threading.Thread(
-            target=self._run_depth_stream,
-            args=(buffer,),
-            name=f"binance-depth-{self.symbol.lower()}",
-            daemon=True,
+        def handle_message(message: dict[str, Any]) -> None:
+            self._handle_depth_message(message, buffer)
+
+        def handle_error(reason: ResyncReason, details: str) -> None:
+            buffer.push_resync(reason, details)
+            self._logger.log(details)
+
+        release = self._stream_pool.register_depth(
+            self.symbol,
+            buffer,
+            handle_message,
+            handle_error,
         )
-        worker.start()
+
+        self._start_depth_snapshot(buffer)
 
         def iterator() -> Iterator[StreamEvent[DepthStreamData]]:
             try:
@@ -252,153 +290,33 @@ class BinanceExchangeData:
                     yield buffer.next()
             finally:
                 buffer.stop()
-                worker.join(timeout=1.0)
+                release()
 
-        return StreamSubscription(events=iterator(), _buffer=buffer, _worker=worker)
+        return StreamSubscription(events=iterator(), _buffer=buffer, _stopper=release)
 
-    def _run_depth_stream(self, buffer: StreamBuffer[DepthStreamData]) -> None:
-        url = f"{self._endpoints.ws_base}/{self.symbol.lower()}@depth@100ms"
-        reconnect_after_silence = False
-        while not buffer.stopped():
-            ws: WebSocketClient | None = None
-            try:
-                if reconnect_after_silence:
-                    self._logger.log(
-                        "Binance depth stream: перезапуск соединения после тайм-аута тишины"
-                    )
-                else:
-                    self._logger.log("Binance depth stream: открываем соединение")
-                ws, timeout_exception = self._connect_websocket(url)
-                ws.settimeout(self._ws_timeout)
-                if reconnect_after_silence:
-                    self._logger.log(
-                        "Binance depth stream: соединение успешно восстановлено"
-                    )
-                    reconnect_after_silence = False
-
-                with self._lock:
-                    initial_snapshot_needed = self._depth_last_update is None
-                    if initial_snapshot_needed:
-                        self._depth_buffered_messages.clear()
-                        self._depth_allow_skip = False
-
-                snapshot_applied = not initial_snapshot_needed
-                snapshot_ready = threading.Event()
-                snapshot_state: dict[str, Any] = {"snapshot": None, "error": None}
-
-                if initial_snapshot_needed:
-
-                    def load_initial_snapshot() -> None:
-                        try:
-                            snapshot = self.fetch_orderbook_snapshot()
-                        except Exception as exc:  # noqa: BLE001
-                            snapshot_state["error"] = exc
-                        else:
-                            snapshot_state["snapshot"] = snapshot
-                        finally:
-                            snapshot_ready.set()
-
-                    threading.Thread(
-                        target=load_initial_snapshot,
-                        name=f"binance-depth-snapshot-{self.symbol.lower()}",
-                        daemon=True,
-                    ).start()
-
-                def ensure_snapshot_applied() -> bool:
-                    nonlocal snapshot_applied
-                    if snapshot_applied:
-                        return True
-                    if not snapshot_ready.is_set():
-                        return True
-                    snapshot_applied = True
-                    snapshot = snapshot_state.get("snapshot")
-                    if snapshot is None:
-                        error = snapshot_state.get("error")
-                        details = (
-                            "Binance depth stream: не удалось получить начальный снапшот: "
-                            f"{error}"
-                        )
-                        buffer.push_resync(ResyncReason.CONNECTION_LOST, details)
-                        self._logger.log_resync(ResyncReason.CONNECTION_LOST, details)
-                        self._reset_depth_state()
-                        return False
-                    self._apply_depth_snapshot(snapshot, buffer)
-                    return True
-
-                def restart_requested(log_message: str) -> bool:
-                    nonlocal reconnect_after_silence
-                    if not buffer.consume_restart_request():
-                        return False
-                    if initial_snapshot_needed and (
-                        not snapshot_applied or not snapshot_ready.is_set()
-                    ):
-                        self._logger.log(
-                            "Binance depth stream: запрос перезапуска получен до применения"
-                            " начального снапшота, продолжаем ожидание",
-                        )
-                        return False
-                    reconnect_after_silence = True
-                    self._logger.log(log_message)
-                    return True
-
-                while not buffer.stopped():
-                    if not ensure_snapshot_applied():
-                        reconnect_after_silence = False
-                        break
-
-                    if restart_requested(
-                        "Binance depth stream: получен запрос перезапуска от буфера"
-                    ):
-                        break
-                    try:
-                        raw = ws.recv()
-                    except timeout_exception:
-                        if restart_requested(
-                            "Binance depth stream: перезапуск по запросу буфера после тайм-аута ожидания"
-                        ):
-                            break
-                        if not ensure_snapshot_applied():
-                            reconnect_after_silence = False
-                            break
-                        buffer.push(StreamEvent.heartbeat())
-                        continue
-                    if not raw:
-                        if restart_requested(
-                            "Binance depth stream: перезапуск по запросу буфера после пустого сообщения"
-                        ):
-                            break
-                        continue
-                    message = json.loads(raw)
-                    self._handle_depth_message(message, buffer)
-                    if restart_requested(
-                        "Binance depth stream: перезапуск по запросу буфера после обработки сообщения"
-                    ):
-                        break
-            except Exception as exc:
-                reason = (
-                    ResyncReason.SILENCE_TIMEOUT
-                    if reconnect_after_silence
-                    else ResyncReason.CONNECTION_LOST
-                )
-                if reason == ResyncReason.SILENCE_TIMEOUT:
+    def _start_depth_snapshot(self, buffer: StreamBuffer[DepthStreamData]) -> None:
+        def load_snapshot() -> None:
+            while not buffer.stopped():
+                try:
+                    snapshot = self.fetch_orderbook_snapshot()
+                except Exception as exc:  # noqa: BLE001
                     details = (
-                        "Binance depth stream: не удалось переподключиться после тайм-аута тишины: "
+                        "Binance depth stream: не удалось получить начальный снапшот: "
                         f"{exc}"
                     )
-                    buffer.push_resync(reason, details)
-                    self._logger.log(details)
+                    buffer.push_resync(ResyncReason.CONNECTION_LOST, details)
+                    self._logger.log_resync(ResyncReason.CONNECTION_LOST, details)
+                    self._reset_depth_state()
                     time.sleep(self._reconnect_delay)
-                else:
-                    details = f"Binance depth stream: {exc}"
-                    buffer.push_resync(reason, details)
-                    self._logger.log_resync(reason, details)
-                    time.sleep(self._reconnect_delay)
-            finally:
-                if ws is not None:
-                    try:
-                        ws.close()
-                    except Exception:
-                        pass
+                    continue
+                self._apply_depth_snapshot(snapshot, buffer)
+                break
+
+        threading.Thread(
+            target=load_snapshot,
+            name=f"binance-depth-snapshot-{self.symbol.lower()}",
+            daemon=True,
+        ).start()
 
     def _handle_depth_message(
         self,
@@ -506,21 +424,73 @@ class BinanceExchangeData:
             )
 
     def stream_book_ticker(self) -> StreamSubscription[BestBidAsk]:
-        return self._run_simple_stream(
+        buffer: StreamBuffer[BestBidAsk] = StreamBuffer(
             name="book_ticker",
-            url=f"{self._endpoints.ws_base}/{self.symbol.lower()}@bookTicker",
-            parser=self._parse_book_ticker,
+            logger=self._logger,
+            silence_timeout=self._silence_timeout,
+            heartbeat_interval=self._heartbeat_interval,
             drop_oldest_on_overflow=True,
         )
 
-    def stream_trades(self) -> StreamSubscription[Trade]:
-        return self._run_simple_stream(
-            name="trades",
-            url=f"{self._endpoints.ws_base}/{self.symbol.lower()}@aggTrade",
-            parser=self._parse_trade,
-            drop_oldest_on_overflow=True,
-            maxsize=4096,
+        def handle_message(message: dict[str, Any]) -> None:
+            for payload in self._parse_book_ticker(message):
+                buffer.push_data(payload)
+
+        def handle_error(reason: ResyncReason, details: str) -> None:
+            buffer.push_resync(reason, details)
+            self._logger.log(details)
+
+        release = self._stream_pool.register_book_ticker(
+            self.symbol,
+            buffer,
+            handle_message,
+            handle_error,
         )
+
+        def iterator() -> Iterator[StreamEvent[BestBidAsk]]:
+            try:
+                while True:
+                    yield buffer.next()
+            finally:
+                buffer.stop()
+                release()
+
+        return StreamSubscription(events=iterator(), _buffer=buffer, _stopper=release)
+
+    def stream_trades(self) -> StreamSubscription[Trade]:
+        buffer: StreamBuffer[Trade] = StreamBuffer(
+            name="trades",
+            logger=self._logger,
+            silence_timeout=self._silence_timeout,
+            heartbeat_interval=self._heartbeat_interval,
+            maxsize=4096,
+            drop_oldest_on_overflow=True,
+        )
+
+        def handle_message(message: dict[str, Any]) -> None:
+            for payload in self._parse_trade(message):
+                buffer.push_data(payload)
+
+        def handle_error(reason: ResyncReason, details: str) -> None:
+            buffer.push_resync(reason, details)
+            self._logger.log(details)
+
+        release = self._stream_pool.register_trades(
+            self.symbol,
+            buffer,
+            handle_message,
+            handle_error,
+        )
+
+        def iterator() -> Iterator[StreamEvent[Trade]]:
+            try:
+                while True:
+                    yield buffer.next()
+            finally:
+                buffer.stop()
+                release()
+
+        return StreamSubscription(events=iterator(), _buffer=buffer, _stopper=release)
 
     def stream_kline_1m(self) -> StreamSubscription[Candle]:
         return self._run_simple_stream(

--- a/data/exchanges/binance_stream_pool.py
+++ b/data/exchanges/binance_stream_pool.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+from websocket import WebSocketTimeoutException, create_connection
+
+from .base import ExchangeLogger, ResyncReason, StreamBuffer
+
+
+@dataclass(slots=True)
+class _Registration:
+    symbol: str
+    buffer: StreamBuffer[Any]
+    on_message: Callable[[dict[str, Any]], None]
+    on_error: Callable[[ResyncReason, str], None]
+
+
+class _CombinedStreamWorker:
+    def __init__(
+        self,
+        name: str,
+        combined_base: str,
+        stream_suffix: str,
+        *,
+        ws_timeout: float,
+        reconnect_delay: float,
+        log_writer: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        self._name = name
+        self._combined_base = combined_base
+        self._stream_suffix = stream_suffix
+        self._ws_timeout = ws_timeout
+        self._reconnect_delay = reconnect_delay
+        self._lock = threading.Lock()
+        self._update_event = threading.Event()
+        self._stop_event = threading.Event()
+        self._registrations: Dict[str, _Registration] = {}
+        self._logger = ExchangeLogger(f"Binance pool:{name}", log_writer)
+        self._thread = threading.Thread(
+            target=self._run,
+            name=f"binance-pool-{name}",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def register(
+        self,
+        symbol: str,
+        buffer: StreamBuffer[Any],
+        on_message: Callable[[dict[str, Any]], None],
+        on_error: Optional[Callable[[ResyncReason, str], None]] = None,
+    ) -> Callable[[], None]:
+        symbol = symbol.upper()
+
+        if on_error is None:
+            def default_error(reason: ResyncReason, details: str) -> None:
+                buffer.push_resync(reason, details)
+
+            on_error = default_error
+
+        registration = _Registration(
+            symbol=symbol,
+            buffer=buffer,
+            on_message=on_message,
+            on_error=on_error,
+        )
+
+        with self._lock:
+            if symbol in self._registrations:
+                raise ValueError(f"Stream {self._name} already registered for {symbol}")
+            self._registrations[symbol] = registration
+            self._update_event.set()
+
+        released = threading.Event()
+
+        def release() -> None:
+            if released.is_set():
+                return
+            with self._lock:
+                self._registrations.pop(symbol, None)
+                self._update_event.set()
+            released.set()
+
+        return release
+
+    def _current_symbols(self) -> tuple[str, ...]:
+        with self._lock:
+            return tuple(self._registrations.keys())
+
+    def _get_registration(self, symbol: str) -> Optional[_Registration]:
+        with self._lock:
+            return self._registrations.get(symbol)
+
+    def _restart_requested(self) -> bool:
+        with self._lock:
+            registrations = list(self._registrations.values())
+        restart_symbols: list[str] = []
+        for registration in registrations:
+            if registration.buffer.consume_restart_request():
+                restart_symbols.append(registration.symbol)
+        if restart_symbols:
+            joined = ", ".join(restart_symbols)
+            self._logger.log(
+                f"Binance {self._name} stream: перезапуск по запросу буферов: {joined}"
+            )
+            return True
+        return False
+
+    def _notify_all(self, reason: ResyncReason, details: str) -> None:
+        with self._lock:
+            registrations = list(self._registrations.values())
+        for registration in registrations:
+            try:
+                registration.on_error(reason, details)
+            except Exception:
+                pass
+
+    def _wait_for_symbols(self) -> tuple[str, ...]:
+        while not self._stop_event.is_set():
+            symbols = self._current_symbols()
+            if symbols:
+                return symbols
+            self._update_event.wait(timeout=1.0)
+            self._update_event.clear()
+        return ()
+
+    def _build_url(self, symbols: tuple[str, ...]) -> str:
+        streams = "/".join(f"{symbol.lower()}@{self._stream_suffix}" for symbol in symbols)
+        return f"{self._combined_base}{streams}"
+
+    def _extract_symbol(self, payload: dict[str, Any]) -> Optional[str]:
+        data = payload.get("data")
+        symbol = None
+        if isinstance(data, dict):
+            raw_symbol = data.get("s")
+            if isinstance(raw_symbol, str):
+                symbol = raw_symbol
+        if symbol is None:
+            raw_stream = payload.get("stream")
+            if isinstance(raw_stream, str):
+                symbol = raw_stream.split("@", 1)[0]
+        if symbol is None:
+            return None
+        return symbol.upper()
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            symbols = self._wait_for_symbols()
+            if not symbols:
+                continue
+
+            url = self._build_url(symbols)
+            ws = None
+            try:
+                ws = create_connection(
+                    url,
+                    timeout=self._ws_timeout,
+                    enable_multithread=True,
+                )
+                ws.settimeout(self._ws_timeout)
+                self._logger.log(
+                    f"Binance {self._name} stream: открыто соединение для {len(symbols)} символов"
+                )
+                while not self._stop_event.is_set():
+                    if self._update_event.is_set():
+                        self._update_event.clear()
+                        break
+                    if self._restart_requested():
+                        break
+                    try:
+                        raw = ws.recv()
+                    except WebSocketTimeoutException:
+                        continue
+                    if not raw:
+                        continue
+                    try:
+                        payload = json.loads(raw)
+                    except json.JSONDecodeError:
+                        continue
+                    symbol = self._extract_symbol(payload)
+                    if symbol is None:
+                        continue
+                    registration = self._get_registration(symbol)
+                    if registration is None:
+                        continue
+                    data = payload.get("data")
+                    if not isinstance(data, dict):
+                        continue
+                    try:
+                        registration.on_message(data)
+                    except Exception as exc:  # noqa: BLE001
+                        details = (
+                            "Binance {stream} stream: ошибка обработки сообщения для {symbol}:"
+                            " {error}"
+                        ).format(stream=self._name, symbol=symbol, error=exc)
+                        self._logger.log(details)
+                        registration.on_error(
+                            ResyncReason.CONNECTION_LOST,
+                            details,
+                        )
+            except Exception as exc:  # noqa: BLE001
+                if self._stop_event.is_set():
+                    break
+                details = f"Binance {self._name} stream: {exc}"
+                self._logger.log(details)
+                self._notify_all(ResyncReason.CONNECTION_LOST, details)
+                time.sleep(self._reconnect_delay)
+            finally:
+                if ws is not None:
+                    try:
+                        ws.close()
+                    except Exception:
+                        pass
+
+
+class BinanceStreamPool:
+    def __init__(
+        self,
+        *,
+        endpoints_ws_base: str,
+        ws_timeout: float,
+        reconnect_delay: float,
+        log_writer: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        base = endpoints_ws_base.rstrip("/")
+        if base.endswith("ws"):
+            base = base[: -2]
+        if base.endswith("/"):
+            base = base[:-1]
+        self._combined_base = f"{base}/stream?streams="
+        self._depth_worker = _CombinedStreamWorker(
+            "depth",
+            self._combined_base,
+            "depth@100ms",
+            ws_timeout=ws_timeout,
+            reconnect_delay=reconnect_delay,
+            log_writer=log_writer,
+        )
+        self._trades_worker = _CombinedStreamWorker(
+            "trades",
+            self._combined_base,
+            "aggTrade",
+            ws_timeout=ws_timeout,
+            reconnect_delay=reconnect_delay,
+            log_writer=log_writer,
+        )
+        self._book_worker = _CombinedStreamWorker(
+            "book_ticker",
+            self._combined_base,
+            "bookTicker",
+            ws_timeout=ws_timeout,
+            reconnect_delay=reconnect_delay,
+            log_writer=log_writer,
+        )
+
+    def register_depth(
+        self,
+        symbol: str,
+        buffer: StreamBuffer[Any],
+        on_message: Callable[[dict[str, Any]], None],
+        on_error: Optional[Callable[[ResyncReason, str], None]] = None,
+    ) -> Callable[[], None]:
+        return self._depth_worker.register(symbol, buffer, on_message, on_error)
+
+    def register_trades(
+        self,
+        symbol: str,
+        buffer: StreamBuffer[Any],
+        on_message: Callable[[dict[str, Any]], None],
+        on_error: Optional[Callable[[ResyncReason, str], None]] = None,
+    ) -> Callable[[], None]:
+        return self._trades_worker.register(symbol, buffer, on_message, on_error)
+
+    def register_book_ticker(
+        self,
+        symbol: str,
+        buffer: StreamBuffer[Any],
+        on_message: Callable[[dict[str, Any]], None],
+        on_error: Optional[Callable[[ResyncReason, str], None]] = None,
+    ) -> Callable[[], None]:
+        return self._book_worker.register(symbol, buffer, on_message, on_error)
+
+
+__all__ = ["BinanceStreamPool"]


### PR DESCRIPTION
## Summary
- add a Binance stream pool that multiplexes combined depth, trade, and book-ticker websocket connections
- update BinanceExchangeData to register per-symbol handlers with the pool and reuse StreamSubscription buffers
- extend StreamSubscription and unsubscribe handling to release pooled registrations when stopping

## Testing
- python -m compileall data/exchanges

------
https://chatgpt.com/codex/tasks/task_e_68e120a4eb988320b532ca5096f2600d