### PR TITLE
Deduplicate Binance session consumers without dict.fromkeys

### DIFF
--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -651,7 +651,14 @@ class _BinanceStreamSession:
             await self._recv_loop(ws)
 
     async def _on_connected(self, ws: WebSocketClientProtocol) -> None:
-        consumers = list(dict.fromkeys(self._consumers.values()))
+        consumers: list[_StreamConsumer[Any]] = []
+        seen_ids: set[int] = set()
+        for consumer in self._consumers.values():
+            consumer_id = id(consumer)
+            if consumer_id in seen_ids:
+                continue
+            seen_ids.add(consumer_id)
+            consumers.append(consumer)
         for consumer in consumers:
             for param in consumer.params:
                 command = _SessionCommand(


### PR DESCRIPTION
## Summary
- replace `dict.fromkeys` deduplication in the Binance stream session with explicit identity-based filtering
- ensure reconnect subscribe commands are enqueued without duplicates and avoid `_StreamConsumer` hash errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68efe219ef8c8320b6c4354d2580a281