### PR TITLE
Switch Binance WebSocket streams to spot endpoint

### DIFF
--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -343,7 +343,7 @@ class _StreamRegistration(Generic[T]):
 class _BinanceStreamSession:
     """Shared websocket session that fans out events to registered consumers."""
 
-    _BASE_ENDPOINT = "wss://fstream.binance.com/stream"
+    _BASE_ENDPOINT = "wss://stream.binance.com:9443/ws"
 
     def __init__(
         self,
@@ -673,7 +673,7 @@ class _BinanceStreamWorker(Generic[T]):
         "_last_ping",
     )
 
-    _BASE_ENDPOINT = "wss://fstream.binance.com/stream"
+    _BASE_ENDPOINT = "wss://stream.binance.com:9443/ws"
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- point Binance stream session and worker clients at the spot WebSocket host instead of the futures endpoint to receive spot data

## Testing
- python - <<'PY' ... (fails: network is unreachable)

------
https://chatgpt.com/codex/tasks/task_e_68ebbd9c1b7c8320abc4c8f4081d6ce2