### PR TITLE
Handle skip-allowed depth diffs covering expected sequence

### DIFF
--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -353,17 +353,24 @@ class BinanceExchangeData:
 
             skip_allowed = allow_skip or self._depth_allow_skip
 
-            if first_update > expected:
-                if skip_allowed:
-                    return
+            if skip_allowed:
+                if first_update <= expected <= last_update:
+                    update = self._build_depth_update(message, event_time)
+                    self._depth_last_update = last_update
+                    self._depth_allow_skip = False
+                else:
+                    resync_reason = ResyncReason.SEQUENCE_GAP
+                    resync_details = (
+                        f"Ожидали {expected}, получили диапазон {first_update}-{last_update}"
+                    )
+                    self._depth_allow_skip = False
+            elif first_update > expected:
                 resync_reason = ResyncReason.SEQUENCE_GAP
                 resync_details = (
                     f"Ожидали {expected}, получили диапазон {first_update}-{last_update}"
                 )
                 self._depth_allow_skip = False
             elif prev_update != self._depth_last_update:
-                if skip_allowed:
-                    return
                 resync_reason = ResyncReason.SEQUENCE_GAP
                 resync_details = (
                     f"Предыдущий апдейт {prev_update} != {self._depth_last_update}"


### PR DESCRIPTION
## Summary
- accept Binance depth diffs that include the expected sequence when skipping is allowed
- reset skip allowance after applying the catch-up diff so future updates must align
- keep resyncs for true sequence gaps so catch-up diffs reach the buffer

## Testing
- not run (environment does not provide live exchange connectivity)


------
https://chatgpt.com/codex/tasks/task_e_68ea4442cd588320a50dd479b99694b4