### PR TITLE
Add stream command scheduler and degrade-aware pooling

### DIFF
--- a/data/exchanges/base/exchange_logger.py
+++ b/data/exchanges/base/exchange_logger.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import Callable, Mapping, Optional
 
 from utils.timez import get_current_time
 from .resync_reason import ResyncReason
@@ -24,6 +24,27 @@ class ExchangeLogger:
     def log_resync(self, reason: ResyncReason, details: str | None = None) -> None:
         suffix = f" {details}" if details else ""
         self.log(f"Ресинк книги. Причина: {reason.value}.{suffix}")
+
+    def metric(
+        self,
+        name: str,
+        value: float,
+        *,
+        tags: Optional[Mapping[str, str]] = None,
+    ) -> None:
+        """Emit a monitoring datapoint using the configured writer."""
+
+        timestamp = get_current_time().astimezone()
+        tag_section = ""
+        if tags:
+            tag_section = " " + ",".join(
+                f"{key}={val}" for key, val in sorted(tags.items())
+            )
+        message = f"{timestamp:%H:%M:%S} METRIC {name} value={value:.6f}{tag_section}"
+        if self._writer:
+            self._writer(message)
+        else:
+            print(message)
 
 
 __all__ = ["ExchangeLogger"]

--- a/data/exchanges/binance_stream_pool.py
+++ b/data/exchanges/binance_stream_pool.py
@@ -5,11 +5,16 @@ import time
 from collections import deque
 from dataclasses import dataclass
 from queue import Empty, Queue
-from typing import Any, Callable, Dict, Mapping, Optional
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional
 
 from utils.async_websocket import AsyncWebSocketClient, WebSocketTimeoutError
 
 from .base import ExchangeLogger, ResyncReason, StreamBuffer
+from .stream_scheduler import (
+    CommandResult,
+    CommandRetryPolicy,
+    StreamCommandScheduler,
+)
 
 from config.stream_limits import (
     DEFAULT_BINANCE_STREAM_PROFILES,
@@ -23,6 +28,17 @@ class _Registration:
     on_message: Callable[[dict[str, Any]], None]
     on_error: Callable[[ResyncReason, str], None]
     weight: float
+
+
+@dataclass(slots=True)
+class _Binding:
+    symbol: str
+    buffer: StreamBuffer[Any]
+    on_message: Callable[[dict[str, Any]], None]
+    on_error: Callable[[ResyncReason, str], None]
+    weight: float
+    worker: "_CombinedStreamWorker"
+    release_wrapper: Callable[[], None]
 
 
 class _RateWindow:
@@ -137,6 +153,7 @@ class _CombinedStreamWorker:
         log_writer: Optional[Callable[[str], None]] = None,
         max_streams: int,
         command_profile: StreamLoadProfile,
+        on_degraded: Callable[["_CombinedStreamWorker", str, str], None],
     ) -> None:
         self._name = name
         self._ws_base = ws_base
@@ -150,9 +167,17 @@ class _CombinedStreamWorker:
         self._registrations: Dict[str, _Registration] = {}
         self._logger = ExchangeLogger(f"Binance pool:{name}", log_writer)
         self._command_queue: "Queue[tuple[str, str]]" = Queue()
-        self._next_request_id = 1
         self._command_limiter = _CommandRateLimiter(command_profile, self._logger, name)
         self._last_resubscribe: Dict[str, float] = {}
+        self._on_degraded = on_degraded
+        self._scheduler = StreamCommandScheduler(
+            logger=self._logger,
+            metrics_sink=self._publish_metric,
+        )
+        self._subscribe_retry = CommandRetryPolicy(max_attempts=4, delay_seconds=0.25, backoff_multiplier=2.0)
+        self._unsubscribe_retry = CommandRetryPolicy(max_attempts=3, delay_seconds=0.25, backoff_multiplier=1.5)
+        self._resubscribe_retry = CommandRetryPolicy(max_attempts=5, delay_seconds=0.5, backoff_multiplier=1.5)
+        self._property_retry = CommandRetryPolicy(max_attempts=3, delay_seconds=0.5, backoff_multiplier=2.0)
         self._thread = threading.Thread(
             target=self._run_thread,
             name=f"binance-pool-{name}",
@@ -162,6 +187,41 @@ class _CombinedStreamWorker:
 
     def _run_thread(self) -> None:
         asyncio.run(self._run())
+
+    def _publish_metric(self, name: str, payload: Mapping[str, Any]) -> None:
+        values = payload.get("values", {}) if isinstance(payload, Mapping) else {}
+        tags = payload.get("tags", {}) if isinstance(payload, Mapping) else {}
+        normalized_tags = {str(key): str(value) for key, value in tags.items()}
+        command_name = normalized_tags.get("command", "command")
+        latency = values.get("latency")
+        if latency is not None:
+            try:
+                numeric_latency = float(latency)
+            except (TypeError, ValueError):  # pragma: no cover - defensive
+                numeric_latency = 0.0
+            self._logger.metric(
+                f"{self._name}.{command_name}.latency",
+                numeric_latency,
+                tags=normalized_tags,
+            )
+        attempts = values.get("attempts")
+        if attempts is not None:
+            try:
+                numeric_attempts = float(attempts)
+            except (TypeError, ValueError):  # pragma: no cover - defensive
+                numeric_attempts = 0.0
+            self._logger.metric(
+                f"{self._name}.{command_name}.attempts",
+                numeric_attempts,
+                tags=normalized_tags,
+            )
+        error = values.get("error")
+        if error:
+            self._logger.log(
+                (
+                    "Binance {stream} stream: ошибка команды {command}: {error}"  # noqa: ISC003
+                ).format(stream=self._name, command=command_name, error=error)
+            )
 
     def register(
         self,
@@ -335,12 +395,6 @@ class _CombinedStreamWorker:
             except Exception:
                 pass
 
-    def _enqueue_all_symbols(self) -> None:
-        with self._lock:
-            symbols = tuple(self._registrations.keys())
-        for symbol in symbols:
-            self._command_queue.put(("subscribe", symbol))
-
     def _extract_symbol(self, payload: dict[str, Any]) -> Optional[str]:
         data = payload.get("data")
         symbol = None
@@ -364,76 +418,218 @@ class _CombinedStreamWorker:
     async def _throttle_if_needed(self) -> None:
         await self._command_limiter.throttle()
 
-    def _record_command_sent(self) -> None:
-        self._command_limiter.record()
-
     def _resubscribe_delay(self) -> float:
         return self._command_limiter.resubscribe_delay()
-
-    async def _send_command(self, client: AsyncWebSocketClient, method: str, params: list[Any]) -> None:
-        request_id = self._next_request_id
-        self._next_request_id += 1
-        payload = {"method": method, "params": params, "id": request_id}
-        await client.send_json(payload)
-
-    async def _send_set_combined(self, client: AsyncWebSocketClient) -> None:
-        try:
-            await self._send_command(client, "SET_PROPERTY", ["combined", True])
-        except Exception:
-            pass
 
     async def _process_commands(
         self,
         client: AsyncWebSocketClient,
         active_symbols: set[str],
     ) -> None:
+        resubscribe_offset = 0.0
         while True:
             try:
                 action, symbol = self._command_queue.get_nowait()
             except Empty:
                 break
             if action == "subscribe":
-                if self._get_registration(symbol) is None or symbol in active_symbols:
-                    continue
-                stream_name = self._stream_name(symbol)
-                try:
-                    await self._throttle_if_needed()
-                    await self._send_command(client, "SUBSCRIBE", [stream_name])
-                    self._record_command_sent()
-                except Exception:
-                    continue
-                active_symbols.add(symbol)
+                self._schedule_subscribe(symbol, active_symbols)
             elif action == "unsubscribe":
-                if symbol not in active_symbols:
-                    continue
-                stream_name = self._stream_name(symbol)
-                try:
-                    await self._throttle_if_needed()
-                    await self._send_command(client, "UNSUBSCRIBE", [stream_name])
-                    self._record_command_sent()
-                except Exception:
-                    pass
-                active_symbols.discard(symbol)
+                self._schedule_unsubscribe(symbol, active_symbols)
             elif action == "resubscribe":
-                if self._get_registration(symbol) is None:
-                    continue
-                stream_name = self._stream_name(symbol)
-                if symbol in active_symbols:
-                    try:
-                        await self._throttle_if_needed()
-                        await self._send_command(client, "UNSUBSCRIBE", [stream_name])
-                        self._record_command_sent()
-                    except Exception:
-                        pass
-                    await asyncio.sleep(self._resubscribe_delay())
+                self._schedule_resubscribe(symbol, active_symbols, resubscribe_offset)
+                resubscribe_offset += self._resubscribe_delay()
+        await self._scheduler.dispatch(
+            throttle=self._throttle_if_needed,
+            send=client.send_json,
+            after_send=lambda _: self._command_limiter.record(),
+        )
+
+    def _schedule_subscribe(self, symbol: str, active_symbols: set[str]) -> None:
+        normalized = symbol.upper()
+        if self._get_registration(normalized) is None or normalized in active_symbols:
+            return
+        stream_name = self._stream_name(normalized)
+        self._scheduler.schedule(
+            "SUBSCRIBE",
+            [stream_name],
+            timeout=self._ws_timeout,
+            retry_policy=self._subscribe_retry,
+            metadata={"type": "subscribe", "symbols": (normalized,)},
+        )
+
+    def _schedule_unsubscribe(self, symbol: str, active_symbols: set[str]) -> None:
+        normalized = symbol.upper()
+        if normalized not in active_symbols:
+            return
+        stream_name = self._stream_name(normalized)
+        self._scheduler.schedule(
+            "UNSUBSCRIBE",
+            [stream_name],
+            timeout=self._ws_timeout,
+            retry_policy=self._unsubscribe_retry,
+            metadata={"type": "unsubscribe", "symbols": (normalized,)},
+        )
+
+    def _schedule_resubscribe(
+        self,
+        symbol: str,
+        active_symbols: set[str],
+        offset: float,
+    ) -> None:
+        normalized = symbol.upper()
+        if self._get_registration(normalized) is None:
+            return
+        stream_name = self._stream_name(normalized)
+        if normalized in active_symbols:
+            self._scheduler.schedule(
+                "UNSUBSCRIBE",
+                [stream_name],
+                timeout=self._ws_timeout,
+                retry_policy=self._unsubscribe_retry,
+                metadata={"type": "resubscribe", "phase": "unsubscribe", "symbols": (normalized,)},
+            )
+            active_symbols.discard(normalized)
+        delay = offset + self._resubscribe_delay()
+        self._scheduler.schedule(
+            "SUBSCRIBE",
+            [stream_name],
+            timeout=self._ws_timeout,
+            retry_policy=self._resubscribe_retry,
+            metadata={"type": "resubscribe", "phase": "subscribe", "symbols": (normalized,)},
+            delay=delay,
+        )
+
+    def _prime_connection(self, symbols: Iterable[str]) -> None:
+        streams: list[str] = []
+        metadata_symbols: list[str] = []
+        for symbol in symbols:
+            normalized = symbol.upper()
+            if self._get_registration(normalized) is None:
+                continue
+            streams.append(self._stream_name(normalized))
+            metadata_symbols.append(normalized)
+        if not streams:
+            return
+        self._scheduler.schedule(
+            "SET_PROPERTY",
+            ["combined", True],
+            timeout=self._ws_timeout,
+            retry_policy=self._property_retry,
+            metadata={"type": "set_property", "symbols": ()},
+        )
+        self._scheduler.schedule(
+            "SUBSCRIBE",
+            streams,
+            timeout=self._ws_timeout,
+            retry_policy=self._subscribe_retry,
+            metadata={"type": "subscribe", "phase": "initial", "symbols": tuple(metadata_symbols)},
+        )
+
+    def _metadata_symbols(self, metadata: Mapping[str, Any]) -> tuple[str, ...]:
+        symbols = metadata.get("symbols")
+        if isinstance(symbols, str):
+            return (symbols.upper(),)
+        if isinstance(symbols, (list, tuple)):
+            return tuple(str(item).upper() for item in symbols)
+        return ()
+
+    def _handle_command_result(
+        self,
+        result: CommandResult,
+        active_symbols: set[str],
+    ) -> None:
+        metadata = result.command.metadata if isinstance(result.command.metadata, Mapping) else {}
+        command_type = metadata.get("type")
+        symbols = self._metadata_symbols(metadata)
+        if command_type == "subscribe":
+            if result.success:
+                for symbol in symbols:
+                    active_symbols.add(symbol)
+            else:
+                details = result.error_details or "subscribe error"
+                for symbol in symbols:
+                    self._failover_symbol(symbol, details, active_symbols)
+        elif command_type == "unsubscribe":
+            if result.success:
+                for symbol in symbols:
                     active_symbols.discard(symbol)
-                try:
-                    await self._throttle_if_needed()
-                    await self._send_command(client, "SUBSCRIBE", [stream_name])
-                    self._record_command_sent()
-                except Exception:
-                    continue
-                active_symbols.add(symbol)
+            else:
+                details = result.error_details or "unsubscribe error"
+                self._logger.log(
+                    (
+                        "Binance {stream} stream: не удалось отписаться от {symbols}: {details}"  # noqa: ISC003
+                    ).format(stream=self._name, symbols=", ".join(symbols), details=details)
+                )
+        elif command_type == "resubscribe":
+            phase = metadata.get("phase")
+            if phase == "unsubscribe":
+                if result.success:
+                    for symbol in symbols:
+                        active_symbols.discard(symbol)
+                else:
+                    details = result.error_details or "resubscribe unsubscribe error"
+                    self._logger.log(
+                        (
+                            "Binance {stream} stream: сбой отписки при ресинке {symbols}: {details}"  # noqa: ISC003
+                        ).format(stream=self._name, symbols=", ".join(symbols), details=details)
+                    )
+            elif phase == "subscribe":
+                if result.success:
+                    for symbol in symbols:
+                        active_symbols.add(symbol)
+                else:
+                    details = result.error_details or "resubscribe subscribe error"
+                    for symbol in symbols:
+                        self._failover_symbol(symbol, details, active_symbols)
+        elif command_type == "set_property":
+            return
+
+    def _handle_command_failures(
+        self,
+        failures: Iterable[CommandResult],
+        active_symbols: set[str],
+    ) -> None:
+        for result in failures:
+            metadata = result.command.metadata if isinstance(result.command.metadata, Mapping) else {}
+            symbols = self._metadata_symbols(metadata)
+            if not symbols:
+                continue
+            details = result.error_details or "timeout"
+            for symbol in symbols:
+                self._failover_symbol(symbol, details, active_symbols)
+
+    def _failover_symbol(
+        self,
+        symbol: str,
+        details: str,
+        active_symbols: set[str],
+    ) -> None:
+        normalized = symbol.upper()
+        active_symbols.discard(normalized)
+        registration = self._get_registration(normalized)
+        if registration is not None:
+            try:
+                registration.on_error(ResyncReason.CONNECTION_LOST, details)
+            except Exception:
+                pass
+        predicate = lambda command: normalized in self._metadata_symbols(command.metadata)  # noqa: E731
+        cancelled = self._scheduler.cancel(predicate)
+        if cancelled:
+            self._logger.log(
+                (
+                    "Binance {stream} stream: отменены {count} команд(ы) для символа {symbol}"  # noqa: ISC003
+                ).format(stream=self._name, count=len(cancelled), symbol=normalized)
+            )
+        self._logger.log(
+            (
+                "Binance {stream} stream: символ {symbol} переводится на резерв из-за ошибки: {details}"  # noqa: ISC003
+            ).format(stream=self._name, symbol=normalized, details=details)
+        )
+        try:
+            self._on_degraded(self, normalized, details)
+        except Exception:
+            pass
 
     def _drain_pending_commands(self) -> None:
         while True:
@@ -458,7 +654,7 @@ class _CombinedStreamWorker:
             if not symbols:
                 continue
 
-            self._enqueue_all_symbols()
+            self._scheduler.reset()
             client: Optional[AsyncWebSocketClient] = None
             try:
                 client = AsyncWebSocketClient(
@@ -469,7 +665,6 @@ class _CombinedStreamWorker:
                 )
                 await client.connect()
                 await client.set_timeout(self._ws_timeout)
-                self._next_request_id = 1
                 self._logger.log(
                     (
                         "Binance {stream} stream: открыто соединение для {count} "
@@ -482,11 +677,22 @@ class _CombinedStreamWorker:
                     )
                 )
                 active_symbols: set[str] = set()
-                await self._send_set_combined(client)
+                self._prime_connection(symbols)
+                await self._scheduler.dispatch(
+                    throttle=self._throttle_if_needed,
+                    send=client.send_json,
+                    after_send=lambda _: self._command_limiter.record(),
+                )
+                self._handle_command_failures(self._scheduler.expire(), active_symbols)
                 while not self._stop_event.is_set():
                     await self._process_commands(client, active_symbols)
+                    self._handle_command_failures(self._scheduler.expire(), active_symbols)
                     self._restart_requested()
-                    if not self._current_symbols() and not active_symbols:
+                    if (
+                        not self._current_symbols()
+                        and not active_symbols
+                        and not self._scheduler.has_activity()
+                    ):
                         break
                     try:
                         payload = await client.recv_json()
@@ -503,10 +709,16 @@ class _CombinedStreamWorker:
                         self._logger.log(details)
                         self._notify_all(ResyncReason.CONNECTION_LOST, details)
                         break
-                    await self._process_commands(client, active_symbols)
-                    if not isinstance(payload, dict):
+                    result: Optional[CommandResult] = None
+                    if isinstance(payload, Mapping):
+                        result = self._scheduler.handle_response(payload)
+                    if result is not None:
+                        self._handle_command_result(result, active_symbols)
+                        self._handle_command_failures(self._scheduler.expire(), active_symbols)
                         continue
-                    if "result" in payload:
+                    await self._process_commands(client, active_symbols)
+                    self._handle_command_failures(self._scheduler.expire(), active_symbols)
+                    if not isinstance(payload, dict):
                         continue
                     symbol = self._extract_symbol(payload)
                     if symbol is None and isinstance(payload.get("s"), str):
@@ -573,13 +785,7 @@ class _CombinedStreamWorker:
                         )
                         self._logger.log(details)
                         if symbol is not None:
-                            registration = self._get_registration(symbol)
-                            if registration is not None:
-                                try:
-                                    registration.on_error(ResyncReason.CONNECTION_LOST, details)
-                                except Exception:
-                                    pass
-                            active_symbols.discard(symbol)
+                            self._failover_symbol(symbol, details, active_symbols)
                         continue
 
                     data = payload.get("data") if isinstance(payload.get("data"), dict) else None
@@ -619,6 +825,7 @@ class _CombinedStreamWorker:
                         await client.close()
                     except Exception:
                         pass
+                self._scheduler.reset()
                 self._drain_pending_commands()
 
 
@@ -644,6 +851,7 @@ class _StreamWorkerPool:
         self._lock = threading.Lock()
         self._workers: list[_CombinedStreamWorker] = []
         self._worker_loads: dict[_CombinedStreamWorker, float] = {}
+        self._bindings: dict[str, _Binding] = {}
         self._counter = 0
 
     def _create_worker(self) -> _CombinedStreamWorker:
@@ -658,15 +866,27 @@ class _StreamWorkerPool:
             log_writer=self._log_writer,
             max_streams=self._profile.max_streams_per_connection,
             command_profile=self._profile,
+            on_degraded=self._handle_degraded,
         )
         self._workers.append(worker)
         self._worker_loads[worker] = 0.0
         return worker
 
-    def _acquire_worker(self) -> _CombinedStreamWorker:
-        available = [worker for worker in self._workers if worker.has_capacity()]
+    def _acquire_worker(
+        self,
+        *,
+        exclude: Optional[_CombinedStreamWorker] = None,
+    ) -> _CombinedStreamWorker:
+        available = [
+            worker
+            for worker in self._workers
+            if worker.has_capacity() and worker is not exclude
+        ]
         if not available:
-            return self._create_worker()
+            worker = self._create_worker()
+            if worker is exclude:
+                worker = self._create_worker()
+            return worker
         return min(
             available,
             key=lambda worker: (
@@ -694,17 +914,24 @@ class _StreamWorkerPool:
         *,
         weight: float = 1.0,
     ) -> Callable[[], None]:
+        normalized_symbol = symbol.upper()
         normalized_weight = max(float(weight), 0.0)
+        resolved_on_error = on_error
+        if resolved_on_error is None:
+            def _default_error(reason: ResyncReason, details: str) -> None:
+                buffer.push_resync(reason, details)
+
+            resolved_on_error = _default_error
         with self._lock:
             worker = self._acquire_worker()
             self._worker_loads[worker] = self._worker_loads.get(worker, 0.0) + normalized_weight
 
         try:
             release = worker.register(
-                symbol,
+                normalized_symbol,
                 buffer,
                 on_message,
-                on_error,
+                resolved_on_error,
                 weight=normalized_weight,
             )
         except Exception:
@@ -713,6 +940,30 @@ class _StreamWorkerPool:
                 self._worker_loads[worker] = max(current, 0.0)
             raise
 
+        release_wrapper = self._wrap_release(worker, normalized_weight, release)
+        binding = _Binding(
+            symbol=normalized_symbol,
+            buffer=buffer,
+            on_message=on_message,
+            on_error=resolved_on_error,
+            weight=normalized_weight,
+            worker=worker,
+            release_wrapper=release_wrapper,
+        )
+        with self._lock:
+            self._bindings[normalized_symbol] = binding
+
+        def _release_handle() -> None:
+            self._release_binding(normalized_symbol, remove=True)
+
+        return _release_handle
+
+    def _wrap_release(
+        self,
+        worker: _CombinedStreamWorker,
+        weight: float,
+        release: Callable[[], None],
+    ) -> Callable[[], None]:
         released = threading.Event()
 
         def _release_wrapper() -> None:
@@ -720,7 +971,7 @@ class _StreamWorkerPool:
                 return
             release()
             with self._lock:
-                current = self._worker_loads.get(worker, 0.0) - normalized_weight
+                current = self._worker_loads.get(worker, 0.0) - weight
                 if current <= 0:
                     self._worker_loads.pop(worker, None)
                 else:
@@ -731,6 +982,63 @@ class _StreamWorkerPool:
             released.set()
 
         return _release_wrapper
+
+    def _release_binding(self, symbol: str, *, remove: bool) -> Optional[_Binding]:
+        normalized = symbol.upper()
+        with self._lock:
+            binding = self._bindings.get(normalized)
+        if binding is None:
+            return None
+        binding.release_wrapper()
+        if remove:
+            with self._lock:
+                self._bindings.pop(normalized, None)
+        return binding
+
+    def _handle_degraded(
+        self,
+        worker: _CombinedStreamWorker,
+        symbol: str,
+        details: str,
+    ) -> None:
+        binding = self._release_binding(symbol, remove=False)
+        if binding is None or binding.worker is not worker:
+            return
+        with self._lock:
+            self._bindings[binding.symbol] = binding
+        new_worker = self._acquire_worker(exclude=worker)
+        with self._lock:
+            self._worker_loads[new_worker] = self._worker_loads.get(new_worker, 0.0) + binding.weight
+        try:
+            release = new_worker.register(
+                binding.symbol,
+                binding.buffer,
+                binding.on_message,
+                binding.on_error,
+                weight=binding.weight,
+            )
+        except Exception as exc:  # noqa: BLE001
+            with self._lock:
+                current = self._worker_loads.get(new_worker, 0.0) - binding.weight
+                if current <= 0:
+                    self._worker_loads.pop(new_worker, None)
+                else:
+                    self._worker_loads[new_worker] = current
+            try:
+                binding.buffer.push_resync(
+                    ResyncReason.CONNECTION_LOST,
+                    f"Не удалось переключить поток {binding.symbol}: {exc}",
+                )
+            except Exception:
+                pass
+            with self._lock:
+                self._bindings.pop(binding.symbol, None)
+            return
+        release_wrapper = self._wrap_release(new_worker, binding.weight, release)
+        binding.worker = new_worker
+        binding.release_wrapper = release_wrapper
+        with self._lock:
+            self._bindings[binding.symbol] = binding
 
 
 class BinanceStreamPool:

--- a/data/exchanges/stream_scheduler.py
+++ b/data/exchanges/stream_scheduler.py
@@ -1,0 +1,331 @@
+"""Command scheduling utilities for websocket stream workers."""
+from __future__ import annotations
+
+import asyncio
+import heapq
+import math
+import time
+from dataclasses import dataclass, field
+from itertools import count
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+from .base import ExchangeLogger
+
+
+@dataclass(slots=True, frozen=True)
+class CommandRetryPolicy:
+    """Retry configuration for a websocket command."""
+
+    max_attempts: int = 3
+    delay_seconds: float = 0.5
+    backoff_multiplier: float = 2.0
+
+
+@dataclass(slots=True)
+class ScheduledCommand:
+    """Represents an outbound websocket command with retry metadata."""
+
+    method: str
+    params: tuple[Any, ...]
+    timeout: float
+    retry_policy: CommandRetryPolicy
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    created_at: float = field(default_factory=lambda: time.monotonic())
+    attempt: int = 0
+    request_id: Optional[int] = None
+    last_sent: float = 0.0
+    deadline: float = 0.0
+    not_before: float = 0.0
+
+    def clone_for_retry(self, *, not_before: float) -> "ScheduledCommand":
+        copy = ScheduledCommand(
+            method=self.method,
+            params=self.params,
+            timeout=self.timeout,
+            retry_policy=self.retry_policy,
+            metadata=self.metadata,
+        )
+        copy.created_at = self.created_at
+        copy.attempt = self.attempt
+        copy.not_before = not_before
+        return copy
+
+
+@dataclass(slots=True)
+class CommandResult:
+    """Outcome of a scheduled command."""
+
+    command: ScheduledCommand
+    success: bool
+    latency: float
+    attempts: int
+    payload: Optional[Mapping[str, Any]] = None
+    error_details: Optional[str] = None
+
+
+class StreamCommandScheduler:
+    """Coordinates websocket command dispatch and retry handling."""
+
+    def __init__(
+        self,
+        *,
+        logger: ExchangeLogger,
+        metrics_sink: Optional[Callable[[str, Mapping[str, Any]], None]] = None,
+    ) -> None:
+        self._logger = logger
+        self._metrics_sink = metrics_sink
+        self._pending: List[tuple[float, int, ScheduledCommand]] = []
+        self._outstanding: Dict[int, ScheduledCommand] = {}
+        self._counter = count()
+        self._next_request_id = 1
+
+    def reset(self) -> None:
+        """Clears all pending and outstanding commands."""
+
+        self._pending.clear()
+        self._outstanding.clear()
+        self._next_request_id = 1
+
+    def schedule(
+        self,
+        method: str,
+        params: Iterable[Any],
+        *,
+        timeout: float,
+        retry_policy: CommandRetryPolicy,
+        metadata: Optional[Mapping[str, Any]] = None,
+        delay: float = 0.0,
+    ) -> ScheduledCommand:
+        """Enqueue a command for dispatch."""
+
+        normalized_params = tuple(params)
+        command = ScheduledCommand(
+            method=method,
+            params=normalized_params,
+            timeout=max(float(timeout), 0.1),
+            retry_policy=retry_policy,
+            metadata=dict(metadata or {}),
+        )
+        loop_now = self._loop_time()
+        command.not_before = loop_now + max(0.0, float(delay))
+        heapq.heappush(self._pending, (command.not_before, next(self._counter), command))
+        return command
+
+    async def dispatch(
+        self,
+        *,
+        throttle: Callable[[], Awaitable[None]],
+        send: Callable[[Mapping[str, Any]], Awaitable[None]],
+        limit: Optional[int] = None,
+        after_send: Optional[Callable[[ScheduledCommand], None]] = None,
+    ) -> None:
+        """Send pending commands that are ready for dispatch."""
+
+        dispatched = 0
+        while self._pending:
+            if limit is not None and dispatched >= limit:
+                break
+            not_before, _, command = self._pending[0]
+            now = self._loop_time()
+            if not_before > now:
+                break
+            heapq.heappop(self._pending)
+            await throttle()
+            request_id = self._next_request_id
+            self._next_request_id += 1
+            payload = {"method": command.method, "params": list(command.params), "id": request_id}
+            try:
+                await send(payload)
+            except Exception as exc:  # pragma: no cover - network safety
+                self._logger.log(
+                    (
+                        "Команда {method} не отправлена (id={id}): {error}"  # noqa: ISC003
+                    ).format(method=command.method, id=request_id, error=exc)
+                )
+                command.request_id = None
+                command.attempt += 1
+                retry_at = self._loop_time() + self._retry_delay(command)
+                clone = command.clone_for_retry(not_before=retry_at)
+                heapq.heappush(self._pending, (clone.not_before, next(self._counter), clone))
+                continue
+            command.request_id = request_id
+            command.attempt += 1
+            command.last_sent = now
+            command.deadline = now + command.timeout
+            self._outstanding[request_id] = command
+            dispatched += 1
+            if after_send is not None:
+                try:
+                    after_send(command)
+                except Exception:
+                    pass
+
+    def expire(self) -> List[CommandResult]:
+        """Requeue timed out commands and return permanent failures."""
+
+        now = self._loop_time()
+        expired: List[CommandResult] = []
+        for request_id, command in list(self._outstanding.items()):
+            if command.deadline > now:
+                continue
+            self._outstanding.pop(request_id, None)
+            if command.attempt >= command.retry_policy.max_attempts:
+                result = CommandResult(
+                    command=command,
+                    success=False,
+                    latency=max(0.0, now - command.last_sent),
+                    attempts=command.attempt,
+                    payload=None,
+                    error_details="timeout",
+                )
+                expired.append(result)
+                self._publish_metrics(result)
+                self._logger.log(
+                    (
+                        "Команда {method} не получила подтверждение после {attempts} попыток"  # noqa: ISC003
+                    ).format(method=command.method, attempts=command.attempt)
+                )
+            else:
+                retry_at = now + self._retry_delay(command)
+                clone = command.clone_for_retry(not_before=retry_at)
+                clone.attempt += 0  # preserve attempt count for logging
+                heapq.heappush(self._pending, (clone.not_before, next(self._counter), clone))
+                self._logger.log(
+                    (
+                        "Повторная отправка команды {method} (попытка {attempt}) через {delay:.2f}с"  # noqa: ISC003
+                    ).format(
+                        method=command.method,
+                        attempt=command.attempt + 1,
+                        delay=max(0.0, retry_at - now),
+                    )
+                )
+        return expired
+
+    def handle_response(self, payload: Mapping[str, Any]) -> Optional[CommandResult]:
+        """Process a websocket response and return the command result if recognised."""
+
+        raw_id = payload.get("id")
+        if raw_id is None:
+            return None
+        try:
+            request_id = int(raw_id)
+        except (TypeError, ValueError):
+            return None
+        command = self._outstanding.pop(request_id, None)
+        if command is None:
+            return None
+        now = self._loop_time()
+        latency = max(0.0, now - command.last_sent)
+        error_details = self._extract_error(payload)
+        success = error_details is None
+        result = CommandResult(
+            command=command,
+            success=success,
+            latency=latency,
+            attempts=command.attempt,
+            payload=payload,
+            error_details=error_details,
+        )
+        self._publish_metrics(result)
+        if success:
+            self._logger.log(
+                (
+                    "Команда {method} подтверждена за {latency:.3f}с (попыток {attempts})"
+                ).format(method=command.method, latency=latency, attempts=command.attempt)
+            )
+        else:
+            self._logger.log(
+                (
+                    "Команда {method} завершилась ошибкой: {details} (попыток {attempts})"  # noqa: ISC003
+                ).format(
+                    method=command.method,
+                    details=error_details,
+                    attempts=command.attempt,
+                )
+            )
+        return result
+
+    def cancel(self, predicate: Callable[[ScheduledCommand], bool]) -> List[ScheduledCommand]:
+        """Cancel pending and outstanding commands that match *predicate*."""
+
+        cancelled: List[ScheduledCommand] = []
+        new_pending: List[tuple[float, int, ScheduledCommand]] = []
+        while self._pending:
+            entry = heapq.heappop(self._pending)
+            _, _, command = entry
+            if predicate(command):
+                cancelled.append(command)
+            else:
+                new_pending.append(entry)
+        for entry in new_pending:
+            heapq.heappush(self._pending, entry)
+        for request_id, command in list(self._outstanding.items()):
+            if predicate(command):
+                cancelled.append(command)
+                self._outstanding.pop(request_id, None)
+        return cancelled
+
+    def has_activity(self) -> bool:
+        return bool(self._pending or self._outstanding)
+
+    def _retry_delay(self, command: ScheduledCommand) -> float:
+        policy = command.retry_policy
+        base = max(policy.delay_seconds, 0.05)
+        exponent = max(command.attempt - 1, 0)
+        return base * math.pow(max(policy.backoff_multiplier, 1.0), exponent)
+
+    def _loop_time(self) -> float:
+        try:
+            loop = asyncio.get_running_loop()
+            return loop.time()
+        except RuntimeError:
+            return time.monotonic()
+
+    def _publish_metrics(self, result: CommandResult) -> None:
+        if self._metrics_sink is None:
+            return
+        tags = dict(result.command.metadata)
+        tags.setdefault("command", result.command.method)
+        tags["success"] = "1" if result.success else "0"
+        payload = {
+            "latency": result.latency,
+            "attempts": result.attempts,
+        }
+        if result.error_details:
+            payload["error"] = result.error_details
+        try:
+            self._metrics_sink("stream_command", {"values": payload, "tags": tags})
+        except Exception:
+            pass
+
+    def _extract_error(self, payload: Mapping[str, Any]) -> Optional[str]:
+        result = payload.get("result")
+        if result is None or result is True:
+            error_section = payload.get("error")
+            if not error_section:
+                return None
+        parts: List[str] = []
+        error_section = payload.get("error")
+        if isinstance(error_section, Mapping):
+            code = error_section.get("code")
+            if code is not None:
+                parts.append(f"code={code}")
+            message = error_section.get("msg") or error_section.get("message")
+            if message:
+                parts.append(str(message))
+        if not parts:
+            for key in ("code", "msg", "message", "error"):
+                value = payload.get(key)
+                if value is not None:
+                    parts.append(f"{key}={value}")
+        if not parts:
+            return None
+        return ", ".join(parts)
+
+
+__all__ = [
+    "CommandResult",
+    "CommandRetryPolicy",
+    "ScheduledCommand",
+    "StreamCommandScheduler",
+]


### PR DESCRIPTION
## Summary
- introduce a reusable stream command scheduler with retry tracking, timeout handling, and metrics hooks
- refactor Binance stream workers to batch initial subscriptions, throttle resyncs, and integrate the scheduler while adding graceful failover to reserve workers
- expose metric logging on ExchangeLogger for command latency/attempt reporting and propagate data to monitoring output

## Testing
- python -m compileall data/exchanges

------
https://chatgpt.com/codex/tasks/task_e_68ea68a432fc832086b8fad14e42ffe1