### PR TITLE
Disable equality comparison on Binance stream consumer

### DIFF
--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -212,7 +212,7 @@ class _CommandBudget:
             return True
 
 
-@dataclass(slots=True)
+@dataclass(slots=True, eq=False)
 class _StreamConsumer(Generic[T]):
     """In-memory handler used by shared sessions to deliver stream events."""
 


### PR DESCRIPTION
## Summary
- disable auto-generated equality methods on the Binance stream consumer dataclass so it uses default identity-based hashing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68efea01d46c8320b253eaa9bed00c5b