### PR TITLE
Add retries for Binance snapshot fetch

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -37,6 +37,7 @@ CONFIG: Final[Config] = Config(
         recent_band_s=5,
         recent_band_s_vol_boost=8,
         vol_spike_mult=2.0,
+        orderbook_snapshot_timeout_s=5.0,
     ),
     turnover=TurnoverThresholds(
         top_usd=700_000,

--- a/config/models/general_settings.py
+++ b/config/models/general_settings.py
@@ -14,6 +14,7 @@ class GeneralSettings:
     recent_band_s: int
     recent_band_s_vol_boost: int
     vol_spike_mult: float
+    orderbook_snapshot_timeout_s: float
 
 
 __all__ = ["GeneralSettings"]

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -1304,19 +1304,49 @@ class BinanceExchangeData:
             "https://fapi.binance.com/fapi/v1/depth"
             f"?symbol={self._symbol}&limit=1000"
         )
-        try:
-            with urlopen(url, timeout=5) as response:  # noqa: S310
-                payload = json.load(response)
-        except (URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:  # pragma: no cover - network
+        timeout_s = getattr(CONFIG.general, "orderbook_snapshot_timeout_s", 5.0)
+        max_attempts = 3
+        base_delay = 0.5
+        last_exception: Exception | None = None
+        payload: Mapping[str, Any] | None = None
+
+        for attempt in range(1, max_attempts + 1):
             try:
-                self._log_writer(
-                    f"[ERROR] failed to fetch depth snapshot for {self._symbol}: {exc}"
-                )
-            except Exception:  # pragma: no cover - logging
-                pass
+                with urlopen(url, timeout=timeout_s) as response:  # noqa: S310
+                    payload = json.load(response)
+                break
+            except (
+                URLError,
+                TimeoutError,
+                OSError,
+                json.JSONDecodeError,
+            ) as exc:  # pragma: no cover - network
+                last_exception = exc
+                if attempt < max_attempts:
+                    backoff = base_delay * (2 ** (attempt - 1))
+                    try:
+                        self._log_writer(
+                            (
+                                f"[WARNING] depth snapshot attempt {attempt} failed for"
+                                f" {self._symbol}: {exc}. Retrying in {backoff:.2f}s"
+                            )
+                        )
+                    except Exception:  # pragma: no cover - logging
+                        pass
+                    time.sleep(backoff)
+                else:
+                    try:
+                        self._log_writer(
+                            f"[ERROR] failed to fetch depth snapshot for {self._symbol}: {exc}"
+                        )
+                    except Exception:  # pragma: no cover - logging
+                        pass
+
+        if payload is None:
+            assert last_exception is not None
             raise RuntimeError(
                 f"failed to fetch orderbook snapshot for {self._symbol}"
-            ) from exc
+            ) from last_exception
 
         if not isinstance(payload, Mapping):
             raise RuntimeError("depth snapshot payload malformed")


### PR DESCRIPTION
## Summary
- add a configurable timeout for Binance REST depth snapshots via general settings
- introduce a bounded retry loop with exponential backoff for depth snapshot fetching
- log warning-level messages for transient failures and preserve the existing error reporting when the retry budget is exhausted

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6904b0c4f30c83208b991ef2ad2d8a7e