### PR TITLE
Adjust Binance stream silence handling and logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -292,7 +292,11 @@ class Application:
             return SECRETS.bybit_api_key, SECRETS.bybit_api_secret
         return None, None
 
-    def _create_exchange_data(self, symbol: str) -> IExchangeData:
+    def _create_exchange_data(
+        self,
+        symbol: str,
+        profile: TradingProfile | None = None,
+    ) -> IExchangeData:
         api_key, api_secret = self._exchange_credentials()
         if CONFIG.general.exchange is ExchangeName.BINANCE:
             return BinanceExchangeData(
@@ -304,6 +308,7 @@ class Application:
                 log_writer=self._sink,
                 api_key=api_key,
                 api_secret=api_secret,
+                profile=profile,
             )
         if CONFIG.general.exchange is ExchangeName.BYBIT:
             return BybitExchangeData(
@@ -795,7 +800,8 @@ class Application:
         context.cycle_started = True
 
     def _create_context(self, symbol: str) -> SymbolContext:
-        exchange_data = self._create_exchange_data(symbol)
+        profile = self._symbol_profiles.get(symbol, CONFIG.general.profile)
+        exchange_data = self._create_exchange_data(symbol, profile)
         filters = exchange_data.fetch_symbol_filters()
         trading_adapter = self._create_trading_adapter(symbol, filters)
         context = SymbolContext(
@@ -811,7 +817,7 @@ class Application:
             ticker_subscription=exchange_data.stream_book_ticker(),
             filters=filters,
             trading_adapter=trading_adapter,
-            profile=self._symbol_profiles.get(symbol, CONFIG.general.profile),
+            profile=profile,
         )
         context.order_book.reset_odr_history()
         startup_timestamp = get_current_time()

--- a/data/exchanges/base/stream_buffer.py
+++ b/data/exchanges/base/stream_buffer.py
@@ -22,6 +22,7 @@ class StreamBuffer(Generic[T]):
         heartbeat_interval: Optional[float] = None,
         maxsize: int | None = None,
         drop_oldest_on_overflow: bool = False,
+        restart_grace_period: Optional[float] = None,
     ) -> None:
         self._name = name
         self._logger = logger
@@ -37,6 +38,13 @@ class StreamBuffer(Generic[T]):
         now = time.monotonic()
         self._last_data = now
         self._last_heartbeat = now
+        self._restart_grace_period = (
+            max(0.0, restart_grace_period)
+            if restart_grace_period is not None
+            else silence_timeout
+        )
+        self._last_restart_requested_at: float | None = None
+        self._last_restart_reason: ResyncReason | None = None
 
     def stopped(self) -> bool:
         return self._stop.is_set()
@@ -50,21 +58,48 @@ class StreamBuffer(Generic[T]):
                 self._drain()
                 self._queue.put_nowait(StreamEvent.stop())
 
-    def request_restart(self) -> None:
+    def request_restart(
+        self,
+        reason: ResyncReason | None = None,
+        *,
+        force: bool = False,
+    ) -> None:
+        now = time.monotonic()
+        if not force:
+            if self._restart_event.is_set():
+                return
+            if (
+                self._last_restart_requested_at is not None
+                and now - self._last_restart_requested_at < self._restart_grace_period
+            ):
+                return
         self._restart_event.set()
+        self._last_restart_requested_at = now
+        self._last_restart_reason = reason
 
-    def consume_restart_request(self) -> bool:
+    def consume_restart_request(self) -> ResyncReason | None:
         if self._restart_event.is_set():
             self._restart_event.clear()
-            return True
-        return False
+            reason = self._last_restart_reason
+            self._last_restart_reason = None
+            return reason
+        return None
 
     def restart_requested(self) -> bool:
         return self._restart_event.is_set()
 
+    def restart_grace_period(self) -> float:
+        return self._restart_grace_period
+
+    def last_restart_request_age(self) -> float | None:
+        if self._last_restart_requested_at is None:
+            return None
+        return time.monotonic() - self._last_restart_requested_at
+
     def push(self, event: StreamEvent[T]) -> None:
         if event.type in {StreamEventType.DATA, StreamEventType.SNAPSHOT}:
             self._last_data = time.monotonic()
+            self._last_restart_requested_at = None
         try:
             self._queue.put_nowait(event)
         except queue.Full:
@@ -112,7 +147,7 @@ class StreamBuffer(Generic[T]):
                 now = time.monotonic()
                 if now - self._last_data >= self._silence_timeout:
                     self._last_data = now
-                    self.request_restart()
+                    self.request_restart(ResyncReason.SILENCE_TIMEOUT)
                     self._last_heartbeat = now
                     return StreamEvent.heartbeat()
                 if now - self._last_heartbeat >= self._heartbeat_interval:

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -12,6 +12,7 @@ from urllib import parse
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from config.models.trading_profile import TradingProfile
 from domain.models import (
     Candle,
     Exchange,
@@ -49,6 +50,21 @@ BINANCE_ALLOWED_DEPTH_LIMITS: frozenset[int] = frozenset({5, 10, 20, 50, 100, 50
 MIN_STREAM_SILENCE_TIMEOUT_MS = 1500.0
 
 
+@dataclass(frozen=True)
+class _StreamTimeoutConfig:
+    depth: float
+    trades: float
+    book_ticker: float
+
+
+_PROFILE_STREAM_TIMEOUTS: dict[TradingProfile, _StreamTimeoutConfig] = {
+    TradingProfile.TOP: _StreamTimeoutConfig(depth=2.5, trades=6.0, book_ticker=6.0),
+    TradingProfile.ALT: _StreamTimeoutConfig(depth=3.5, trades=8.0, book_ticker=8.0),
+    TradingProfile.LISTING: _StreamTimeoutConfig(depth=1.5, trades=5.0, book_ticker=5.0),
+    TradingProfile.AUTO: _StreamTimeoutConfig(depth=3.0, trades=7.0, book_ticker=7.0),
+}
+
+
 class BinanceExchangeData:
     _pool_lock: ClassVar[threading.Lock] = threading.Lock()
     _shared_stream_pools: ClassVar[dict[tuple[str, int], BinanceStreamPool]] = {}
@@ -70,6 +86,7 @@ class BinanceExchangeData:
         api_key: Optional[str] = None,
         api_secret: Optional[str] = None,
         silence_timeout_ms: float | None = None,
+        profile: TradingProfile | None = None,
     ) -> None:
         self.symbol = symbol.upper()
         self._endpoints = endpoints or BinanceEndpoints()
@@ -96,15 +113,44 @@ class BinanceExchangeData:
                 "Binance depth stream: интервал {interval} мс, лимит снапшота {limit}"
             ).format(interval=self._depth_stream_interval_ms, limit=self._depth_limit)
         )
-        if silence_timeout_ms is not None:
-            effective_silence_timeout_ms = max(
-                float(silence_timeout_ms),
-                MIN_STREAM_SILENCE_TIMEOUT_MS,
+        self._profile = profile or TradingProfile.AUTO
+        base_timeout_ms = (
+            max(float(silence_timeout_ms), MIN_STREAM_SILENCE_TIMEOUT_MS)
+            if silence_timeout_ms is not None
+            else MIN_STREAM_SILENCE_TIMEOUT_MS
+        )
+        base_timeout_s = max(0.1, base_timeout_ms / 1000.0)
+        timeouts = self._resolve_stream_silence_timeouts(
+            base_timeout_s,
+            self._profile,
+        )
+        self._depth_silence_timeout = timeouts.depth
+        self._trade_silence_timeout = timeouts.trades
+        self._book_ticker_silence_timeout = timeouts.book_ticker
+        self._generic_silence_timeout = max(
+            MIN_STREAM_SILENCE_TIMEOUT_MS / 1000.0,
+            min(base_timeout_s, max(timeouts.trades, timeouts.book_ticker)),
+        )
+        self._heartbeat_interval = max(
+            min(
+                self._depth_silence_timeout,
+                self._trade_silence_timeout,
+                self._book_ticker_silence_timeout,
             )
-        else:
-            effective_silence_timeout_ms = MIN_STREAM_SILENCE_TIMEOUT_MS
-        self._silence_timeout = max(0.1, effective_silence_timeout_ms / 1000.0)
-        self._heartbeat_interval = max(self._silence_timeout / 2, 0.1)
+            / 2,
+            0.1,
+        )
+        self._logger.log(
+            (
+                "Binance streams: таймауты тишины (профиль {profile}): "
+                "depth={depth:.1f} c, trades={trades:.1f} c, book_ticker={ticker:.1f} c"
+            ).format(
+                profile=self._profile.value,
+                depth=self._depth_silence_timeout,
+                trades=self._trade_silence_timeout,
+                ticker=self._book_ticker_silence_timeout,
+            )
+        )
         self._depth_last_update: Optional[int] = None
         self._depth_buffered_messages: list[dict[str, Any]] = []
         self._depth_allow_skip = False
@@ -177,6 +223,21 @@ class BinanceExchangeData:
             f"Binance depth limit {requested_limit} is unsupported, using {normalized} instead"
         )
         return normalized
+
+    def _resolve_stream_silence_timeouts(
+        self,
+        base_timeout_s: float,
+        profile: TradingProfile,
+    ) -> _StreamTimeoutConfig:
+        template = _PROFILE_STREAM_TIMEOUTS.get(profile)
+        if template is None:
+            template = _PROFILE_STREAM_TIMEOUTS[TradingProfile.AUTO]
+        min_timeout_s = max(0.1, MIN_STREAM_SILENCE_TIMEOUT_MS / 1000.0)
+        return _StreamTimeoutConfig(
+            depth=max(min_timeout_s, min(template.depth, base_timeout_s)),
+            trades=max(min_timeout_s, min(template.trades, base_timeout_s)),
+            book_ticker=max(min_timeout_s, min(template.book_ticker, base_timeout_s)),
+        )
 
     @classmethod
     def _get_stream_pool(
@@ -308,14 +369,15 @@ class BinanceExchangeData:
         return next_funding
 
     def stream_depth(self) -> StreamSubscription[DepthStreamData]:
-        silence_timeout = self._silence_timeout
-        heartbeat_interval = self._heartbeat_interval
+        silence_timeout = self._depth_silence_timeout
+        heartbeat_interval = max(silence_timeout / 2, 0.1)
 
         buffer: StreamBuffer[DepthStreamData] = StreamBuffer(
             name="depth",
             logger=self._logger,
             silence_timeout=silence_timeout,
             heartbeat_interval=heartbeat_interval,
+            restart_grace_period=silence_timeout,
         )
         self._reset_depth_state()
 
@@ -484,12 +546,16 @@ class BinanceExchangeData:
             )
 
     def stream_book_ticker(self) -> StreamSubscription[BestBidAsk]:
+        silence_timeout = self._book_ticker_silence_timeout
+        heartbeat_interval = max(silence_timeout / 2, 0.1)
+
         buffer: StreamBuffer[BestBidAsk] = StreamBuffer(
             name="book_ticker",
             logger=self._logger,
-            silence_timeout=self._silence_timeout,
-            heartbeat_interval=self._heartbeat_interval,
+            silence_timeout=silence_timeout,
+            heartbeat_interval=heartbeat_interval,
             drop_oldest_on_overflow=True,
+            restart_grace_period=silence_timeout,
         )
 
         def handle_message(message: dict[str, Any]) -> None:
@@ -525,13 +591,17 @@ class BinanceExchangeData:
         return StreamSubscription(events=iterator(), _buffer=buffer, _stopper=release)
 
     def stream_trades(self) -> StreamSubscription[Trade]:
+        silence_timeout = self._trade_silence_timeout
+        heartbeat_interval = max(silence_timeout / 2, 0.1)
+
         buffer: StreamBuffer[Trade] = StreamBuffer(
             name="trades",
             logger=self._logger,
-            silence_timeout=self._silence_timeout,
-            heartbeat_interval=self._heartbeat_interval,
+            silence_timeout=silence_timeout,
+            heartbeat_interval=heartbeat_interval,
             maxsize=4096,
             drop_oldest_on_overflow=True,
+            restart_grace_period=silence_timeout,
         )
 
         def handle_message(message: dict[str, Any]) -> None:
@@ -582,8 +652,8 @@ class BinanceExchangeData:
         drop_oldest_on_overflow: bool = False,
         maxsize: int | None = None,
     ) -> StreamSubscription[Any]:
-        silence_timeout = self._silence_timeout
-        heartbeat_interval = self._heartbeat_interval
+        silence_timeout = self._generic_silence_timeout
+        heartbeat_interval = max(silence_timeout / 2, 0.1)
 
         buffer: StreamBuffer[Any] = StreamBuffer(
             name=name,
@@ -592,6 +662,7 @@ class BinanceExchangeData:
             heartbeat_interval=heartbeat_interval,
             maxsize=maxsize,
             drop_oldest_on_overflow=drop_oldest_on_overflow,
+            restart_grace_period=silence_timeout,
         )
 
         worker = threading.Thread(
@@ -619,61 +690,81 @@ class BinanceExchangeData:
         buffer: StreamBuffer[Any],
         name: str,
     ) -> None:
-        reconnect_after_silence = False
+        pending_restart_reason: ResyncReason | None = None
+
+        def _describe(reason: ResyncReason | None) -> str:
+            if reason == ResyncReason.SILENCE_TIMEOUT:
+                return "тайм-аута тишины"
+            if reason == ResyncReason.CONNECTION_LOST:
+                return "обрыва соединения"
+            return "неизвестного события"
+
+        def _log(message: str, reason: ResyncReason | None = None) -> None:
+            if reason is None:
+                self._logger.log(f"Binance {name} stream: {message}")
+            else:
+                self._logger.log(
+                    f"Binance {name} stream: {message} ({_describe(reason)})"
+                )
+
         while not buffer.stopped():
             client: WebSocketClient | None = None
             try:
-                if reconnect_after_silence:
-                    self._logger.log(
-                        f"Binance {name} stream: перезапуск соединения после тайм-аута тишины"
-                    )
-                else:
+                if pending_restart_reason is None:
                     self._logger.log(f"Binance {name} stream: открываем соединение")
+                else:
+                    _log("перезапуск соединения", pending_restart_reason)
                 client = self._connect_websocket(url)
                 client.settimeout(self._ws_timeout)
-                if reconnect_after_silence:
-                    self._logger.log(
-                        f"Binance {name} stream: соединение успешно восстановлено"
+                if pending_restart_reason is not None:
+                    _log(
+                        "соединение успешно восстановлено",
+                        pending_restart_reason,
                     )
-                    reconnect_after_silence = False
+                    pending_restart_reason = None
                 while not buffer.stopped():
-                    if buffer.consume_restart_request():
-                        reconnect_after_silence = True
-                        self._logger.log(
-                            f"Binance {name} stream: получен запрос перезапуска от буфера"
-                        )
+                    restart_reason = buffer.consume_restart_request()
+                    if restart_reason is not None:
+                        pending_restart_reason = restart_reason
+                        _log("получен запрос перезапуска от буфера", restart_reason)
                         break
                     try:
                         message = cast(dict[str, Any], client.recv_json())
                     except WebSocketTimeoutError:
-                        if buffer.consume_restart_request():
-                            reconnect_after_silence = True
-                            self._logger.log(
-                                f"Binance {name} stream: перезапуск по запросу буфера после тайм-аута ожидания"
+                        restart_reason = buffer.consume_restart_request()
+                        if restart_reason is not None:
+                            pending_restart_reason = restart_reason
+                            _log(
+                                "перезапуск по запросу буфера после тайм-аута ожидания",
+                                restart_reason,
                             )
                             break
                         buffer.push(StreamEvent.heartbeat())
                         continue
                     if not message:
-                        if buffer.consume_restart_request():
-                            reconnect_after_silence = True
-                            self._logger.log(
-                                f"Binance {name} stream: перезапуск по запросу буфера после пустого сообщения"
+                        restart_reason = buffer.consume_restart_request()
+                        if restart_reason is not None:
+                            pending_restart_reason = restart_reason
+                            _log(
+                                "перезапуск по запросу буфера после пустого сообщения",
+                                restart_reason,
                             )
                             break
                         continue
                     for payload in parser(message):
                         buffer.push_data(payload)
-                    if buffer.consume_restart_request():
-                        reconnect_after_silence = True
-                        self._logger.log(
-                            f"Binance {name} stream: перезапуск по запросу буфера после обработки сообщения"
+                    restart_reason = buffer.consume_restart_request()
+                    if restart_reason is not None:
+                        pending_restart_reason = restart_reason
+                        _log(
+                            "перезапуск по запросу буфера после обработки сообщения",
+                            restart_reason,
                         )
                         break
             except Exception as exc:
                 reason = (
                     ResyncReason.SILENCE_TIMEOUT
-                    if reconnect_after_silence
+                    if pending_restart_reason == ResyncReason.SILENCE_TIMEOUT
                     else ResyncReason.CONNECTION_LOST
                 )
                 if reason == ResyncReason.SILENCE_TIMEOUT:
@@ -684,10 +775,13 @@ class BinanceExchangeData:
                     self._logger.log(details)
                     time.sleep(self._reconnect_delay)
                 else:
-                    details = f"Binance {name} stream: {exc}"
+                    details = (
+                        f"Binance {name} stream: обнаружен обрыв соединения: {exc}"
+                    )
                     buffer.push_resync(reason, details)
                     self._logger.log(details)
                     time.sleep(self._reconnect_delay)
+                pending_restart_reason = reason
             finally:
                 if client is not None:
                     try:

--- a/data/exchanges/binance_stream_pool.py
+++ b/data/exchanges/binance_stream_pool.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import threading
+import time
 from dataclasses import dataclass
 from queue import Empty, Queue
 from typing import Any, Callable, Dict, Optional
@@ -51,6 +52,7 @@ class _CombinedStreamWorker:
         self._command_window_start = 0.0
         self._commands_sent_in_window = 0
         self._last_command_timestamp = 0.0
+        self._last_resubscribe: Dict[str, float] = {}
         self._thread = threading.Thread(
             target=self._run_thread,
             name=f"binance-pool-{name}",
@@ -161,29 +163,58 @@ class _CombinedStreamWorker:
         with self._lock:
             registrations = list(self._registrations.values())
 
-        processed_symbols: list[str] = []
+        processed: list[tuple[str, ResyncReason]] = []
+        suppressed: list[str] = []
+        now = time.monotonic()
         for registration in registrations:
-            if not registration.buffer.consume_restart_request():
+            reason = registration.buffer.consume_restart_request()
+            if reason is None:
                 continue
 
-            processed_symbols.append(registration.symbol)
+            actual_reason = reason or ResyncReason.CONNECTION_LOST
+            grace = max(registration.buffer.restart_grace_period(), 0.0)
+            last_request = self._last_resubscribe.get(registration.symbol)
+            if last_request is not None and now - last_request < grace:
+                suppressed.append(registration.symbol)
+                continue
+
+            self._last_resubscribe[registration.symbol] = now
+            processed.append((registration.symbol, actual_reason))
             self._command_queue.put(("resubscribe", registration.symbol))
             details = (
-                "Binance {stream} stream: таймаут тишины для {symbol}, "
+                "Binance {stream} stream: {reason} для {symbol}, "
                 "запрос повторной синхронизации"
-            ).format(stream=self._name, symbol=registration.symbol)
+            ).format(
+                stream=self._name,
+                reason=(
+                    "таймаут тишины"
+                    if actual_reason == ResyncReason.SILENCE_TIMEOUT
+                    else "обрыв соединения"
+                ),
+                symbol=registration.symbol,
+            )
 
             try:
-                registration.on_error(ResyncReason.SILENCE_TIMEOUT, details)
+                registration.on_error(actual_reason, details)
             except Exception:
                 pass
 
-        if processed_symbols:
-            joined = ", ".join(processed_symbols)
+        if processed:
+            joined = ", ".join(
+                f"{symbol} ({reason.name})" for symbol, reason in processed
+            )
             self._logger.log(
                 (
                     "Binance {stream} stream: обработан запрос повторной "
                     "синхронизации из буферов: {symbols}"
+                ).format(stream=self._name, symbols=joined)
+            )
+        if suppressed:
+            joined = ", ".join(suppressed)
+            self._logger.log(
+                (
+                    "Binance {stream} stream: проигнорированы повторные запросы "
+                    "синхронизации: {symbols}"
                 ).format(stream=self._name, symbols=joined)
             )
 


### PR DESCRIPTION
## Summary
- add profile-aware silence timeout configuration for Binance depth, trade, and book ticker streams
- guard WebSocket restart requests with grace periods and richer logging that differentiates silence from real disconnects
- propagate symbol profiles when creating Binance exchange data and prevent duplicate resubscribe commands

## Testing
- pytest tests/data/exchanges/test_binance_depth.py

------
https://chatgpt.com/codex/tasks/task_e_68ea5a2098fc83209312ed63d7164901