### PR TITLE
Add structured log levels to event and exchange logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,7 +39,6 @@ from domain.models import (
     BalanceSource,
     Exchange,
     ExecutionReport,
-    LogLine,
     MarginMode,
     OrderBookSnapshot,
     OrderBookUpdate,
@@ -274,7 +273,7 @@ class Application:
                 symbol=symbol,
                 loop_interval_ms=CONFIG.general.loop_interval_ms,
                 silence_timeout_ms=CONFIG.general.ws_silence_timeout_ms,
-                log_writer=self._sink,
+                log_writer=self._log_writer,
                 api_key=api_key,
                 api_secret=api_secret,
             )
@@ -283,7 +282,7 @@ class Application:
                 symbol=symbol,
                 loop_interval_ms=CONFIG.general.loop_interval_ms,
                 silence_timeout_ms=CONFIG.general.ws_silence_timeout_ms,
-                log_writer=self._sink,
+                log_writer=self._log_writer,
                 api_key=api_key,
                 api_secret=api_secret,
             )
@@ -411,7 +410,7 @@ class Application:
         self._update_best_from_book(context)
         timestamp = snapshot.received_at
         context.order_book_updated_at = timestamp
-        self._event_logger.log(
+        self._event_logger.log_info(
             (
                 f"Снимок стакана {context.symbol} применён. "
                 f"ID {snapshot.last_update_id}."
@@ -462,14 +461,14 @@ class Application:
                 f"Не удалось восстановить стакан {context.symbol} после тишины: {exc}"
             )
             timestamp = occurred_at.astimezone(CURRENT_TIMEZONE)
-            self._event_logger.log(message, timestamp)
+            self._event_logger.log_error(message, timestamp)
             return False
         self._apply_snapshot(context, snapshot)
         context.feed_monitor.has_silence_timeout = False
         context.last_depth_silence_recovery_at = now
         timestamp = occurred_at.astimezone(CURRENT_TIMEZONE)
         suffix = f" {details}" if details else ""
-        self._event_logger.log(
+        self._event_logger.log_info(
             f"Стакан {context.symbol} восстановлен после тишины.{suffix}",
             timestamp,
         )
@@ -522,7 +521,7 @@ class Application:
                 context.order_book_updated_at = None
                 timestamp = event.timestamp.astimezone(CURRENT_TIMEZONE)
                 details = f" {event.details}." if event.details else ""
-                self._event_logger.log(
+                self._event_logger.log_error(
                     (
                         f"Поток стакана {context.symbol} требует ресинк: "
                         f"{event.reason.value}.{details}"
@@ -642,7 +641,7 @@ class Application:
             if new_messages:
                 details = "; ".join(new_messages)
                 log_timestamp = now.astimezone(CURRENT_TIMEZONE)
-                self._event_logger.log(
+                self._event_logger.log_error(
                     f"Пропуск наблюдения {context.symbol}: {details}.",
                     log_timestamp,
                 )
@@ -753,7 +752,7 @@ class Application:
         if context.cycle_started:
             return
         timestamp = get_current_time()
-        self._event_logger.log(
+        self._event_logger.log_info(
             f"Запущен цикл обработки для {context.symbol}.",
             timestamp,
         )
@@ -780,12 +779,12 @@ class Application:
         )
         context.order_book.reset_odr_history()
         startup_timestamp = get_current_time()
-        self._event_logger.log(
+        self._event_logger.log_info(
             f"Старт бота для {symbol} на {self._exchange.value}.",
             startup_timestamp,
         )
         filters_timestamp = get_current_time()
-        self._event_logger.log(
+        self._event_logger.log_info(
             (
                 f"Получены фильтры {symbol}: "
                 f"шаг цены {context.filters.price_tick_size:g}."
@@ -820,11 +819,11 @@ class Application:
 
     def _log_error(self, message: str) -> None:
         timestamp = get_current_time()
-        self._log_writer(LogLine(timestamp=timestamp, message=message, level="ERROR"))
+        self._event_logger.log_error(message, timestamp)
 
     def _log_scanner_message(self, message: str) -> None:
         timestamp = get_current_time()
-        self._event_logger.log(
+        self._event_logger.log_info(
             f"Сканер рынка: {message}",
             timestamp,
         )
@@ -840,7 +839,7 @@ class Application:
         timestamp = get_current_time()
         context.balance = balance
         context.balance_updated_at = timestamp
-        self._event_logger.log(
+        self._event_logger.log_info(
             f"Баланс {context.symbol} обновлён: {balance:g}.",
             timestamp,
         )
@@ -871,7 +870,7 @@ class Application:
         try:
             next_funding = context.exchange_data.fetch_next_funding_time()
         except Exception as exc:
-            self._event_logger.log(
+            self._event_logger.log_error(
                 f"Не удалось обновить время фандинга для {context.symbol}: {exc}",
                 now,
             )
@@ -883,14 +882,14 @@ class Application:
         context.funding_block_logged = False
         if next_funding is None:
             if previous is not None:
-                self._event_logger.log(
+                self._event_logger.log_info(
                     f"Следующее время фандинга для {context.symbol} недоступно.",
                     now,
                 )
             return
         if previous is None or next_funding != previous:
             localized = next_funding.astimezone(CURRENT_TIMEZONE)
-            self._event_logger.log(
+            self._event_logger.log_info(
                 (
                     f"Следующее время фандинга для {context.symbol}: "
                     f"{localized:%Y-%m-%d %H:%M:%S %Z}."
@@ -925,7 +924,7 @@ class Application:
                         f"{context.symbol}: блокировка из-за фандинга. "
                         f"Фандинг в {funding_local:%H:%M:%S %Z}."
                     )
-                self._event_logger.log(message, timestamp)
+                self._event_logger.log_error(message, timestamp)
                 context.funding_block_logged = True
         elif context.funding_block_logged and timestamp > end:
             context.funding_block_logged = False

--- a/data/exchanges/base/exchange_logger.py
+++ b/data/exchanges/base/exchange_logger.py
@@ -1,5 +1,6 @@
 from typing import Callable, Optional
 
+from domain.models import LogLine
 from utils.timez import get_current_time
 from .resync_reason import ResyncReason
 
@@ -8,22 +9,31 @@ class ExchangeLogger:
     def __init__(
         self,
         name: str,
-        writer: Optional[Callable[[str], None]] = None,
+        writer: Optional[Callable[[LogLine], None]] = None,
     ) -> None:
         self._name = name
         self._writer = writer
 
-    def log(self, message: str) -> None:
+    def log(self, message: str, level: str = "INFO") -> None:
         timestamp = get_current_time().astimezone()
-        formatted = f"{timestamp:%H:%M:%S} {message}"
         if self._writer:
-            self._writer(formatted)
+            self._writer(LogLine(timestamp=timestamp, message=message, level=level))
         else:
-            print(formatted)
+            level_tag = level.upper() if level else "INFO"
+            print(f"{timestamp:%H:%M:%S} [{level_tag}] {message}")
+
+    def log_info(self, message: str) -> None:
+        self.log(message, level="INFO")
+
+    def log_error(self, message: str) -> None:
+        self.log(message, level="ERROR")
+
+    def log_trade(self, message: str) -> None:
+        self.log(message, level="TRADE")
 
     def log_resync(self, reason: ResyncReason, details: str | None = None) -> None:
         suffix = f" {details}" if details else ""
-        self.log(f"Ресинк книги. Причина: {reason.value}.{suffix}")
+        self.log_error(f"Ресинк книги. Причина: {reason.value}.{suffix}")
 
 
 __all__ = ["ExchangeLogger"]

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -25,6 +25,8 @@ from domain.models import (
 from utils.async_websocket import ThreadedWebSocketClient, WebSocketTimeoutError
 from utils.timez import from_exchange_timestamp, get_current_time
 
+from data.logger import LogLineWriter
+
 from .base import (
     BestBidAsk,
     DepthStreamData,
@@ -64,7 +66,7 @@ class BinanceExchangeData:
         rest_retry_backoff: float = 2.0,
         ws_timeout: float = 10.0,
         reconnect_delay: float = 1.0,
-        log_writer: Optional[Callable[[str], None]] = None,
+        log_writer: Optional[LogLineWriter] = None,
         endpoints: Optional[BinanceEndpoints] = None,
         api_key: Optional[str] = None,
         api_secret: Optional[str] = None,
@@ -108,13 +110,13 @@ class BinanceExchangeData:
         try:
             requested_limit = int(depth_limit)
         except (TypeError, ValueError):
-            self._logger.log(
+            self._logger.log_error(
                 f"Binance depth limit {depth_limit!r} is invalid, using {default_limit} instead"
             )
             return default_limit
 
         if requested_limit <= 0:
-            self._logger.log(
+            self._logger.log_error(
                 f"Binance depth limit {requested_limit} is unsupported, using {default_limit} instead"
             )
             return default_limit
@@ -123,7 +125,7 @@ class BinanceExchangeData:
             return requested_limit
 
         normalized = min(allowed, key=lambda value: abs(value - requested_limit))
-        self._logger.log(
+        self._logger.log_error(
             f"Binance depth limit {requested_limit} is unsupported, using {normalized} instead"
         )
         return normalized
@@ -135,7 +137,7 @@ class BinanceExchangeData:
         endpoints: BinanceEndpoints,
         ws_timeout: float,
         reconnect_delay: float,
-        log_writer: Optional[Callable[[str], None]],
+        log_writer: Optional[LogLineWriter],
     ) -> BinanceStreamPool:
         with cls._pool_lock:
             if cls._shared_stream_pool is None:
@@ -276,7 +278,7 @@ class BinanceExchangeData:
             )
             buffer.push_resync(reason, message)
             if should_log:
-                self._logger.log(message)
+                self._logger.log_error(message)
 
         release = self._stream_pool.register_depth(
             self.symbol,
@@ -448,7 +450,7 @@ class BinanceExchangeData:
             )
             buffer.push_resync(reason, message)
             if should_log:
-                self._logger.log(message)
+                self._logger.log_error(message)
 
         release = self._stream_pool.register_book_ticker(
             self.symbol,
@@ -490,7 +492,7 @@ class BinanceExchangeData:
             )
             buffer.push_resync(reason, message)
             if should_log:
-                self._logger.log(message)
+                self._logger.log_error(message)
 
         release = self._stream_pool.register_trades(
             self.symbol,
@@ -567,22 +569,22 @@ class BinanceExchangeData:
             client: WebSocketClient | None = None
             try:
                 if reconnect_after_silence:
-                    self._logger.log(
+                    self._logger.log_error(
                         f"Binance {name} stream: перезапуск соединения после тайм-аута тишины"
                     )
                 else:
-                    self._logger.log(f"Binance {name} stream: открываем соединение")
+                    self._logger.log_info(f"Binance {name} stream: открываем соединение")
                 client = self._connect_websocket(url)
                 client.settimeout(self._ws_timeout)
                 if reconnect_after_silence:
-                    self._logger.log(
+                    self._logger.log_info(
                         f"Binance {name} stream: соединение успешно восстановлено"
                     )
                     reconnect_after_silence = False
                 while not buffer.stopped():
                     if buffer.consume_restart_request():
                         reconnect_after_silence = True
-                        self._logger.log(
+                        self._logger.log_error(
                             f"Binance {name} stream: получен запрос перезапуска от буфера"
                         )
                         break
@@ -591,7 +593,7 @@ class BinanceExchangeData:
                     except WebSocketTimeoutError:
                         if buffer.consume_restart_request():
                             reconnect_after_silence = True
-                            self._logger.log(
+                            self._logger.log_error(
                                 f"Binance {name} stream: перезапуск по запросу буфера после тайм-аута ожидания"
                             )
                             break
@@ -600,7 +602,7 @@ class BinanceExchangeData:
                     if not message:
                         if buffer.consume_restart_request():
                             reconnect_after_silence = True
-                            self._logger.log(
+                            self._logger.log_error(
                                 f"Binance {name} stream: перезапуск по запросу буфера после пустого сообщения"
                             )
                             break
@@ -609,7 +611,7 @@ class BinanceExchangeData:
                         buffer.push_data(payload)
                     if buffer.consume_restart_request():
                         reconnect_after_silence = True
-                        self._logger.log(
+                        self._logger.log_error(
                             f"Binance {name} stream: перезапуск по запросу буфера после обработки сообщения"
                         )
                         break
@@ -624,12 +626,12 @@ class BinanceExchangeData:
                         f"Binance {name} stream: не удалось переподключиться после тайм-аута тишины: {exc}"
                     )
                     buffer.push_resync(reason, details)
-                    self._logger.log(details)
+                    self._logger.log_error(details)
                     time.sleep(self._reconnect_delay)
                 else:
                     details = f"Binance {name} stream: {exc}"
                     buffer.push_resync(reason, details)
-                    self._logger.log(details)
+                    self._logger.log_error(details)
                     time.sleep(self._reconnect_delay)
             finally:
                 if client is not None:

--- a/data/exchanges/binance_stream_pool.py
+++ b/data/exchanges/binance_stream_pool.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from queue import Empty, Queue
 from typing import Any, Callable, Dict, Optional
 
+from data.logger import LogLineWriter
 from utils.async_websocket import AsyncWebSocketClient, WebSocketTimeoutError
 
 from .base import ExchangeLogger, ResyncReason, StreamBuffer
@@ -30,7 +31,7 @@ class _CombinedStreamWorker:
         *,
         ws_timeout: float,
         reconnect_delay: float,
-        log_writer: Optional[Callable[[str], None]] = None,
+        log_writer: Optional[LogLineWriter] = None,
         max_streams: int,
     ) -> None:
         self._name = name
@@ -89,7 +90,7 @@ class _CombinedStreamWorker:
             current = len(self._registrations)
             self._update_event.set()
 
-        self._logger.log(
+        self._logger.log_info(
             (
                 "Binance {stream} stream: добавлен символ {symbol}, "
                 "активных {count}/{limit}"
@@ -113,7 +114,7 @@ class _CombinedStreamWorker:
                 self._update_event.set()
             released.set()
             self._command_queue.put(("unsubscribe", symbol))
-            self._logger.log(
+            self._logger.log_info(
                 (
                     "Binance {stream} stream: удален символ {symbol}, "
                     "активных {count}/{limit}"
@@ -138,7 +139,7 @@ class _CombinedStreamWorker:
     def stop(self) -> None:
         if self._stop_event.is_set():
             return
-        self._logger.log(
+        self._logger.log_info(
             f"Binance {self._name} stream: остановка, активных символов нет"
         )
         self._stop_event.set()
@@ -175,7 +176,7 @@ class _CombinedStreamWorker:
 
         if processed_symbols:
             joined = ", ".join(processed_symbols)
-            self._logger.log(
+            self._logger.log_error(
                 (
                     "Binance {stream} stream: обработан запрос повторной "
                     "синхронизации из буферов: {symbols}"
@@ -310,7 +311,7 @@ class _CombinedStreamWorker:
                 await client.connect()
                 await client.set_timeout(self._ws_timeout)
                 self._next_request_id = 1
-                self._logger.log(
+                self._logger.log_info(
                     (
                         "Binance {stream} stream: открыто соединение для {count} "
                         "символов из {limit}"
@@ -340,7 +341,7 @@ class _CombinedStreamWorker:
                         details = (
                             "Binance {stream} stream: ошибка чтения сокета: {error}"
                         ).format(stream=self._name, error=exc)
-                        self._logger.log(details)
+                        self._logger.log_error(details)
                         self._notify_all(ResyncReason.CONNECTION_LOST, details)
                         break
                     await self._process_commands(client, active_symbols)
@@ -370,7 +371,7 @@ class _CombinedStreamWorker:
                             "Binance {stream} stream: ошибка обработки сообщения для {symbol}:"
                             " {error}"
                         ).format(stream=self._name, symbol=symbol, error=exc)
-                        self._logger.log(details)
+                        self._logger.log_error(details)
                         registration.on_error(
                             ResyncReason.CONNECTION_LOST,
                             details,
@@ -379,7 +380,7 @@ class _CombinedStreamWorker:
                 if self._stop_event.is_set():
                     break
                 details = f"Binance {self._name} stream: {exc}"
-                self._logger.log(details)
+                self._logger.log_error(details)
                 self._notify_all(ResyncReason.CONNECTION_LOST, details)
                 await asyncio.sleep(self._reconnect_delay)
             finally:
@@ -400,7 +401,7 @@ class _StreamWorkerPool:
         stream_suffix: str,
         ws_timeout: float,
         reconnect_delay: float,
-        log_writer: Optional[Callable[[str], None]] = None,
+        log_writer: Optional[LogLineWriter] = None,
     ) -> None:
         self._name = name
         self._ws_base = ws_base
@@ -466,7 +467,7 @@ class BinanceStreamPool:
         endpoints_ws_base: str,
         ws_timeout: float,
         reconnect_delay: float,
-        log_writer: Optional[Callable[[str], None]] = None,
+        log_writer: Optional[LogLineWriter] = None,
     ) -> None:
         base = endpoints_ws_base.rstrip("/")
         if not base.endswith("/ws"):

--- a/data/exchanges/bybit.py
+++ b/data/exchanges/bybit.py
@@ -33,6 +33,7 @@ from domain.models import (
     SymbolFilters,
     Trade,
 )
+from data.logger import LogLineWriter
 from utils.async_websocket import AsyncWebSocketClient, WebSocketTimeoutError
 from utils.timez import from_exchange_timestamp, get_current_time
 from .base import (
@@ -110,7 +111,7 @@ class BybitExchangeData:
         rest_retry_backoff: float = 2.0,
         ws_timeout: float = 10.0,
         reconnect_delay: float = 1.0,
-        log_writer: Optional[Callable[[str], None]] = None,
+        log_writer: Optional[LogLineWriter] = None,
         endpoints: Optional[BybitEndpoints] = None,
         api_key: Optional[str] = None,
         api_secret: Optional[str] = None,
@@ -307,21 +308,21 @@ class BybitExchangeData:
             client: WebSocketClient | None = None
             try:
                 if reconnect_after_silence:
-                    self._logger.log(
+                    self._logger.log_error(
                         "Bybit depth stream: перезапуск соединения после тайм-аута тишины"
                     )
                 else:
-                    self._logger.log("Bybit depth stream: открываем соединение")
+                    self._logger.log_info("Bybit depth stream: открываем соединение")
                 client = await self._connect_websocket(url)
                 await client.set_timeout(self._ws_timeout)
                 await client.send_json(subscribe_payload)
                 if reconnect_after_silence:
-                    self._logger.log("Bybit depth stream: соединение успешно восстановлено")
+                    self._logger.log_info("Bybit depth stream: соединение успешно восстановлено")
                     reconnect_after_silence = False
                 while not buffer.stopped():
                     if buffer.consume_restart_request():
                         reconnect_after_silence = True
-                        self._logger.log(
+                        self._logger.log_error(
                             "Bybit depth stream: получен запрос перезапуска от буфера"
                         )
                         break
@@ -330,7 +331,7 @@ class BybitExchangeData:
                     except WebSocketTimeoutError:
                         if buffer.consume_restart_request():
                             reconnect_after_silence = True
-                            self._logger.log(
+                            self._logger.log_error(
                                 "Bybit depth stream: перезапуск по запросу буфера после тайм-аута ожидания"
                             )
                             break
@@ -339,7 +340,7 @@ class BybitExchangeData:
                     if not raw:
                         if buffer.consume_restart_request():
                             reconnect_after_silence = True
-                            self._logger.log(
+                            self._logger.log_error(
                                 "Bybit depth stream: перезапуск по запросу буфера после пустого сообщения"
                             )
                             break
@@ -349,7 +350,7 @@ class BybitExchangeData:
                         await client.send_json({"op": "pong", "req_id": message.get("req_id")})
                         if buffer.consume_restart_request():
                             reconnect_after_silence = True
-                            self._logger.log(
+                            self._logger.log_error(
                                 "Bybit depth stream: перезапуск по запросу буфера после ответа на ping"
                             )
                             break
@@ -357,7 +358,7 @@ class BybitExchangeData:
                     if message.get("topic") != topic:
                         if buffer.consume_restart_request():
                             reconnect_after_silence = True
-                            self._logger.log(
+                            self._logger.log_error(
                                 "Bybit depth stream: перезапуск по запросу буфера при ожидании целевой темы"
                             )
                             break
@@ -365,7 +366,7 @@ class BybitExchangeData:
                     self._handle_depth_message(message, buffer)
                     if buffer.consume_restart_request():
                         reconnect_after_silence = True
-                        self._logger.log(
+                        self._logger.log_error(
                             "Bybit depth stream: перезапуск по запросу буфера после обработки сообщения"
                         )
                         break
@@ -381,7 +382,7 @@ class BybitExchangeData:
                         f"{exc}"
                     )
                     buffer.push_resync(reason, details)
-                    self._logger.log(details)
+                    self._logger.log_error(details)
                     await asyncio.sleep(self._reconnect_delay)
                 else:
                     details = f"Bybit depth stream: {exc}"
@@ -643,23 +644,23 @@ class BybitExchangeData:
             client: WebSocketClient | None = None
             try:
                 if reconnect_after_silence:
-                    self._logger.log(
+                    self._logger.log_error(
                         f"Bybit {name} stream: перезапуск соединения после тайм-аута тишины"
                     )
                 else:
-                    self._logger.log(f"Bybit {name} stream: открываем соединение")
+                    self._logger.log_info(f"Bybit {name} stream: открываем соединение")
                 client = await self._connect_websocket(url)
                 await client.set_timeout(self._ws_timeout)
                 await client.send_json(subscribe_payload)
                 if reconnect_after_silence:
-                    self._logger.log(
+                    self._logger.log_info(
                         f"Bybit {name} stream: соединение успешно восстановлено"
                     )
                     reconnect_after_silence = False
                 while not buffer.stopped():
                     if buffer.consume_restart_request():
                         reconnect_after_silence = True
-                        self._logger.log(
+                        self._logger.log_error(
                             f"Bybit {name} stream: получен запрос перезапуска от буфера"
                         )
                         break
@@ -668,7 +669,7 @@ class BybitExchangeData:
                     except WebSocketTimeoutError:
                         if buffer.consume_restart_request():
                             reconnect_after_silence = True
-                            self._logger.log(
+                            self._logger.log_error(
                                 f"Bybit {name} stream: перезапуск по запросу буфера после тайм-аута ожидания"
                             )
                             break
@@ -677,7 +678,7 @@ class BybitExchangeData:
                     if not raw:
                         if buffer.consume_restart_request():
                             reconnect_after_silence = True
-                            self._logger.log(
+                            self._logger.log_error(
                                 f"Bybit {name} stream: перезапуск по запросу буфера после пустого сообщения"
                             )
                             break
@@ -687,7 +688,7 @@ class BybitExchangeData:
                         await client.send_json({"op": "pong", "req_id": message.get("req_id")})
                         if buffer.consume_restart_request():
                             reconnect_after_silence = True
-                            self._logger.log(
+                            self._logger.log_error(
                                 f"Bybit {name} stream: перезапуск по запросу буфера после ответа на ping"
                             )
                             break
@@ -695,7 +696,7 @@ class BybitExchangeData:
                     if message.get("topic") != topic:
                         if buffer.consume_restart_request():
                             reconnect_after_silence = True
-                            self._logger.log(
+                            self._logger.log_error(
                                 f"Bybit {name} stream: перезапуск по запросу буфера при ожидании целевой темы"
                             )
                             break
@@ -704,7 +705,7 @@ class BybitExchangeData:
                         buffer.push_data(payload)
                     if buffer.consume_restart_request():
                         reconnect_after_silence = True
-                        self._logger.log(
+                        self._logger.log_error(
                             f"Bybit {name} stream: перезапуск по запросу буфера после обработки сообщения"
                         )
                         break
@@ -719,12 +720,12 @@ class BybitExchangeData:
                         f"Bybit {name} stream: не удалось переподключиться после тайм-аута тишины: {exc}"
                     )
                     buffer.push_resync(reason, details)
-                    self._logger.log(details)
+                    self._logger.log_error(details)
                     await asyncio.sleep(self._reconnect_delay)
                 else:
                     details = f"Bybit {name} stream: {exc}"
                     buffer.push_resync(reason, details)
-                    self._logger.log(details)
+                    self._logger.log_error(details)
                     await asyncio.sleep(self._reconnect_delay)
             finally:
                 if client is not None:

--- a/data/logger.py
+++ b/data/logger.py
@@ -38,7 +38,8 @@ def create_log_writer(sink: LogSink | None = None) -> LogLineWriter:
     def _write(entry: LogLine) -> None:
         timestamp = entry.timestamp.astimezone()
         message = _strip_prefix(entry.message)
-        text_sink(f"{timestamp:%H:%M:%S} {message}")
+        level = entry.level.upper() if entry.level else "INFO"
+        text_sink(f"{timestamp:%H:%M:%S} [{level}] {message}")
 
     return _write
 

--- a/domain/strategy/event_logger.py
+++ b/domain/strategy/event_logger.py
@@ -11,9 +11,18 @@ from .types import LogWriter
 class EventLogger:
     write: LogWriter
 
-    def log(self, message: str, timestamp: datetime) -> None:
-        entry = LogLine(timestamp=timestamp, message=message, level="INFO")
+    def log(self, message: str, timestamp: datetime, level: str = "INFO") -> None:
+        entry = LogLine(timestamp=timestamp, message=message, level=level)
         self.write(entry)
+
+    def log_info(self, message: str, timestamp: datetime) -> None:
+        self.log(message, timestamp, level="INFO")
+
+    def log_error(self, message: str, timestamp: datetime) -> None:
+        self.log(message, timestamp, level="ERROR")
+
+    def log_trade(self, message: str, timestamp: datetime) -> None:
+        self.log(message, timestamp, level="TRADE")
 
 
 __all__ = ["EventLogger"]

--- a/domain/strategy/focus.py
+++ b/domain/strategy/focus.py
@@ -21,7 +21,7 @@ class FocusController:
         if self._current is not None:
             self.defocus(timestamp)
         self.focus_symbol(symbol)
-        self.logger.log(f"Фокус на {symbol}.", timestamp)
+        self.logger.log_info(f"Фокус на {symbol}.", timestamp)
         self._current = symbol
 
     def defocus(self, timestamp: datetime) -> None:
@@ -29,7 +29,7 @@ class FocusController:
             return
         current = self._current
         self.defocus_symbol()
-        self.logger.log(f"Дефокус со {current}.", timestamp)
+        self.logger.log_info(f"Дефокус со {current}.", timestamp)
         self._current = None
 
     @property

--- a/domain/strategy/kill_switch.py
+++ b/domain/strategy/kill_switch.py
@@ -63,7 +63,7 @@ class KillSwitch:
         self._last_block_at = timestamp
         self._block_reason = "ожидание после ресинка"
         self._funding_event_at = None
-        self.logger.log("Блокировка торгов: ожидание после ресинка.", timestamp)
+        self.logger.log_error("Блокировка торгов: ожидание после ресинка.", timestamp)
 
     def handle_funding(self, funding_time: datetime) -> None:
         if self.funding_block <= timedelta(0):
@@ -90,7 +90,7 @@ class KillSwitch:
             self._block_reason = "окно фандинга"
         funding_str = funding_time.strftime("%Y-%m-%d %H:%M:%S %Z")
         release = (self._block_until or end).strftime("%Y-%m-%d %H:%M:%S %Z")
-        self.logger.log(
+        self.logger.log_error(
             (
                 "Блокировка торгов: окно фандинга."
                 f" Фандинг в {funding_str}, блокировка до {release}."
@@ -129,7 +129,7 @@ class KillSwitch:
         self._last_block_at = timestamp
         self._block_reason = reason
         self._funding_event_at = None
-        self.logger.log(f"Блокировка торгов: {reason}.", timestamp)
+        self.logger.log_error(f"Блокировка торгов: {reason}.", timestamp)
 
 
 __all__ = ["KillSwitch"]

--- a/domain/strategy/position.py
+++ b/domain/strategy/position.py
@@ -19,7 +19,7 @@ class PositionController:
         if not self.enter_position(symbol, signal, wall):
             return False
         direction = "лонг" if signal is Signal.LONG else "шорт"
-        self.logger.log(
+        self.logger.log_trade(
             f"Вход {direction} {symbol} по стене {wall.price:g}.",
             timestamp,
         )
@@ -28,13 +28,13 @@ class PositionController:
     def exit(self, symbol: str, reason: str, timestamp: datetime) -> bool:
         if not self.exit_position(symbol, reason):
             return False
-        self.logger.log(f"Выход {symbol}. Причина: {reason}.", timestamp)
+        self.logger.log_trade(f"Выход {symbol}. Причина: {reason}.", timestamp)
         return True
 
     def adjust_stop(self, symbol: str, price: float, timestamp: datetime) -> bool:
         if not self.move_stop(symbol, price):
             return False
-        self.logger.log(f"Перенос стопа {symbol} на {price:g}.", timestamp)
+        self.logger.log_trade(f"Перенос стопа {symbol} на {price:g}.", timestamp)
         return True
 
 

--- a/domain/strategy/strategy.py
+++ b/domain/strategy/strategy.py
@@ -82,7 +82,7 @@ class Strategy:
     def complete_resync(self, timestamp: datetime) -> StrategyState:
         if self._state is not StrategyState.RESYNC:
             return self._state
-        self._logger.log("Ресинк завершён.", timestamp)
+        self._logger.log_info("Ресинк завершён.", timestamp)
         self._state = self._previous_state
         self._resync_reason = None
         return self._state
@@ -143,7 +143,7 @@ class Strategy:
                     self._last_focus_signal_at = timestamp
                     self._focused_wall = wall
         if self._should_defocus(timestamp):
-            self._logger.log(
+            self._logger.log_info(
                 f"Аптик {symbol} потерян: таймаут сигнала.",
                 timestamp,
             )
@@ -230,7 +230,7 @@ class Strategy:
         self._focused_wall = wall
         self._last_focus_signal_at = timestamp
         direction = "лонг" if signal is Signal.LONG else "шорт"
-        self._logger.log(
+        self._logger.log_info(
             (
                 f"Аптик {symbol} {direction}. "
                 f"Стена {wall.price:g} объём {wall.notional:g}. "
@@ -295,7 +295,7 @@ class Strategy:
                 message = f"{message} ({reason})."
             else:
                 message = f"{message}."
-            self._logger.log(message, timestamp)
+            self._logger.log_error(message, timestamp)
             return
         if not self._position.enter(symbol, signal, wall, timestamp):
             return
@@ -423,7 +423,7 @@ class Strategy:
         self._previous_state = self._state
         self._state = StrategyState.RESYNC
         self._resync_reason = reason
-        self._logger.log(
+        self._logger.log_error(
             f"Ресинк книги. Причина: {reason.value}.", timestamp
         )
         self._track_resync_summary(timestamp)
@@ -434,7 +434,7 @@ class Strategy:
             self._resync_summary_start = timestamp
         elapsed = timestamp - self._resync_summary_start
         if elapsed >= timedelta(hours=1):
-            self._logger.log(
+            self._logger.log_info(
                 f"Ресинков за час: {self._resync_summary_count}.",
                 timestamp,
             )

--- a/domain/strategy/subscription.py
+++ b/domain/strategy/subscription.py
@@ -24,18 +24,22 @@ class SubscriptionManager:
             try:
                 self.subscribe(symbol)
             except Exception as exc:  # noqa: BLE001
-                self.logger.log(f"Не удалось подписаться на {symbol}: {exc}", timestamp)
+                self.logger.log_error(
+                    f"Не удалось подписаться на {symbol}: {exc}", timestamp
+                )
                 continue
-            self.logger.log(f"Подписка на {symbol}.", timestamp)
+            self.logger.log_info(f"Подписка на {symbol}.", timestamp)
             active.append(symbol)
             active_set.add(symbol)
         for symbol in removals:
             try:
                 self.unsubscribe(symbol)
             except Exception as exc:  # noqa: BLE001
-                self.logger.log(f"Не удалось отписаться от {symbol}: {exc}", timestamp)
+                self.logger.log_error(
+                    f"Не удалось отписаться от {symbol}: {exc}", timestamp
+                )
                 continue
-            self.logger.log(f"Отписка от {symbol}.", timestamp)
+            self.logger.log_info(f"Отписка от {symbol}.", timestamp)
             if symbol in active_set:
                 active_set.remove(symbol)
             if symbol in active:


### PR DESCRIPTION
## Summary
- extend the event logging pipeline with dedicated info/error/trade helpers and include levels in formatted output
- update strategy and application workflows to tag log entries with appropriate levels for recoveries, trades, and routine updates
- adapt exchange loggers and stream pools to emit level-aware messages using the shared log writer

## Testing
- python -m compileall app.py domain data

------
https://chatgpt.com/codex/tasks/task_e_68e7fca592e883209472dfa004c00865