### PR TITLE
Improve Binance depth update continuity handling

### DIFF
--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -346,39 +346,31 @@ class BinanceExchangeData:
                     self._depth_buffered_messages.append(message)
                 return
 
-            expected = self._depth_last_update + 1
-
             if last_update <= self._depth_last_update:
                 return
 
             skip_allowed = allow_skip or self._depth_allow_skip
 
-            if skip_allowed:
+            expected = self._depth_last_update + 1
+
+            if prev_update == self._depth_last_update:
+                update = self._build_depth_update(message, event_time)
+                self._depth_last_update = last_update
+                self._depth_allow_skip = False
+            elif skip_allowed and first_update <= expected <= last_update:
+                update = self._build_depth_update(message, event_time)
+                self._depth_last_update = last_update
+                self._depth_allow_skip = False
+            else:
+                resync_reason = ResyncReason.SEQUENCE_GAP
                 if first_update <= expected <= last_update:
-                    update = self._build_depth_update(message, event_time)
-                    self._depth_last_update = last_update
-                    self._depth_allow_skip = False
+                    resync_details = (
+                        f"Предыдущий апдейт {prev_update} != {self._depth_last_update}"
+                    )
                 else:
-                    resync_reason = ResyncReason.SEQUENCE_GAP
                     resync_details = (
                         f"Ожидали {expected}, получили диапазон {first_update}-{last_update}"
                     )
-                    self._depth_allow_skip = False
-            elif first_update > expected:
-                resync_reason = ResyncReason.SEQUENCE_GAP
-                resync_details = (
-                    f"Ожидали {expected}, получили диапазон {first_update}-{last_update}"
-                )
-                self._depth_allow_skip = False
-            elif prev_update != self._depth_last_update:
-                resync_reason = ResyncReason.SEQUENCE_GAP
-                resync_details = (
-                    f"Предыдущий апдейт {prev_update} != {self._depth_last_update}"
-                )
-                self._depth_allow_skip = False
-            else:
-                update = self._build_depth_update(message, event_time)
-                self._depth_last_update = last_update
                 self._depth_allow_skip = False
 
         if resync_reason is not None:


### PR DESCRIPTION
## Summary
- prioritize continuity checks on Binance depth updates so matching `pu` values are accepted even if the diff skips ahead
- keep the post-snapshot skip window while only triggering resyncs when continuity and catch-up conditions both fail
- reset the skip allowance only after applying an update or detecting a real sequence gap to avoid repeated resyncs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea461de3408320902ac7980d6001d7