### PR TITLE
Refine Binance spot market scanning

### DIFF
--- a/app.py
+++ b/app.py
@@ -192,6 +192,7 @@ class Application:
         self._focused_symbol: Optional[str] = None
         self._desired_symbols: Tuple[str, ...] = ()
         self._symbol_profiles: Dict[str, TradingProfile] = {}
+        self._symbol_weights: Dict[str, float] = {}
         self._telegram_client = TelegramClient(
             token=SECRETS.tg_bot_token,
             chat_id=CONFIG.telegram.chat_id,
@@ -239,6 +240,7 @@ class Application:
             CONFIG.general.exchange,
             CONFIG.general.profile,
             CONFIG.turnover,
+            CONFIG.profile_weights,
             log=self._log_scanner_message,
         )
         self._last_scan_at: Optional[datetime] = None
@@ -333,7 +335,11 @@ class Application:
         manager = self._binance_streams
         if manager is not None:
             profile = self._symbol_profiles.get(symbol, CONFIG.general.profile)
+            weight = self._symbol_weights.get(symbol)
+            if weight is None:
+                weight = self._scanner.get_symbol_weight(symbol)
             manager.update_profiles({symbol: profile})
+            manager.update_weights({symbol: weight})
         try:
             if manager is not None:
                 manager_streams = manager.subscribe(symbol)
@@ -788,8 +794,11 @@ class Application:
         scan_result = self._scanner.scan()
         profile_by_symbol = {symbol: profile for symbol, profile in scan_result}
         self._symbol_profiles = profile_by_symbol
+        weights_by_symbol = self._scanner.symbol_weights
+        self._symbol_weights = weights_by_symbol
         if self._binance_streams is not None:
             self._binance_streams.update_profiles(profile_by_symbol)
+            self._binance_streams.update_weights(weights_by_symbol)
         symbols = tuple(profile_by_symbol.keys())
         self._desired_symbols = symbols
         for symbol, context in self._contexts.items():

--- a/application/market_scanner.py
+++ b/application/market_scanner.py
@@ -4,12 +4,13 @@ import json
 import socket
 import time
 from http.client import RemoteDisconnected
-from typing import Callable, Iterable, Optional, Sequence, Tuple
+from typing import Callable, Iterable, Mapping, Optional, Sequence, Tuple
 from urllib import parse
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from config.models.exchange_name import ExchangeName
+from config.models.profile_weights import ProfileWeights
 from config.models.trading_profile import TradingProfile
 from config.models.turnover_thresholds import TurnoverThresholds
 
@@ -20,6 +21,7 @@ class MarketScanner:
         exchange: ExchangeName,
         profile: TradingProfile,
         thresholds: TurnoverThresholds,
+        profile_weights: ProfileWeights,
         *,
         timeout: float = 5.0,
         retries: int = 3,
@@ -30,14 +32,20 @@ class MarketScanner:
         self._exchange = exchange
         self._profile = profile
         self._thresholds = thresholds
+        self._profile_weights = profile_weights
         self._timeout = timeout
         self._retries = max(0, int(retries))
         self._retry_delay = max(0.0, float(retry_delay))
         self._retry_backoff = max(1.0, float(retry_backoff))
         self._log = log
         self._last_symbols: Tuple[Tuple[str, TradingProfile], ...] = ()
+        self._last_weights: dict[str, float] = {}
         self._listing_dates: dict[str, int] = {}
         self._recent_listing_cache: dict[str, bool] = {}
+        self._binance_exchange_info: dict[str, dict[str, object]] = {}
+        self._exchange_info_fetched_at: float | None = None
+        self._exchange_info_ttl = 300.0
+        self._max_symbols = 550
 
     def scan(self) -> Tuple[Tuple[str, TradingProfile], ...]:
         try:
@@ -56,12 +64,33 @@ class MarketScanner:
             return self._last_symbols
 
     def _scan_binance(self) -> Tuple[Tuple[str, TradingProfile], ...]:
-        url = "https://fapi.binance.com/fapi/v1/ticker/24hr"
+        exchange_info = self._load_binance_exchange_info()
+        listing_dates = self._extract_listing_dates(exchange_info)
+        if listing_dates:
+            self._listing_dates = listing_dates
+        self._recent_listing_cache.clear()
+        url = "https://api.binance.com/api/v3/ticker/24hr"
         request = Request(url, method="GET", headers={"User-Agent": "mtf-trend/1.0"})
         data = self._request_json(request)
-        self._listing_dates = self._fetch_listing_dates()
-        self._recent_listing_cache.clear()
-        entries = ((item.get("symbol", ""), item.get("quoteVolume", "0")) for item in data)
+        symbols: Sequence[dict[str, object]] = []
+        if isinstance(data, Sequence):
+            symbols = [item for item in data if isinstance(item, dict)]
+        allowed = exchange_info or self._binance_exchange_info
+        seen: set[str] = set()
+        entries: list[Tuple[str, object]] = []
+        for item in symbols:
+            raw_symbol = item.get("symbol")
+            if not raw_symbol:
+                continue
+            symbol = str(raw_symbol).upper()
+            if not symbol.endswith("USDT"):
+                continue
+            if allowed and symbol not in allowed:
+                continue
+            if symbol in seen:
+                continue
+            seen.add(symbol)
+            entries.append((symbol, item.get("quoteVolume") or item.get("volume")))
         return self._filter_and_sort(entries)
 
     def _scan_bybit(self) -> Tuple[Tuple[str, TradingProfile], ...]:
@@ -83,6 +112,62 @@ class MarketScanner:
             for row in entries
         )
         return self._filter_and_sort(rows)
+
+    def _load_binance_exchange_info(
+        self, *, refresh: bool = False
+    ) -> Mapping[str, dict[str, object]]:
+        if self._binance_exchange_info and not refresh:
+            fetched_at = self._exchange_info_fetched_at or 0.0
+            if time.time() - fetched_at < self._exchange_info_ttl:
+                return self._binance_exchange_info
+        url = "https://api.binance.com/api/v3/exchangeInfo"
+        request = Request(url, method="GET", headers={"User-Agent": "mtf-trend/1.0"})
+        data = self._request_json(request)
+        exchange_info = self._parse_binance_exchange_info(data)
+        if exchange_info:
+            self._binance_exchange_info = exchange_info
+            self._exchange_info_fetched_at = time.time()
+        return self._binance_exchange_info
+
+    def _parse_binance_exchange_info(
+        self, payload: object
+    ) -> dict[str, dict[str, object]]:
+        symbols: Sequence[dict[str, object]] = []
+        if isinstance(payload, dict):
+            raw_symbols = payload.get("symbols")
+            if isinstance(raw_symbols, Sequence):
+                symbols = [item for item in raw_symbols if isinstance(item, dict)]
+        result: dict[str, dict[str, object]] = {}
+        for item in symbols:
+            raw_symbol = item.get("symbol")
+            if not raw_symbol:
+                continue
+            symbol = str(raw_symbol).upper()
+            status = str(item.get("status") or "").upper()
+            if status != "TRADING":
+                continue
+            if not bool(item.get("isSpotTradingAllowed", False)):
+                continue
+            permissions = item.get("permissions")
+            if isinstance(permissions, Sequence) and permissions:
+                normalized = {str(entry).upper() for entry in permissions}
+                if "SPOT" not in normalized:
+                    continue
+            result[symbol] = dict(item)
+        return result
+
+    def _extract_listing_dates(
+        self, exchange_info: Mapping[str, Mapping[str, object]]
+    ) -> dict[str, int]:
+        listing_dates: dict[str, int] = {}
+        for symbol, item in exchange_info.items():
+            raw_onboard = item.get("onboardDate")
+            try:
+                onboard_ts = int(str(raw_onboard))
+            except (TypeError, ValueError):
+                continue
+            listing_dates[symbol] = onboard_ts
+        return listing_dates
 
     def _request_json(self, request: Request) -> dict[str, object] | list[object]:
         retries_remaining = self._retries
@@ -130,15 +215,30 @@ class MarketScanner:
                     continue
                 pairs.append((symbol, turnover_per_minute))
         pairs.sort(key=lambda item: item[1], reverse=True)
+        max_symbols = self._max_symbols if self._max_symbols > 0 else None
+        self._last_weights = {}
         if self._profile is TradingProfile.AUTO:
             classified: list[Tuple[str, TradingProfile]] = []
             for symbol, turnover in pairs:
                 profile = self._classify_turnover(symbol, turnover)
                 if profile is TradingProfile.LISTING and not self._is_recent_listing(symbol):
                     continue
+                self._last_weights[symbol] = self._resolve_weight(profile)
                 classified.append((symbol, profile))
+                if max_symbols is not None and len(classified) >= max_symbols:
+                    break
             return tuple(classified)
-        return tuple((symbol, self._profile) for symbol, _ in pairs)
+        default_profile = self._profile
+        default_weight = self._resolve_weight(default_profile)
+        result: list[Tuple[str, TradingProfile]] = []
+        for symbol, _ in pairs:
+            if default_profile is TradingProfile.LISTING and not self._is_recent_listing(symbol):
+                continue
+            self._last_weights[symbol] = default_weight
+            result.append((symbol, default_profile))
+            if max_symbols is not None and len(result) >= max_symbols:
+                break
+        return tuple(result)
 
     def _resolve_threshold(self) -> float:
         thresholds = self._thresholds
@@ -159,6 +259,33 @@ class MarketScanner:
         if self._profile is TradingProfile.LISTING:
             return float(thresholds.listing_usd)
         return float(thresholds.top_usd)
+
+    def _resolve_weight(self, profile: TradingProfile) -> float:
+        weights = self._profile_weights
+        if profile is TradingProfile.TOP:
+            return float(weights.top)
+        if profile is TradingProfile.ALT:
+            return float(weights.alt)
+        if profile is TradingProfile.LISTING:
+            return float(weights.listing)
+        return float(weights.auto)
+
+    @property
+    def symbol_weights(self) -> dict[str, float]:
+        return dict(self._last_weights)
+
+    def get_symbol_weight(self, symbol: str) -> float:
+        normalized = symbol.upper()
+        weight = self._last_weights.get(normalized)
+        if weight is not None:
+            return weight
+        if self._profile is TradingProfile.TOP:
+            return self._resolve_weight(TradingProfile.TOP)
+        if self._profile is TradingProfile.ALT:
+            return self._resolve_weight(TradingProfile.ALT)
+        if self._profile is TradingProfile.LISTING:
+            return self._resolve_weight(TradingProfile.LISTING)
+        return self._resolve_weight(TradingProfile.AUTO)
 
     def _classify_turnover(self, symbol: str, turnover: float) -> TradingProfile:
         thresholds = self._thresholds
@@ -208,27 +335,8 @@ class MarketScanner:
         return {}
 
     def _fetch_binance_listing_dates(self) -> dict[str, int]:
-        url = "https://fapi.binance.com/fapi/v1/exchangeInfo"
-        request = Request(url, method="GET", headers={"User-Agent": "mtf-trend/1.0"})
-        data = self._request_json(request)
-        symbols: Sequence[dict[str, object]] = []
-        if isinstance(data, dict):
-            raw_symbols = data.get("symbols")
-            if isinstance(raw_symbols, Sequence):
-                symbols = [item for item in raw_symbols if isinstance(item, dict)]
-        mapping: dict[str, int] = {}
-        for item in symbols:
-            raw_symbol = item.get("symbol")
-            if not raw_symbol:
-                continue
-            symbol = str(raw_symbol).upper()
-            raw_onboard = item.get("onboardDate")
-            try:
-                onboard_ts = int(str(raw_onboard))
-            except (TypeError, ValueError):
-                continue
-            mapping[symbol] = onboard_ts
-        return mapping
+        exchange_info = self._load_binance_exchange_info(refresh=True)
+        return self._extract_listing_dates(exchange_info)
 
     def _fetch_bybit_listing_dates(self) -> dict[str, int]:
         params = parse.urlencode({"category": "linear"})

--- a/config/config.py
+++ b/config/config.py
@@ -12,6 +12,7 @@ from config.models import (
     MarginMode,
     OdrSettings,
     PositionSettings,
+    ProfileWeights,
     StopTrigger,
     TelegramSettings,
     TradingProfile,
@@ -84,6 +85,12 @@ CONFIG: Final[Config] = Config(
         chat_id=739865715,
         silent=False,
         uptick_cooldown_min=5,
+    ),
+    profile_weights=ProfileWeights(
+        top=1.0,
+        alt=0.5,
+        listing=0.8,
+        auto=0.3,
     ),
 )
 

--- a/config/models/__init__.py
+++ b/config/models/__init__.py
@@ -7,6 +7,7 @@ from .general_settings import GeneralSettings
 from .margin_mode import MarginMode
 from .odr_settings import OdrSettings
 from .position_settings import PositionSettings
+from .profile_weights import ProfileWeights
 from .secrets import Secrets
 from .stop_trigger import StopTrigger
 from .telegram_settings import TelegramSettings
@@ -26,6 +27,7 @@ __all__ = [
     "MarginMode",
     "OdrSettings",
     "PositionSettings",
+    "ProfileWeights",
     "StopTrigger",
     "TelegramSettings",
     "TradingProfile",

--- a/config/models/config_model.py
+++ b/config/models/config_model.py
@@ -7,6 +7,7 @@ from .funding_kill_switch_settings import FundingKillSwitchSettings
 from .general_settings import GeneralSettings
 from .odr_settings import OdrSettings
 from .position_settings import PositionSettings
+from .profile_weights import ProfileWeights
 from .telegram_settings import TelegramSettings
 from .turnover_thresholds import TurnoverThresholds
 from .wall_settings import WallSettings
@@ -24,6 +25,7 @@ class Config:
     focus: FocusSettings
     funding_ks: FundingKillSwitchSettings
     telegram: TelegramSettings
+    profile_weights: ProfileWeights
 
 
 __all__ = ["Config"]

--- a/config/models/profile_weights.py
+++ b/config/models/profile_weights.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ProfileWeights:
+    top: float
+    alt: float
+    listing: float
+    auto: float
+
+
+__all__ = ["ProfileWeights"]

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -11,6 +11,7 @@ from typing import Callable, Deque, Dict, Generic, Iterator, Mapping, Optional, 
 from urllib.error import URLError
 from urllib.request import urlopen
 
+from config.config import CONFIG
 from config.timezone import CURRENT_TIMEZONE
 from data.logger import LogSink
 from domain.models import Exchange, OrderBookSnapshot, OrderBookUpdate, SymbolFilters, Trade
@@ -103,10 +104,10 @@ class BinanceExchangeData:
     """A pragmatic placeholder implementation of the data interface."""
 
     PROFILE_WEIGHTS: Dict[str, float] = {
-        "TOP": 1.0,
-        "LISTING": 0.8,
-        "ALT": 0.5,
-        "AUTO": 0.3,
+        TradingProfile.TOP.value: float(CONFIG.profile_weights.top),
+        TradingProfile.LISTING.value: float(CONFIG.profile_weights.listing),
+        TradingProfile.ALT.value: float(CONFIG.profile_weights.alt),
+        TradingProfile.AUTO.value: float(CONFIG.profile_weights.auto),
     }
 
     def __init__(
@@ -270,6 +271,7 @@ class BinanceStreamManager:
         self._streams: Dict[str, BinanceSymbolStreams] = {}
         self._active: set[str] = set()
         self._profiles: Dict[str, TradingProfile] = {}
+        self._weights: Dict[str, float] = {}
         self._max_symbols = self._resolve_capacity()
         self._reserve = self._resolve_reserve()
         self._limiters = self._build_limiters(self._limits)
@@ -311,7 +313,12 @@ class BinanceStreamManager:
         return max(values)
 
     def update_profiles(self, profiles: Mapping[str, TradingProfile]) -> None:
-        self._profiles.update(profiles)
+        for symbol, profile in profiles.items():
+            self._profiles[symbol.upper()] = profile
+
+    def update_weights(self, weights: Mapping[str, float]) -> None:
+        for symbol, weight in weights.items():
+            self._weights[symbol.upper()] = float(weight)
 
     def plan_subscriptions(self, symbols: Tuple[str, ...]) -> Tuple[str, ...]:
         if not symbols:
@@ -343,7 +350,11 @@ class BinanceStreamManager:
         return max(capacity, 0)
 
     def _profile_weight(self, symbol: str) -> float:
-        profile = self._profiles.get(symbol, TradingProfile.AUTO)
+        normalized = symbol.upper()
+        weight = self._weights.get(normalized)
+        if weight is not None:
+            return weight
+        profile = self._profiles.get(normalized, TradingProfile.AUTO)
         return float(BinanceExchangeData.PROFILE_WEIGHTS.get(profile.value, 0.0))
 
     def subscribe(self, symbol: str) -> BinanceSymbolStreams:


### PR DESCRIPTION
## Summary
- load Binance spot exchange information to filter active USDT pairs, cache listing dates, and compute per-symbol profile weights during market scans
- introduce configurable trading profile weights and pass them into the scanner so the application can persist symbol weightings alongside profiles
- extend the Binance stream manager and application wiring to forward the scanner's profile and weight data when planning WebSocket subscriptions

## Testing
- python -m compileall application/market_scanner.py app.py data/exchanges/binance.py config

------
https://chatgpt.com/codex/tasks/task_e_68eb8cc4c0d083209d5e69624f8c183f