### PR TITLE
Handle connection loss in feed monitoring

### DIFF
--- a/application/runtime.py
+++ b/application/runtime.py
@@ -34,10 +34,13 @@ class FeedMonitor:
     has_sequence_gap: bool = False
     has_silence_timeout: bool = False
     has_queue_overflow: bool = False
+    has_connection_loss: bool = False
 
     def flag(self, reason: StreamResyncReason) -> None:
         if reason is StreamResyncReason.SEQUENCE_GAP:
             self.has_sequence_gap = True
+        elif reason is StreamResyncReason.CONNECTION_LOST:
+            self.has_connection_loss = True
         elif reason is StreamResyncReason.QUEUE_OVERFLOW:
             self.has_queue_overflow = True
         else:
@@ -46,12 +49,14 @@ class FeedMonitor:
     def snapshot(self) -> FeedStatus:
         return FeedStatus(
             has_sequence_gap=self.has_sequence_gap,
+            has_connection_loss=self.has_connection_loss,
             has_silence_timeout=self.has_silence_timeout,
             has_queue_overflow=self.has_queue_overflow,
         )
 
     def clear(self) -> None:
         self.has_sequence_gap = False
+        self.has_connection_loss = False
         self.has_silence_timeout = False
         self.has_queue_overflow = False
 

--- a/domain/strategy/resync.py
+++ b/domain/strategy/resync.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 class ResyncReason(str, Enum):
     SEQUENCE_GAP = "пропуск последовательности"
+    CONNECTION_LOSS = "потеря соединения"
     SILENCE = "тишина канала"
     BACKPRESSURE = "переполнение очереди"
 
@@ -14,12 +15,15 @@ class ResyncReason(str, Enum):
 @dataclass(frozen=True)
 class FeedStatus:
     has_sequence_gap: bool = False
+    has_connection_loss: bool = False
     has_silence_timeout: bool = False
     has_queue_overflow: bool = False
 
     def resolve_reason(self) -> Optional[ResyncReason]:
         if self.has_sequence_gap:
             return ResyncReason.SEQUENCE_GAP
+        if self.has_connection_loss:
+            return ResyncReason.CONNECTION_LOSS
         if self.has_silence_timeout:
             return ResyncReason.SILENCE
         if self.has_queue_overflow:


### PR DESCRIPTION
## Summary
- track connection loss in the runtime feed monitor and include it in feed snapshots
- expose a new strategy resync reason for connection loss so it is prioritised ahead of silence

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e14669851c832089bea68ca5b54190