### PR TITLE
Enhance log output with colored levels

### DIFF
--- a/data/logger.py
+++ b/data/logger.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Callable, TextIO, TYPE_CHECKING
+import os
+import sys
+from typing import Callable, NamedTuple, TextIO, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from domain.models import LogLine
@@ -9,8 +11,36 @@ LogSink = Callable[[str], None]
 LogLineWriter = Callable[["LogLine"], None]
 
 
+class _LevelStyle(NamedTuple):
+    color: str
+    emoji: str
+
+
+_RESET_COLOR = "\033[0m"
+_LEVEL_STYLES: dict[str, _LevelStyle] = {
+    "INFO": _LevelStyle(color="", emoji=""),
+    "ERROR": _LevelStyle(color="\033[31m", emoji="❗"),
+    "TRADING": _LevelStyle(color="\033[32m", emoji="💹"),
+}
+
+
+def _supports_color_output(stream: TextIO | None) -> bool:
+    if stream is None:
+        return False
+    try:
+        if stream.isatty():
+            return True
+    except Exception:
+        pass
+    if os.environ.get("PYCHARM_HOSTED") == "1" and stream in {sys.stdout, sys.stderr}:
+        return True
+    return False
+
+
 def _print_sink(message: str) -> None:
     print(message)
+
+setattr(_print_sink, "_supports_color", _supports_color_output(getattr(sys, "stdout", None)))
 
 
 def create_text_log_sink(stream: TextIO | None = None) -> LogSink:
@@ -21,11 +51,26 @@ def create_text_log_sink(stream: TextIO | None = None) -> LogSink:
         stream.write(f"{message}\n")
         stream.flush()
 
+    setattr(_write, "_supports_color", _supports_color_output(stream))
+
     return _write
 
 
 def create_log_writer(sink: LogSink | None = None) -> LogLineWriter:
     text_sink = sink or _print_sink
+    use_color_attr = getattr(text_sink, "_supports_color", None)
+    if use_color_attr is None:
+        use_color = os.environ.get("PYCHARM_HOSTED") == "1"
+    else:
+        use_color = bool(use_color_attr)
+
+    def _decorate(message: str, level: str) -> str:
+        style = _LEVEL_STYLES.get(level, _LEVEL_STYLES["INFO"])
+        if use_color and style.color:
+            return f"{style.color}{message}{_RESET_COLOR}"
+        if not use_color and style.emoji:
+            return f"{style.emoji} {message}"
+        return message
 
     def _strip_prefix(message: str) -> str:
         stripped = message.strip()
@@ -38,7 +83,9 @@ def create_log_writer(sink: LogSink | None = None) -> LogLineWriter:
     def _write(entry: LogLine) -> None:
         timestamp = entry.timestamp.astimezone()
         message = _strip_prefix(entry.message)
-        text_sink(f"{timestamp:%H:%M:%S} {message}")
+        level = entry.level.upper() if entry.level else "INFO"
+        formatted = f"{timestamp:%H:%M:%S} {message}"
+        text_sink(_decorate(formatted, level))
 
     return _write
 

--- a/domain/strategy/event_logger.py
+++ b/domain/strategy/event_logger.py
@@ -11,8 +11,8 @@ from .types import LogWriter
 class EventLogger:
     write: LogWriter
 
-    def log(self, message: str, timestamp: datetime) -> None:
-        entry = LogLine(timestamp=timestamp, message=message, level="INFO")
+    def log(self, message: str, timestamp: datetime, *, level: str = "INFO") -> None:
+        entry = LogLine(timestamp=timestamp, message=message, level=level)
         self.write(entry)
 
 

--- a/domain/strategy/position.py
+++ b/domain/strategy/position.py
@@ -22,19 +22,28 @@ class PositionController:
         self.logger.log(
             f"Вход {direction} {symbol} по стене {wall.price:g}.",
             timestamp,
+            level="TRADING",
         )
         return True
 
     def exit(self, symbol: str, reason: str, timestamp: datetime) -> bool:
         if not self.exit_position(symbol, reason):
             return False
-        self.logger.log(f"Выход {symbol}. Причина: {reason}.", timestamp)
+        self.logger.log(
+            f"Выход {symbol}. Причина: {reason}.",
+            timestamp,
+            level="TRADING",
+        )
         return True
 
     def adjust_stop(self, symbol: str, price: float, timestamp: datetime) -> bool:
         if not self.move_stop(symbol, price):
             return False
-        self.logger.log(f"Перенос стопа {symbol} на {price:g}.", timestamp)
+        self.logger.log(
+            f"Перенос стопа {symbol} на {price:g}.",
+            timestamp,
+            level="TRADING",
+        )
         return True
 
 


### PR DESCRIPTION
## Summary
- add styling metadata for log lines to colorize or decorate output by level
- allow trading-related events to be logged with a dedicated level for distinct formatting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e802ea73188320b0b4daf434963b6f