### PR TITLE
Handle Binance depth mismatches during initial catch-up

### DIFF
--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -351,13 +351,19 @@ class BinanceExchangeData:
             if last_update <= self._depth_last_update:
                 return
 
+            skip_allowed = allow_skip or self._depth_allow_skip
+
             if first_update > expected:
+                if skip_allowed:
+                    return
                 resync_reason = ResyncReason.SEQUENCE_GAP
                 resync_details = (
                     f"Ожидали {expected}, получили диапазон {first_update}-{last_update}"
                 )
                 self._depth_allow_skip = False
             elif prev_update != self._depth_last_update:
+                if skip_allowed:
+                    return
                 resync_reason = ResyncReason.SEQUENCE_GAP
                 resync_details = (
                     f"Предыдущий апдейт {prev_update} != {self._depth_last_update}"


### PR DESCRIPTION
## Summary
- allow Binance depth handler to temporarily skip mismatched updates when catch-up mode is enabled
- keep the skip allowance active only until the first matching update is applied

## Testing
- python app.py *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_68e8b8a9a03483208034da1b8e1e1b19