### PR TITLE
Introduce centralized Binance stream manager

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,7 +18,8 @@ from config.secrets import SECRETS
 from config.timezone import CURRENT_TIMEZONE
 from data.exchanges import (
     BestBidAsk,
-    BinanceExchangeData,
+    BinanceStreamManager,
+    BinanceSymbolStreams,
     BinanceTradingAdapter,
     BybitExchangeData,
     BybitTradingAdapter,
@@ -27,6 +28,7 @@ from data.exchanges import (
     ResyncReason as StreamResyncReason,
     StreamEventType,
     StreamSubscription,
+    StreamLimitError,
 )
 from data.exchanges.binance_trade import BinanceAPIError
 from data.exchanges.bybit_trade import BybitAPIError
@@ -202,11 +204,6 @@ class Application:
         self._balance_refresh_interval = timedelta(hours=CONFIG.position.balance_refresh_h)
         self._last_balance_refresh_at: Optional[datetime] = None
         self._silence_recovery_cooldown = timedelta(seconds=5)
-        self._subscription_manager = SubscriptionManager(
-            subscribe=self._subscribe_symbol,
-            unsubscribe=self._unsubscribe_symbol,
-            logger=self._event_logger,
-        )
         self._data_freshness_threshold = timedelta(
             milliseconds=CONFIG.general.ws_silence_timeout_ms
         )
@@ -217,6 +214,27 @@ class Application:
             logger=self._event_logger,
         )
         self._exchange = Exchange(CONFIG.general.exchange.value)
+        api_key, api_secret = self._exchange_credentials()
+        self._binance_streams: Optional[BinanceStreamManager] = None
+        if CONFIG.general.exchange is ExchangeName.BINANCE:
+            self._binance_streams = BinanceStreamManager(
+                loop_interval_ms=CONFIG.general.loop_interval_ms,
+                silence_timeout_ms=CONFIG.general.ws_silence_timeout_ms,
+                log_writer=self._sink,
+                api_key=api_key,
+                api_secret=api_secret,
+            )
+        prioritizer = (
+            self._binance_streams.plan_subscriptions
+            if self._binance_streams is not None
+            else None
+        )
+        self._subscription_manager = SubscriptionManager(
+            subscribe=self._subscribe_symbol,
+            unsubscribe=self._unsubscribe_symbol,
+            logger=self._event_logger,
+            prioritizer=prioritizer,
+        )
         self._scanner = MarketScanner(
             CONFIG.general.exchange,
             CONFIG.general.profile,
@@ -268,17 +286,12 @@ class Application:
         return None, None
 
     def _create_exchange_data(self, symbol: str) -> IExchangeData:
-        api_key, api_secret = self._exchange_credentials()
         if CONFIG.general.exchange is ExchangeName.BINANCE:
-            return BinanceExchangeData(
-                symbol=symbol,
-                loop_interval_ms=CONFIG.general.loop_interval_ms,
-                silence_timeout_ms=CONFIG.general.ws_silence_timeout_ms,
-                log_writer=self._sink,
-                api_key=api_key,
-                api_secret=api_secret,
-            )
+            if self._binance_streams is None:
+                raise RuntimeError("Binance stream manager is not initialized")
+            return self._binance_streams.get_exchange_data(symbol)
         if CONFIG.general.exchange is ExchangeName.BYBIT:
+            api_key, api_secret = self._exchange_credentials()
             return BybitExchangeData(
                 symbol=symbol,
                 loop_interval_ms=CONFIG.general.loop_interval_ms,
@@ -316,9 +329,16 @@ class Application:
         symbol = symbol.upper()
         context = self._contexts.get(symbol)
         new_context: Optional[SymbolContext] = None
+        manager_streams: Optional[BinanceSymbolStreams] = None
+        manager = self._binance_streams
+        if manager is not None:
+            profile = self._symbol_profiles.get(symbol, CONFIG.general.profile)
+            manager.update_profiles({symbol: profile})
         try:
+            if manager is not None:
+                manager_streams = manager.subscribe(symbol)
             if context is None:
-                new_context = self._create_context(symbol)
+                new_context = self._create_context(symbol, streams=manager_streams)
                 context = new_context
             if context is None:
                 return
@@ -326,11 +346,16 @@ class Application:
             context.cycle_started = False
         except Exception as exc:  # noqa: BLE001
             self._log_error(f"Не удалось активировать {symbol}: {exc}")
+            if manager is not None and manager_streams is not None:
+                try:
+                    manager.unsubscribe(symbol)
+                except StreamLimitError:
+                    manager.cancel(symbol)
             if new_context is not None:
                 self._dispose_context(new_context)
             elif context is not None:
                 self._dispose_context(context)
-            return
+            raise
         if new_context is not None:
             self._contexts[symbol] = new_context
 
@@ -340,6 +365,31 @@ class Application:
             subscription.stop()
         except Exception:
             pass
+
+    def _resubscribe_symbol_streams(self, context: SymbolContext) -> None:
+        manager = self._binance_streams
+        if manager is None:
+            return
+        try:
+            streams = manager.resubscribe(context.symbol)
+        except StreamLimitError as exc:
+            timestamp = get_current_time()
+            self._event_logger.log(
+                f"Не удалось переподписать {context.symbol}: {exc}",
+                timestamp,
+            )
+            return
+        subscriptions = (
+            context.depth_subscription,
+            context.trade_subscription,
+            context.ticker_subscription,
+        )
+        for subscription in subscriptions:
+            self._stop_stream_subscription(subscription)
+        context.depth_subscription = streams.depth
+        context.trade_subscription = streams.trades
+        context.ticker_subscription = streams.ticker
+        context.exchange_data = streams.exchange_data
 
     def _dispose_context(self, context: SymbolContext) -> None:
         context.active = False
@@ -356,9 +406,21 @@ class Application:
 
     def _unsubscribe_symbol(self, symbol: str) -> None:
         symbol = symbol.upper()
-        context = self._contexts.pop(symbol, None)
+        context = self._contexts.get(symbol)
         if context is None:
             return
+        manager = self._binance_streams
+        if manager is not None:
+            try:
+                manager.unsubscribe(symbol)
+            except StreamLimitError as exc:
+                timestamp = get_current_time()
+                self._event_logger.log(
+                    f"Не удалось отписаться от {symbol}: {exc}",
+                    timestamp,
+                )
+                raise
+        context = self._contexts.pop(symbol)
         self._stale_warnings.pop(symbol, None)
         self._dispose_context(context)
 
@@ -403,6 +465,7 @@ class Application:
             if event.type is StreamEventType.RESYNC and event.reason is not None:
                 context.feed_monitor.flag(event.reason)
                 context.last_update_id = None
+                self._resubscribe_symbol_streams(context)
 
     def _apply_snapshot(self, context: SymbolContext, snapshot: OrderBookSnapshot) -> None:
         context.order_book.reset_odr_history()
@@ -529,6 +592,7 @@ class Application:
                     ),
                     timestamp,
                 )
+                self._resubscribe_symbol_streams(context)
         return processed
 
     def _process_trade_stream(self, context: SymbolContext) -> bool:
@@ -724,6 +788,8 @@ class Application:
         scan_result = self._scanner.scan()
         profile_by_symbol = {symbol: profile for symbol, profile in scan_result}
         self._symbol_profiles = profile_by_symbol
+        if self._binance_streams is not None:
+            self._binance_streams.update_profiles(profile_by_symbol)
         symbols = tuple(profile_by_symbol.keys())
         self._desired_symbols = symbols
         for symbol, context in self._contexts.items():
@@ -759,8 +825,19 @@ class Application:
         )
         context.cycle_started = True
 
-    def _create_context(self, symbol: str) -> SymbolContext:
-        exchange_data = self._create_exchange_data(symbol)
+    def _create_context(
+        self, symbol: str, streams: Optional[BinanceSymbolStreams] = None
+    ) -> SymbolContext:
+        if streams is not None:
+            exchange_data = streams.exchange_data
+            depth_subscription = streams.depth
+            trade_subscription = streams.trades
+            ticker_subscription = streams.ticker
+        else:
+            exchange_data = self._create_exchange_data(symbol)
+            depth_subscription = exchange_data.stream_depth()
+            trade_subscription = exchange_data.stream_trades()
+            ticker_subscription = exchange_data.stream_book_ticker()
         filters = exchange_data.fetch_symbol_filters()
         trading_adapter = self._create_trading_adapter(symbol, filters)
         context = SymbolContext(
@@ -771,9 +848,9 @@ class Application:
                 recent_band_volume_boost=CONFIG.general.recent_band_s_vol_boost,
             ),
             feed_monitor=FeedMonitor(),
-            depth_subscription=exchange_data.stream_depth(),
-            trade_subscription=exchange_data.stream_trades(),
-            ticker_subscription=exchange_data.stream_book_ticker(),
+            depth_subscription=depth_subscription,
+            trade_subscription=trade_subscription,
+            ticker_subscription=ticker_subscription,
             filters=filters,
             trading_adapter=trading_adapter,
             profile=self._symbol_profiles.get(symbol, CONFIG.general.profile),

--- a/data/exchanges/__init__.py
+++ b/data/exchanges/__init__.py
@@ -19,7 +19,15 @@ from domain.models import (
     Trade,
 )
 
-from .binance import BestBidAsk, BinanceExchangeData, DepthStreamData, StreamSubscription
+from .binance import (
+    BestBidAsk,
+    BinanceExchangeData,
+    BinanceStreamManager,
+    BinanceSymbolStreams,
+    DepthStreamData,
+    StreamLimitError,
+    StreamSubscription,
+)
 from .events import ResyncReason, StreamEvent, StreamEventType
 from .stream_buffer import StreamBuffer
 
@@ -192,7 +200,10 @@ class BybitTradingAdapter(IExchangeTrade):
 __all__ = [
     "BestBidAsk",
     "BinanceExchangeData",
+    "BinanceStreamManager",
+    "BinanceSymbolStreams",
     "BinanceTradingAdapter",
+    "StreamLimitError",
     "BybitExchangeData",
     "BybitTradingAdapter",
     "DepthStreamData",

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import json
 import math
 import time
-from dataclasses import dataclass
-from datetime import datetime, timedelta
-from typing import Callable, Dict, Generic, Iterator, Optional, TypeVar
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Deque, Dict, Generic, Iterator, Mapping, Optional, Tuple, TypeVar
 
 from urllib.error import URLError
 from urllib.request import urlopen
@@ -13,6 +14,7 @@ from urllib.request import urlopen
 from config.timezone import CURRENT_TIMEZONE
 from data.logger import LogSink
 from domain.models import Exchange, OrderBookSnapshot, OrderBookUpdate, SymbolFilters, Trade
+from config.models.trading_profile import TradingProfile
 
 from .events import StreamEvent, StreamEventType
 from .limits import StreamLimits, load_stream_limits
@@ -53,6 +55,48 @@ class StreamSubscription(Generic[T]):
         self._stopped = True
         if self._stop is not None:
             self._stop()
+
+
+class StreamLimitError(RuntimeError):
+    """Raised when stream scheduling exceeds the calculated limits."""
+
+
+@dataclass
+class _RateLimiter:
+    """Simple window-based rate limiter used by the stream manager."""
+
+    limit: int
+    window: timedelta
+    _events: Deque[datetime] = field(default_factory=deque, init=False, repr=False)
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple initializer
+        # ensure window is at least positive to avoid division by zero semantics
+        if self.window <= timedelta(0):
+            object.__setattr__(self, "window", timedelta(seconds=1))
+
+    def _trim(self, timestamp: datetime) -> None:
+        while self._events and timestamp - self._events[0] >= self.window:
+            self._events.popleft()
+
+    def has_capacity(self, timestamp: datetime) -> bool:
+        if self.limit <= 0:
+            return True
+        self._trim(timestamp)
+        return len(self._events) < self.limit
+
+    def commit(self, timestamp: datetime) -> None:
+        if self.limit <= 0:
+            return
+        self._trim(timestamp)
+        self._events.append(timestamp)
+
+
+@dataclass(frozen=True, slots=True)
+class BinanceSymbolStreams:
+    exchange_data: "BinanceExchangeData"
+    depth: "StreamSubscription[DepthStreamData]"
+    trades: "StreamSubscription[Trade]"
+    ticker: "StreamSubscription[BestBidAsk]"
 
 
 class BinanceExchangeData:
@@ -202,5 +246,192 @@ class BinanceExchangeData:
                 "notional": notional_filter.get("minNotional", notional_filter.get("minQty", 5.0)),
             }
         self._exchange_info = info
+
+
+class BinanceStreamManager:
+    """Manages Binance stream subscriptions with centralized limits."""
+
+    def __init__(
+        self,
+        *,
+        loop_interval_ms: int,
+        silence_timeout_ms: int,
+        log_writer: LogSink,
+        api_key: Optional[str] = None,
+        api_secret: Optional[str] = None,
+    ) -> None:
+        self._loop_interval_ms = loop_interval_ms
+        self._silence_timeout_ms = silence_timeout_ms
+        self._log_writer = log_writer
+        self._api_key = api_key
+        self._api_secret = api_secret
+        self._limits = load_stream_limits()
+        self._exchange_data: Dict[str, BinanceExchangeData] = {}
+        self._streams: Dict[str, BinanceSymbolStreams] = {}
+        self._active: set[str] = set()
+        self._profiles: Dict[str, TradingProfile] = {}
+        self._max_symbols = self._resolve_capacity()
+        self._reserve = self._resolve_reserve()
+        self._limiters = self._build_limiters(self._limits)
+
+    @staticmethod
+    def _build_limiters(limits: StreamLimits) -> Dict[str, tuple[_RateLimiter, _RateLimiter]]:
+        return {
+            "depth": (
+                _RateLimiter(limits.depth.steady_per_min, timedelta(minutes=1)),
+                _RateLimiter(limits.depth.burst_per_5s, timedelta(seconds=5)),
+            ),
+            "trades": (
+                _RateLimiter(limits.trades.steady_per_min, timedelta(minutes=1)),
+                _RateLimiter(limits.trades.burst_per_5s, timedelta(seconds=5)),
+            ),
+            "book_ticker": (
+                _RateLimiter(limits.book_ticker.steady_per_min, timedelta(minutes=1)),
+                _RateLimiter(limits.book_ticker.burst_per_5s, timedelta(seconds=5)),
+            ),
+        }
+
+    def _resolve_capacity(self) -> int:
+        values = [
+            self._limits.depth.max_symbols,
+            self._limits.trades.max_symbols,
+            self._limits.book_ticker.max_symbols,
+        ]
+        positives = [value for value in values if value > 0]
+        if not positives:
+            return 0
+        return min(positives)
+
+    def _resolve_reserve(self) -> int:
+        values = [
+            self._limits.depth.resubscribe_buffer,
+            self._limits.trades.resubscribe_buffer,
+            self._limits.book_ticker.resubscribe_buffer,
+        ]
+        return max(values)
+
+    def update_profiles(self, profiles: Mapping[str, TradingProfile]) -> None:
+        self._profiles.update(profiles)
+
+    def plan_subscriptions(self, symbols: Tuple[str, ...]) -> Tuple[str, ...]:
+        if not symbols:
+            return symbols
+        available = self._available_slots()
+        if available == 0:
+            return tuple()
+        ordered = sorted(
+            symbols,
+            key=lambda sym: self._profile_weight(sym),
+            reverse=True,
+        )
+        planned: list[str] = []
+        for symbol in ordered:
+            if symbol in self._active:
+                continue
+            if available <= 0:
+                break
+            planned.append(symbol)
+            available -= 1
+        return tuple(planned)
+
+    def _available_slots(self) -> int:
+        if self._max_symbols <= 0:
+            return 1_000_000
+        active = len(self._active)
+        reserve = min(self._reserve, self._max_symbols)
+        capacity = self._max_symbols - reserve - active
+        return max(capacity, 0)
+
+    def _profile_weight(self, symbol: str) -> float:
+        profile = self._profiles.get(symbol, TradingProfile.AUTO)
+        return float(BinanceExchangeData.PROFILE_WEIGHTS.get(profile.value, 0.0))
+
+    def subscribe(self, symbol: str) -> BinanceSymbolStreams:
+        symbol = symbol.upper()
+        now = datetime.now(tz=timezone.utc)
+        self._ensure_capacity(symbol)
+        self._consume_limits(now)
+        exchange_data = self._exchange_data.get(symbol)
+        if exchange_data is None:
+            exchange_data = BinanceExchangeData(
+                symbol=symbol,
+                loop_interval_ms=self._loop_interval_ms,
+                silence_timeout_ms=self._silence_timeout_ms,
+                log_writer=self._log_writer,
+                api_key=self._api_key,
+                api_secret=self._api_secret,
+            )
+            self._exchange_data[symbol] = exchange_data
+        streams = BinanceSymbolStreams(
+            exchange_data=exchange_data,
+            depth=exchange_data.stream_depth(),
+            trades=exchange_data.stream_trades(),
+            ticker=exchange_data.stream_book_ticker(),
+        )
+        self._streams[symbol] = streams
+        self._active.add(symbol)
+        return streams
+
+    def get_exchange_data(self, symbol: str) -> BinanceExchangeData:
+        symbol = symbol.upper()
+        exchange_data = self._exchange_data.get(symbol)
+        if exchange_data is None:
+            exchange_data = BinanceExchangeData(
+                symbol=symbol,
+                loop_interval_ms=self._loop_interval_ms,
+                silence_timeout_ms=self._silence_timeout_ms,
+                log_writer=self._log_writer,
+                api_key=self._api_key,
+                api_secret=self._api_secret,
+            )
+            self._exchange_data[symbol] = exchange_data
+        return exchange_data
+
+    def unsubscribe(self, symbol: str) -> None:
+        symbol = symbol.upper()
+        now = datetime.now(tz=timezone.utc)
+        self._consume_limits(now)
+        self._streams.pop(symbol, None)
+        self._active.discard(symbol)
+
+    def resubscribe(self, symbol: str) -> BinanceSymbolStreams:
+        symbol = symbol.upper()
+        now = datetime.now(tz=timezone.utc)
+        self._consume_limits(now)
+        exchange_data = self.get_exchange_data(symbol)
+        streams = BinanceSymbolStreams(
+            exchange_data=exchange_data,
+            depth=exchange_data.stream_depth(),
+            trades=exchange_data.stream_trades(),
+            ticker=exchange_data.stream_book_ticker(),
+        )
+        self._streams[symbol] = streams
+        self._active.add(symbol)
+        return streams
+
+    def cancel(self, symbol: str) -> None:
+        """Release internal state without sending an unsubscribe command."""
+        symbol = symbol.upper()
+        self._streams.pop(symbol, None)
+        self._active.discard(symbol)
+
+    def _ensure_capacity(self, symbol: str) -> None:
+        if self._max_symbols <= 0:
+            return
+        if symbol in self._active:
+            return
+        available = self._available_slots()
+        if available <= 0:
+            raise StreamLimitError("max stream capacity reached")
+
+    def _consume_limits(self, timestamp: datetime) -> None:
+        pending_limiters: list[_RateLimiter] = []
+        for limiters in self._limiters.values():
+            for limiter in limiters:
+                if not limiter.has_capacity(timestamp):
+                    raise StreamLimitError("stream command rate exceeded")
+                pending_limiters.append(limiter)
+        for limiter in pending_limiters:
+            limiter.commit(timestamp)
 
 

--- a/domain/strategy/subscription.py
+++ b/domain/strategy/subscription.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List, Set, Tuple
+from typing import Callable, List, Optional, Set, Tuple
 
 from .event_logger import EventLogger
 from .types import SubscriptionHandler
@@ -13,11 +13,14 @@ class SubscriptionManager:
     subscribe: SubscriptionHandler
     unsubscribe: SubscriptionHandler
     logger: EventLogger
+    prioritizer: Optional[Callable[[Tuple[str, ...]], Tuple[str, ...]]] = None
     _active: Tuple[str, ...] = field(default_factory=tuple)
 
     def update(self, symbols: Tuple[str, ...], timestamp: datetime) -> None:
         additions = self._compute_additions(symbols)
         removals = self._compute_removals(symbols)
+        if self.prioritizer is not None and additions:
+            additions = self.prioritizer(additions)
         active: List[str] = list(self._active)
         active_set: Set[str] = set(active)
         for symbol in additions:


### PR DESCRIPTION
## Summary
- add a Binance stream manager that caches exchange data, enforces stream limits, and orders subscribe commands by profile weight
- wire Application to use the shared manager for creating contexts, refreshing profiles, and handling subscribe, unsubscribe, and resubscribe flows
- allow SubscriptionManager to accept a prioritizer so new symbols are ordered by the stream manager before scheduling

## Testing
- python -m compileall app.py data/exchanges/binance.py domain/strategy/subscription.py

------
https://chatgpt.com/codex/tasks/task_e_68eb8a6202d48320a8aac7fba661e694