### PR TITLE
Handle subscription and resync failures

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,6 +37,7 @@ from domain.models import (
     BalanceSource,
     Exchange,
     ExecutionReport,
+    LogLine,
     MarginMode,
     OrderBookSnapshot,
     OrderBookUpdate,
@@ -312,11 +313,24 @@ class Application:
     def _subscribe_symbol(self, symbol: str) -> None:
         symbol = symbol.upper()
         context = self._contexts.get(symbol)
-        if context is None:
-            context = self._create_context(symbol)
-            self._contexts[symbol] = context
-        context.active = True
-        context.cycle_started = False
+        new_context: Optional[SymbolContext] = None
+        try:
+            if context is None:
+                new_context = self._create_context(symbol)
+                context = new_context
+            if context is None:
+                return
+            context.active = True
+            context.cycle_started = False
+        except Exception as exc:  # noqa: BLE001
+            self._log_error(f"Не удалось активировать {symbol}: {exc}")
+            if new_context is not None:
+                self._dispose_context(new_context)
+            elif context is not None:
+                self._dispose_context(context)
+            return
+        if new_context is not None:
+            self._contexts[symbol] = new_context
 
     @staticmethod
     def _stop_stream_subscription(subscription: StreamSubscription[Any]) -> None:
@@ -325,13 +339,8 @@ class Application:
         except Exception:
             pass
 
-    def _unsubscribe_symbol(self, symbol: str) -> None:
-        symbol = symbol.upper()
-        context = self._contexts.pop(symbol, None)
-        if context is None:
-            return
+    def _dispose_context(self, context: SymbolContext) -> None:
         context.active = False
-        self._stale_warnings.pop(symbol, None)
         subscriptions = (
             context.depth_subscription,
             context.trade_subscription,
@@ -339,9 +348,17 @@ class Application:
         )
         for subscription in subscriptions:
             self._stop_stream_subscription(subscription)
-        if self._focus_controller.current == symbol:
+        if self._focus_controller.current == context.symbol:
             timestamp = get_current_time()
             self._focus_controller.defocus(timestamp)
+
+    def _unsubscribe_symbol(self, symbol: str) -> None:
+        symbol = symbol.upper()
+        context = self._contexts.pop(symbol, None)
+        if context is None:
+            return
+        self._stale_warnings.pop(symbol, None)
+        self._dispose_context(context)
 
     def _focus_symbol(self, symbol: str) -> None:
         symbol = symbol.upper()
@@ -362,7 +379,11 @@ class Application:
         context = self._contexts.get(symbol)
         if context is None:
             return
-        snapshot = context.exchange_data.fetch_orderbook_snapshot()
+        try:
+            snapshot = context.exchange_data.fetch_orderbook_snapshot()
+        except Exception as exc:  # noqa: BLE001
+            self._log_error(f"Не удалось выполнить ресинк стакана {symbol}: {exc}")
+            return
         self._apply_snapshot(context, snapshot)
         timestamp = snapshot.received_at.astimezone(CURRENT_TIMEZONE)
         context.feed_monitor.clear()
@@ -794,6 +815,10 @@ class Application:
                 api_secret=api_secret,
             )
         raise RuntimeError("unsupported exchange")
+
+    def _log_error(self, message: str) -> None:
+        timestamp = get_current_time()
+        self._log_writer(LogLine(timestamp=timestamp, message=message, level="ERROR"))
 
     def _log_scanner_message(self, message: str) -> None:
         timestamp = get_current_time()

--- a/domain/strategy/subscription.py
+++ b/domain/strategy/subscription.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Tuple
+from typing import List, Set, Tuple
 
 from .event_logger import EventLogger
 from .types import SubscriptionHandler
@@ -18,13 +18,31 @@ class SubscriptionManager:
     def update(self, symbols: Tuple[str, ...], timestamp: datetime) -> None:
         additions = self._compute_additions(symbols)
         removals = self._compute_removals(symbols)
+        active: List[str] = list(self._active)
+        active_set: Set[str] = set(active)
         for symbol in additions:
-            self.subscribe(symbol)
+            try:
+                self.subscribe(symbol)
+            except Exception as exc:  # noqa: BLE001
+                self.logger.log(f"Не удалось подписаться на {symbol}: {exc}", timestamp)
+                continue
             self.logger.log(f"Подписка на {symbol}.", timestamp)
+            active.append(symbol)
+            active_set.add(symbol)
         for symbol in removals:
-            self.unsubscribe(symbol)
+            try:
+                self.unsubscribe(symbol)
+            except Exception as exc:  # noqa: BLE001
+                self.logger.log(f"Не удалось отписаться от {symbol}: {exc}", timestamp)
+                continue
             self.logger.log(f"Отписка от {symbol}.", timestamp)
-        self._active = tuple(symbols)
+            if symbol in active_set:
+                active_set.remove(symbol)
+            if symbol in active:
+                active.remove(symbol)
+        ordered = [symbol for symbol in symbols if symbol in active_set]
+        extras = [symbol for symbol in active if symbol not in symbols]
+        self._active = tuple(ordered + extras)
 
     def _compute_additions(self, symbols: Tuple[str, ...]) -> Tuple[str, ...]:
         return tuple(symbol for symbol in symbols if symbol not in self._active)


### PR DESCRIPTION
## Summary
- harden symbol subscription in `app.py` by cleaning up on failures and logging them
- guard `SubscriptionManager.update` against handler exceptions so broken symbols do not block updates
- keep strategies in RESYNC until snapshots succeed by logging snapshot fetch failures

## Testing
- python -m compileall app.py domain/strategy/subscription.py

------
https://chatgpt.com/codex/tasks/task_e_68e7f88e60348320b448df9d60cd78f3