### PR TITLE
Improve log formatting with colored levels

### DIFF
--- a/data/exchanges/base/exchange_logger.py
+++ b/data/exchanges/base/exchange_logger.py
@@ -1,6 +1,7 @@
 from typing import Callable, Optional
 
 from domain.models import LogLine
+from data.logger import format_log_message
 from utils.timez import get_current_time
 from .resync_reason import ResyncReason
 
@@ -20,7 +21,7 @@ class ExchangeLogger:
             self._writer(LogLine(timestamp=timestamp, message=message, level=level))
         else:
             level_tag = level.upper() if level else "INFO"
-            print(f"{timestamp:%H:%M:%S} [{level_tag}] {message}")
+            print(format_log_message(timestamp, level_tag, message, use_color=True))
 
     def log_info(self, message: str) -> None:
         self.log(message, level="INFO")

--- a/data/logger.py
+++ b/data/logger.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from datetime import datetime
 from typing import Callable, TextIO, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -9,8 +11,43 @@ LogSink = Callable[[str], None]
 LogLineWriter = Callable[["LogLine"], None]
 
 
+RESET_COLOR = "\x1b[0m"
+
+
+@dataclass(frozen=True)
+class _LogStyle:
+    color: str = ""
+    emoji: str = ""
+
+
+_LEVEL_STYLES: dict[str, _LogStyle] = {
+    "ERROR": _LogStyle(color="\x1b[31m", emoji="❗"),
+    "TRADE": _LogStyle(color="\x1b[36m", emoji="💱"),
+    "WARNING": _LogStyle(color="\x1b[33m", emoji="⚠"),
+}
+_DEFAULT_STYLE = _LogStyle()
+
+
 def _print_sink(message: str) -> None:
     print(message)
+
+
+_print_sink._supports_color = True  # type: ignore[attr-defined]
+
+
+def _get_log_style(level: str) -> _LogStyle:
+    return _LEVEL_STYLES.get(level, _DEFAULT_STYLE)
+
+
+def format_log_message(timestamp: datetime, level: str, message: str, *, use_color: bool) -> str:
+    level_tag = level.upper() if level else "INFO"
+    formatted = f"{timestamp:%H:%M:%S} [{level_tag}] {message}"
+    style = _get_log_style(level_tag)
+    if use_color and style.color:
+        return f"{style.color}{formatted}{RESET_COLOR}"
+    if not use_color and style.emoji:
+        return f"{formatted} {style.emoji}"
+    return formatted
 
 
 def create_text_log_sink(stream: TextIO | None = None) -> LogSink:
@@ -21,11 +58,14 @@ def create_text_log_sink(stream: TextIO | None = None) -> LogSink:
         stream.write(f"{message}\n")
         stream.flush()
 
+    supports_color = bool(getattr(stream, "isatty", lambda: False)())
+    _write._supports_color = supports_color  # type: ignore[attr-defined]
     return _write
 
 
 def create_log_writer(sink: LogSink | None = None) -> LogLineWriter:
     text_sink = sink or _print_sink
+    supports_color = bool(getattr(text_sink, "_supports_color", sink is None))
 
     def _strip_prefix(message: str) -> str:
         stripped = message.strip()
@@ -39,9 +79,15 @@ def create_log_writer(sink: LogSink | None = None) -> LogLineWriter:
         timestamp = entry.timestamp.astimezone()
         message = _strip_prefix(entry.message)
         level = entry.level.upper() if entry.level else "INFO"
-        text_sink(f"{timestamp:%H:%M:%S} [{level}] {message}")
+        text_sink(format_log_message(timestamp, level, message, use_color=supports_color))
 
     return _write
 
 
-__all__ = ["LogSink", "LogLineWriter", "create_text_log_sink", "create_log_writer"]
+__all__ = [
+    "LogSink",
+    "LogLineWriter",
+    "create_text_log_sink",
+    "create_log_writer",
+    "format_log_message",
+]


### PR DESCRIPTION
## Summary
- add centralized log formatting that colors error and trade records when supported and falls back to emojis otherwise
- reuse the shared formatter inside the exchange logger when no custom writer is provided

## Testing
- python -m compileall data

------
https://chatgpt.com/codex/tasks/task_e_68e8013729088320bf478a2fab6993ac