### PR TITLE
Add exchange data scaffolding for Binance integration

### DIFF
--- a/config/stream_limits.json
+++ b/config/stream_limits.json
@@ -1,0 +1,20 @@
+{
+  "depth": {
+    "steady_per_min": 1200,
+    "burst_per_5s": 300,
+    "max_symbols": 200,
+    "resubscribe_buffer": 20
+  },
+  "trades": {
+    "steady_per_min": 1200,
+    "burst_per_5s": 300,
+    "max_symbols": 200,
+    "resubscribe_buffer": 20
+  },
+  "book_ticker": {
+    "steady_per_min": 1200,
+    "burst_per_5s": 300,
+    "max_symbols": 200,
+    "resubscribe_buffer": 20
+  }
+}

--- a/data/exchanges/__init__.py
+++ b/data/exchanges/__init__.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional, Protocol
+
+from config.timezone import CURRENT_TIMEZONE
+from data.logger import LogSink
+from domain.models import (
+    BalanceSource,
+    Exchange,
+    ExecutionReport,
+    MarginMode,
+    Side,
+    OrderBookSnapshot,
+    OrderBookUpdate,
+    StopTrigger,
+    SymbolFilters,
+    Trade,
+)
+
+from .binance import BestBidAsk, BinanceExchangeData, DepthStreamData, StreamSubscription
+from .events import ResyncReason, StreamEvent, StreamEventType
+from .stream_buffer import StreamBuffer
+
+
+@dataclass(slots=True)
+class ExchangeLogger:
+    sink: LogSink
+
+    def log(self, message: str) -> None:
+        timestamp = datetime.now(tz=CURRENT_TIMEZONE)
+        formatted = f"{timestamp:%H:%M:%S} {message}"
+        self.sink(formatted)
+
+
+class IExchangeData(Protocol):
+    def fetch_symbol_filters(self) -> SymbolFilters: ...
+
+    def fetch_orderbook_snapshot(self) -> OrderBookSnapshot: ...
+
+    def fetch_next_funding_time(self) -> Optional[datetime]: ...
+
+    def stream_depth(self) -> StreamSubscription[DepthStreamData]: ...
+
+    def stream_trades(self) -> StreamSubscription[Trade]: ...
+
+    def stream_book_ticker(self) -> StreamSubscription[BestBidAsk]: ...
+
+
+class IExchangeTrade(Protocol):
+    def get_balance(self, source: BalanceSource) -> float: ...
+
+    def set_leverage(self, leverage: int, margin_mode: MarginMode) -> Optional[int]: ...
+
+    def place_market(self, side, quantity, *, reason: Optional[str] = None) -> ExecutionReport: ...
+
+    def place_stop_market(
+        self,
+        side,
+        stop_price: float,
+        quantity: float,
+        trigger: StopTrigger,
+    ) -> None: ...
+
+
+class BinanceTradingAdapter(IExchangeTrade):
+    def __init__(
+        self,
+        *,
+        symbol: str,
+        quote_asset: str,
+        api_key: Optional[str] = None,
+        api_secret: Optional[str] = None,
+    ) -> None:
+        self._symbol = symbol.upper()
+        self._quote_asset = quote_asset
+        self._api_key = api_key
+        self._api_secret = api_secret
+
+    def get_balance(self, source: BalanceSource) -> float:
+        return 0.0
+
+    def set_leverage(self, leverage: int, margin_mode: MarginMode) -> Optional[int]:
+        return leverage
+
+    def place_market(
+        self,
+        side: Side,
+        quantity: float,
+        *,
+        reason: Optional[str] = None,
+    ) -> ExecutionReport:
+        executed_at = datetime.now(tz=CURRENT_TIMEZONE)
+        return ExecutionReport(
+            exchange=Exchange.BINANCE,
+            symbol=self._symbol,
+            order_id="SIMULATED",
+            side=side,
+            price=0.0,
+            quantity=quantity,
+            executed_qty=quantity,
+            status="FILLED",
+            commission=0.0,
+            executed_at=executed_at,
+        )
+
+    def place_stop_market(
+        self,
+        side: Side,
+        stop_price: float,
+        quantity: float,
+        trigger: StopTrigger,
+    ) -> None:
+        return None
+
+
+class BybitExchangeData(IExchangeData):
+    def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+        raise NotImplementedError("Bybit data access is not available")
+
+    def fetch_symbol_filters(self) -> SymbolFilters:
+        raise NotImplementedError
+
+    def fetch_orderbook_snapshot(self) -> OrderBookSnapshot:
+        raise NotImplementedError
+
+    def fetch_next_funding_time(self) -> Optional[datetime]:
+        raise NotImplementedError
+
+    def stream_depth(self) -> StreamSubscription[DepthStreamData]:
+        raise NotImplementedError
+
+    def stream_trades(self) -> StreamSubscription[Trade]:
+        raise NotImplementedError
+
+    def stream_book_ticker(self) -> StreamSubscription[BestBidAsk]:
+        raise NotImplementedError
+
+
+class BybitTradingAdapter(IExchangeTrade):
+    def __init__(
+        self,
+        *,
+        symbol: str,
+        settle_coin: str,
+        api_key: Optional[str] = None,
+        api_secret: Optional[str] = None,
+    ) -> None:
+        self._symbol = symbol.upper()
+        self._settle_coin = settle_coin
+        self._api_key = api_key
+        self._api_secret = api_secret
+
+    def get_balance(self, source: BalanceSource) -> float:
+        return 0.0
+
+    def set_leverage(self, leverage: int, margin_mode: MarginMode) -> Optional[int]:
+        return leverage
+
+    def place_market(
+        self,
+        side: Side,
+        quantity: float,
+        *,
+        reason: Optional[str] = None,
+    ) -> ExecutionReport:
+        executed_at = datetime.now(tz=CURRENT_TIMEZONE)
+        return ExecutionReport(
+            exchange=Exchange.BYBIT,
+            symbol=self._symbol,
+            order_id="SIMULATED",
+            side=side,
+            price=0.0,
+            quantity=quantity,
+            executed_qty=quantity,
+            status="FILLED",
+            commission=0.0,
+            executed_at=executed_at,
+        )
+
+    def place_stop_market(
+        self,
+        side: Side,
+        stop_price: float,
+        quantity: float,
+        trigger: StopTrigger,
+    ) -> None:
+        return None
+
+
+__all__ = [
+    "BestBidAsk",
+    "BinanceExchangeData",
+    "BinanceTradingAdapter",
+    "BybitExchangeData",
+    "BybitTradingAdapter",
+    "DepthStreamData",
+    "ExchangeLogger",
+    "IExchangeData",
+    "IExchangeTrade",
+    "ResyncReason",
+    "StreamBuffer",
+    "StreamEvent",
+    "StreamEventType",
+    "StreamSubscription",
+]
+

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+import math
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Callable, Dict, Generic, Iterator, Optional, TypeVar
+
+from urllib.error import URLError
+from urllib.request import urlopen
+
+from config.timezone import CURRENT_TIMEZONE
+from data.logger import LogSink
+from domain.models import Exchange, OrderBookSnapshot, OrderBookUpdate, SymbolFilters, Trade
+
+from .events import StreamEvent, StreamEventType
+from .limits import StreamLimits, load_stream_limits
+from .stream_buffer import StreamBuffer
+
+
+@dataclass(frozen=True, slots=True)
+class BestBidAsk:
+    bid: float
+    ask: float
+    timestamp: datetime
+
+
+DepthStreamData = OrderBookUpdate | OrderBookSnapshot
+
+T = TypeVar("T")
+
+
+class StreamSubscription(Generic[T]):
+    """A simple subscription wrapper used by the application."""
+
+    __slots__ = ("events", "_buffer", "_stop", "_stopped")
+
+    def __init__(
+        self,
+        events: Iterator[StreamEvent[T]],
+        buffer: StreamBuffer[T],
+        stop_callback: Optional[Callable[[], None]] = None,
+    ) -> None:
+        self.events = events
+        self._buffer = buffer
+        self._stop = stop_callback
+        self._stopped = False
+
+    def stop(self) -> None:
+        if self._stopped:
+            return
+        self._stopped = True
+        if self._stop is not None:
+            self._stop()
+
+
+class BinanceExchangeData:
+    """A pragmatic placeholder implementation of the data interface."""
+
+    PROFILE_WEIGHTS: Dict[str, float] = {
+        "TOP": 1.0,
+        "LISTING": 0.8,
+        "ALT": 0.5,
+        "AUTO": 0.3,
+    }
+
+    def __init__(
+        self,
+        *,
+        symbol: str,
+        loop_interval_ms: int,
+        silence_timeout_ms: int,
+        log_writer: LogSink,
+        api_key: Optional[str] = None,
+        api_secret: Optional[str] = None,
+    ) -> None:
+        self._symbol = symbol.upper()
+        self._loop_interval = max(loop_interval_ms, 100)
+        self._silence_timeout = max(silence_timeout_ms, 1_000)
+        self._log_writer = log_writer
+        self._api_key = api_key
+        self._api_secret = api_secret
+        self._limits: StreamLimits = load_stream_limits()
+        self._exchange_info: Dict[str, Dict[str, object]] = {}
+        self._load_exchange_info()
+
+    # ------------------------------------------------------------------
+    # Interface implementation expected by the application
+    def fetch_symbol_filters(self) -> SymbolFilters:
+        info = self._exchange_info.get(self._symbol)
+        base_asset = self._symbol.replace("USDT", "")
+        quote_asset = "USDT"
+        price_tick = 0.1
+        qty_step = 0.001
+        min_notional = 5.0
+        if info is not None:
+            base_asset = str(info.get("baseAsset", base_asset))
+            quote_asset = str(info.get("quoteAsset", quote_asset))
+            price_tick = float(info.get("tickSize", price_tick))
+            qty_step = float(info.get("stepSize", qty_step))
+            min_notional = float(info.get("notional", min_notional))
+        return SymbolFilters(
+            exchange=Exchange.BINANCE,
+            symbol=self._symbol,
+            base_asset=base_asset,
+            quote_asset=quote_asset,
+            price_tick_size=price_tick,
+            quantity_step_size=qty_step,
+            min_price=0.0,
+            max_price=math.inf,
+            min_qty=qty_step,
+            max_qty=math.inf,
+            min_notional=min_notional,
+        )
+
+    def fetch_orderbook_snapshot(self) -> OrderBookSnapshot:
+        now = datetime.now(tz=CURRENT_TIMEZONE)
+        return OrderBookSnapshot(
+            exchange=Exchange.BINANCE,
+            symbol=self._symbol,
+            last_update_id=0,
+            bids=(),
+            asks=(),
+            received_at=now,
+        )
+
+    def fetch_next_funding_time(self) -> Optional[datetime]:
+        return datetime.now(tz=CURRENT_TIMEZONE) + timedelta(hours=8)
+
+    def stream_depth(self) -> StreamSubscription[DepthStreamData]:
+        buffer: StreamBuffer[DepthStreamData] = StreamBuffer()
+
+        def generator() -> Iterator[StreamEvent[DepthStreamData]]:
+            snapshot = self.fetch_orderbook_snapshot()
+            yield StreamEvent(StreamEventType.SNAPSHOT, snapshot, snapshot.received_at)
+            interval = self._loop_interval / 1000.0
+            while True:
+                pending = buffer.drain_pending()
+                for event in pending:
+                    yield event
+                time.sleep(interval)
+                yield StreamEvent(StreamEventType.DATA, None, datetime.now(tz=CURRENT_TIMEZONE))
+
+        return StreamSubscription(generator(), buffer)
+
+    def stream_trades(self) -> StreamSubscription[Trade]:
+        buffer: StreamBuffer[Trade] = StreamBuffer()
+
+        def generator() -> Iterator[StreamEvent[Trade]]:
+            interval = self._loop_interval / 1000.0
+            while True:
+                pending = buffer.drain_pending()
+                for event in pending:
+                    yield event
+                time.sleep(interval)
+                yield StreamEvent(StreamEventType.DATA, None, datetime.now(tz=CURRENT_TIMEZONE))
+
+        return StreamSubscription(generator(), buffer)
+
+    def stream_book_ticker(self) -> StreamSubscription[BestBidAsk]:
+        buffer: StreamBuffer[BestBidAsk] = StreamBuffer()
+
+        def generator() -> Iterator[StreamEvent[BestBidAsk]]:
+            interval = self._loop_interval / 1000.0
+            while True:
+                pending = buffer.drain_pending()
+                for event in pending:
+                    yield event
+                time.sleep(interval)
+                best = BestBidAsk(0.0, 0.0, datetime.now(tz=CURRENT_TIMEZONE))
+                yield StreamEvent(StreamEventType.DATA, best, best.timestamp)
+
+        return StreamSubscription(generator(), buffer)
+
+    # ------------------------------------------------------------------
+    def _load_exchange_info(self) -> None:
+        url = "https://fapi.binance.com/fapi/v1/exchangeInfo"
+        try:
+            with urlopen(url, timeout=5) as response:  # noqa: S310
+                payload = json.load(response)
+        except (URLError, TimeoutError, ValueError, OSError):
+            self._exchange_info = {}
+            return
+        info: Dict[str, Dict[str, object]] = {}
+        for entry in payload.get("symbols", []):
+            if entry.get("status") != "TRADING":
+                continue
+            name = str(entry.get("symbol"))
+            filters = entry.get("filters", [])
+            price_filter = next((f for f in filters if f.get("filterType") == "PRICE_FILTER"), {})
+            lot_filter = next((f for f in filters if f.get("filterType") == "LOT_SIZE"), {})
+            notional_filter = next(
+                (f for f in filters if f.get("filterType") in {"MIN_NOTIONAL", "MARKET_LOT_SIZE"}),
+                {},
+            )
+            info[name] = {
+                "baseAsset": entry.get("baseAsset", ""),
+                "quoteAsset": entry.get("quoteAsset", ""),
+                "tickSize": price_filter.get("tickSize", 0.1),
+                "stepSize": lot_filter.get("stepSize", 0.001),
+                "notional": notional_filter.get("minNotional", notional_filter.get("minQty", 5.0)),
+            }
+        self._exchange_info = info
+
+

--- a/data/exchanges/events.py
+++ b/data/exchanges/events.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum, auto
+from typing import Generic, Optional, TypeVar
+
+from config.timezone import CURRENT_TIMEZONE
+
+
+class ResyncReason(Enum):
+    SEQUENCE_GAP = auto()
+    SILENCE_TIMEOUT = auto()
+    QUEUE_OVERFLOW = auto()
+    CONNECTION_LOST = auto()
+
+
+class StreamEventType(Enum):
+    DATA = auto()
+    SNAPSHOT = auto()
+    RESYNC = auto()
+
+
+T_cov = TypeVar("T_cov")
+
+
+@dataclass(slots=True)
+class StreamEvent(Generic[T_cov]):
+    type: StreamEventType
+    data: Optional[T_cov]
+    timestamp: datetime
+    reason: Optional[ResyncReason] = None
+    details: Optional[str] = None
+
+    @staticmethod
+    def now(type: StreamEventType, data: Optional[T_cov] = None) -> "StreamEvent[T_cov]":
+        return StreamEvent(
+            type=type,
+            data=data,
+            timestamp=datetime.now(tz=CURRENT_TIMEZONE),
+        )
+
+

--- a/data/exchanges/limits.py
+++ b/data/exchanges/limits.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+from config import config as app_config
+
+
+@dataclass(frozen=True, slots=True)
+class StreamLimit:
+    steady_per_min: int
+    burst_per_5s: int
+    max_symbols: int
+    resubscribe_buffer: int
+
+    @classmethod
+    def from_mapping(cls, mapping: Dict[str, Any]) -> "StreamLimit":
+        return cls(
+            steady_per_min=int(mapping.get("steady_per_min", 0)),
+            burst_per_5s=int(mapping.get("burst_per_5s", 0)),
+            max_symbols=int(mapping.get("max_symbols", 0)),
+            resubscribe_buffer=int(mapping.get("resubscribe_buffer", 0)),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class StreamLimits:
+    depth: StreamLimit
+    trades: StreamLimit
+    book_ticker: StreamLimit
+
+    @classmethod
+    def from_mapping(cls, mapping: Dict[str, Any]) -> "StreamLimits":
+        return cls(
+            depth=StreamLimit.from_mapping(mapping.get("depth", {})),
+            trades=StreamLimit.from_mapping(mapping.get("trades", {})),
+            book_ticker=StreamLimit.from_mapping(mapping.get("book_ticker", {})),
+        )
+
+
+def _default_limits_path() -> Path:
+    base = Path(app_config.__file__).resolve().parent
+    return base / "stream_limits.json"
+
+
+def load_stream_limits(path: Path | None = None) -> StreamLimits:
+    source = path or _default_limits_path()
+    data: Dict[str, Any]
+    if not source.exists():
+        data = {}
+    else:
+        with source.open("r", encoding="utf-8") as fp:
+            data = json.load(fp)
+    return StreamLimits.from_mapping(data)
+
+

--- a/data/exchanges/stream_buffer.py
+++ b/data/exchanges/stream_buffer.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import Deque, Generic, Iterable, List, Optional, TypeVar
+
+from .events import StreamEvent
+
+T = TypeVar("T")
+
+
+class StreamBuffer(Generic[T]):
+    """A tiny FIFO buffer used by stream subscriptions."""
+
+    __slots__ = ("_maxsize", "_queue")
+
+    def __init__(self, maxsize: Optional[int] = None) -> None:
+        self._maxsize = maxsize
+        self._queue: Deque[StreamEvent[T]] = deque()
+
+    def __len__(self) -> int:
+        return len(self._queue)
+
+    def append(self, event: StreamEvent[T]) -> bool:
+        if self._maxsize is not None and len(self._queue) >= self._maxsize:
+            return False
+        self._queue.append(event)
+        return True
+
+    def extend(self, events: Iterable[StreamEvent[T]]) -> None:
+        for event in events:
+            appended = self.append(event)
+            if not appended:
+                break
+
+    def drain_pending(self) -> List[StreamEvent[T]]:
+        if not self._queue:
+            return []
+        drained = list(self._queue)
+        self._queue.clear()
+        return drained
+
+


### PR DESCRIPTION
## Summary
- add the `data.exchanges` package exposing stream types expected by the application
- implement a placeholder `BinanceExchangeData` that loads stream limits and produces stream subscriptions
- provide stub trading adapters and a default stream limit configuration file

## Testing
- python -m compileall data/exchanges

------
https://chatgpt.com/codex/tasks/task_e_68eb873b235c8320974d153beefa3d03