### PR TITLE
feat: replace websocket client with asyncio facade

### DIFF
--- a/data/exchanges/__init__.py
+++ b/data/exchanges/__init__.py
@@ -1,3 +1,5 @@
+from utils.async_websocket import ThreadedWebSocketClient
+
 from .base import (
     BestBidAsk,
     DepthStreamData,
@@ -15,6 +17,8 @@ from .binance_trade import BinanceTradingAdapter
 from .bybit import BybitExchangeData
 from .bybit_trade import BybitTradingAdapter
 
+WebSocketClient = ThreadedWebSocketClient
+
 __all__ = [
     "BestBidAsk",
     "DepthStreamData",
@@ -30,4 +34,5 @@ __all__ = [
     "BinanceTradingAdapter",
     "BybitExchangeData",
     "BybitTradingAdapter",
+    "WebSocketClient",
 ]

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -7,7 +7,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from http.client import RemoteDisconnected
-from typing import Any, Callable, ClassVar, Iterable, Iterator, Optional, Protocol
+from typing import Any, Callable, ClassVar, Iterable, Iterator, Optional
 from urllib import parse
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
@@ -22,7 +22,9 @@ from domain.models import (
     SymbolFilters,
     Trade,
 )
+from utils.async_websocket import ThreadedWebSocketClient, WebSocketTimeoutError
 from utils.timez import from_exchange_timestamp, get_current_time
+
 from .base import (
     BestBidAsk,
     DepthStreamData,
@@ -35,21 +37,13 @@ from .base import (
 from .binance_stream_pool import BinanceStreamPool
 
 
+WebSocketClient = ThreadedWebSocketClient
+
+
 @dataclass(slots=True)
 class BinanceEndpoints:
     rest_base: str = "https://fapi.binance.com"
     ws_base: str = "wss://fstream.binance.com/ws"
-
-
-class WebSocketClient(Protocol):
-    def recv(self) -> str: ...
-
-    def send(self, data: str) -> None: ...
-
-    def close(self) -> None: ...
-
-    def settimeout(self, timeout: float) -> None: ...
-
 
 BINANCE_ALLOWED_DEPTH_LIMITS: frozenset[int] = frozenset({5, 10, 20, 50, 100, 500, 1000})
 MIN_STREAM_SILENCE_TIMEOUT_MS = 1500.0
@@ -646,10 +640,13 @@ class BinanceExchangeData:
     def _connect_websocket(
         self, url: str
     ) -> tuple["WebSocketClient", type[Exception]]:
-        from websocket import WebSocketTimeoutException, create_connection
-
-        connection = create_connection(url, timeout=self._ws_timeout, enable_multithread=True)
-        return connection, WebSocketTimeoutException
+        connection = ThreadedWebSocketClient(
+            url,
+            timeout=self._ws_timeout,
+            heartbeat_interval=self._heartbeat_interval,
+            heartbeat_timeout=self._ws_timeout,
+        )
+        return connection, WebSocketTimeoutError
 
     @staticmethod
     def _build_level(

--- a/data/exchanges/binance_stream_pool.py
+++ b/data/exchanges/binance_stream_pool.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from queue import Empty, Queue
 from typing import Any, Callable, Dict, Optional
 
-from websocket import WebSocketTimeoutException, create_connection
+from utils.async_websocket import ThreadedWebSocketClient, WebSocketTimeoutError
 
 from .base import ExchangeLogger, ResyncReason, StreamBuffer
 
@@ -291,12 +291,13 @@ class _CombinedStreamWorker:
                 continue
 
             self._enqueue_all_symbols()
-            ws = None
+            ws: Optional[ThreadedWebSocketClient] = None
             try:
-                ws = create_connection(
+                ws = ThreadedWebSocketClient(
                     self._ws_base,
                     timeout=self._ws_timeout,
-                    enable_multithread=True,
+                    heartbeat_interval=self._ws_timeout / 2 if self._ws_timeout > 0 else None,
+                    heartbeat_timeout=self._ws_timeout,
                 )
                 ws.settimeout(self._ws_timeout)
                 self._next_request_id = 1
@@ -320,7 +321,7 @@ class _CombinedStreamWorker:
                         break
                     try:
                         raw = ws.recv()
-                    except WebSocketTimeoutException:
+                    except WebSocketTimeoutError:
                         continue
                     except Exception as exc:  # noqa: BLE001
                         if self._stop_event.is_set():

--- a/data/exchanges/bybit.py
+++ b/data/exchanges/bybit.py
@@ -13,7 +13,6 @@ from typing import (
     Iterable,
     Iterator,
     Optional,
-    Protocol,
     Sequence,
     TypeAlias,
     TypedDict,
@@ -33,6 +32,7 @@ from domain.models import (
     SymbolFilters,
     Trade,
 )
+from utils.async_websocket import ThreadedWebSocketClient, WebSocketTimeoutError
 from utils.timez import from_exchange_timestamp, get_current_time
 from .base import (
     BestBidAsk,
@@ -91,14 +91,7 @@ class DepthEnvelope:
     event_time: datetime
 
 
-class WebSocketClient(Protocol):
-    def recv(self) -> str: ...
-
-    def send(self, data: str) -> None: ...
-
-    def close(self) -> None: ...
-
-    def settimeout(self, timeout: float) -> None: ...
+WebSocketClient = ThreadedWebSocketClient
 
 
 MIN_STREAM_SILENCE_TIMEOUT_MS = 1500.0
@@ -470,10 +463,13 @@ class BybitExchangeData:
     def _connect_websocket(
         self, url: str
     ) -> tuple[WebSocketClient, type[Exception]]:
-        from websocket import WebSocketTimeoutException, create_connection
-
-        connection = create_connection(url, timeout=self._ws_timeout, enable_multithread=True)
-        return connection, WebSocketTimeoutException
+        connection = ThreadedWebSocketClient(
+            url,
+            timeout=self._ws_timeout,
+            heartbeat_interval=self._heartbeat_interval,
+            heartbeat_timeout=self._ws_timeout,
+        )
+        return connection, WebSocketTimeoutError
 
     @staticmethod
     def _coerce_sequence_number(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+websockets>=10,<12

--- a/utils/async_websocket.py
+++ b/utils/async_websocket.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from typing import Any, Awaitable, Optional, TypeVar, Union
+
+import websockets
+from websockets.client import WebSocketClientProtocol
+
+__all__ = [
+    "AsyncWebSocketClient",
+    "ThreadedWebSocketClient",
+    "WebSocketTimeoutError",
+]
+
+
+class WebSocketTimeoutError(TimeoutError):
+    """Exception raised when websocket operations exceed the configured timeout."""
+
+
+class AsyncWebSocketClient:
+    """High-level helper around :func:`websockets.connect` with heartbeat support."""
+
+    def __init__(
+        self,
+        uri: str,
+        *,
+        timeout: float = 10.0,
+        heartbeat_interval: Optional[float] = None,
+        heartbeat_payload: Union[str, bytes, None] = None,
+        heartbeat_timeout: Optional[float] = None,
+    ) -> None:
+        self._uri = uri
+        self._timeout = max(0.0, float(timeout))
+        self._heartbeat_interval = (
+            float(heartbeat_interval) if heartbeat_interval and heartbeat_interval > 0 else None
+        )
+        self._heartbeat_payload = heartbeat_payload
+        self._heartbeat_timeout = float(heartbeat_timeout) if heartbeat_timeout else self._timeout
+        self._connection: WebSocketClientProtocol | None = None
+        self._heartbeat_task: asyncio.Task[None] | None = None
+        self._closed = asyncio.Event()
+
+    async def connect(self) -> None:
+        if self._connection is not None:
+            return
+        self._connection = await websockets.connect(
+            self._uri,
+            ping_interval=None,
+            open_timeout=self._timeout or None,
+            close_timeout=self._timeout or None,
+        )
+        self._closed.clear()
+        if self._heartbeat_interval is not None:
+            self._heartbeat_task = asyncio.create_task(self._heartbeat(), name="ws-heartbeat")
+
+    async def _ensure_connection(self) -> WebSocketClientProtocol:
+        if self._connection is None:
+            await self.connect()
+        assert self._connection is not None
+        return self._connection
+
+    async def _heartbeat(self) -> None:
+        assert self._connection is not None
+        try:
+            while not self._closed.is_set():
+                await asyncio.sleep(self._heartbeat_interval or 0)
+                if self._closed.is_set():
+                    break
+                try:
+                    await self._send_heartbeat()
+                except Exception:
+                    await self.close()
+                    break
+        except asyncio.CancelledError:
+            pass
+
+    async def _send_heartbeat(self) -> None:
+        connection = await self._ensure_connection()
+        timeout = self._heartbeat_timeout or self._timeout
+        if self._heartbeat_payload is None:
+            waiter = await connection.ping()
+            await asyncio.wait_for(waiter, timeout=timeout if timeout > 0 else None)
+        else:
+            await asyncio.wait_for(connection.send(self._heartbeat_payload), timeout=timeout if timeout > 0 else None)
+
+    async def set_timeout(self, timeout: float) -> None:
+        self._timeout = max(0.0, float(timeout))
+
+    async def send(self, data: Union[str, bytes]) -> None:
+        connection = await self._ensure_connection()
+        try:
+            await asyncio.wait_for(connection.send(data), timeout=self._timeout or None)
+        except asyncio.TimeoutError as exc:  # pragma: no cover - defensive
+            raise WebSocketTimeoutError(str(exc)) from exc
+
+    async def recv(self) -> str:
+        connection = await self._ensure_connection()
+        try:
+            message = await asyncio.wait_for(connection.recv(), timeout=self._timeout or None)
+        except asyncio.TimeoutError as exc:
+            raise WebSocketTimeoutError(str(exc)) from exc
+        if isinstance(message, bytes):
+            return message.decode("utf-8", errors="replace")
+        return message
+
+    async def send_json(self, payload: Any) -> None:
+        await self.send(json.dumps(payload))
+
+    async def recv_json(self) -> Any:
+        raw = await self.recv()
+        return json.loads(raw)
+
+    async def close(self) -> None:
+        if self._closed.is_set():
+            return
+        self._closed.set()
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            try:
+                await self._heartbeat_task
+            except asyncio.CancelledError:
+                pass
+            finally:
+                self._heartbeat_task = None
+        if self._connection is not None:
+            try:
+                await self._connection.close()
+            finally:
+                self._connection = None
+
+
+T = TypeVar("T")
+
+
+class ThreadedWebSocketClient:
+    """Synchronous facade over :class:`AsyncWebSocketClient`."""
+
+    def __init__(
+        self,
+        uri: str,
+        *,
+        timeout: float = 10.0,
+        heartbeat_interval: Optional[float] = None,
+        heartbeat_payload: Union[str, bytes, None] = None,
+        heartbeat_timeout: Optional[float] = None,
+    ) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._loop_ready = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run_loop,
+            name="ws-client",
+            daemon=True,
+        )
+        self._thread.start()
+        self._loop_ready.wait()
+        self._client = self._run(
+            self._create_client(
+                uri,
+                timeout=timeout,
+                heartbeat_interval=heartbeat_interval,
+                heartbeat_payload=heartbeat_payload,
+                heartbeat_timeout=heartbeat_timeout,
+            )
+        )
+        self._closed = False
+
+    def _run_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop_ready.set()
+        self._loop.run_forever()
+
+    async def _create_client(
+        self,
+        uri: str,
+        *,
+        timeout: float,
+        heartbeat_interval: Optional[float],
+        heartbeat_payload: Union[str, bytes, None],
+        heartbeat_timeout: Optional[float],
+    ) -> AsyncWebSocketClient:
+        client = AsyncWebSocketClient(
+            uri,
+            timeout=timeout,
+            heartbeat_interval=heartbeat_interval,
+            heartbeat_payload=heartbeat_payload,
+            heartbeat_timeout=heartbeat_timeout,
+        )
+        await client.connect()
+        return client
+
+    def _run(self, awaitable: Awaitable[T]) -> T:
+        future = asyncio.run_coroutine_threadsafe(awaitable, self._loop)
+        return future.result()
+
+    def settimeout(self, timeout: float) -> None:
+        self._ensure_open()
+        self._run(self._client.set_timeout(timeout))
+
+    def send(self, data: Union[str, bytes]) -> None:
+        self._ensure_open()
+        try:
+            self._run(self._client.send(data))
+        except WebSocketTimeoutError:
+            raise
+
+    def recv(self) -> str:
+        self._ensure_open()
+        try:
+            return self._run(self._client.recv())
+        except WebSocketTimeoutError:
+            raise
+
+    def send_json(self, payload: Any) -> None:
+        self._ensure_open()
+        self._run(self._client.send_json(payload))
+
+    def recv_json(self) -> Any:
+        self._ensure_open()
+        return self._run(self._client.recv_json())
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._run(self._client.close())
+        finally:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            self._thread.join(timeout=1.0)
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("WebSocket client is closed")
+
+    def __del__(self) -> None:  # pragma: no cover - best effort cleanup
+        try:
+            self.close()
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- add the websockets package to the runtime dependency manifest
- implement AsyncWebSocketClient and its ThreadedWebSocketClient facade to manage heartbeats and JSON helpers
- update exchange modules to rely on the new threaded websocket client instead of websocket-client

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e2bd1da84483209ed9ac8e816b7b2e