### PR TITLE
Handle DNS errors in network retries

### DIFF
--- a/application/market_scanner.py
+++ b/application/market_scanner.py
@@ -99,7 +99,9 @@ class MarketScanner:
                 RemoteDisconnected,
                 TimeoutError,
                 socket.timeout,
+                socket.gaierror,
                 ConnectionError,
+                OSError,
             ):
                 if retries_remaining <= 0:
                     raise

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -171,7 +171,9 @@ class BinanceExchangeData:
                 RemoteDisconnected,
                 TimeoutError,
                 socket.timeout,
+                socket.gaierror,
                 ConnectionError,
+                OSError,
             ):
                 if retries_remaining <= 0:
                     raise

--- a/data/exchanges/binance_trade.py
+++ b/data/exchanges/binance_trade.py
@@ -287,7 +287,9 @@ class BinanceTradingAdapter(TradingAdapter):
                 RemoteDisconnected,
                 TimeoutError,
                 socket.timeout,
+                socket.gaierror,
                 ConnectionError,
+                OSError,
             ) as error:
                 if retries_remaining <= 0:
                     message = self._format_network_error(error)

--- a/data/exchanges/bybit.py
+++ b/data/exchanges/bybit.py
@@ -167,7 +167,9 @@ class BybitExchangeData:
                 RemoteDisconnected,
                 TimeoutError,
                 socket.timeout,
+                socket.gaierror,
                 ConnectionError,
+                OSError,
             ):
                 if retries_remaining <= 0:
                     raise

--- a/data/exchanges/bybit_trade.py
+++ b/data/exchanges/bybit_trade.py
@@ -279,7 +279,9 @@ class BybitTradingAdapter(TradingAdapter):
                 RemoteDisconnected,
                 TimeoutError,
                 socket.timeout,
+                socket.gaierror,
                 ConnectionError,
+                OSError,
             ) as error:
                 if retries_remaining <= 0:
                     message = self._format_network_error(error)

--- a/data/telegram.py
+++ b/data/telegram.py
@@ -54,7 +54,9 @@ class TelegramClient:
                 RemoteDisconnected,
                 TimeoutError,
                 socket.timeout,
+                socket.gaierror,
                 ConnectionError,
+                OSError,
             ):
                 if retries_remaining <= 0:
                     raise


### PR DESCRIPTION
## Summary
- treat DNS and address resolution failures as retryable across Binance and Bybit REST and trading adapters
- extend the market scanner and Telegram client retry loops to cover socket.gaierror/OSError for consistent messaging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7f4a9505c832092f43ebc1f7fd614