### PR TITLE
Introduce stream pipelines and feed degradation controls

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,6 +38,7 @@ from data.telegram import TelegramClient
 from domain.book import OrderBook
 from domain.detectors import check_if_has_near_wall, check_if_has_opposite_wall, compute_odr
 from domain.execution import create_execution_handlers, initialize_account
+from streams import StreamPipeline
 from domain.models import (
     BalanceSource,
     Exchange,
@@ -159,6 +160,10 @@ class SymbolContext:
     ticker_resync_reason: Optional[StreamResyncReason] = None
     ticker_resync_details: Optional[str] = None
     ticker_resync_timestamp: Optional[datetime] = None
+    depth_pipeline: Optional[StreamPipeline[Any]] = None
+    trade_pipeline: Optional[StreamPipeline[Any]] = None
+    ticker_pipeline: Optional[StreamPipeline[Any]] = None
+    degraded_streams: set[str] = field(default_factory=set)
 
 
 class TradingAdapterRouter(TradingAdapter):
@@ -648,6 +653,7 @@ class Application:
     def _build_observation(self, context: SymbolContext) -> MarketObservation:
         now = get_current_time()
         with context.lock:
+            self._update_degradation_state(context)
             stale_entries: list[tuple[str, str]] = []
             order_book_updated_at = context.order_book_updated_at
             trade_updated_at = context.trade_updated_at
@@ -804,6 +810,13 @@ class Application:
         exchange_data = self._create_exchange_data(symbol, profile)
         filters = exchange_data.fetch_symbol_filters()
         trading_adapter = self._create_trading_adapter(symbol, filters)
+        depth_subscription = exchange_data.stream_depth()
+        trade_subscription = exchange_data.stream_trades()
+        ticker_subscription = exchange_data.stream_book_ticker()
+        depth_pipeline = getattr(exchange_data, "depth_pipeline", None)
+        trade_pipeline = getattr(exchange_data, "trades_pipeline", None)
+        ticker_pipeline = getattr(exchange_data, "ticker_pipeline", None)
+
         context = SymbolContext(
             symbol=symbol,
             exchange_data=exchange_data,
@@ -812,12 +825,15 @@ class Application:
                 recent_band_volume_boost=CONFIG.general.recent_band_s_vol_boost,
             ),
             feed_monitor=FeedMonitor(),
-            depth_subscription=exchange_data.stream_depth(),
-            trade_subscription=exchange_data.stream_trades(),
-            ticker_subscription=exchange_data.stream_book_ticker(),
+            depth_subscription=depth_subscription,
+            trade_subscription=trade_subscription,
+            ticker_subscription=ticker_subscription,
             filters=filters,
             trading_adapter=trading_adapter,
             profile=profile,
+            depth_pipeline=depth_pipeline,
+            trade_pipeline=trade_pipeline,
+            ticker_pipeline=ticker_pipeline,
         )
         context.order_book.reset_odr_history()
         startup_timestamp = get_current_time()
@@ -951,6 +967,69 @@ class Application:
         context.ticker_pump.start()
         self._refresh_context_funding(context, force=True)
         return context
+
+    def _update_degradation_state(self, context: SymbolContext) -> None:
+        pipelines = {
+            "depth": context.depth_pipeline,
+            "trades": context.trade_pipeline,
+            "book": context.ticker_pipeline,
+        }
+        for stream, pipeline in pipelines.items():
+            if pipeline is None:
+                continue
+            is_degraded = pipeline.is_degraded
+            tracked = stream in context.degraded_streams
+            if is_degraded and not tracked:
+                context.degraded_streams.add(stream)
+                context.feed_monitor.set_degraded(stream, True)
+                self._handle_stream_degradation(context, stream, pipeline)
+            elif not is_degraded and tracked:
+                context.degraded_streams.discard(stream)
+                context.feed_monitor.set_degraded(stream, False)
+                self._handle_stream_recovery(context, stream)
+            else:
+                context.feed_monitor.set_degraded(stream, is_degraded)
+
+    def _handle_stream_degradation(
+        self,
+        context: SymbolContext,
+        stream: str,
+        pipeline: StreamPipeline[Any],
+    ) -> None:
+        timestamp = get_current_time()
+        health = pipeline.health_snapshot()
+        backlog = health.backlog
+        capacity = health.capacity
+        fallback = health.fallback_mode.value
+        self._event_logger.log(
+            (
+                "Деградация стрима {stream} для {symbol}: очередь {backlog}/{capacity}, "
+                "fallback={fallback}."
+            ).format(
+                stream=stream,
+                symbol=context.symbol,
+                backlog=backlog,
+                capacity=capacity,
+                fallback=fallback,
+            ),
+            timestamp,
+        )
+        hold_seconds = pipeline.degradation_hold_s
+        self._scanner.record_degradation(context.symbol, hold_seconds)
+        self._kill_switch.handle_degradation(
+            timestamp,
+            context.symbol,
+            tuple(sorted(context.degraded_streams)),
+        )
+
+    def _handle_stream_recovery(self, context: SymbolContext, stream: str) -> None:
+        timestamp = get_current_time()
+        self._event_logger.log(
+            f"Поток {stream} для {context.symbol} восстановлен.",
+            timestamp,
+        )
+        if not context.degraded_streams:
+            self._scanner.clear_degradation(context.symbol)
 
     def _create_trading_adapter(self, symbol: str, filters: SymbolFilters) -> TradingAdapter:
         api_key, api_secret = self._exchange_credentials()

--- a/application/market_scanner.py
+++ b/application/market_scanner.py
@@ -38,6 +38,7 @@ class MarketScanner:
         self._last_symbols: Tuple[Tuple[str, TradingProfile], ...] = ()
         self._listing_dates: dict[str, int] = {}
         self._recent_listing_cache: dict[str, bool] = {}
+        self._degraded_until: dict[str, float] = {}
 
     def scan(self) -> Tuple[Tuple[str, TradingProfile], ...]:
         try:
@@ -120,6 +121,8 @@ class MarketScanner:
             symbol = str(raw_symbol or "").upper()
             if not symbol.endswith("USDT"):
                 continue
+            if self._is_degraded(symbol):
+                continue
             try:
                 turnover_24h = float(raw_turnover or 0.0)
             except (TypeError, ValueError):
@@ -159,6 +162,24 @@ class MarketScanner:
         if self._profile is TradingProfile.LISTING:
             return float(thresholds.listing_usd)
         return float(thresholds.top_usd)
+
+    def record_degradation(self, symbol: str, hold_seconds: float) -> None:
+        normalized = symbol.upper()
+        deadline = time.monotonic() + max(0.0, float(hold_seconds))
+        self._degraded_until[normalized] = deadline
+
+    def clear_degradation(self, symbol: str) -> None:
+        self._degraded_until.pop(symbol.upper(), None)
+
+    def _is_degraded(self, symbol: str) -> bool:
+        normalized = symbol.upper()
+        expiry = self._degraded_until.get(normalized)
+        if expiry is None:
+            return False
+        if time.monotonic() >= expiry:
+            self._degraded_until.pop(normalized, None)
+            return False
+        return True
 
     def _classify_turnover(self, symbol: str, turnover: float) -> TradingProfile:
         thresholds = self._thresholds

--- a/application/runtime.py
+++ b/application/runtime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 from config.models.exchange_name import ExchangeName
@@ -35,6 +35,7 @@ class FeedMonitor:
     has_silence_timeout: bool = False
     has_queue_overflow: bool = False
     has_connection_loss: bool = False
+    _degraded_streams: dict[str, bool] = field(default_factory=dict, repr=False)
 
     def flag(self, reason: StreamResyncReason) -> None:
         if reason is StreamResyncReason.SEQUENCE_GAP:
@@ -52,6 +53,7 @@ class FeedMonitor:
             has_connection_loss=self.has_connection_loss,
             has_silence_timeout=self.has_silence_timeout,
             has_queue_overflow=self.has_queue_overflow,
+            degraded_streams=tuple(sorted(self._degraded_streams)),
         )
 
     def clear(self) -> None:
@@ -59,6 +61,17 @@ class FeedMonitor:
         self.has_connection_loss = False
         self.has_silence_timeout = False
         self.has_queue_overflow = False
+        self._degraded_streams.clear()
+
+    def set_degraded(self, stream: str, degraded: bool) -> bool:
+        key = stream.lower()
+        if degraded:
+            changed = not self._degraded_streams.get(key, False)
+            self._degraded_streams[key] = True
+            return changed
+        if self._degraded_streams.pop(key, None):
+            return True
+        return False
 
 
 GUARDS = RuntimeGuards()

--- a/data/exchanges/base/stream_buffer.py
+++ b/data/exchanges/base/stream_buffer.py
@@ -28,6 +28,7 @@ class StreamBuffer(Generic[T]):
         self._logger = logger
         queue_size = 1024 if maxsize is None else int(maxsize)
         self._queue: "queue.Queue[StreamEvent[T]]" = queue.Queue(queue_size)
+        self._maxsize = queue_size
         self._silence_timeout = silence_timeout
         self._heartbeat_interval = (
             heartbeat_interval if heartbeat_interval is not None else silence_timeout / 2
@@ -173,6 +174,16 @@ class StreamBuffer(Generic[T]):
                 self._queue.get_nowait()
             except queue.Empty:
                 break
+
+    def backlog(self) -> int:
+        try:
+            return self._queue.qsize()
+        except NotImplementedError:  # pragma: no cover - platform specific
+            return 0
+
+    @property
+    def capacity(self) -> int:
+        return self._maxsize
 
 
 __all__ = ["StreamBuffer"]

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -37,6 +37,11 @@ from .base import (
     StreamSubscription,
 )
 from .binance_stream_manager import BinanceStreamManager
+from streams import (
+    BookTickerStreamPipeline,
+    DepthStreamPipeline,
+    TradesStreamPipeline,
+)
 
 
 WebSocketClient = ThreadedWebSocketClient
@@ -71,6 +76,14 @@ _STREAM_PROFILE_WEIGHTS: dict[TradingProfile, dict[str, float]] = {
     TradingProfile.ALT: {"depth": 1.0, "trades": 1.0, "book": 0.8},
     TradingProfile.LISTING: {"depth": 2.5, "trades": 3.0, "book": 1.5},
     TradingProfile.AUTO: {"depth": 1.5, "trades": 1.5, "book": 1.0},
+}
+
+
+_RESTART_GRACE_FACTORS: dict[TradingProfile, dict[str, float]] = {
+    TradingProfile.TOP: {"depth": 0.5, "trades": 0.7, "book": 0.7},
+    TradingProfile.ALT: {"depth": 1.0, "trades": 1.2, "book": 1.2},
+    TradingProfile.LISTING: {"depth": 1.5, "trades": 1.6, "book": 1.6},
+    TradingProfile.AUTO: {"depth": 0.9, "trades": 1.0, "book": 1.0},
 }
 
 
@@ -166,6 +179,9 @@ class BinanceExchangeData:
         self._lock = threading.Lock()
         self._api_key = api_key
         self._api_secret = api_secret
+        self._depth_pipeline: Optional[DepthStreamPipeline] = None
+        self._trades_pipeline: Optional[TradesStreamPipeline] = None
+        self._ticker_pipeline: Optional[BookTickerStreamPipeline] = None
 
     def _normalize_depth_stream_interval(self, interval_ms: int) -> int:
         default_interval = 250
@@ -253,6 +269,45 @@ class BinanceExchangeData:
         fallback = _STREAM_PROFILE_WEIGHTS[TradingProfile.AUTO]
         weight = profile_weights.get(stream_type, fallback.get(stream_type, 1.0))
         return max(float(weight), 0.1)
+
+    def _resolve_restart_grace_period(self, stream_type: str) -> float:
+        factors = _RESTART_GRACE_FACTORS.get(self._profile, _RESTART_GRACE_FACTORS[TradingProfile.AUTO])
+        factor = max(float(factors.get(stream_type, 1.0)), 0.1)
+        if stream_type == "depth":
+            base = self._depth_silence_timeout
+        elif stream_type == "trades":
+            base = self._trade_silence_timeout
+        else:
+            base = self._book_ticker_silence_timeout
+        return max(0.5, base * factor)
+
+    def _request_stream_migration(
+        self,
+        stream_type: str,
+        reason: ResyncReason,
+        details: str,
+    ) -> None:
+        message = details or reason.value
+        self._logger.log(
+            (
+                "Binance {stream} stream: хроничная деградация символа {symbol}, попытка миграции: {message}"
+            ).format(stream=stream_type, symbol=self.symbol, message=message)
+        )
+        try:
+            migrated = self._stream_manager.migrate_stream(stream_type, self.symbol, message)
+        except Exception as exc:  # noqa: BLE001
+            self._logger.log(
+                (
+                    "Binance {stream} stream: ошибка миграции символа {symbol}: {error}"
+                ).format(stream=stream_type, symbol=self.symbol, error=exc)
+            )
+            return
+        if not migrated:
+            self._logger.log(
+                (
+                    "Binance {stream} stream: миграция символа {symbol} не выполнена (нет доступных воркеров)"
+                ).format(stream=stream_type, symbol=self.symbol)
+            )
 
     @classmethod
     def _get_stream_manager(
@@ -398,12 +453,23 @@ class BinanceExchangeData:
             logger=self._logger,
             silence_timeout=silence_timeout,
             heartbeat_interval=heartbeat_interval,
-            restart_grace_period=silence_timeout,
+            maxsize=DepthStreamPipeline.buffer_size(self._profile),
+            drop_oldest_on_overflow=True,
+            restart_grace_period=self._resolve_restart_grace_period("depth"),
         )
+        pipeline = DepthStreamPipeline(
+            name="depth",
+            buffer=buffer,
+            profile=self._profile,
+            on_chronic_error=lambda reason, details: self._request_stream_migration(
+                "depth", reason, details or "depth stream chronic degradation"
+            ),
+        )
+        self._depth_pipeline = pipeline
         self._reset_depth_state()
 
         def handle_message(message: dict[str, Any]) -> None:
-            self._handle_depth_message(message, buffer)
+            self._handle_depth_message(message, pipeline)
 
         def handle_error(reason: ResyncReason, details: str) -> None:
             suffix = f"(symbol {self.symbol})"
@@ -412,31 +478,33 @@ class BinanceExchangeData:
                 reason == ResyncReason.CONNECTION_LOST
                 and "ошибка чтения сокета" in details
             )
-            buffer.push_resync(reason, message)
+            pipeline.push_resync(reason, message)
             if should_log:
                 self._logger.log(message)
 
         release = self._stream_manager.register_depth(
             self.symbol,
-            buffer,
+            pipeline.buffer,
             handle_message,
             handle_error,
             weight=self._stream_weight("depth"),
         )
 
-        self._start_depth_snapshot(buffer)
+        self._start_depth_snapshot(pipeline)
 
         def iterator() -> Iterator[StreamEvent[DepthStreamData]]:
             try:
                 while True:
-                    yield buffer.next()
+                    yield pipeline.next_event()
             finally:
-                buffer.stop()
+                pipeline.buffer.stop()
                 release()
 
-        return StreamSubscription(events=iterator(), _buffer=buffer, _stopper=release)
+        return StreamSubscription(events=iterator(), _buffer=pipeline.buffer, _stopper=release)
 
-    def _start_depth_snapshot(self, buffer: StreamBuffer[DepthStreamData]) -> None:
+    def _start_depth_snapshot(self, pipeline: DepthStreamPipeline) -> None:
+        buffer = pipeline.buffer
+
         def load_snapshot() -> None:
             while not buffer.stopped():
                 try:
@@ -446,12 +514,12 @@ class BinanceExchangeData:
                         "Binance depth stream: не удалось получить начальный снапшот: "
                         f"{exc}"
                     )
-                    buffer.push_resync(ResyncReason.CONNECTION_LOST, details)
+                    pipeline.push_resync(ResyncReason.CONNECTION_LOST, details)
                     self._logger.log_resync(ResyncReason.CONNECTION_LOST, details)
                     self._reset_depth_state()
                     time.sleep(self._reconnect_delay)
                     continue
-                self._apply_depth_snapshot(snapshot, buffer)
+                self._apply_depth_snapshot(snapshot, pipeline)
                 break
 
         threading.Thread(
@@ -463,11 +531,12 @@ class BinanceExchangeData:
     def _handle_depth_message(
         self,
         message: dict[str, Any],
-        buffer: StreamBuffer[DepthStreamData],
+        pipeline: DepthStreamPipeline,
         *,
         buffer_if_uninitialized: bool = True,
         allow_skip: bool = False,
     ) -> None:
+        buffer = pipeline.buffer
         if message.get("e") != "depthUpdate":
             return
         first_update = int(message.get("U", 0))
@@ -514,33 +583,33 @@ class BinanceExchangeData:
 
         if resync_reason is not None:
             self._trigger_depth_resync(
-                buffer,
+                pipeline,
                 reason=resync_reason,
                 details=resync_details,
             )
             return
 
         if update is not None:
-            buffer.push_data(update)
+            pipeline.push_data(update)
 
     def _trigger_depth_resync(
         self,
-        buffer: StreamBuffer[DepthStreamData],
+        pipeline: DepthStreamPipeline,
         reason: ResyncReason,
         details: str,
     ) -> None:
         self._logger.log_resync(reason, details)
-        buffer.push_resync(reason, details)
+        pipeline.push_resync(reason, details)
         self._reset_depth_state()
         try:
             snapshot = self.fetch_orderbook_snapshot()
         except Exception as exc:  # noqa: BLE001
-            buffer.push_resync(
+            pipeline.push_resync(
                 ResyncReason.CONNECTION_LOST,
                 details=f"Ошибка получения снапшота: {exc}",
             )
             return
-        self._apply_depth_snapshot(snapshot, buffer)
+        self._apply_depth_snapshot(snapshot, pipeline)
 
     def _reset_depth_state(self) -> None:
         with self._lock:
@@ -549,7 +618,7 @@ class BinanceExchangeData:
             self._depth_buffered_messages.clear()
 
     def _apply_depth_snapshot(
-        self, snapshot: OrderBookSnapshot, buffer: StreamBuffer[DepthStreamData]
+        self, snapshot: OrderBookSnapshot, pipeline: DepthStreamPipeline
     ) -> None:
         with self._lock:
             self._depth_last_update = snapshot.last_update_id
@@ -557,12 +626,13 @@ class BinanceExchangeData:
             pending = tuple(self._depth_buffered_messages)
             self._depth_buffered_messages.clear()
 
-        buffer.push_snapshot(snapshot)
+        pipeline.reset()
+        pipeline.push_snapshot(snapshot)
 
         for message in pending:
             self._handle_depth_message(
                 message,
-                buffer,
+                pipeline,
                 buffer_if_uninitialized=False,
                 allow_skip=True,
             )
@@ -576,13 +646,23 @@ class BinanceExchangeData:
             logger=self._logger,
             silence_timeout=silence_timeout,
             heartbeat_interval=heartbeat_interval,
+            maxsize=BookTickerStreamPipeline.buffer_size(self._profile),
             drop_oldest_on_overflow=True,
-            restart_grace_period=silence_timeout,
+            restart_grace_period=self._resolve_restart_grace_period("book"),
         )
+        pipeline = BookTickerStreamPipeline(
+            name="book_ticker",
+            buffer=buffer,
+            profile=self._profile,
+            on_chronic_error=lambda reason, details: self._request_stream_migration(
+                "book", reason, details or "book ticker chronic degradation"
+            ),
+        )
+        self._ticker_pipeline = pipeline
 
         def handle_message(message: dict[str, Any]) -> None:
             for payload in self._parse_book_ticker(message):
-                buffer.push_data(payload)
+                pipeline.push_data(payload)
 
         def handle_error(reason: ResyncReason, details: str) -> None:
             suffix = f"(symbol {self.symbol})"
@@ -591,13 +671,13 @@ class BinanceExchangeData:
                 reason == ResyncReason.CONNECTION_LOST
                 and "ошибка чтения сокета" in details
             )
-            buffer.push_resync(reason, message)
+            pipeline.push_resync(reason, message)
             if should_log:
                 self._logger.log(message)
 
         release = self._stream_manager.register_book_ticker(
             self.symbol,
-            buffer,
+            pipeline.buffer,
             handle_message,
             handle_error,
             weight=self._stream_weight("book"),
@@ -606,12 +686,12 @@ class BinanceExchangeData:
         def iterator() -> Iterator[StreamEvent[BestBidAsk]]:
             try:
                 while True:
-                    yield buffer.next()
+                    yield pipeline.next_event()
             finally:
-                buffer.stop()
+                pipeline.buffer.stop()
                 release()
 
-        return StreamSubscription(events=iterator(), _buffer=buffer, _stopper=release)
+        return StreamSubscription(events=iterator(), _buffer=pipeline.buffer, _stopper=release)
 
     def stream_trades(self) -> StreamSubscription[Trade]:
         silence_timeout = self._trade_silence_timeout
@@ -622,14 +702,23 @@ class BinanceExchangeData:
             logger=self._logger,
             silence_timeout=silence_timeout,
             heartbeat_interval=heartbeat_interval,
-            maxsize=4096,
+            maxsize=TradesStreamPipeline.buffer_size(self._profile),
             drop_oldest_on_overflow=True,
-            restart_grace_period=silence_timeout,
+            restart_grace_period=self._resolve_restart_grace_period("trades"),
         )
+        pipeline = TradesStreamPipeline(
+            name="trades",
+            buffer=buffer,
+            profile=self._profile,
+            on_chronic_error=lambda reason, details: self._request_stream_migration(
+                "trades", reason, details or "trade stream chronic degradation"
+            ),
+        )
+        self._trades_pipeline = pipeline
 
         def handle_message(message: dict[str, Any]) -> None:
             for payload in self._parse_trade(message):
-                buffer.push_data(payload)
+                pipeline.push_data(payload)
 
         def handle_error(reason: ResyncReason, details: str) -> None:
             suffix = f"(symbol {self.symbol})"
@@ -638,13 +727,13 @@ class BinanceExchangeData:
                 reason == ResyncReason.CONNECTION_LOST
                 and "ошибка чтения сокета" in details
             )
-            buffer.push_resync(reason, message)
+            pipeline.push_resync(reason, message)
             if should_log:
                 self._logger.log(message)
 
         release = self._stream_manager.register_trades(
             self.symbol,
-            buffer,
+            pipeline.buffer,
             handle_message,
             handle_error,
             weight=self._stream_weight("trades"),
@@ -653,12 +742,24 @@ class BinanceExchangeData:
         def iterator() -> Iterator[StreamEvent[Trade]]:
             try:
                 while True:
-                    yield buffer.next()
+                    yield pipeline.next_event()
             finally:
-                buffer.stop()
+                pipeline.buffer.stop()
                 release()
 
-        return StreamSubscription(events=iterator(), _buffer=buffer, _stopper=release)
+        return StreamSubscription(events=iterator(), _buffer=pipeline.buffer, _stopper=release)
+
+    @property
+    def depth_pipeline(self) -> Optional[DepthStreamPipeline]:
+        return self._depth_pipeline
+
+    @property
+    def trades_pipeline(self) -> Optional[TradesStreamPipeline]:
+        return self._trades_pipeline
+
+    @property
+    def ticker_pipeline(self) -> Optional[BookTickerStreamPipeline]:
+        return self._ticker_pipeline
 
     def stream_kline_1m(self) -> StreamSubscription[Candle]:
         return self._run_simple_stream(

--- a/data/exchanges/binance_stream_manager.py
+++ b/data/exchanges/binance_stream_manager.py
@@ -188,5 +188,11 @@ class BinanceStreamManager:
 
         return _release_wrapper
 
+    def migrate_stream(self, stream_type: str, symbol: str, reason: str) -> bool:
+        pool = self._pools.get(stream_type)
+        if pool is None:
+            return False
+        return pool.migrate(symbol, reason)
+
 
 __all__ = ["BinanceStreamManager"]

--- a/data/exchanges/binance_stream_pool.py
+++ b/data/exchanges/binance_stream_pool.py
@@ -1006,6 +1006,20 @@ class _StreamWorkerPool:
             return
         with self._lock:
             self._bindings[binding.symbol] = binding
+
+    def migrate(self, symbol: str, details: str) -> bool:
+        normalized = symbol.upper()
+        with self._lock:
+            binding = self._bindings.get(normalized)
+        if binding is None:
+            return False
+        self._logger.log(
+            (
+                "Binance {stream} stream: инициирована миграция символа {symbol}: {details}"
+            ).format(stream=self._name, symbol=normalized, details=details)
+        )
+        self._handle_degraded(binding.worker, normalized, details)
+        return True
         new_worker = self._acquire_worker(exclude=worker)
         with self._lock:
             self._worker_loads[new_worker] = self._worker_loads.get(new_worker, 0.0) + binding.weight

--- a/docs/streaming_architecture.md
+++ b/docs/streaming_architecture.md
@@ -65,3 +65,15 @@ This guarantees that high-priority symbols do not contend with low-liquidity one
    workers are precreated during service bootstrap.
 4. All changes should be validated in staging by monitoring reconnect storms and
    ensuring command throttling logs stay within the expected windows.
+5. Pipelines expose backlog metrics and chronic error hooks via
+   `StreamPipeline`. Depth, trades, and book-ticker feeds now have per-profile buffer
+   sizing, thresholds, and fallback behaviour defined under `streams/`. Review the
+   thresholds when updating `TradingProfile` allocations to ensure the SLA balance
+   between TOP and thinly traded symbols remains appropriate.
+6. The stream manager reacts to chronic error callbacks by migrating the impacted
+   symbol to a reserve socket without disrupting other workers. For incidents focused on
+   a single market, prefer tuning the pipeline thresholds before widening global
+   restart timers.
+7. Downstream strategies consume degradation signals surfaced by the runtime. Expect
+   automated position throttling (reduced leverage or temporary suspensions) whenever a
+   stream enters a degraded state; coordinate with risk to adjust policy parameters.

--- a/domain/strategy/kill_switch.py
+++ b/domain/strategy/kill_switch.py
@@ -65,6 +65,17 @@ class KillSwitch:
         self._funding_event_at = None
         self.logger.log("Блокировка торгов: ожидание после ресинка.", timestamp)
 
+    def handle_degradation(
+        self,
+        timestamp: datetime,
+        symbol: str,
+        streams: tuple[str, ...],
+    ) -> None:
+        if not streams:
+            return
+        reason = ", ".join(streams)
+        self._trigger_block(f"деградация потоков ({symbol}: {reason})", timestamp)
+
     def handle_funding(self, funding_time: datetime) -> None:
         if self.funding_block <= timedelta(0):
             return

--- a/domain/strategy/resync.py
+++ b/domain/strategy/resync.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import Optional, Tuple
 
 
 class ResyncReason(str, Enum):
@@ -18,6 +18,7 @@ class FeedStatus:
     has_connection_loss: bool = False
     has_silence_timeout: bool = False
     has_queue_overflow: bool = False
+    degraded_streams: Tuple[str, ...] = ()
 
     def resolve_reason(self) -> Optional[ResyncReason]:
         if self.has_sequence_gap:
@@ -29,6 +30,9 @@ class FeedStatus:
         if self.has_queue_overflow:
             return ResyncReason.BACKPRESSURE
         return None
+
+    def is_degraded(self) -> bool:
+        return bool(self.degraded_streams)
 
 
 __all__ = ["ResyncReason", "FeedStatus"]

--- a/domain/strategy/strategy.py
+++ b/domain/strategy/strategy.py
@@ -69,6 +69,12 @@ class Strategy:
         if reason is not None and self._state is not StrategyState.RESYNC:
             self._enter_resync(reason, observation.timestamp)
             return self._state
+        if observation.feed_status.degraded_streams:
+            self._handle_degraded_observation(
+                observation,
+                observation.feed_status.degraded_streams,
+            )
+            return self._state
         if self._state is StrategyState.RESYNC:
             return self._state
         if self._state is StrategyState.SCANNING:
@@ -337,6 +343,33 @@ class Strategy:
         self._focused_wall = None
         self._last_focus_signal_at = None
         self._last_uptick_loss_at[symbol] = timestamp
+
+    def _handle_degraded_observation(
+        self,
+        observation: MarketObservation,
+        streams: tuple[str, ...],
+    ) -> None:
+        description = ", ".join(streams)
+        self._logger.log(
+            f"Деградация потоков ({description}) для {observation.symbol}.",
+            observation.timestamp,
+        )
+        if (
+            self._state is StrategyState.IN_POSITION
+            and self._position_symbol == observation.symbol
+        ):
+            self._exit_position(
+                f"деградация каналов: {description}",
+                observation.timestamp,
+                observation.last_price,
+            )
+            return
+        if self._focus.current == observation.symbol:
+            self._focus.defocus(observation.timestamp)
+            self._focused_signal = Signal.NONE
+            self._focused_wall = None
+            self._last_focus_signal_at = None
+            self._state = StrategyState.SCANNING
 
     @staticmethod
     def _is_odr_neutral(pressure: Pressure) -> bool:

--- a/streams/__init__.py
+++ b/streams/__init__.py
@@ -1,0 +1,21 @@
+"""Stream pipeline utilities for exchange data feeds."""
+
+from .base import (
+    AlarmThresholds,
+    FallbackMode,
+    PipelineHealth,
+    StreamPipeline,
+)
+from .depth_pipeline import DepthStreamPipeline
+from .ticker_pipeline import BookTickerStreamPipeline
+from .trades_pipeline import TradesStreamPipeline
+
+__all__ = [
+    "AlarmThresholds",
+    "FallbackMode",
+    "PipelineHealth",
+    "StreamPipeline",
+    "DepthStreamPipeline",
+    "BookTickerStreamPipeline",
+    "TradesStreamPipeline",
+]

--- a/streams/base.py
+++ b/streams/base.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Generic, Optional, TypeVar
+
+from data.exchanges import ResyncReason, StreamBuffer, StreamEvent
+
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class AlarmThresholds:
+    """Defines queue backlog thresholds for warning and critical states."""
+
+    warning: int
+    critical: int
+
+
+class FallbackMode(str, Enum):
+    """Fallback strategy when the pipeline becomes overloaded."""
+
+    AGGREGATE = "aggregate"
+    SKIP = "skip"
+
+
+@dataclass(frozen=True)
+class PipelineHealth:
+    """Snapshot of the pipeline health and mitigation state."""
+
+    backlog: int
+    capacity: int
+    is_degraded: bool
+    fallback_mode: FallbackMode
+    aggregated_events: int
+    skipped_events: int
+    degraded_since: Optional[float]
+
+
+class StreamPipeline(Generic[T]):
+    """Wraps a :class:`StreamBuffer` with overload mitigation helpers."""
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        buffer: StreamBuffer[T],
+        thresholds: AlarmThresholds,
+        fallback_mode: FallbackMode,
+        aggregator: Optional[Callable[[T, T], T]] = None,
+        degradation_hold_s: float = 30.0,
+        chronic_error_threshold: int = 3,
+        chronic_error_window_s: float = 30.0,
+        on_chronic_error: Optional[Callable[[ResyncReason, str], None]] = None,
+    ) -> None:
+        self._name = name
+        self._buffer = buffer
+        self._thresholds = thresholds
+        self._fallback_mode = fallback_mode
+        self._aggregator = aggregator
+        self._pending_aggregate: Optional[T] = None
+        self._aggregated_events = 0
+        self._skipped_events = 0
+        self._degraded_since: Optional[float] = None
+        self._degradation_hold_s = max(float(degradation_hold_s), 0.0)
+        self._error_timestamps: list[float] = []
+        self._chronic_error_threshold = max(1, int(chronic_error_threshold))
+        self._chronic_error_window_s = max(float(chronic_error_window_s), 0.0)
+        self._on_chronic_error = on_chronic_error
+
+    @property
+    def buffer(self) -> StreamBuffer[T]:
+        return self._buffer
+
+    @property
+    def fallback_mode(self) -> FallbackMode:
+        return self._fallback_mode
+
+    @property
+    def degradation_hold_s(self) -> float:
+        return self._degradation_hold_s
+
+    @property
+    def is_degraded(self) -> bool:
+        if self._degraded_since is None:
+            return False
+        now = time.monotonic()
+        if now - self._degraded_since >= self._degradation_hold_s:
+            return False
+        return True
+
+    def reset(self) -> None:
+        self._pending_aggregate = None
+        self._aggregated_events = 0
+        self._skipped_events = 0
+        self._degraded_since = None
+        self._error_timestamps.clear()
+
+    def push_data(self, payload: T) -> None:
+        backlog = self._buffer.backlog()
+        if backlog >= self._thresholds.critical:
+            self._enter_degraded_state()
+            if self._fallback_mode is FallbackMode.SKIP:
+                self._skipped_events += 1
+                return
+            if self._fallback_mode is FallbackMode.AGGREGATE and self._aggregator is not None:
+                self._aggregate(payload)
+                return
+        elif backlog >= self._thresholds.warning:
+            self._enter_degraded_state()
+            if self._fallback_mode is FallbackMode.AGGREGATE and self._aggregator is not None:
+                self._aggregate(payload)
+                return
+        else:
+            self._flush_pending()
+            self._maybe_expire_degradation()
+        self._buffer.push_data(payload)
+
+    def push_snapshot(self, payload: T) -> None:
+        self._flush_pending()
+        self._maybe_expire_degradation()
+        self._buffer.push_snapshot(payload)
+
+    def push_resync(self, reason: ResyncReason, details: str | None = None) -> None:
+        self._flush_pending()
+        self._enter_degraded_state()
+        self._buffer.push_resync(reason, details)
+        self._record_error(reason, details)
+
+    def next_event(self) -> StreamEvent[T]:
+        event = self._buffer.next()
+        if event.type is not None:
+            backlog = self._buffer.backlog()
+            if backlog < self._thresholds.warning:
+                self._maybe_expire_degradation()
+        return event
+
+    def health_snapshot(self) -> PipelineHealth:
+        return PipelineHealth(
+            backlog=self._buffer.backlog(),
+            capacity=self._buffer.capacity,
+            is_degraded=self.is_degraded,
+            fallback_mode=self._fallback_mode,
+            aggregated_events=self._aggregated_events,
+            skipped_events=self._skipped_events,
+            degraded_since=self._degraded_since,
+        )
+
+    def _aggregate(self, payload: T) -> None:
+        if self._pending_aggregate is None:
+            self._pending_aggregate = payload
+        else:
+            if self._aggregator is None:
+                self._pending_aggregate = payload
+            else:
+                self._pending_aggregate = self._aggregator(self._pending_aggregate, payload)
+        self._aggregated_events += 1
+
+    def _flush_pending(self) -> None:
+        if self._pending_aggregate is None:
+            return
+        aggregated = self._pending_aggregate
+        self._pending_aggregate = None
+        self._buffer.push_data(aggregated)
+
+    def _enter_degraded_state(self) -> None:
+        self._degraded_since = time.monotonic()
+
+    def _maybe_expire_degradation(self) -> None:
+        if self._degraded_since is None:
+            return
+        now = time.monotonic()
+        if now - self._degraded_since >= self._degradation_hold_s:
+            self._degraded_since = None
+
+    def _record_error(self, reason: ResyncReason, details: str | None) -> None:
+        if self._on_chronic_error is None:
+            return
+        now = time.monotonic()
+        self._error_timestamps.append(now)
+        window = self._chronic_error_window_s
+        if window > 0.0:
+            cutoff = now - window
+            self._error_timestamps = [ts for ts in self._error_timestamps if ts >= cutoff]
+        if len(self._error_timestamps) >= self._chronic_error_threshold:
+            try:
+                self._on_chronic_error(reason, details or "chronic stream error")
+            finally:
+                self._error_timestamps.clear()
+
+*** End of File

--- a/streams/depth_pipeline.py
+++ b/streams/depth_pipeline.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from config.models.trading_profile import TradingProfile
+from data.exchanges import StreamBuffer
+from data.exchanges.base import DepthStreamData
+from domain.models import OrderBookSnapshot, OrderBookUpdate
+
+from .base import AlarmThresholds, FallbackMode, StreamPipeline
+
+
+@dataclass(frozen=True)
+class _DepthPipelineProfile:
+    buffer_size: int
+    warning: int
+    critical: int
+    degradation_hold_s: float
+    fallback: FallbackMode
+    chronic_threshold: int
+    chronic_window_s: float
+
+
+_PROFILE_SETTINGS: dict[TradingProfile, _DepthPipelineProfile] = {
+    TradingProfile.TOP: _DepthPipelineProfile(
+        buffer_size=640,
+        warning=160,
+        critical=320,
+        degradation_hold_s=20.0,
+        fallback=FallbackMode.AGGREGATE,
+        chronic_threshold=3,
+        chronic_window_s=20.0,
+    ),
+    TradingProfile.ALT: _DepthPipelineProfile(
+        buffer_size=768,
+        warning=256,
+        critical=448,
+        degradation_hold_s=40.0,
+        fallback=FallbackMode.AGGREGATE,
+        chronic_threshold=4,
+        chronic_window_s=30.0,
+    ),
+    TradingProfile.LISTING: _DepthPipelineProfile(
+        buffer_size=896,
+        warning=384,
+        critical=640,
+        degradation_hold_s=60.0,
+        fallback=FallbackMode.AGGREGATE,
+        chronic_threshold=5,
+        chronic_window_s=45.0,
+    ),
+    TradingProfile.AUTO: _DepthPipelineProfile(
+        buffer_size=768,
+        warning=240,
+        critical=448,
+        degradation_hold_s=30.0,
+        fallback=FallbackMode.AGGREGATE,
+        chronic_threshold=4,
+        chronic_window_s=30.0,
+    ),
+}
+
+
+class DepthStreamPipeline(StreamPipeline[DepthStreamData]):
+    @classmethod
+    def buffer_size(cls, profile: TradingProfile) -> int:
+        return _PROFILE_SETTINGS.get(profile, _PROFILE_SETTINGS[TradingProfile.AUTO]).buffer_size
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        buffer: StreamBuffer[DepthStreamData],
+        profile: TradingProfile,
+        on_chronic_error,
+    ) -> None:
+        settings = _PROFILE_SETTINGS.get(profile, _PROFILE_SETTINGS[TradingProfile.AUTO])
+        super().__init__(
+            name=name,
+            buffer=buffer,
+            thresholds=AlarmThresholds(settings.warning, settings.critical),
+            fallback_mode=settings.fallback,
+            aggregator=self._aggregate,
+            degradation_hold_s=settings.degradation_hold_s,
+            chronic_error_threshold=settings.chronic_threshold,
+            chronic_error_window_s=settings.chronic_window_s,
+            on_chronic_error=on_chronic_error,
+        )
+
+    @staticmethod
+    def _aggregate(current: DepthStreamData, incoming: DepthStreamData) -> DepthStreamData:
+        if isinstance(current, OrderBookUpdate) and isinstance(incoming, OrderBookUpdate):
+            first_id = min(current.first_update_id, incoming.first_update_id)
+            last_id = max(current.last_update_id, incoming.last_update_id)
+            return OrderBookUpdate(
+                exchange=incoming.exchange,
+                symbol=incoming.symbol,
+                first_update_id=first_id,
+                last_update_id=last_id,
+                bids=incoming.bids,
+                asks=incoming.asks,
+                event_time=incoming.event_time,
+            )
+        if isinstance(incoming, OrderBookSnapshot):
+            return incoming
+        return incoming
+
+*** End of File

--- a/streams/ticker_pipeline.py
+++ b/streams/ticker_pipeline.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from config.models.trading_profile import TradingProfile
+from data.exchanges import StreamBuffer
+from data.exchanges.base import BestBidAsk
+
+from .base import AlarmThresholds, FallbackMode, StreamPipeline
+
+
+@dataclass(frozen=True)
+class _TickerPipelineProfile:
+    buffer_size: int
+    warning: int
+    critical: int
+    degradation_hold_s: float
+    fallback: FallbackMode
+    chronic_threshold: int
+    chronic_window_s: float
+
+
+_PROFILE_SETTINGS: dict[TradingProfile, _TickerPipelineProfile] = {
+    TradingProfile.TOP: _TickerPipelineProfile(
+        buffer_size=512,
+        warning=128,
+        critical=240,
+        degradation_hold_s=20.0,
+        fallback=FallbackMode.AGGREGATE,
+        chronic_threshold=3,
+        chronic_window_s=20.0,
+    ),
+    TradingProfile.ALT: _TickerPipelineProfile(
+        buffer_size=640,
+        warning=192,
+        critical=320,
+        degradation_hold_s=35.0,
+        fallback=FallbackMode.AGGREGATE,
+        chronic_threshold=4,
+        chronic_window_s=30.0,
+    ),
+    TradingProfile.LISTING: _TickerPipelineProfile(
+        buffer_size=768,
+        warning=256,
+        critical=384,
+        degradation_hold_s=45.0,
+        fallback=FallbackMode.AGGREGATE,
+        chronic_threshold=5,
+        chronic_window_s=45.0,
+    ),
+    TradingProfile.AUTO: _TickerPipelineProfile(
+        buffer_size=640,
+        warning=192,
+        critical=320,
+        degradation_hold_s=30.0,
+        fallback=FallbackMode.AGGREGATE,
+        chronic_threshold=4,
+        chronic_window_s=30.0,
+    ),
+}
+
+
+class BookTickerStreamPipeline(StreamPipeline[BestBidAsk]):
+    @classmethod
+    def buffer_size(cls, profile: TradingProfile) -> int:
+        return _PROFILE_SETTINGS.get(profile, _PROFILE_SETTINGS[TradingProfile.AUTO]).buffer_size
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        buffer: StreamBuffer[BestBidAsk],
+        profile: TradingProfile,
+        on_chronic_error,
+    ) -> None:
+        settings = _PROFILE_SETTINGS.get(profile, _PROFILE_SETTINGS[TradingProfile.AUTO])
+        super().__init__(
+            name=name,
+            buffer=buffer,
+            thresholds=AlarmThresholds(settings.warning, settings.critical),
+            fallback_mode=settings.fallback,
+            aggregator=self._aggregate,
+            degradation_hold_s=settings.degradation_hold_s,
+            chronic_error_threshold=settings.chronic_threshold,
+            chronic_error_window_s=settings.chronic_window_s,
+            on_chronic_error=on_chronic_error,
+        )
+
+    @staticmethod
+    def _aggregate(current: BestBidAsk, incoming: BestBidAsk) -> BestBidAsk:
+        return BestBidAsk(
+            exchange=incoming.exchange,
+            symbol=incoming.symbol,
+            bid_price=incoming.bid_price,
+            bid_quantity=incoming.bid_quantity,
+            ask_price=incoming.ask_price,
+            ask_quantity=incoming.ask_quantity,
+            event_time=incoming.event_time,
+        )
+
+*** End of File

--- a/streams/trades_pipeline.py
+++ b/streams/trades_pipeline.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from config.models.trading_profile import TradingProfile
+from data.exchanges import StreamBuffer
+from domain.models import Trade
+
+from .base import AlarmThresholds, FallbackMode, StreamPipeline
+
+
+@dataclass(frozen=True)
+class _TradePipelineProfile:
+    buffer_size: int
+    warning: int
+    critical: int
+    degradation_hold_s: float
+    fallback: FallbackMode
+    chronic_threshold: int
+    chronic_window_s: float
+
+
+_PROFILE_SETTINGS: dict[TradingProfile, _TradePipelineProfile] = {
+    TradingProfile.TOP: _TradePipelineProfile(
+        buffer_size=512,
+        warning=120,
+        critical=240,
+        degradation_hold_s=20.0,
+        fallback=FallbackMode.AGGREGATE,
+        chronic_threshold=3,
+        chronic_window_s=20.0,
+    ),
+    TradingProfile.ALT: _TradePipelineProfile(
+        buffer_size=640,
+        warning=200,
+        critical=320,
+        degradation_hold_s=35.0,
+        fallback=FallbackMode.AGGREGATE,
+        chronic_threshold=4,
+        chronic_window_s=30.0,
+    ),
+    TradingProfile.LISTING: _TradePipelineProfile(
+        buffer_size=768,
+        warning=256,
+        critical=384,
+        degradation_hold_s=50.0,
+        fallback=FallbackMode.SKIP,
+        chronic_threshold=5,
+        chronic_window_s=45.0,
+    ),
+    TradingProfile.AUTO: _TradePipelineProfile(
+        buffer_size=640,
+        warning=200,
+        critical=320,
+        degradation_hold_s=30.0,
+        fallback=FallbackMode.AGGREGATE,
+        chronic_threshold=4,
+        chronic_window_s=30.0,
+    ),
+}
+
+
+class TradesStreamPipeline(StreamPipeline[Trade]):
+    @classmethod
+    def buffer_size(cls, profile: TradingProfile) -> int:
+        return _PROFILE_SETTINGS.get(profile, _PROFILE_SETTINGS[TradingProfile.AUTO]).buffer_size
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        buffer: StreamBuffer[Trade],
+        profile: TradingProfile,
+        on_chronic_error,
+    ) -> None:
+        settings = _PROFILE_SETTINGS.get(profile, _PROFILE_SETTINGS[TradingProfile.AUTO])
+        super().__init__(
+            name=name,
+            buffer=buffer,
+            thresholds=AlarmThresholds(settings.warning, settings.critical),
+            fallback_mode=settings.fallback,
+            aggregator=self._aggregate if settings.fallback is FallbackMode.AGGREGATE else None,
+            degradation_hold_s=settings.degradation_hold_s,
+            chronic_error_threshold=settings.chronic_threshold,
+            chronic_error_window_s=settings.chronic_window_s,
+            on_chronic_error=on_chronic_error,
+        )
+
+    @staticmethod
+    def _aggregate(current: Trade, incoming: Trade) -> Trade:
+        return Trade(
+            trade_id=incoming.trade_id,
+            exchange=incoming.exchange,
+            symbol=incoming.symbol,
+            executed_at=incoming.executed_at,
+            price=incoming.price,
+            quantity=incoming.quantity,
+            side=incoming.side,
+        )
+
+*** End of File


### PR DESCRIPTION
## Summary
- add stream pipeline classes with drop-oldest buffers, thresholds, and fallback modes
- integrate Binance stream management with the pipelines and migrate symbols on chronic errors
- surface degradation signals to the runtime, scanner, and strategy so trading reacts to impaired feeds

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea6e9cdb5c83208fe2bae199625d3e