### PR TITLE
Make JSON metrics logging optional

### DIFF
--- a/app.py
+++ b/app.py
@@ -228,7 +228,7 @@ class Application:
         METRICS.configure(
             enabled=metrics_settings.enabled,
             prometheus_port=metrics_settings.prometheus_port if metrics_settings.enabled else None,
-            json_sink=self._sink,
+            json_sink=self._sink if metrics_settings.emit_json_logs else None,
             thresholds=thresholds,
             daily_report_hour=metrics_settings.daily_report_hour_utc,
         )

--- a/config/config.py
+++ b/config/config.py
@@ -105,6 +105,7 @@ CONFIG: Final[Config] = Config(
         resubscribe_window_minutes=5,
         silence_timeout_minutes=6,
         backpressure_ratio_threshold=0.75,
+        emit_json_logs=False,
     ),
     admin=AdminSettings(
         host="127.0.0.1",

--- a/config/models/metrics_settings.py
+++ b/config/models/metrics_settings.py
@@ -10,6 +10,6 @@ class MetricsSettings:
     resubscribe_window_minutes: int = 5
     silence_timeout_minutes: int = 5
     backpressure_ratio_threshold: float = 0.7
-
+    emit_json_logs: bool = False
 
 __all__ = ["MetricsSettings"]

--- a/docs/streaming_alert_runbook.md
+++ b/docs/streaming_alert_runbook.md
@@ -10,7 +10,7 @@
   * `stream_queue_backlog` и `stream_queue_ratio` (labels: `stream`, `symbol`).
   * `stream_migrations_total` — общее количество миграций потоков.
   * `stream_resync_duration_seconds` (labels: `symbol`, `reason`, `success`).
-* **JSON-логи** — каждая метрика дублируется в stdout в виде JSON-объекта. Дополнительно пишутся события `ALERT` с типами `high_resubscribe_ratio`, `extended_silence`, `backpressure` и `silence_recovered`.
+* **JSON-логи (если включены `CONFIG.metrics.emit_json_logs`)** — каждая метрика дублируется в stdout в виде JSON-объекта. Дополнительно пишутся события `ALERT` с типами `high_resubscribe_ratio`, `extended_silence`, `backpressure` и `silence_recovered`.
 * **Ежедневный отчёт** (`report=daily_metrics`) — собирает агрегаты по латентности команд, длительности ресинков, пикам очередей и миграциям.
 
 ## SLA-алерты и реакция
@@ -18,7 +18,7 @@
 ### 1. Высокая доля переподписок (`alert=high_resubscribe_ratio`)
 * **Триггер:** отношение количества `resubscribe` к `subscribe` за окно `METRICS.resubscribe_window_minutes` (по умолчанию 5 минут) превышает `CONFIG.metrics.resubscribe_ratio_threshold`.
 * **Действия:**
-  1. Проверить JSON-логи и Prometheus, убедиться, что в `stream_command_latency_seconds` нет всплеска ошибок.
+  1. Проверить Prometheus и (если включены) JSON-логи, убедиться, что в `stream_command_latency_seconds` нет всплеска ошибок.
   2. Через CLI `stream_admin.py status` оценить деградацию очередей и ручных пауз.
   3. При необходимости принудительно выполнить `stream_admin.py migrate SYMBOL --stream depth` (или другой стрим), чтобы перераспределить нагрузку.
   4. Зафиксировать инцидент и, если всплеск связан с конкретным профилем, скорректировать лимиты в `config/stream_limits.py` после анализа дневного отчёта.
@@ -56,4 +56,4 @@
 ## Контакты и эскалация
 
 * При повторяющихся проблемах миграции — эскалировать в команду инфраструктуры стриминга.
-* При аномалиях в Prometheus/JSON-логах, не отражённых в приложении, уведомить владельцев мониторинга.
+* При аномалиях в Prometheus или (при включённых логах) JSON-логах, не отражённых в приложении, уведомить владельцев мониторинга.


### PR DESCRIPTION
## Summary
- add a configuration flag to toggle JSON metrics logging and thread it through the default config
- conditionally attach the application log sink to the metrics subsystem
- update the streaming alert runbook to describe the optional JSON log output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea9d3e965083208a5520ba35e3501b