### PR TITLE
Add resync coordinator and integrate Binance recovery

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from threading import Lock
 from typing import Any, Deque, Dict, Iterable, Optional, Sequence, Tuple, cast
 
 from application import FeedMonitor, GUARDS
+from application.resync_coordinator import ResyncCoordinator
 from application.stream_pump import StreamPump
 from application.market_scanner import MarketScanner
 from config.config import CONFIG
@@ -35,6 +36,7 @@ from data.exchanges.binance_trade import BinanceAPIError
 from data.exchanges.bybit_trade import BybitAPIError
 from data.logger import LogSink, create_log_writer, create_text_log_sink
 from data.telegram import TelegramClient
+from state.resync_registry import ResyncStatus
 from domain.book import OrderBook
 from domain.detectors import check_if_has_near_wall, check_if_has_opposite_wall, compute_odr
 from domain.execution import create_execution_handlers, initialize_account
@@ -288,6 +290,14 @@ class Application:
             resync=self._handle_resync,
             safety=self._kill_switch,
         )
+        self._resync_lock = Lock()
+        self._resync_alerts: Deque[Tuple[ResyncStatus, str]] = deque()
+        self._resync_quarantine: Deque[str] = deque()
+        self._resync_quarantine_pending: set[str] = set()
+        self._resync_coordinator = ResyncCoordinator(
+            monitor_callback=self._handle_resync_alert,
+            quarantine_callback=self._schedule_resync_quarantine,
+        )
 
     @staticmethod
     def _exchange_credentials() -> tuple[str | None, str | None]:
@@ -314,6 +324,7 @@ class Application:
                 api_key=api_key,
                 api_secret=api_secret,
                 profile=profile,
+                resync_coordinator=self._resync_coordinator,
             )
         if CONFIG.general.exchange is ExchangeName.BYBIT:
             return BybitExchangeData(
@@ -424,6 +435,40 @@ class Application:
 
     def _send_telegram(self, message: str) -> None:
         self._telegram_client.send_message(message)
+
+    def _handle_resync_alert(self, status: ResyncStatus, message: str) -> None:
+        with self._resync_lock:
+            self._resync_alerts.append((status, message))
+
+    def _schedule_resync_quarantine(self, symbol: str) -> None:
+        with self._resync_lock:
+            if symbol in self._resync_quarantine_pending:
+                return
+            self._resync_quarantine_pending.add(symbol)
+            self._resync_quarantine.append(symbol)
+
+    def _drain_resync_notifications(self) -> None:
+        alerts: list[Tuple[ResyncStatus, str]] = []
+        quarantine: list[str] = []
+        with self._resync_lock:
+            while self._resync_alerts:
+                alerts.append(self._resync_alerts.popleft())
+            while self._resync_quarantine:
+                symbol = self._resync_quarantine.popleft()
+                self._resync_quarantine_pending.discard(symbol)
+                quarantine.append(symbol)
+        for status, message in alerts:
+            timestamp = get_current_time()
+            self._event_logger.log(message, timestamp)
+            self._send_telegram(message)
+        for symbol in quarantine:
+            if symbol not in self._contexts:
+                continue
+            self._event_logger.log(
+                f"{symbol}: символ выведен из торгов из-за зависшего восстановления.",
+                get_current_time(),
+            )
+            self._unsubscribe_symbol(symbol)
 
     def _handle_resync(self, reason: StrategyResyncReason) -> None:
         symbol = self._current_symbol
@@ -1186,7 +1231,9 @@ class Application:
         self._refresh_balances(force=True)
         startup_timestamp = get_current_time()
         self._subscription_manager.activate_pending(startup_timestamp)
+        self._drain_resync_notifications()
         while True:
+            self._drain_resync_notifications()
             self._refresh_symbol_scan()
             activation_timestamp = get_current_time()
             self._subscription_manager.activate_pending(activation_timestamp)

--- a/application/resync_coordinator.py
+++ b/application/resync_coordinator.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import queue
+import threading
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Callable, Optional, Sequence
+
+from data.exchanges import ResyncReason
+from domain.models import OrderBookSnapshot
+from state.resync_registry import ResyncRegistry, ResyncStatus
+from utils.timez import get_current_time
+
+
+DepthMessage = dict[str, object]
+SnapshotFetcher = Callable[[], OrderBookSnapshot]
+SnapshotApplier = Callable[[OrderBookSnapshot], Sequence[DepthMessage]]
+DeltaReplayer = Callable[[Sequence[DepthMessage]], None]
+Validator = Callable[[], bool]
+FailureCallback = Callable[[Exception], None]
+SuccessCallback = Callable[[], None]
+MonitorCallback = Callable[[ResyncStatus, str], None]
+QuarantineCallback = Callable[[str], None]
+
+
+@dataclass(frozen=True)
+class ResyncTask:
+    symbol: str
+    reason: ResyncReason
+    fetch_snapshot: SnapshotFetcher
+    apply_snapshot: SnapshotApplier
+    replay_delta: DeltaReplayer
+    validate: Validator
+    on_failure: Optional[FailureCallback] = None
+    on_success: Optional[SuccessCallback] = None
+
+
+class ResyncCoordinator:
+    """Coordinates snapshot → replay → validate phases with bounded concurrency."""
+
+    def __init__(
+        self,
+        *,
+        max_parallel_rest: int = 2,
+        registry: Optional[ResyncRegistry] = None,
+        health_timeout: timedelta = timedelta(minutes=5),
+        health_check_interval: timedelta = timedelta(seconds=30),
+        monitor_callback: Optional[MonitorCallback] = None,
+        quarantine_callback: Optional[QuarantineCallback] = None,
+    ) -> None:
+        self._max_parallel_rest = max(1, int(max_parallel_rest))
+        self._registry = registry or ResyncRegistry()
+        self._monitor_callback = monitor_callback
+        self._quarantine_callback = quarantine_callback
+        self._health_timeout = health_timeout
+        self._health_interval = max(float(health_check_interval.total_seconds()), 1.0)
+
+        self._queue: "queue.Queue[ResyncTask | None]" = queue.Queue()
+        self._pending: set[str] = set()
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._workers = [
+            threading.Thread(target=self._worker_loop, name=f"resync-worker-{i}", daemon=True)
+            for i in range(self._max_parallel_rest)
+        ]
+        self._health_thread = threading.Thread(
+            target=self._health_loop,
+            name="resync-health",
+            daemon=True,
+        )
+
+        for worker in self._workers:
+            worker.start()
+        self._health_thread.start()
+
+    @property
+    def registry(self) -> ResyncRegistry:
+        return self._registry
+
+    def submit(self, task: ResyncTask) -> bool:
+        """Submits a new resync task unless it is already pending."""
+
+        with self._lock:
+            if task.symbol in self._pending:
+                return False
+            self._pending.add(task.symbol)
+            self._queue.put(task)
+            return True
+
+    def stop(self) -> None:
+        """Stops all worker threads."""
+
+        self._stop_event.set()
+        for _ in self._workers:
+            self._queue.put(None)
+        for worker in self._workers:
+            worker.join(timeout=1.0)
+        self._health_thread.join(timeout=1.0)
+
+    def _worker_loop(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                task = self._queue.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            if task is None:
+                break
+            self._execute_task(task)
+
+    def _execute_task(self, task: ResyncTask) -> None:
+        symbol = task.symbol
+        worker_id = threading.current_thread().name
+        now = get_current_time()
+        self._registry.record_start(symbol, worker_id, now)
+        try:
+            snapshot = task.fetch_snapshot()
+            pending = task.apply_snapshot(snapshot)
+            task.replay_delta(pending)
+            if not task.validate():
+                raise RuntimeError(f"validation failed for {symbol}")
+        except Exception as exc:  # noqa: BLE001
+            self._registry.record_failure(symbol, get_current_time(), str(exc), worker_id=worker_id)
+            if task.on_failure is not None:
+                try:
+                    task.on_failure(exc)
+                except Exception:
+                    pass
+        else:
+            self._registry.record_success(symbol, get_current_time())
+            if task.on_success is not None:
+                try:
+                    task.on_success()
+                except Exception:
+                    pass
+        finally:
+            with self._lock:
+                self._pending.discard(symbol)
+
+    def _health_loop(self) -> None:
+        while not self._stop_event.wait(self._health_interval):
+            self.perform_health_check()
+
+    def perform_health_check(self) -> Sequence[ResyncStatus]:
+        now = get_current_time()
+        stalled = tuple(self._registry.stalled(self._health_timeout, now))
+        if not stalled:
+            return stalled
+        for status in stalled:
+            message = (
+                f"Resync stalled for {status.symbol}: attempts={status.attempts}, "
+                f"worker={status.worker_id}, started_at={status.started_at}"
+            )
+            if self._monitor_callback is not None:
+                try:
+                    self._monitor_callback(status, message)
+                except Exception:
+                    pass
+            if self._quarantine_callback is not None:
+                try:
+                    self._quarantine_callback(status.symbol)
+                except Exception:
+                    pass
+        return stalled
+
+
+__all__ = ["ResyncCoordinator", "ResyncTask"]

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -7,11 +7,12 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from http.client import RemoteDisconnected
-from typing import Any, Callable, ClassVar, Iterable, Iterator, Optional, cast
+from typing import Any, Callable, ClassVar, Iterable, Iterator, Optional, Sequence, cast
 from urllib import parse
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from application.resync_coordinator import ResyncCoordinator, ResyncTask
 from config.models.trading_profile import TradingProfile
 from config.stream_limits import DEFAULT_BINANCE_STREAM_PROFILES
 from domain.models import (
@@ -44,7 +45,50 @@ from streams import (
 )
 
 
+DepthMessage = dict[str, Any]
+DeltaHandler = Callable[[DepthMessage], None]
 WebSocketClient = ThreadedWebSocketClient
+
+
+def fetch_snapshot(
+    *,
+    rest_get: Callable[[str, dict[str, Any]], Any],
+    symbol: str,
+    depth_limit: int,
+    level_builder: Callable[[float, float, datetime], OrderBookLevel],
+    now_provider: Callable[[], datetime] = get_current_time,
+) -> OrderBookSnapshot:
+    data = rest_get("/fapi/v1/depth", {"symbol": symbol, "limit": depth_limit})
+    last_update_id = int(data["lastUpdateId"])
+    now = now_provider()
+    bids = tuple(
+        level_builder(float(price), float(qty), now) for price, qty in data.get("bids", [])
+    )
+    asks = tuple(
+        level_builder(float(price), float(qty), now) for price, qty in data.get("asks", [])
+    )
+    return OrderBookSnapshot(
+        exchange=Exchange.BINANCE,
+        symbol=symbol,
+        last_update_id=last_update_id,
+        bids=bids,
+        asks=asks,
+        received_at=now,
+    )
+
+
+def apply_snapshot(
+    *, pipeline: DepthStreamPipeline, snapshot: OrderBookSnapshot
+) -> None:
+    pipeline.reset()
+    pipeline.push_snapshot(snapshot)
+
+
+def replay_delta(
+    messages: Sequence[DepthMessage], handler: DeltaHandler
+) -> None:
+    for message in messages:
+        handler(message)
 
 
 @dataclass(slots=True)
@@ -109,6 +153,7 @@ class BinanceExchangeData:
         api_secret: Optional[str] = None,
         silence_timeout_ms: float | None = None,
         profile: TradingProfile | None = None,
+        resync_coordinator: ResyncCoordinator | None = None,
     ) -> None:
         self.symbol = symbol.upper()
         self._endpoints = endpoints or BinanceEndpoints()
@@ -182,6 +227,7 @@ class BinanceExchangeData:
         self._depth_pipeline: Optional[DepthStreamPipeline] = None
         self._trades_pipeline: Optional[TradesStreamPipeline] = None
         self._ticker_pipeline: Optional[BookTickerStreamPipeline] = None
+        self._resync_coordinator = resync_coordinator
 
     def _normalize_depth_stream_interval(self, interval_ms: int) -> int:
         default_interval = 250
@@ -399,29 +445,12 @@ class BinanceExchangeData:
         )
 
     def fetch_orderbook_snapshot(self) -> OrderBookSnapshot:
-        data = self._rest_get(
-            "/fapi/v1/depth",
-            {"symbol": self.symbol, "limit": self._depth_limit},
-        )
-        last_update_id = int(data["lastUpdateId"])
-        now = get_current_time()
-        bids = tuple(
-            self._build_level(float(price), float(qty), now)
-            for price, qty in data.get("bids", [])
-        )
-        asks = tuple(
-            self._build_level(float(price), float(qty), now)
-            for price, qty in data.get("asks", [])
-        )
-        snapshot = OrderBookSnapshot(
-            exchange=Exchange.BINANCE,
+        return fetch_snapshot(
+            rest_get=self._rest_get,
             symbol=self.symbol,
-            last_update_id=last_update_id,
-            bids=bids,
-            asks=asks,
-            received_at=now,
+            depth_limit=self._depth_limit,
+            level_builder=self._build_level,
         )
-        return snapshot
 
     def fetch_next_funding_time(self) -> Optional[datetime]:
         response = self._rest_get(
@@ -601,15 +630,94 @@ class BinanceExchangeData:
         self._logger.log_resync(reason, details)
         pipeline.push_resync(reason, details)
         self._reset_depth_state()
+        coordinator = self._resync_coordinator
+        if coordinator is not None:
+            task = self._build_depth_resync_task(pipeline, reason, details)
+            if coordinator.submit(task):
+                return
+            self._logger.log(
+                (
+                    "Binance depth stream {symbol}: восстановление уже в обработке"
+                ).format(symbol=self.symbol)
+            )
+            return
         try:
             snapshot = self.fetch_orderbook_snapshot()
         except Exception as exc:  # noqa: BLE001
-            pipeline.push_resync(
-                ResyncReason.CONNECTION_LOST,
-                details=f"Ошибка получения снапшота: {exc}",
-            )
+            message = f"Ошибка получения снапшота: {exc}"
+            pipeline.push_resync(ResyncReason.CONNECTION_LOST, details=message)
+            self._logger.log_resync(ResyncReason.CONNECTION_LOST, message)
             return
         self._apply_depth_snapshot(snapshot, pipeline)
+
+    def _build_depth_resync_task(
+        self,
+        pipeline: DepthStreamPipeline,
+        reason: ResyncReason,
+        details: str,
+    ) -> ResyncTask:
+        symbol = self.symbol
+
+        def fetch() -> OrderBookSnapshot:
+            return fetch_snapshot(
+                rest_get=self._rest_get,
+                symbol=symbol,
+                depth_limit=self._depth_limit,
+                level_builder=self._build_level,
+            )
+
+        def apply(snapshot: OrderBookSnapshot) -> Sequence[DepthMessage]:
+            with self._lock:
+                self._depth_last_update = snapshot.last_update_id
+                self._depth_allow_skip = True
+                pending = tuple(self._depth_buffered_messages)
+                self._depth_buffered_messages.clear()
+            apply_snapshot(pipeline=pipeline, snapshot=snapshot)
+            return pending
+
+        def replay(pending: Sequence[DepthMessage]) -> None:
+            replay_delta(
+                pending,
+                lambda message: self._handle_depth_message(
+                    message,
+                    pipeline,
+                    buffer_if_uninitialized=False,
+                    allow_skip=True,
+                ),
+            )
+
+        def validate() -> bool:
+            with self._lock:
+                return self._depth_last_update is not None
+
+        def on_failure(exc: Exception) -> None:
+            message = (
+                f"Binance depth stream {symbol}: не удалось восстановить ({details}): {exc}"
+            )
+            pipeline.push_resync(ResyncReason.CONNECTION_LOST, details=message)
+            self._logger.log_resync(ResyncReason.CONNECTION_LOST, message)
+            self._reset_depth_state()
+
+        def on_success() -> None:
+            with self._lock:
+                update_id = self._depth_last_update
+            self._logger.log(
+                (
+                    "Binance depth stream {symbol}: восстановление завершено, "
+                    "ID {update_id}"
+                ).format(symbol=symbol, update_id=update_id)
+            )
+
+        return ResyncTask(
+            symbol=symbol,
+            reason=reason,
+            fetch_snapshot=fetch,
+            apply_snapshot=apply,
+            replay_delta=replay,
+            validate=validate,
+            on_failure=on_failure,
+            on_success=on_success,
+        )
 
     def _reset_depth_state(self) -> None:
         with self._lock:
@@ -626,16 +734,16 @@ class BinanceExchangeData:
             pending = tuple(self._depth_buffered_messages)
             self._depth_buffered_messages.clear()
 
-        pipeline.reset()
-        pipeline.push_snapshot(snapshot)
-
-        for message in pending:
-            self._handle_depth_message(
+        apply_snapshot(pipeline=pipeline, snapshot=snapshot)
+        replay_delta(
+            pending,
+            lambda message: self._handle_depth_message(
                 message,
                 pipeline,
                 buffer_if_uninitialized=False,
                 allow_skip=True,
-            )
+            ),
+        )
 
     def stream_book_ticker(self) -> StreamSubscription[BestBidAsk]:
         silence_timeout = self._book_ticker_silence_timeout
@@ -1017,4 +1125,4 @@ class BinanceExchangeData:
         )
 
 
-__all__ = ["BinanceExchangeData"]
+__all__ = ["BinanceExchangeData", "fetch_snapshot", "apply_snapshot", "replay_delta"]

--- a/state/resync_registry.py
+++ b/state/resync_registry.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta
+from threading import Lock
+from typing import Dict, Iterable, Optional
+
+
+@dataclass(frozen=True)
+class ResyncStatus:
+    """Represents the recovery status of a trading symbol."""
+
+    symbol: str
+    attempts: int
+    last_success_at: Optional[datetime]
+    last_failure_at: Optional[datetime]
+    last_failure_reason: Optional[str]
+    worker_id: Optional[str]
+    started_at: Optional[datetime]
+
+
+class ResyncRegistry:
+    """Thread-safe registry that keeps track of resync attempts."""
+
+    def __init__(self) -> None:
+        self._records: Dict[str, ResyncStatus] = {}
+        self._lock = Lock()
+
+    def record_start(self, symbol: str, worker_id: str, started_at: datetime) -> ResyncStatus:
+        with self._lock:
+            status = self._records.get(symbol)
+            if status is None:
+                status = ResyncStatus(
+                    symbol=symbol,
+                    attempts=0,
+                    last_success_at=None,
+                    last_failure_at=None,
+                    last_failure_reason=None,
+                    worker_id=None,
+                    started_at=None,
+                )
+            status = replace(
+                status,
+                attempts=status.attempts + 1,
+                worker_id=worker_id,
+                started_at=started_at,
+            )
+            self._records[symbol] = status
+            return status
+
+    def record_success(self, symbol: str, completed_at: datetime) -> ResyncStatus:
+        with self._lock:
+            status = self._records.get(symbol)
+            if status is None:
+                status = ResyncStatus(
+                    symbol=symbol,
+                    attempts=0,
+                    last_success_at=completed_at,
+                    last_failure_at=None,
+                    last_failure_reason=None,
+                    worker_id=None,
+                    started_at=None,
+                )
+            else:
+                status = replace(
+                    status,
+                    last_success_at=completed_at,
+                    last_failure_at=None,
+                    last_failure_reason=None,
+                    worker_id=None,
+                    started_at=None,
+                )
+            self._records[symbol] = status
+            return status
+
+    def record_failure(
+        self, symbol: str, failure_at: datetime, reason: str, *, worker_id: Optional[str] = None
+    ) -> ResyncStatus:
+        with self._lock:
+            status = self._records.get(symbol)
+            if status is None:
+                status = ResyncStatus(
+                    symbol=symbol,
+                    attempts=1,
+                    last_success_at=None,
+                    last_failure_at=failure_at,
+                    last_failure_reason=reason,
+                    worker_id=worker_id,
+                    started_at=None,
+                )
+            else:
+                status = replace(
+                    status,
+                    last_failure_at=failure_at,
+                    last_failure_reason=reason,
+                    worker_id=worker_id if worker_id is not None else status.worker_id,
+                    started_at=None,
+                )
+            self._records[symbol] = status
+            return status
+
+    def status(self, symbol: str) -> Optional[ResyncStatus]:
+        with self._lock:
+            status = self._records.get(symbol)
+            return None if status is None else replace(status)
+
+    def all_statuses(self) -> Iterable[ResyncStatus]:
+        with self._lock:
+            return [replace(status) for status in self._records.values()]
+
+    def stalled(self, timeout: timedelta, now: datetime) -> Iterable[ResyncStatus]:
+        with self._lock:
+            result = []
+            for status in self._records.values():
+                started_at = status.started_at
+                if started_at is None:
+                    continue
+                if now - started_at >= timeout:
+                    result.append(replace(status))
+            return result
+
+
+__all__ = ["ResyncRegistry", "ResyncStatus"]


### PR DESCRIPTION
## Summary
- add an application-level resync coordinator service to orchestrate snapshot/replay/validate phases with bounded REST concurrency and health monitoring
- introduce a resync registry to persist attempt metadata for monitoring and health checks
- refactor Binance depth recovery logic to share pure snapshot/replay helpers and schedule resyncs through the coordinator, wiring the coordinator into the application loop for alerts and symbol quarantine

## Testing
- python -m compileall app.py application/resync_coordinator.py state/resync_registry.py data/exchanges/binance.py

------
https://chatgpt.com/codex/tasks/task_e_68ea922c00488320bfacc55ed784267a