### PR TITLE
Refactor Binance stream profile weights

### DIFF
--- a/app.py
+++ b/app.py
@@ -192,7 +192,7 @@ class Application:
         self._focused_symbol: Optional[str] = None
         self._desired_symbols: Tuple[str, ...] = ()
         self._symbol_profiles: Dict[str, TradingProfile] = {}
-        self._symbol_weights: Dict[str, float] = {}
+        self._symbol_weights: Dict[str, Dict[str, float]] = {}
         self._telegram_client = TelegramClient(
             token=SECRETS.tg_bot_token,
             chat_id=CONFIG.telegram.chat_id,
@@ -240,7 +240,7 @@ class Application:
             CONFIG.general.exchange,
             CONFIG.general.profile,
             CONFIG.turnover,
-            CONFIG.profile_weights,
+            CONFIG.profile_stream_weights,
             log=self._log_scanner_message,
         )
         self._last_scan_at: Optional[datetime] = None
@@ -335,11 +335,11 @@ class Application:
         manager = self._binance_streams
         if manager is not None:
             profile = self._symbol_profiles.get(symbol, CONFIG.general.profile)
-            weight = self._symbol_weights.get(symbol)
-            if weight is None:
-                weight = self._scanner.get_symbol_weight(symbol)
+            weights = self._symbol_weights.get(symbol)
+            if weights is None:
+                weights = self._scanner.get_symbol_weight(symbol)
             manager.update_profiles({symbol: profile})
-            manager.update_weights({symbol: weight})
+            manager.update_weights({symbol: weights})
         try:
             if manager is not None:
                 manager_streams = manager.subscribe(symbol)

--- a/application/market_scanner.py
+++ b/application/market_scanner.py
@@ -11,7 +11,7 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from config.models.exchange_name import ExchangeName
-from config.models.profile_weights import ProfileWeights
+from config.models.profile_stream_weights import ProfileStreamWeights
 from config.models.trading_profile import TradingProfile
 from config.models.turnover_thresholds import TurnoverThresholds
 
@@ -22,7 +22,7 @@ class MarketScanner:
         exchange: ExchangeName,
         profile: TradingProfile,
         thresholds: TurnoverThresholds,
-        profile_weights: ProfileWeights,
+        profile_weights: ProfileStreamWeights,
         *,
         timeout: float = 5.0,
         retries: int = 3,
@@ -40,7 +40,7 @@ class MarketScanner:
         self._retry_backoff = max(1.0, float(retry_backoff))
         self._log = log
         self._last_symbols: Tuple[Tuple[str, TradingProfile], ...] = ()
-        self._last_weights: dict[str, float] = {}
+        self._last_weights: dict[str, dict[str, float]] = {}
         self._listing_dates: dict[str, int] = {}
         self._recent_listing_cache: dict[str, bool] = {}
         self._binance_exchange_info: dict[str, dict[str, object]] = {}
@@ -343,7 +343,7 @@ class MarketScanner:
         for symbol, _ in pairs:
             if default_profile is TradingProfile.LISTING and not self._is_recent_listing(symbol):
                 continue
-            self._last_weights[symbol] = default_weight
+            self._last_weights[symbol] = dict(default_weight)
             self._store_symbol_profile(symbol, default_profile)
             result.append((symbol, default_profile))
             if max_symbols is not None and len(result) >= max_symbols:
@@ -370,29 +370,38 @@ class MarketScanner:
             return float(thresholds.listing_usd)
         return float(thresholds.top_usd)
 
-    def _resolve_weight(self, profile: TradingProfile) -> float:
-        weights = self._profile_weights
-        if profile is TradingProfile.TOP:
-            return float(weights.top)
-        if profile is TradingProfile.ALT:
-            return float(weights.alt)
-        if profile is TradingProfile.LISTING:
-            return float(weights.listing)
-        return float(weights.auto)
+    def _resolve_weight(self, profile: TradingProfile) -> dict[str, float]:
+        stream_weights = self._profile_weights
+
+        def resolve_for_stream(name: str) -> float:
+            stream_profile = getattr(stream_weights, name)
+            if profile is TradingProfile.TOP:
+                return float(stream_profile.top)
+            if profile is TradingProfile.ALT:
+                return float(stream_profile.alt)
+            if profile is TradingProfile.LISTING:
+                return float(stream_profile.listing)
+            return float(stream_profile.auto)
+
+        return {
+            "depth": resolve_for_stream("depth"),
+            "trades": resolve_for_stream("trades"),
+            "book_ticker": resolve_for_stream("book_ticker"),
+        }
 
     @property
-    def symbol_weights(self) -> dict[str, float]:
-        return dict(self._last_weights)
+    def symbol_weights(self) -> dict[str, dict[str, float]]:
+        return {symbol: dict(weights) for symbol, weights in self._last_weights.items()}
 
     @property
     def binance_exchange_info(self) -> dict[str, dict[str, object]]:
         return dict(self._binance_exchange_info)
 
-    def get_symbol_weight(self, symbol: str) -> float:
+    def get_symbol_weight(self, symbol: str) -> dict[str, float]:
         normalized = symbol.upper()
         weight = self._last_weights.get(normalized)
         if weight is not None:
-            return weight
+            return dict(weight)
         if self._profile is TradingProfile.TOP:
             return self._resolve_weight(TradingProfile.TOP)
         if self._profile is TradingProfile.ALT:

--- a/config/config.py
+++ b/config/config.py
@@ -12,6 +12,7 @@ from config.models import (
     MarginMode,
     OdrSettings,
     PositionSettings,
+    ProfileStreamWeights,
     ProfileWeights,
     StopTrigger,
     TelegramSettings,
@@ -86,11 +87,25 @@ CONFIG: Final[Config] = Config(
         silent=False,
         uptick_cooldown_min=5,
     ),
-    profile_weights=ProfileWeights(
-        top=1.0,
-        alt=0.5,
-        listing=0.8,
-        auto=0.3,
+    profile_stream_weights=ProfileStreamWeights(
+        depth=ProfileWeights(
+            top=1.0,
+            alt=0.5,
+            listing=0.8,
+            auto=0.3,
+        ),
+        trades=ProfileWeights(
+            top=1.0,
+            alt=0.5,
+            listing=0.8,
+            auto=0.3,
+        ),
+        book_ticker=ProfileWeights(
+            top=1.0,
+            alt=0.5,
+            listing=0.8,
+            auto=0.3,
+        ),
     ),
 )
 

--- a/config/models/__init__.py
+++ b/config/models/__init__.py
@@ -7,6 +7,7 @@ from .general_settings import GeneralSettings
 from .margin_mode import MarginMode
 from .odr_settings import OdrSettings
 from .position_settings import PositionSettings
+from .profile_stream_weights import ProfileStreamWeights
 from .profile_weights import ProfileWeights
 from .secrets import Secrets
 from .stop_trigger import StopTrigger
@@ -27,6 +28,7 @@ __all__ = [
     "MarginMode",
     "OdrSettings",
     "PositionSettings",
+    "ProfileStreamWeights",
     "ProfileWeights",
     "StopTrigger",
     "TelegramSettings",

--- a/config/models/config_model.py
+++ b/config/models/config_model.py
@@ -7,7 +7,7 @@ from .funding_kill_switch_settings import FundingKillSwitchSettings
 from .general_settings import GeneralSettings
 from .odr_settings import OdrSettings
 from .position_settings import PositionSettings
-from .profile_weights import ProfileWeights
+from .profile_stream_weights import ProfileStreamWeights
 from .telegram_settings import TelegramSettings
 from .turnover_thresholds import TurnoverThresholds
 from .wall_settings import WallSettings
@@ -25,7 +25,7 @@ class Config:
     focus: FocusSettings
     funding_ks: FundingKillSwitchSettings
     telegram: TelegramSettings
-    profile_weights: ProfileWeights
+    profile_stream_weights: ProfileStreamWeights
 
 
 __all__ = ["Config"]

--- a/config/models/profile_stream_weights.py
+++ b/config/models/profile_stream_weights.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+from .profile_weights import ProfileWeights
+
+
+@dataclass(frozen=True)
+class ProfileStreamWeights:
+    depth: ProfileWeights
+    trades: ProfileWeights
+    book_ticker: ProfileWeights
+
+
+__all__ = ["ProfileStreamWeights"]

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -406,6 +406,11 @@ class _BinanceStreamSession:
             return float("inf")
         return float(max(self._usable_capacity - len(self._consumers), 0))
 
+    def available_symbols(self) -> float:
+        if self._usable_capacity <= 0:
+            return float("inf")
+        return float(max(self._usable_capacity - len(self._consumers), 0))
+
     def register_consumer(
         self,
         consumer: _StreamConsumer[Any],
@@ -981,24 +986,37 @@ class BinanceSymbolStreams:
 class BinanceExchangeData:
     """A pragmatic placeholder implementation of the data interface."""
 
+    _PROFILE_STREAM_WEIGHTS = CONFIG.profile_stream_weights
     PROFILE_WEIGHTS: Dict[str, Dict[str, float]] = {
         "depth": {
-            TradingProfile.TOP.value: float(CONFIG.profile_weights.top),
-            TradingProfile.LISTING.value: float(CONFIG.profile_weights.listing),
-            TradingProfile.ALT.value: float(CONFIG.profile_weights.alt),
-            TradingProfile.AUTO.value: float(CONFIG.profile_weights.auto),
+            TradingProfile.TOP.value: float(_PROFILE_STREAM_WEIGHTS.depth.top),
+            TradingProfile.LISTING.value: float(
+                _PROFILE_STREAM_WEIGHTS.depth.listing
+            ),
+            TradingProfile.ALT.value: float(_PROFILE_STREAM_WEIGHTS.depth.alt),
+            TradingProfile.AUTO.value: float(_PROFILE_STREAM_WEIGHTS.depth.auto),
         },
         "trades": {
-            TradingProfile.TOP.value: float(CONFIG.profile_weights.top),
-            TradingProfile.LISTING.value: float(CONFIG.profile_weights.listing),
-            TradingProfile.ALT.value: float(CONFIG.profile_weights.alt),
-            TradingProfile.AUTO.value: float(CONFIG.profile_weights.auto),
+            TradingProfile.TOP.value: float(_PROFILE_STREAM_WEIGHTS.trades.top),
+            TradingProfile.LISTING.value: float(
+                _PROFILE_STREAM_WEIGHTS.trades.listing
+            ),
+            TradingProfile.ALT.value: float(_PROFILE_STREAM_WEIGHTS.trades.alt),
+            TradingProfile.AUTO.value: float(_PROFILE_STREAM_WEIGHTS.trades.auto),
         },
         "book_ticker": {
-            TradingProfile.TOP.value: float(CONFIG.profile_weights.top),
-            TradingProfile.LISTING.value: float(CONFIG.profile_weights.listing),
-            TradingProfile.ALT.value: float(CONFIG.profile_weights.alt),
-            TradingProfile.AUTO.value: float(CONFIG.profile_weights.auto),
+            TradingProfile.TOP.value: float(
+                _PROFILE_STREAM_WEIGHTS.book_ticker.top
+            ),
+            TradingProfile.LISTING.value: float(
+                _PROFILE_STREAM_WEIGHTS.book_ticker.listing
+            ),
+            TradingProfile.ALT.value: float(
+                _PROFILE_STREAM_WEIGHTS.book_ticker.alt
+            ),
+            TradingProfile.AUTO.value: float(
+                _PROFILE_STREAM_WEIGHTS.book_ticker.auto
+            ),
         },
     }
 
@@ -1552,12 +1570,21 @@ class BinanceStreamManager:
             if exchange_data is not None:
                 exchange_data.set_symbol_profile(normalized, profile)
 
-    def update_weights(self, weights: Mapping[str, float]) -> None:
-        for symbol, weight in weights.items():
+    def update_weights(self, weights: Mapping[str, Mapping[str, float] | float]) -> None:
+        for symbol, weight_map in weights.items():
             normalized = symbol.upper()
+            if not normalized:
+                continue
+            if isinstance(weight_map, Mapping):
+                for stream, value in weight_map.items():
+                    if stream not in self._limit_map:
+                        continue
+                    stream_weights = self._weights.setdefault(stream, {})
+                    stream_weights[normalized] = float(value)
+                continue
             for stream in self._limit_map:
                 stream_weights = self._weights.setdefault(stream, {})
-                stream_weights[normalized] = float(weight)
+                stream_weights[normalized] = float(weight_map)
 
     def update_exchange_info(self, info: Mapping[str, Mapping[str, object]]) -> None:
         if not info:
@@ -1579,12 +1606,22 @@ class BinanceStreamManager:
     def plan_subscriptions(self, symbols: Tuple[str, ...]) -> Tuple[str, ...]:
         if not symbols:
             return symbols
-        available_by_stream = {
-            stream: self._available_for_stream(stream)
+        available_weight_by_stream = {
+            stream: self._available_weight_for_stream(stream)
+            for stream in self._limit_map
+        }
+        available_symbols_by_stream = {
+            stream: self._available_symbol_capacity(stream)
             for stream in self._limit_map
         }
         has_capacity = any(
-            math.isinf(value) or value > 0.0 for value in available_by_stream.values()
+            (math.isinf(available_weight_by_stream[stream])
+            or available_weight_by_stream[stream] > 0.0)
+            and (
+                math.isinf(available_symbols_by_stream[stream])
+                or available_symbols_by_stream[stream] > 0.0
+            )
+            for stream in self._limit_map
         )
         if not has_capacity:
             return tuple()
@@ -1607,24 +1644,37 @@ class BinanceStreamManager:
                 for stream in self._limit_map
             }
             if all(
-                math.isinf(available_by_stream[stream])
-                or available_by_stream[stream] >= weight
+                (
+                    math.isinf(available_weight_by_stream[stream])
+                    or available_weight_by_stream[stream] >= weight
+                )
+                and (
+                    math.isinf(available_symbols_by_stream[stream])
+                    or available_symbols_by_stream[stream] >= 1.0
+                )
                 for stream, weight in requirements.items()
             ):
                 planned.append(normalized)
                 for stream, weight in requirements.items():
-                    if math.isinf(available_by_stream[stream]):
+                    if not math.isinf(available_symbols_by_stream[stream]):
+                        available_symbols_by_stream[stream] = max(
+                            available_symbols_by_stream[stream] - 1.0,
+                            0.0,
+                        )
+                    if math.isinf(available_weight_by_stream[stream]):
                         continue
                     if weight <= 0.0:
                         continue
-                    available_by_stream[stream] = max(
-                        available_by_stream[stream] - weight,
+                    available_weight_by_stream[stream] = max(
+                        available_weight_by_stream[stream] - weight,
                         0.0,
                     )
         return tuple(planned)
 
     def _available_slots(self) -> float:
-        capacities = [self._available_for_stream(name) for name in self._limit_map]
+        capacities = [
+            self._available_weight_for_stream(name) for name in self._limit_map
+        ]
         if not capacities:
             return 0.0
         finite = [value for value in capacities if not math.isinf(value)]
@@ -1632,7 +1682,7 @@ class BinanceStreamManager:
             return float("inf")
         return max(min(finite), 0.0)
 
-    def _available_for_stream(self, stream: str) -> float:
+    def _available_weight_for_stream(self, stream: str) -> float:
         sessions = self._sessions.get(stream, [])
         if not sessions:
             return self._session_weight_capacity(stream)
@@ -1646,6 +1696,24 @@ class BinanceStreamManager:
         if math.isinf(additional):
             return float("inf")
         return total + additional
+
+    def _available_symbol_capacity(self, stream: str) -> float:
+        sessions = self._sessions.get(stream, [])
+        if not sessions:
+            capacity = self._session_capacity(stream)
+            if capacity <= 0:
+                return float("inf")
+            return float(capacity)
+        total = 0.0
+        for session in sessions:
+            capacity = session.available_symbols()
+            if math.isinf(capacity):
+                return float("inf")
+            total += capacity
+        additional = self._session_capacity(stream)
+        if additional <= 0:
+            return float("inf")
+        return total + float(additional)
 
     def _session_capacity(self, stream: str) -> int:
         limit = self._limit_map[stream]


### PR DESCRIPTION
## Summary
- add per-stream profile weight configuration and update Binance defaults
- update market scanner and stream manager to consume stream-specific weights
- adjust subscription planning to respect per-stream weight and symbol capacities

## Testing
- python -m compileall application config data app.py


------
https://chatgpt.com/codex/tasks/task_e_68ebc88b393c8320ad889132d4e0b870