### PR TITLE
Handle tolerated Binance trade gaps

### DIFF
--- a/app.py
+++ b/app.py
@@ -123,6 +123,8 @@ class SymbolContext:
     funding_block_logged: bool = False
     last_update_id: Optional[int] = None
     last_trade_price: Optional[float] = None
+    last_trade_id: Optional[int] = None
+    missed_trade_ids: int = 0
     best_bid: Optional[float] = None
     best_ask: Optional[float] = None
     order_book_updated_at: Optional[datetime] = None
@@ -684,6 +686,22 @@ class Application:
                     trade_time = trade.executed_at
                     context.trade_updated_at = trade_time
                     context.last_trade_price = trade.price
+                    trade_id_value: Optional[int]
+                    try:
+                        trade_id_value = int(trade.trade_id)
+                    except (TypeError, ValueError):
+                        trade_id_value = None
+                    if trade_id_value is not None:
+                        previous_id = context.last_trade_id
+                        if previous_id is not None:
+                            gap = trade_id_value - previous_id
+                            if gap > 1:
+                                context.missed_trade_ids += gap - 1
+                            elif gap == 1 and context.missed_trade_ids > 0:
+                                context.missed_trade_ids -= 1
+                            elif gap <= 0:
+                                context.missed_trade_ids += 1
+                        context.last_trade_id = trade_id_value
                     now = get_current_time()
                     if self._is_data_fresh(trade_time, now):
                         _, _, ratio, ready = context.volume_tracker.observe(

--- a/config/config.py
+++ b/config/config.py
@@ -25,6 +25,7 @@ from config.models import (
 
 MAX_ACTIVE_STREAMS: Final[int] = 60
 MAX_NEW_SUBSCRIPTIONS: Final[int] = 3
+ALLOWED_GAP: Final[int] = 3
 
 
 CONFIG: Final[Config] = Config(
@@ -114,4 +115,9 @@ CONFIG: Final[Config] = Config(
     ),
 )
 
-__all__ = ["CONFIG", "MAX_ACTIVE_STREAMS", "MAX_NEW_SUBSCRIPTIONS"]
+__all__ = [
+    "CONFIG",
+    "MAX_ACTIVE_STREAMS",
+    "MAX_NEW_SUBSCRIPTIONS",
+    "ALLOWED_GAP",
+]

--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -26,7 +26,7 @@ from typing import (
 from urllib.error import URLError
 from urllib.request import urlopen
 
-from config.config import CONFIG, MAX_ACTIVE_STREAMS
+from config.config import ALLOWED_GAP, CONFIG, MAX_ACTIVE_STREAMS
 from config.timezone import CURRENT_TIMEZONE
 from data.logger import LogSink
 from domain.models import Exchange, OrderBookLevel, OrderBookSnapshot, OrderBookUpdate, Side, SymbolFilters, Trade
@@ -1550,11 +1550,31 @@ class BinanceExchangeData:
                     ResyncReason.SEQUENCE_GAP,
                     "trade id missing",
                 )
-            if last_trade_id is not None and trade_id <= last_trade_id:
-                raise _StreamValidationError(
-                    ResyncReason.SEQUENCE_GAP,
-                    "out-of-order trade sequence",
-                )
+            if last_trade_id is not None:
+                gap = trade_id - last_trade_id
+                if gap <= 0:
+                    raise _StreamValidationError(
+                        ResyncReason.SEQUENCE_GAP,
+                        "out-of-order trade sequence",
+                    )
+                if gap == 1:
+                    pass
+                elif gap <= ALLOWED_GAP:
+                    try:
+                        self._log_writer(
+                            (
+                                f"Поток сделок {self._symbol}: пропущено"
+                                f" {gap - 1} id", 
+                                f" (gap={gap}, допуск до {ALLOWED_GAP}).",
+                            )
+                        )
+                    except Exception:
+                        pass
+                else:
+                    raise _StreamValidationError(
+                        ResyncReason.SEQUENCE_GAP,
+                        "trade sequence gap exceeds allowance",
+                    )
             price = _safe_float(message.get("p"), 0.0)
             quantity = _safe_float(message.get("q"), 0.0)
             event_time = _milliseconds_to_datetime(message.get("T"))


### PR DESCRIPTION
## Summary
- add an `ALLOWED_GAP` configuration constant to control tolerated trade id gaps
- update the Binance trade stream parser to warn on small gaps and resync on large ones
- track missed trade ids while processing trades so volume logic can adapt

## Testing
- python -m compileall app.py data/exchanges/binance.py config/config.py

------
https://chatgpt.com/codex/tasks/task_e_6905129985848320b3c7a2a2a7f42739