### PR TITLE
Add delay threshold slot to Binance stream consumer

### DIFF
--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -225,6 +225,7 @@ class _StreamConsumer(Generic[T]):
     log: LogSink
     silence_timeout_ms: int
     snapshot_factory: SnapshotFactory[T] = None
+    _delay_threshold_ms: float = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         self._delay_threshold_ms = max(float(self.silence_timeout_ms) / 4.0, 250.0)


### PR DESCRIPTION
## Summary
- include the delay threshold attribute in the Binance stream consumer dataclass slots so post-init assignment succeeds

## Testing
- python - <<'PY'
from data.exchanges.binance import _StreamConsumer, _StreamMetrics, StreamBuffer

buffer = StreamBuffer(maxsize=10)
metrics = _StreamMetrics(name="test")

def parser(payload):
    return []

def log(message: str):
    print(f"LOG: {message}")

consumer = _StreamConsumer(
    stream="depth",
    symbol="BTCUSDT",
    params=("btcusdt",),
    buffer=buffer,
    parser=parser,
    metrics=metrics,
    log=log,
    silence_timeout_ms=1000,
)

print("delay_threshold", consumer._delay_threshold_ms)
PY

------
https://chatgpt.com/codex/tasks/task_e_68efdcf7a6a08320b8a992cdedc3ab82