### PR TITLE
Clarify Binance stream error logging

### DIFF
--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -272,8 +272,10 @@ class BinanceExchangeData:
             self._handle_depth_message(message, buffer)
 
         def handle_error(reason: ResyncReason, details: str) -> None:
-            buffer.push_resync(reason, details)
-            self._logger.log(details)
+            suffix = f"(symbol {self.symbol})"
+            message = details if suffix in details else f"{details} {suffix}"
+            buffer.push_resync(reason, message)
+            self._logger.log(message)
 
         release = self._stream_pool.register_depth(
             self.symbol,
@@ -437,8 +439,10 @@ class BinanceExchangeData:
                 buffer.push_data(payload)
 
         def handle_error(reason: ResyncReason, details: str) -> None:
-            buffer.push_resync(reason, details)
-            self._logger.log(details)
+            suffix = f"(symbol {self.symbol})"
+            message = details if suffix in details else f"{details} {suffix}"
+            buffer.push_resync(reason, message)
+            self._logger.log(message)
 
         release = self._stream_pool.register_book_ticker(
             self.symbol,
@@ -472,8 +476,10 @@ class BinanceExchangeData:
                 buffer.push_data(payload)
 
         def handle_error(reason: ResyncReason, details: str) -> None:
-            buffer.push_resync(reason, details)
-            self._logger.log(details)
+            suffix = f"(symbol {self.symbol})"
+            message = details if suffix in details else f"{details} {suffix}"
+            buffer.push_resync(reason, message)
+            self._logger.log(message)
 
         release = self._stream_pool.register_trades(
             self.symbol,

--- a/data/exchanges/binance_stream_pool.py
+++ b/data/exchanges/binance_stream_pool.py
@@ -166,7 +166,8 @@ class _CombinedStreamWorker:
             registrations = list(self._registrations.values())
         for registration in registrations:
             try:
-                registration.on_error(reason, details)
+                detailed_message = f"{details} (symbol {registration.symbol})"
+                registration.on_error(reason, detailed_message)
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary
- include symbol context when notifying Binance stream subscribers about pool errors
- ensure Binance stream error handlers append the symbol context before logging or pushing resync events

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e141133a18832082f5dd35e5a33498