### PR TITLE
Throttle subscription activation with pending queue

### DIFF
--- a/app.py
+++ b/app.py
@@ -224,10 +224,13 @@ class Application:
         self._balance_refresh_interval = timedelta(hours=CONFIG.position.balance_refresh_h)
         self._last_balance_refresh_at: Optional[datetime] = None
         self._silence_recovery_cooldown = timedelta(seconds=5)
+        subscription_limits = CONFIG.subscriptions
         self._subscription_manager = SubscriptionManager(
             subscribe=self._subscribe_symbol,
             unsubscribe=self._unsubscribe_symbol,
             logger=self._event_logger,
+            max_new_per_cycle=subscription_limits.max_new_per_cycle,
+            max_total=subscription_limits.max_total,
         )
         self._data_freshness_threshold = timedelta(
             milliseconds=CONFIG.general.ws_silence_timeout_ms
@@ -352,7 +355,7 @@ class Application:
                 self._dispose_context(new_context)
             elif context is not None:
                 self._dispose_context(context)
-            return
+            raise
         if new_context is not None:
             self._contexts[symbol] = new_context
 
@@ -1094,8 +1097,12 @@ class Application:
         interval = CONFIG.general.loop_interval_ms / 1000.0
         self._refresh_symbol_scan(force=True)
         self._refresh_balances(force=True)
+        startup_timestamp = get_current_time()
+        self._subscription_manager.activate_pending(startup_timestamp)
         while True:
             self._refresh_symbol_scan()
+            activation_timestamp = get_current_time()
+            self._subscription_manager.activate_pending(activation_timestamp)
             self._refresh_balances()
             resync_triggered = False
             work_done = False

--- a/config/config.py
+++ b/config/config.py
@@ -13,6 +13,7 @@ from config.models import (
     OdrSettings,
     PositionSettings,
     StopTrigger,
+    SubscriptionSettings,
     TelegramSettings,
     TradingProfile,
     TurnoverThresholds,
@@ -84,6 +85,13 @@ CONFIG: Final[Config] = Config(
         chat_id=739865715,
         silent=False,
         uptick_cooldown_min=5,
+    ),
+    subscriptions=SubscriptionSettings(
+        # При мониторинге сотен инструментов рекомендуется удерживать
+        # порядка 80 одновременных подписок и подключать не более четырёх
+        # новых потоков за цикл, чтобы избежать бурстов и перегрузки.
+        max_total=80,
+        max_new_per_cycle=4,
     ),
 )
 

--- a/config/models/__init__.py
+++ b/config/models/__init__.py
@@ -9,6 +9,7 @@ from .odr_settings import OdrSettings
 from .position_settings import PositionSettings
 from .secrets import Secrets
 from .stop_trigger import StopTrigger
+from .subscription_settings import SubscriptionSettings
 from .telegram_settings import TelegramSettings
 from .trading_profile import TradingProfile
 from .turnover_thresholds import TurnoverThresholds
@@ -27,6 +28,7 @@ __all__ = [
     "OdrSettings",
     "PositionSettings",
     "StopTrigger",
+    "SubscriptionSettings",
     "TelegramSettings",
     "TradingProfile",
     "Secrets",

--- a/config/models/config_model.py
+++ b/config/models/config_model.py
@@ -7,6 +7,7 @@ from .funding_kill_switch_settings import FundingKillSwitchSettings
 from .general_settings import GeneralSettings
 from .odr_settings import OdrSettings
 from .position_settings import PositionSettings
+from .subscription_settings import SubscriptionSettings
 from .telegram_settings import TelegramSettings
 from .turnover_thresholds import TurnoverThresholds
 from .wall_settings import WallSettings
@@ -24,6 +25,7 @@ class Config:
     focus: FocusSettings
     funding_ks: FundingKillSwitchSettings
     telegram: TelegramSettings
+    subscriptions: SubscriptionSettings
 
 
 __all__ = ["Config"]

--- a/config/models/subscription_settings.py
+++ b/config/models/subscription_settings.py
@@ -1,0 +1,19 @@
+"""Subscription activation throttling settings."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SubscriptionSettings:
+    """Limits controlling how aggressively the bot subscribes to symbols.
+
+    Recommended values for monitoring several hundred instruments:
+        * ``max_total`` around 80 keeps concurrent streams manageable.
+        * ``max_new_per_cycle`` around 4 avoids bursts when recovering feeds.
+    """
+
+    max_total: int
+    max_new_per_cycle: int
+
+
+__all__ = ["SubscriptionSettings"]

--- a/domain/strategy/subscription.py
+++ b/domain/strategy/subscription.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List, Set, Tuple
+from typing import Dict, List, Set, Tuple
 
 from .event_logger import EventLogger
 from .types import SubscriptionHandler
@@ -13,42 +13,120 @@ class SubscriptionManager:
     subscribe: SubscriptionHandler
     unsubscribe: SubscriptionHandler
     logger: EventLogger
+    max_new_per_cycle: int
+    max_total: int
     _active: Tuple[str, ...] = field(default_factory=tuple)
+    _pending: Tuple[str, ...] = field(default_factory=tuple)
+    _desired: Tuple[str, ...] = field(default_factory=tuple)
+    _desired_order: Dict[str, int] = field(default_factory=dict)
 
     def update(self, symbols: Tuple[str, ...], timestamp: datetime) -> None:
-        additions = self._compute_additions(symbols)
-        removals = self._compute_removals(symbols)
+        desired = tuple(symbols)
+        desired_set: Set[str] = set(desired)
+        self._desired = desired
+        self._desired_order = {symbol: index for index, symbol in enumerate(desired)}
+
         active: List[str] = list(self._active)
-        active_set: Set[str] = set(active)
-        for symbol in additions:
+        pending: List[str] = [symbol for symbol in self._pending if symbol in desired_set]
+
+        active.sort(key=lambda symbol: self._desired_order.get(symbol, len(desired)))
+
+        if self.max_total > 0:
+            active_capacity = min(self.max_total, len(desired))
+        else:
+            active_capacity = 0
+
+        kept: List[str] = []
+        pending_set = set(pending)
+        for symbol in active:
+            if symbol not in desired_set:
+                if not self._perform_unsubscribe(symbol, timestamp):
+                    kept.append(symbol)
+                continue
+            if len(kept) < active_capacity:
+                kept.append(symbol)
+                continue
+            if self._perform_unsubscribe(
+                symbol, timestamp, reason="лимита активных подписок"
+            ):
+                if symbol not in pending_set:
+                    pending.append(symbol)
+                    pending_set.add(symbol)
+                continue
+            kept.append(symbol)
+
+        for symbol in desired:
+            if symbol in kept:
+                continue
+            if symbol in pending_set:
+                continue
+            pending.append(symbol)
+            pending_set.add(symbol)
+
+        self._active = tuple(kept)
+        self._pending = tuple(pending)
+
+    def activate_pending(self, timestamp: datetime) -> None:
+        if self.max_total <= 0:
+            return
+        remaining_capacity = self.max_total - len(self._active)
+        if remaining_capacity <= 0:
+            return
+        allowed_new = self.max_new_per_cycle if self.max_new_per_cycle > 0 else 0
+        if allowed_new <= 0:
+            return
+        allowed_new = min(allowed_new, remaining_capacity)
+        if allowed_new <= 0:
+            return
+
+        active = list(self._active)
+        pending = list(self._pending)
+        activated = 0
+        while pending and activated < allowed_new and len(active) < self.max_total:
+            symbol = pending.pop(0)
             try:
                 self.subscribe(symbol)
             except Exception as exc:  # noqa: BLE001
                 self.logger.log(f"Не удалось подписаться на {symbol}: {exc}", timestamp)
-                continue
+                pending.insert(0, symbol)
+                break
             self.logger.log(f"Подписка на {symbol}.", timestamp)
+            self._insert_active(active, symbol)
+            activated += 1
+
+        self._active = tuple(active)
+        self._pending = tuple(pending)
+
+    def _insert_active(self, active: List[str], symbol: str) -> None:
+        order = self._desired_order
+        position = order.get(symbol)
+        if position is None:
             active.append(symbol)
-            active_set.add(symbol)
-        for symbol in removals:
-            try:
-                self.unsubscribe(symbol)
-            except Exception as exc:  # noqa: BLE001
-                self.logger.log(f"Не удалось отписаться от {symbol}: {exc}", timestamp)
+            return
+        index = len(active)
+        for offset, current in enumerate(active):
+            current_position = order.get(current)
+            if current_position is None:
                 continue
-            self.logger.log(f"Отписка от {symbol}.", timestamp)
-            if symbol in active_set:
-                active_set.remove(symbol)
-            if symbol in active:
-                active.remove(symbol)
-        ordered = [symbol for symbol in symbols if symbol in active_set]
-        extras = [symbol for symbol in active if symbol not in symbols]
-        self._active = tuple(ordered + extras)
+            if current_position > position:
+                index = offset
+                break
+        active.insert(index, symbol)
 
-    def _compute_additions(self, symbols: Tuple[str, ...]) -> Tuple[str, ...]:
-        return tuple(symbol for symbol in symbols if symbol not in self._active)
-
-    def _compute_removals(self, symbols: Tuple[str, ...]) -> Tuple[str, ...]:
-        return tuple(symbol for symbol in self._active if symbol not in symbols)
+    def _perform_unsubscribe(
+        self, symbol: str, timestamp: datetime, reason: str | None = None
+    ) -> bool:
+        try:
+            self.unsubscribe(symbol)
+        except Exception as exc:  # noqa: BLE001
+            self.logger.log(f"Не удалось отписаться от {symbol}: {exc}", timestamp)
+            return False
+        if reason:
+            message = f"Отписка от {symbol} из-за {reason}."
+        else:
+            message = f"Отписка от {symbol}."
+        self.logger.log(message, timestamp)
+        return True
 
 
 __all__ = ["SubscriptionManager"]


### PR DESCRIPTION
## Summary
- extend the subscription manager with a pending queue, per-cycle activation limits, and retry logic that preserves ordering
- wire the new throttling limits into the application loop so only a bounded number of feeds are activated each cycle
- expose subscription throttling settings in the config, including documented recommendations for monitoring hundreds of symbols

## Testing
- python -m compileall -f app.py config

------
https://chatgpt.com/codex/tasks/task_e_68ea52c2590c832088434c001e0e51f5