### PR TITLE
Refactor Binance streaming architecture with weighted manager

### DIFF
--- a/config/stream_limits.py
+++ b/config/stream_limits.py
@@ -1,0 +1,52 @@
+"""Stream rate limit configuration for Binance streaming components."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class CommandWindow:
+    """Represents a single rate window for command dispatch."""
+
+    window_seconds: float
+    command_limit: int
+
+
+@dataclass(frozen=True)
+class StreamLoadProfile:
+    """Describes how a stream should be scheduled across websocket workers."""
+
+    max_streams_per_connection: int
+    steady: CommandWindow
+    burst: CommandWindow
+    minimum_command_reserve: int
+
+
+DEFAULT_BINANCE_STREAM_PROFILES: Mapping[str, StreamLoadProfile] = {
+    "depth": StreamLoadProfile(
+        max_streams_per_connection=180,
+        steady=CommandWindow(window_seconds=1.0, command_limit=5),
+        burst=CommandWindow(window_seconds=0.25, command_limit=2),
+        minimum_command_reserve=1,
+    ),
+    "trades": StreamLoadProfile(
+        max_streams_per_connection=220,
+        steady=CommandWindow(window_seconds=1.0, command_limit=5),
+        burst=CommandWindow(window_seconds=0.5, command_limit=3),
+        minimum_command_reserve=1,
+    ),
+    "book": StreamLoadProfile(
+        max_streams_per_connection=240,
+        steady=CommandWindow(window_seconds=1.0, command_limit=5),
+        burst=CommandWindow(window_seconds=0.5, command_limit=3),
+        minimum_command_reserve=1,
+    ),
+}
+
+
+__all__ = [
+    "CommandWindow",
+    "StreamLoadProfile",
+    "DEFAULT_BINANCE_STREAM_PROFILES",
+]

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -13,6 +13,7 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from config.models.trading_profile import TradingProfile
+from config.stream_limits import DEFAULT_BINANCE_STREAM_PROFILES
 from domain.models import (
     Candle,
     Exchange,
@@ -35,7 +36,7 @@ from .base import (
     StreamEvent,
     StreamSubscription,
 )
-from .binance_stream_pool import BinanceStreamPool
+from .binance_stream_manager import BinanceStreamManager
 
 
 WebSocketClient = ThreadedWebSocketClient
@@ -65,9 +66,17 @@ _PROFILE_STREAM_TIMEOUTS: dict[TradingProfile, _StreamTimeoutConfig] = {
 }
 
 
+_STREAM_PROFILE_WEIGHTS: dict[TradingProfile, dict[str, float]] = {
+    TradingProfile.TOP: {"depth": 3.0, "trades": 2.5, "book": 2.0},
+    TradingProfile.ALT: {"depth": 1.0, "trades": 1.0, "book": 0.8},
+    TradingProfile.LISTING: {"depth": 2.5, "trades": 3.0, "book": 1.5},
+    TradingProfile.AUTO: {"depth": 1.5, "trades": 1.5, "book": 1.0},
+}
+
+
 class BinanceExchangeData:
-    _pool_lock: ClassVar[threading.Lock] = threading.Lock()
-    _shared_stream_pools: ClassVar[dict[tuple[str, int], BinanceStreamPool]] = {}
+    _manager_lock: ClassVar[threading.Lock] = threading.Lock()
+    _shared_stream_managers: ClassVar[dict[tuple[str, int], BinanceStreamManager]] = {}
 
     def __init__(
         self,
@@ -101,7 +110,7 @@ class BinanceExchangeData:
             depth_stream_interval_ms
         )
         self._depth_limit = self._normalize_depth_limit(depth_limit)
-        self._stream_pool = self._get_stream_pool(
+        self._stream_manager = self._get_stream_manager(
             endpoints=self._endpoints,
             depth_stream_interval_ms=self._depth_stream_interval_ms,
             ws_timeout=self._ws_timeout,
@@ -239,8 +248,14 @@ class BinanceExchangeData:
             book_ticker=max(min_timeout_s, min(template.book_ticker, base_timeout_s)),
         )
 
+    def _stream_weight(self, stream_type: str) -> float:
+        profile_weights = _STREAM_PROFILE_WEIGHTS.get(self._profile, {})
+        fallback = _STREAM_PROFILE_WEIGHTS[TradingProfile.AUTO]
+        weight = profile_weights.get(stream_type, fallback.get(stream_type, 1.0))
+        return max(float(weight), 0.1)
+
     @classmethod
-    def _get_stream_pool(
+    def _get_stream_manager(
         cls,
         *,
         endpoints: BinanceEndpoints,
@@ -248,20 +263,26 @@ class BinanceExchangeData:
         ws_timeout: float,
         reconnect_delay: float,
         log_writer: Optional[Callable[[str], None]],
-    ) -> BinanceStreamPool:
-        with cls._pool_lock:
+    ) -> BinanceStreamManager:
+        with cls._manager_lock:
             key = (endpoints.ws_base.rstrip("/"), depth_stream_interval_ms)
-            pool = cls._shared_stream_pools.get(key)
-            if pool is None:
-                pool = BinanceStreamPool(
+            manager = cls._shared_stream_managers.get(key)
+            if manager is None:
+                profiles = DEFAULT_BINANCE_STREAM_PROFILES
+                expected_weights = {
+                    stream: profile.max_streams_per_connection * 1.5
+                    for stream, profile in profiles.items()
+                }
+                manager = BinanceStreamManager(
                     endpoints_ws_base=endpoints.ws_base,
                     ws_timeout=ws_timeout,
                     reconnect_delay=reconnect_delay,
                     log_writer=log_writer,
                     depth_stream_interval_ms=depth_stream_interval_ms,
+                    expected_stream_weights=expected_weights,
                 )
-                cls._shared_stream_pools[key] = pool
-            return pool
+                cls._shared_stream_managers[key] = manager
+            return manager
 
     def _rest_get(self, path: str, params: Optional[dict[str, Any]] = None) -> Any:
         params = params or {}
@@ -395,11 +416,12 @@ class BinanceExchangeData:
             if should_log:
                 self._logger.log(message)
 
-        release = self._stream_pool.register_depth(
+        release = self._stream_manager.register_depth(
             self.symbol,
             buffer,
             handle_message,
             handle_error,
+            weight=self._stream_weight("depth"),
         )
 
         self._start_depth_snapshot(buffer)
@@ -573,11 +595,12 @@ class BinanceExchangeData:
             if should_log:
                 self._logger.log(message)
 
-        release = self._stream_pool.register_book_ticker(
+        release = self._stream_manager.register_book_ticker(
             self.symbol,
             buffer,
             handle_message,
             handle_error,
+            weight=self._stream_weight("book"),
         )
 
         def iterator() -> Iterator[StreamEvent[BestBidAsk]]:
@@ -619,11 +642,12 @@ class BinanceExchangeData:
             if should_log:
                 self._logger.log(message)
 
-        release = self._stream_pool.register_trades(
+        release = self._stream_manager.register_trades(
             self.symbol,
             buffer,
             handle_message,
             handle_error,
+            weight=self._stream_weight("trades"),
         )
 
         def iterator() -> Iterator[StreamEvent[Trade]]:

--- a/data/exchanges/binance_stream_manager.py
+++ b/data/exchanges/binance_stream_manager.py
@@ -1,0 +1,192 @@
+"""Binance streaming manager with weighted scheduling."""
+from __future__ import annotations
+
+import math
+import threading
+from typing import Any, Callable, Mapping, Optional
+
+from config.stream_limits import (
+    DEFAULT_BINANCE_STREAM_PROFILES,
+    StreamLoadProfile,
+)
+
+from .base import ResyncReason, StreamBuffer
+from .binance_stream_pool import _StreamWorkerPool
+
+
+class BinanceStreamManager:
+    """Coordinates Binance stream workers with weighted symbol allocation."""
+
+    def __init__(
+        self,
+        *,
+        endpoints_ws_base: str,
+        ws_timeout: float,
+        reconnect_delay: float,
+        log_writer: Optional[Callable[[str], None]] = None,
+        depth_stream_interval_ms: int = 100,
+        profiles: Mapping[str, StreamLoadProfile] | None = None,
+        expected_stream_weights: Mapping[str, float] | None = None,
+    ) -> None:
+        base = endpoints_ws_base.rstrip("/")
+        if not base.endswith("/ws"):
+            base = f"{base}/ws"
+        self._ws_base = base
+        interval = max(1, int(depth_stream_interval_ms))
+        self._depth_stream_interval_ms = interval
+        self._profiles = dict(DEFAULT_BINANCE_STREAM_PROFILES)
+        if profiles is not None:
+            self._profiles.update(profiles)
+        self._expected_stream_weights = {
+            key: max(float(value), 0.0)
+            for key, value in (expected_stream_weights or {}).items()
+        }
+
+        self._lock = threading.Lock()
+        self._pools: dict[str, _StreamWorkerPool] = {}
+        self._pools["depth"] = self._create_pool(
+            name=f"depth@{interval}ms",
+            stream_suffix=f"depth@{interval}ms",
+            profile=self._profiles["depth"],
+            ws_timeout=ws_timeout,
+            reconnect_delay=reconnect_delay,
+            log_writer=log_writer,
+        )
+        self._pools["trades"] = self._create_pool(
+            name="trades",
+            stream_suffix="aggTrade",
+            profile=self._profiles["trades"],
+            ws_timeout=ws_timeout,
+            reconnect_delay=reconnect_delay,
+            log_writer=log_writer,
+        )
+        self._pools["book"] = self._create_pool(
+            name="book_ticker",
+            stream_suffix="bookTicker",
+            profile=self._profiles["book"],
+            ws_timeout=ws_timeout,
+            reconnect_delay=reconnect_delay,
+            log_writer=log_writer,
+        )
+
+        for stream_type, pool in self._pools.items():
+            profile = self._profiles.get(stream_type)
+            if profile is None:
+                continue
+            expected_weight = self._expected_stream_weights.get(stream_type, 0.0)
+            if expected_weight <= 0:
+                target = 1
+            else:
+                capacity = max(profile.max_streams_per_connection, 1)
+                target = max(1, math.ceil(expected_weight / capacity))
+            pool.ensure_workers(target)
+        self._assigned_weights: dict[str, float] = {key: 0.0 for key in self._pools}
+
+    @property
+    def depth_stream_interval_ms(self) -> int:
+        return self._depth_stream_interval_ms
+
+    def register_depth(
+        self,
+        symbol: str,
+        buffer: StreamBuffer[Any],
+        on_message: Callable[[dict[str, Any]], None],
+        on_error: Optional[Callable[[ResyncReason, str], None]] = None,
+        *,
+        weight: float = 1.0,
+    ) -> Callable[[], None]:
+        return self._register(
+            "depth", symbol, buffer, on_message, on_error, weight=weight
+        )
+
+    def register_trades(
+        self,
+        symbol: str,
+        buffer: StreamBuffer[Any],
+        on_message: Callable[[dict[str, Any]], None],
+        on_error: Optional[Callable[[ResyncReason, str], None]] = None,
+        *,
+        weight: float = 1.0,
+    ) -> Callable[[], None]:
+        return self._register(
+            "trades", symbol, buffer, on_message, on_error, weight=weight
+        )
+
+    def register_book_ticker(
+        self,
+        symbol: str,
+        buffer: StreamBuffer[Any],
+        on_message: Callable[[dict[str, Any]], None],
+        on_error: Optional[Callable[[ResyncReason, str], None]] = None,
+        *,
+        weight: float = 1.0,
+    ) -> Callable[[], None]:
+        return self._register(
+            "book", symbol, buffer, on_message, on_error, weight=weight
+        )
+
+    def _create_pool(
+        self,
+        *,
+        name: str,
+        stream_suffix: str,
+        profile: StreamLoadProfile,
+        ws_timeout: float,
+        reconnect_delay: float,
+        log_writer: Optional[Callable[[str], None]],
+    ) -> _StreamWorkerPool:
+        return _StreamWorkerPool(
+            name=name,
+            ws_base=self._ws_base,
+            stream_suffix=stream_suffix,
+            ws_timeout=ws_timeout,
+            reconnect_delay=reconnect_delay,
+            log_writer=log_writer,
+            profile=profile,
+        )
+
+    def _register(
+        self,
+        stream_type: str,
+        symbol: str,
+        buffer: StreamBuffer[Any],
+        on_message: Callable[[dict[str, Any]], None],
+        on_error: Optional[Callable[[ResyncReason, str], None]],
+        *,
+        weight: float,
+    ) -> Callable[[], None]:
+        pool = self._pools.get(stream_type)
+        if pool is None:
+            raise ValueError(f"Unknown stream type: {stream_type}")
+        profile = self._profiles.get(stream_type)
+        if profile is None:
+            raise ValueError(f"No load profile configured for {stream_type}")
+        with self._lock:
+            current_total = self._assigned_weights.get(stream_type, 0.0)
+            projected_total = current_total + weight
+            capacity_per_worker = max(profile.max_streams_per_connection, 1)
+            target_workers = max(1, math.ceil(projected_total / capacity_per_worker))
+        if target_workers > pool.worker_count():
+            pool.ensure_workers(target_workers)
+        release = pool.register(
+            symbol,
+            buffer,
+            on_message,
+            on_error,
+            weight=weight,
+        )
+        with self._lock:
+            self._assigned_weights[stream_type] = projected_total
+
+        def _release_wrapper() -> None:
+            try:
+                release()
+            finally:
+                with self._lock:
+                    current = self._assigned_weights.get(stream_type, 0.0) - weight
+                    self._assigned_weights[stream_type] = max(current, 0.0)
+
+        return _release_wrapper
+
+
+__all__ = ["BinanceStreamManager"]

--- a/data/exchanges/binance_stream_pool.py
+++ b/data/exchanges/binance_stream_pool.py
@@ -2,19 +2,19 @@ import asyncio
 import json
 import threading
 import time
+from collections import deque
 from dataclasses import dataclass
 from queue import Empty, Queue
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Mapping, Optional
 
 from utils.async_websocket import AsyncWebSocketClient, WebSocketTimeoutError
 
 from .base import ExchangeLogger, ResyncReason, StreamBuffer
 
-
-MAX_STREAMS_PER_CONNECTION = 200
-COMMAND_RATE_LIMIT_PER_SECOND = 5
-COMMAND_RATE_LIMIT_WINDOW = 1.0
-
+from config.stream_limits import (
+    DEFAULT_BINANCE_STREAM_PROFILES,
+    StreamLoadProfile,
+)
 
 @dataclass(slots=True)
 class _Registration:
@@ -22,6 +22,107 @@ class _Registration:
     buffer: StreamBuffer[Any]
     on_message: Callable[[dict[str, Any]], None]
     on_error: Callable[[ResyncReason, str], None]
+    weight: float
+
+
+class _RateWindow:
+    def __init__(self, window: float, limit: int, reserve: int) -> None:
+        self._window = max(float(window), 0.01)
+        self._limit = max(int(limit), 1)
+        self._reserve = max(0, min(int(reserve), self._limit - 1))
+        self._timestamps: deque[float] = deque()
+
+    @property
+    def window(self) -> float:
+        return self._window
+
+    @property
+    def limit(self) -> int:
+        return self._limit
+
+    def effective_limit(self) -> int:
+        return max(min(self._limit, self._limit - self._reserve), 1)
+
+    def prune(self, now: float) -> None:
+        boundary = now - self._window
+        while self._timestamps and self._timestamps[0] <= boundary:
+            self._timestamps.popleft()
+
+    def register(self, timestamp: float) -> None:
+        self.prune(timestamp)
+        self._timestamps.append(timestamp)
+
+    def required_delay(self, now: float) -> float:
+        self.prune(now)
+        limit = self.effective_limit()
+        if len(self._timestamps) < limit:
+            return 0.0
+        earliest_allowed = self._timestamps[0] + self._window
+        return max(0.0, earliest_allowed - now)
+
+
+class _CommandRateLimiter:
+    def __init__(self, profile: StreamLoadProfile, logger: ExchangeLogger, name: str) -> None:
+        self._steady = _RateWindow(
+            profile.steady.window_seconds,
+            profile.steady.command_limit,
+            profile.minimum_command_reserve,
+        )
+        self._burst = _RateWindow(
+            profile.burst.window_seconds,
+            profile.burst.command_limit,
+            profile.minimum_command_reserve,
+        )
+        self._logger = logger
+        self._name = name
+        self._last_command_timestamp = 0.0
+
+    async def throttle(self) -> None:
+        loop = asyncio.get_running_loop()
+        while True:
+            now = loop.time()
+            delay, window = self._required_delay(now)
+            if delay <= 0.0:
+                return
+            limit = window.limit if window is not None else 0
+            window_size = window.window if window is not None else 0.0
+            self._logger.log(
+                (
+                    "Binance {stream} stream: достигнут предел {limit} команд за {window:.2f}с, "
+                    "ожидаем {sleep:.2f}с"
+                ).format(
+                    stream=self._name,
+                    limit=limit,
+                    window=window_size,
+                    sleep=delay,
+                )
+            )
+            await asyncio.sleep(delay)
+
+    def _required_delay(self, now: float) -> tuple[float, _RateWindow | None]:
+        windows = (self._steady, self._burst)
+        delays = [(window.required_delay(now), window) for window in windows]
+        delay, window = max(delays, key=lambda item: item[0])
+        if delay <= 0.0:
+            return 0.0, None
+        return delay, window
+
+    def record(self) -> None:
+        loop = asyncio.get_running_loop()
+        now = loop.time()
+        for window in (self._steady, self._burst):
+            window.register(now)
+        self._last_command_timestamp = now
+
+    def resubscribe_delay(self) -> float:
+        limit = self._steady.effective_limit()
+        if limit <= 0:
+            return 0.05
+        return max(0.05, self._steady.window / limit)
+
+    @property
+    def last_command_timestamp(self) -> float:
+        return self._last_command_timestamp
 
 
 class _CombinedStreamWorker:
@@ -35,6 +136,7 @@ class _CombinedStreamWorker:
         reconnect_delay: float,
         log_writer: Optional[Callable[[str], None]] = None,
         max_streams: int,
+        command_profile: StreamLoadProfile,
     ) -> None:
         self._name = name
         self._ws_base = ws_base
@@ -49,9 +151,7 @@ class _CombinedStreamWorker:
         self._logger = ExchangeLogger(f"Binance pool:{name}", log_writer)
         self._command_queue: "Queue[tuple[str, str]]" = Queue()
         self._next_request_id = 1
-        self._command_window_start = 0.0
-        self._commands_sent_in_window = 0
-        self._last_command_timestamp = 0.0
+        self._command_limiter = _CommandRateLimiter(command_profile, self._logger, name)
         self._last_resubscribe: Dict[str, float] = {}
         self._thread = threading.Thread(
             target=self._run_thread,
@@ -69,6 +169,8 @@ class _CombinedStreamWorker:
         buffer: StreamBuffer[Any],
         on_message: Callable[[dict[str, Any]], None],
         on_error: Optional[Callable[[ResyncReason, str], None]] = None,
+        *,
+        weight: float,
     ) -> Callable[[], None]:
         symbol = symbol.upper()
 
@@ -83,6 +185,7 @@ class _CombinedStreamWorker:
             buffer=buffer,
             on_message=on_message,
             on_error=on_error,
+            weight=max(float(weight), 0.0),
         )
 
         with self._lock:
@@ -141,6 +244,10 @@ class _CombinedStreamWorker:
     def is_empty(self) -> bool:
         with self._lock:
             return not self._registrations
+
+    def registration_count(self) -> int:
+        with self._lock:
+            return len(self._registrations)
 
     def stop(self) -> None:
         if self._stop_event.is_set():
@@ -255,55 +362,13 @@ class _CombinedStreamWorker:
         return f"{symbol.lower()}@{self._stream_suffix}"
 
     async def _throttle_if_needed(self) -> None:
-        limit = COMMAND_RATE_LIMIT_PER_SECOND
-        if limit <= 0:
-            return
-        loop = asyncio.get_running_loop()
-        now = loop.time()
-        if self._command_window_start == 0.0:
-            self._command_window_start = now
-            self._commands_sent_in_window = 0
-            return
-        elapsed = now - self._command_window_start
-        if elapsed >= COMMAND_RATE_LIMIT_WINDOW:
-            self._command_window_start = now
-            self._commands_sent_in_window = 0
-            return
-        if self._commands_sent_in_window < limit:
-            return
-        sleep_for = COMMAND_RATE_LIMIT_WINDOW - elapsed
-        if sleep_for > 0:
-            self._logger.log(
-                (
-                    "Binance {stream} stream: достигнут предел {limit} команд за "
-                    "{window:.1f}с, ожидаем {sleep:.2f}с"
-                ).format(
-                    stream=self._name,
-                    limit=limit,
-                    window=COMMAND_RATE_LIMIT_WINDOW,
-                    sleep=sleep_for,
-                )
-            )
-            await asyncio.sleep(sleep_for)
-        now = loop.time()
-        self._command_window_start = now
-        self._commands_sent_in_window = 0
+        await self._command_limiter.throttle()
 
     def _record_command_sent(self) -> None:
-        loop = asyncio.get_running_loop()
-        now = loop.time()
-        if self._command_window_start == 0.0:
-            self._command_window_start = now
-            self._commands_sent_in_window = 0
-        self._commands_sent_in_window += 1
-        self._last_command_timestamp = now
+        self._command_limiter.record()
 
     def _resubscribe_delay(self) -> float:
-        limit = COMMAND_RATE_LIMIT_PER_SECOND
-        if limit > 0:
-            minimum_step = COMMAND_RATE_LIMIT_WINDOW / limit
-            return max(0.05, minimum_step)
-        return 0.05
+        return self._command_limiter.resubscribe_delay()
 
     async def _send_command(self, client: AsyncWebSocketClient, method: str, params: list[Any]) -> None:
         request_id = self._next_request_id
@@ -567,6 +632,7 @@ class _StreamWorkerPool:
         ws_timeout: float,
         reconnect_delay: float,
         log_writer: Optional[Callable[[str], None]] = None,
+        profile: StreamLoadProfile,
     ) -> None:
         self._name = name
         self._ws_base = ws_base
@@ -574,8 +640,10 @@ class _StreamWorkerPool:
         self._ws_timeout = ws_timeout
         self._reconnect_delay = reconnect_delay
         self._log_writer = log_writer
+        self._profile = profile
         self._lock = threading.Lock()
         self._workers: list[_CombinedStreamWorker] = []
+        self._worker_loads: dict[_CombinedStreamWorker, float] = {}
         self._counter = 0
 
     def _create_worker(self) -> _CombinedStreamWorker:
@@ -588,16 +656,34 @@ class _StreamWorkerPool:
             ws_timeout=self._ws_timeout,
             reconnect_delay=self._reconnect_delay,
             log_writer=self._log_writer,
-            max_streams=MAX_STREAMS_PER_CONNECTION,
+            max_streams=self._profile.max_streams_per_connection,
+            command_profile=self._profile,
         )
         self._workers.append(worker)
+        self._worker_loads[worker] = 0.0
         return worker
 
     def _acquire_worker(self) -> _CombinedStreamWorker:
-        for worker in self._workers:
-            if worker.has_capacity():
-                return worker
-        return self._create_worker()
+        available = [worker for worker in self._workers if worker.has_capacity()]
+        if not available:
+            return self._create_worker()
+        return min(
+            available,
+            key=lambda worker: (
+                self._worker_loads.get(worker, 0.0),
+                worker.registration_count(),
+            ),
+        )
+
+    def ensure_workers(self, count: int) -> None:
+        target = max(0, int(count))
+        with self._lock:
+            while len(self._workers) < target:
+                self._create_worker()
+
+    def worker_count(self) -> int:
+        with self._lock:
+            return len(self._workers)
 
     def register(
         self,
@@ -605,11 +691,28 @@ class _StreamWorkerPool:
         buffer: StreamBuffer[Any],
         on_message: Callable[[dict[str, Any]], None],
         on_error: Optional[Callable[[ResyncReason, str], None]] = None,
+        *,
+        weight: float = 1.0,
     ) -> Callable[[], None]:
+        normalized_weight = max(float(weight), 0.0)
         with self._lock:
             worker = self._acquire_worker()
+            self._worker_loads[worker] = self._worker_loads.get(worker, 0.0) + normalized_weight
 
-        release = worker.register(symbol, buffer, on_message, on_error)
+        try:
+            release = worker.register(
+                symbol,
+                buffer,
+                on_message,
+                on_error,
+                weight=normalized_weight,
+            )
+        except Exception:
+            with self._lock:
+                current = self._worker_loads.get(worker, 0.0) - normalized_weight
+                self._worker_loads[worker] = max(current, 0.0)
+            raise
+
         released = threading.Event()
 
         def _release_wrapper() -> None:
@@ -617,6 +720,11 @@ class _StreamWorkerPool:
                 return
             release()
             with self._lock:
+                current = self._worker_loads.get(worker, 0.0) - normalized_weight
+                if current <= 0:
+                    self._worker_loads.pop(worker, None)
+                else:
+                    self._worker_loads[worker] = current
                 if worker.is_empty() and worker in self._workers:
                     self._workers.remove(worker)
                     worker.stop()
@@ -634,6 +742,7 @@ class BinanceStreamPool:
         reconnect_delay: float,
         log_writer: Optional[Callable[[str], None]] = None,
         depth_stream_interval_ms: int = 100,
+        profiles: Mapping[str, StreamLoadProfile] | None = None,
     ) -> None:
         base = endpoints_ws_base.rstrip("/")
         if not base.endswith("/ws"):
@@ -642,6 +751,12 @@ class BinanceStreamPool:
         interval = max(1, int(depth_stream_interval_ms))
         depth_suffix = f"depth@{interval}ms"
         self._depth_stream_interval_ms = interval
+        resolved_profiles = dict(DEFAULT_BINANCE_STREAM_PROFILES)
+        if profiles is not None:
+            resolved_profiles.update(profiles)
+        depth_profile = resolved_profiles.get("depth", DEFAULT_BINANCE_STREAM_PROFILES["depth"])
+        trades_profile = resolved_profiles.get("trades", DEFAULT_BINANCE_STREAM_PROFILES["trades"])
+        book_profile = resolved_profiles.get("book", DEFAULT_BINANCE_STREAM_PROFILES["book"])
         self._depth_worker = _StreamWorkerPool(
             name=depth_suffix,
             ws_base=self._ws_base,
@@ -649,6 +764,7 @@ class BinanceStreamPool:
             ws_timeout=ws_timeout,
             reconnect_delay=reconnect_delay,
             log_writer=log_writer,
+            profile=depth_profile,
         )
         self._trades_worker = _StreamWorkerPool(
             name="trades",
@@ -657,6 +773,7 @@ class BinanceStreamPool:
             ws_timeout=ws_timeout,
             reconnect_delay=reconnect_delay,
             log_writer=log_writer,
+            profile=trades_profile,
         )
         self._book_worker = _StreamWorkerPool(
             name="book_ticker",
@@ -665,6 +782,7 @@ class BinanceStreamPool:
             ws_timeout=ws_timeout,
             reconnect_delay=reconnect_delay,
             log_writer=log_writer,
+            profile=book_profile,
         )
 
     def register_depth(

--- a/docs/streaming_architecture.md
+++ b/docs/streaming_architecture.md
@@ -1,0 +1,67 @@
+# Binance Streaming Architecture
+
+## Rate limiting profiles
+
+The streaming layer uses [`config/stream_limits.py`](../config/stream_limits.py) to describe
+command budgets for the three Binance stream types. Each profile defines:
+
+* `max_streams_per_connection` – the maximum number of symbols that share a single
+  websocket connection.
+* `steady` – a long living window (`CommandWindow`) with a sustainable command budget.
+* `burst` – a shorter window that allows quick recovery bursts.
+* `minimum_command_reserve` – the amount of capacity that should remain unused so that
+  emergency commands (e.g. resubscribe after disconnects) can be issued without waiting
+  for the steady window to replenish.
+
+Default values are tuned as follows:
+
+| Stream | Max streams | Steady window | Burst window | Reserve |
+| ------ | ----------- | ------------- | ------------ | ------- |
+| Depth  | 180         | 5 commands / 1.0s | 2 commands / 0.25s | 1 |
+| Trades | 220         | 5 commands / 1.0s | 3 commands / 0.5s  | 1 |
+| Book   | 240         | 5 commands / 1.0s | 3 commands / 0.5s  | 1 |
+
+Operations may override these defaults by editing `DEFAULT_BINANCE_STREAM_PROFILES` or by
+passing a custom mapping when instantiating `BinanceStreamManager`. Adjust `steady` and
+`burst` to match exchange changes; increase `minimum_command_reserve` if manual command
+bursts are expected during maintenance windows.
+
+## Worker planning
+
+`BinanceStreamManager` precomputes the number of websocket workers per stream type at
+startup using the configured capacities. By default we provision 1.5× the stream
+capacity of each profile to create at least two warm connections per stream type. This
+provides spare headroom for symbol churn without incurring connection setup latency.
+
+When a registration request would push the weighted load above the current capacity, the
+manager automatically expands the worker pool before subscribing the symbol. Operations
+can fine tune the preallocation by providing `expected_stream_weights` when constructing
+`BinanceStreamManager`.
+
+## Symbol weighting
+
+Symbols are assigned to workers based on liquidity/priority hints sourced from
+`TradingProfile`. The mapping lives in `BinanceExchangeData` and can be adjusted to
+reflect the actual portfolio mix:
+
+* TOP profile symbols reserve the most capacity (depth weight 3.0, trades 2.5, book 2.0).
+* LISTING symbols emphasise trade streams (depth 2.5, trades 3.0).
+* ALT profile keeps a near-uniform load (1.0 across streams).
+* AUTO acts as the fallback (depth/trades 1.5, book 1.0).
+
+Weights feed into a per-stream total; once the weighted sum reaches the available
+capacity the manager prepares an additional websocket before issuing subscribe commands.
+This guarantees that high-priority symbols do not contend with low-liquidity ones.
+
+## Operational guidance
+
+1. Update `config/stream_limits.py` whenever Binance changes websocket or command limits.
+   Reflect the new values in both steady and burst windows, and review the reserve to
+   maintain enough emergency capacity.
+2. Revisit the per-profile weights in `BinanceExchangeData` after onboarding new market
+   segments to keep worker utilisation balanced.
+3. If capacity alerts are raised, adjust `expected_stream_weights` passed to
+   `BinanceStreamManager` (or override `DEFAULT_BINANCE_STREAM_PROFILES`) so that more
+   workers are precreated during service bootstrap.
+4. All changes should be validated in staging by monitoring reconnect storms and
+   ensuring command throttling logs stay within the expected windows.


### PR DESCRIPTION
## Summary
- introduce configurable stream load profiles that describe steady and burst command windows
- add a Binance stream manager that preallocates workers and balances symbols by weight
- migrate BinanceExchangeData to the new manager and document tuning guidance for operations

## Testing
- python -m compileall config/stream_limits.py data/exchanges/binance_stream_manager.py data/exchanges/binance_stream_pool.py data/exchanges/binance.py

------
https://chatgpt.com/codex/tasks/task_e_68ea651fd36083209e84eddbf6b4cf0e