### PR TITLE
Reset Binance depth stream sequence after snapshots

### DIFF
--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -1215,7 +1215,9 @@ class BinanceExchangeData:
         last_final_id: Optional[int] = None
 
         def snapshot_factory() -> Optional[StreamEvent[DepthStreamData]]:
+            nonlocal last_final_id
             snapshot = self.fetch_orderbook_snapshot()
+            last_final_id = snapshot.last_update_id
             return StreamEvent(StreamEventType.SNAPSHOT, snapshot, snapshot.received_at)
 
         def parser(message: Dict[str, Any]) -> Iterable[StreamEvent[DepthStreamData]]:


### PR DESCRIPTION
## Summary
- ensure Binance depth snapshot resets the cached final update id
- allow the first diff after a snapshot or resync to bypass stale sequence checks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68efeb63c824832088a221244a2a1f2b