### PR TITLE
Limit concurrent stream subscriptions

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ from typing import Any, Deque, Dict, Iterable, Optional, Sequence, Tuple, cast
 
 from application import FeedMonitor, GUARDS
 from application.market_scanner import MarketScanner
-from config.config import CONFIG
+from config.config import CONFIG, MAX_NEW_SUBSCRIPTIONS
 from config.models.balance_source import BalanceSource as ConfigBalanceSource
 from config.models.exchange_name import ExchangeName
 from config.models.trading_profile import TradingProfile
@@ -198,6 +198,8 @@ class Application:
         )
         self._telegram_notifier = TelegramNotifier(send_message=self._send_telegram)
         self._contexts: Dict[str, SymbolContext] = {}
+        self._pending_symbols: Deque[str] = deque()
+        self._pending_symbol_set: set[str] = set()
         self._trading_router = TradingAdapterRouter(self._contexts)
         self._balance_source = self._map_balance_source(CONFIG.position.balance_source)
         self._balance_refresh_interval = timedelta(hours=CONFIG.position.balance_refresh_h)
@@ -790,9 +792,14 @@ class Application:
             if timestamp - self._last_scan_at < self._scanner_interval:
                 return
         scan_result = self._scanner.scan()
-        profile_by_symbol = {symbol: profile for symbol, profile in scan_result}
+        profile_by_symbol = {
+            symbol.upper(): profile for symbol, profile in scan_result
+        }
         self._symbol_profiles = profile_by_symbol
-        weights_by_symbol = self._scanner.symbol_weights
+        weights_by_symbol = {
+            symbol.upper(): weights
+            for symbol, weights in self._scanner.symbol_weights.items()
+        }
         self._symbol_weights = weights_by_symbol
         symbols = tuple(profile_by_symbol.keys())
         if self._binance_streams is not None:
@@ -807,13 +814,117 @@ class Application:
                     self._binance_streams.get_exchange_data(first_symbol).fetch_symbol_filters()
                 except Exception:
                     pass
+        desired_set = set(symbols)
+        if self._pending_symbols:
+            filtered_pending: Deque[str] = deque()
+            seen_pending: set[str] = set()
+            for symbol in self._pending_symbols:
+                if symbol not in desired_set:
+                    continue
+                context = self._contexts.get(symbol)
+                if context is not None and context.active:
+                    continue
+                if symbol in seen_pending:
+                    continue
+                filtered_pending.append(symbol)
+                seen_pending.add(symbol)
+            self._pending_symbols = filtered_pending
+            self._pending_symbol_set = set(filtered_pending)
+        for symbol in symbols:
+            if symbol in self._pending_symbol_set:
+                continue
+            context = self._contexts.get(symbol)
+            if context is not None and context.active:
+                continue
+            self._pending_symbols.append(symbol)
+            self._pending_symbol_set.add(symbol)
         self._desired_symbols = symbols
         for symbol, context in self._contexts.items():
             profile = profile_by_symbol.get(symbol)
             if profile is not None:
                 context.profile = profile
-        self._subscription_manager.update(symbols, timestamp)
         self._last_scan_at = timestamp
+
+    def _maybe_refresh_subscriptions(self, timestamp: Optional[datetime] = None) -> None:
+        timestamp = timestamp or get_current_time()
+        desired = tuple(symbol.upper() for symbol in self._desired_symbols)
+        desired_set = set(desired)
+        if not desired_set:
+            self._subscription_manager.update(tuple(), timestamp, max_new=0)
+            self._pending_symbols.clear()
+            self._pending_symbol_set.clear()
+            return
+        filtered: Deque[str] = deque()
+        seen_pending: set[str] = set()
+        for symbol in self._pending_symbols:
+            if symbol not in desired_set:
+                continue
+            context = self._contexts.get(symbol)
+            if context is not None and context.active:
+                continue
+            if symbol in seen_pending:
+                continue
+            filtered.append(symbol)
+            seen_pending.add(symbol)
+        self._pending_symbols = filtered
+        self._pending_symbol_set = set(filtered)
+        candidates = tuple(self._pending_symbols)
+        if not candidates:
+            scheduled: list[str] = []
+        else:
+            prioritizer = self._subscription_manager.prioritizer
+            ordered = (
+                prioritizer(candidates)
+                if prioritizer is not None and candidates
+                else candidates
+            )
+            limit = MAX_NEW_SUBSCRIPTIONS
+            if limit <= 0:
+                selected = ordered
+            else:
+                selected = ordered[:limit]
+            selected_set = set(selected)
+            if selected_set:
+                remaining: Deque[str] = deque(
+                    symbol for symbol in self._pending_symbols if symbol not in selected_set
+                )
+                self._pending_symbols = remaining
+                self._pending_symbol_set = set(remaining)
+            else:
+                selected = tuple()
+            scheduled = [symbol for symbol in selected]
+        active_symbols: list[str] = []
+        seen: set[str] = set()
+        for symbol in desired:
+            context = self._contexts.get(symbol)
+            if context is not None and context.active and symbol not in seen:
+                active_symbols.append(symbol)
+                seen.add(symbol)
+        for symbol in scheduled:
+            if symbol in seen:
+                continue
+            active_symbols.append(symbol)
+            seen.add(symbol)
+        max_new: Optional[int]
+        if scheduled:
+            max_new = len(scheduled) if MAX_NEW_SUBSCRIPTIONS > 0 else None
+        else:
+            max_new = 0
+        self._subscription_manager.update(tuple(active_symbols), timestamp, max_new=max_new)
+        if not scheduled:
+            return
+        desired_set = set(self._desired_symbols)
+        failed: list[str] = []
+        for symbol in scheduled:
+            context = self._contexts.get(symbol)
+            if context is None or not context.active:
+                if symbol in desired_set:
+                    failed.append(symbol)
+        for symbol in reversed(failed):
+            if symbol in self._pending_symbol_set:
+                continue
+            self._pending_symbols.appendleft(symbol)
+            self._pending_symbol_set.add(symbol)
 
     def _iter_active_contexts(self) -> Iterable[SymbolContext]:
         ordered: Tuple[str, ...] = self._desired_symbols
@@ -1043,9 +1154,11 @@ class Application:
     def run(self) -> None:
         interval = CONFIG.general.loop_interval_ms / 1000.0
         self._refresh_symbol_scan(force=True)
+        self._maybe_refresh_subscriptions()
         self._refresh_balances(force=True)
         while True:
             self._refresh_symbol_scan()
+            self._maybe_refresh_subscriptions()
             self._refresh_balances()
             resync_triggered = False
             work_done = False

--- a/config/config.py
+++ b/config/config.py
@@ -23,6 +23,10 @@ from config.models import (
     WallShiftSettings,
 )
 
+MAX_ACTIVE_STREAMS: Final[int] = 60
+MAX_NEW_SUBSCRIPTIONS: Final[int] = 3
+
+
 CONFIG: Final[Config] = Config(
     general=GeneralSettings(
         exchange=ExchangeName.BINANCE,
@@ -109,4 +113,4 @@ CONFIG: Final[Config] = Config(
     ),
 )
 
-__all__ = ["CONFIG"]
+__all__ = ["CONFIG", "MAX_ACTIVE_STREAMS", "MAX_NEW_SUBSCRIPTIONS"]

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -26,7 +26,7 @@ from typing import (
 from urllib.error import URLError
 from urllib.request import urlopen
 
-from config.config import CONFIG
+from config.config import CONFIG, MAX_ACTIVE_STREAMS
 from config.timezone import CURRENT_TIMEZONE
 from data.logger import LogSink
 from domain.models import Exchange, OrderBookLevel, OrderBookSnapshot, OrderBookUpdate, Side, SymbolFilters, Trade
@@ -1667,6 +1667,7 @@ class BinanceStreamManager:
         ] = {}
         self._exchange_info_cache: Dict[str, Dict[str, object]] = {}
         self._active: set[str] = set()
+        self._max_active_streams = MAX_ACTIVE_STREAMS
         for name in self._limit_map:
             self._weights[name] = {}
             session = self._create_session(name)
@@ -1734,6 +1735,13 @@ class BinanceStreamManager:
             stream: self._available_symbol_capacity(stream)
             for stream in self._limit_map
         }
+        remaining_global = (
+            float("inf")
+            if self._max_active_streams <= 0
+            else max(self._max_active_streams - len(self._active), 0)
+        )
+        if remaining_global <= 0:
+            return tuple()
         has_capacity = any(
             (math.isinf(available_weight_by_stream[stream])
             or available_weight_by_stream[stream] > 0.0)
@@ -1775,6 +1783,10 @@ class BinanceStreamManager:
                 for stream, weight in requirements.items()
             ):
                 planned.append(normalized)
+                if not math.isinf(remaining_global):
+                    remaining_global = max(remaining_global - 1, 0)
+                    if remaining_global <= 0:
+                        break
                 for stream, weight in requirements.items():
                     if not math.isinf(available_symbols_by_stream[stream]):
                         available_symbols_by_stream[stream] = max(
@@ -1879,6 +1891,13 @@ class BinanceStreamManager:
         existing = self._streams.get(symbol)
         if existing is not None:
             return existing
+        if (
+            self._max_active_streams > 0
+            and len(self._active) >= self._max_active_streams
+        ):
+            raise StreamLimitError(
+                f"достигнут лимит активных стримов {self._max_active_streams}"
+            )
         exchange_data = self.get_exchange_data(symbol)
         streams, registrations = exchange_data.create_stream_bundle()
         stream_weights = {

--- a/domain/strategy/subscription.py
+++ b/domain/strategy/subscription.py
@@ -16,11 +16,21 @@ class SubscriptionManager:
     prioritizer: Optional[Callable[[Tuple[str, ...]], Tuple[str, ...]]] = None
     _active: Tuple[str, ...] = field(default_factory=tuple)
 
-    def update(self, symbols: Tuple[str, ...], timestamp: datetime) -> None:
-        additions = self._compute_additions(symbols)
+    def update(
+        self,
+        symbols: Tuple[str, ...],
+        timestamp: datetime,
+        max_new: Optional[int] = None,
+    ) -> None:
+        additions = list(self._compute_additions(symbols))
         removals = self._compute_removals(symbols)
         if self.prioritizer is not None and additions:
-            additions = self.prioritizer(additions)
+            additions = list(self.prioritizer(tuple(additions)))
+        if max_new is not None:
+            if max_new <= 0:
+                additions = []
+            else:
+                additions = additions[:max_new]
         active: List[str] = list(self._active)
         active_set: Set[str] = set(active)
         for symbol in additions:


### PR DESCRIPTION
## Summary
- add configuration constants to cap total active streams and new subscriptions per iteration
- maintain a queued set of scanner candidates and throttle subscription updates accordingly
- enforce the global stream cap inside the Binance stream manager while keeping prioritised scheduling

## Testing
- python -m compileall app.py domain/strategy/subscription.py data/exchanges/binance.py config/config.py


------
https://chatgpt.com/codex/tasks/task_e_68f09911cce883208e0ba42a1636ee14