### PR TITLE
Add resync diagnostics and partial logging controls

### DIFF
--- a/app.py
+++ b/app.py
@@ -281,6 +281,7 @@ class Application:
             logger=self._event_logger,
             resync=self._handle_resync,
             safety=self._kill_switch,
+            detailed_diagnostics=CONFIG.general.enable_detailed_diagnostics,
         )
 
     @staticmethod
@@ -639,16 +640,28 @@ class Application:
                     continue
                 context.feed_monitor.flag(event.reason)
                 context.last_update_id = None
-                context.order_book_updated_at = None
                 timestamp = event.timestamp.astimezone(CURRENT_TIMEZONE)
                 details = f" {event.details}." if event.details else ""
+                lost_seconds: Optional[float]
+                if context.order_book_updated_at is not None:
+                    lost_seconds = (
+                        event.timestamp - context.order_book_updated_at
+                    ).total_seconds()
+                else:
+                    lost_seconds = None
+                loss_suffix = (
+                    f" (stream=depth, lost={lost_seconds:.1f}с)."
+                    if lost_seconds is not None
+                    else " (stream=depth, lost=н/д)."
+                )
                 self._event_logger.log(
                     (
                         f"Поток стакана {context.symbol} требует ресинк: "
-                        f"{event.reason.value}.{details}"
+                        f"{event.reason.value}.{details}{loss_suffix}"
                     ),
                     timestamp,
                 )
+                context.order_book_updated_at = None
                 manager = self._binance_streams
                 if manager is not None:
                     cooldown_until = manager.get_cooldown_until(context.symbol)
@@ -714,10 +727,33 @@ class Application:
                     else:
                         context.volume_ratio = 0.0
                         context.volume_spike = False
+            elif event.type is StreamEventType.RESYNC and event.reason is not None:
+                timestamp = event.timestamp.astimezone(CURRENT_TIMEZONE)
+                last_trade_at = context.trade_updated_at
+                lost_seconds: Optional[float]
+                if last_trade_at is not None:
+                    lost_seconds = (
+                        event.timestamp - last_trade_at
+                    ).total_seconds()
+                else:
+                    lost_seconds = None
+                details = f" {event.details}." if event.details else ""
+                loss_suffix = (
+                    f" (stream=trades, lost={lost_seconds:.1f}с)."
+                    if lost_seconds is not None
+                    else " (stream=trades, lost=н/д)."
+                )
+                self._event_logger.log(
+                    (
+                        f"Поток сделок {context.symbol} требует ресинк: "
+                        f"{event.reason.value}.{details}{loss_suffix}"
+                    ),
+                    timestamp,
+                )
+                context.trade_updated_at = None
         return processed
 
-    @staticmethod
-    def _process_ticker_stream(context: SymbolContext) -> bool:
+    def _process_ticker_stream(self, context: SymbolContext) -> bool:
         buffer = context.ticker_subscription._buffer
         events = buffer.drain_pending()
         if not events:
@@ -735,6 +771,30 @@ class Application:
                 ticker = cast(BestBidAsk, event.data)
                 if ticker is not None:
                     latest_ticker = ticker
+            elif event.type is StreamEventType.RESYNC and event.reason is not None:
+                timestamp = event.timestamp.astimezone(CURRENT_TIMEZONE)
+                last_ticker_at = context.ticker_updated_at
+                lost_seconds: Optional[float]
+                if last_ticker_at is not None:
+                    lost_seconds = (
+                        event.timestamp - last_ticker_at
+                    ).total_seconds()
+                else:
+                    lost_seconds = None
+                details = f" {event.details}." if event.details else ""
+                loss_suffix = (
+                    f" (stream=ticker, lost={lost_seconds:.1f}с)."
+                    if lost_seconds is not None
+                    else " (stream=ticker, lost=н/д)."
+                )
+                self._event_logger.log(
+                    (
+                        f"Поток тикера {context.symbol} требует ресинк: "
+                        f"{event.reason.value}.{details}{loss_suffix}"
+                    ),
+                    timestamp,
+                )
+                context.ticker_updated_at = None
         if latest_ticker is not None:
             context.best_bid = latest_ticker.bid_price
             context.best_ask = latest_ticker.ask_price

--- a/config/config.py
+++ b/config/config.py
@@ -39,6 +39,7 @@ CONFIG: Final[Config] = Config(
         recent_band_s_vol_boost=8,
         vol_spike_mult=2.0,
         orderbook_snapshot_timeout_s=5.0,
+        enable_detailed_diagnostics=True,
     ),
     turnover=TurnoverThresholds(
         top_usd=700_000,

--- a/config/models/general_settings.py
+++ b/config/models/general_settings.py
@@ -15,6 +15,7 @@ class GeneralSettings:
     recent_band_s_vol_boost: int
     vol_spike_mult: float
     orderbook_snapshot_timeout_s: float
+    enable_detailed_diagnostics: bool
 
 
 __all__ = ["GeneralSettings"]

--- a/domain/strategy/strategy.py
+++ b/domain/strategy/strategy.py
@@ -29,6 +29,7 @@ class Strategy:
         logger: EventLogger,
         resync: ResyncHandler,
         safety: KillSwitch,
+        detailed_diagnostics: bool = False,
     ) -> None:
         self._subscriptions = subscriptions
         self._focus = focus
@@ -47,6 +48,7 @@ class Strategy:
         self._last_trade_at: dict[str, datetime] = {}
         self._last_stop_move_at: dict[str, datetime] = {}
         self._last_uptick_loss_at: dict[str, datetime] = {}
+        self._last_partial_log_at: dict[str, datetime] = {}
         self._position_symbol: Optional[str] = None
         self._position_signal = Signal.NONE
         self._position_wall: Optional[Wall] = None
@@ -58,6 +60,8 @@ class Strategy:
         self._resync_reason: Optional[ResyncReason] = None
         self._resync_summary_start: Optional[datetime] = None
         self._resync_summary_count = 0
+        self._detailed_diagnostics_enabled = detailed_diagnostics
+        self._partial_log_interval = timedelta(seconds=30)
 
     @property
     def state(self) -> StrategyState:
@@ -93,6 +97,28 @@ class Strategy:
             self._subscriptions.update(observation.available_symbols, observation.timestamp)
             self._last_scan_at = observation.timestamp
 
+    def _log_partial_diagnostics(
+        self,
+        symbol: str,
+        timestamp: datetime,
+        *,
+        wall_present: bool,
+        volume_spike: bool,
+    ) -> None:
+        if not self._detailed_diagnostics_enabled:
+            return
+        if wall_present == volume_spike:
+            return
+        last_logged = self._last_partial_log_at.get(symbol)
+        if last_logged is not None and timestamp - last_logged < self._partial_log_interval:
+            return
+        self._last_partial_log_at[symbol] = timestamp
+        if wall_present:
+            detail = "обнаружена стенка, но нет всплеска объёма"
+        else:
+            detail = "есть всплеск объёма, но стенка не найдена"
+        self._logger.log(f"Диагностика {symbol}: {detail}.", timestamp)
+
     def _handle_scanning(self, observation: MarketObservation) -> None:
         if observation.pressure is None:
             return
@@ -108,6 +134,12 @@ class Strategy:
         else:
             return
         if wall is None or not observation.volume_spike:
+            self._log_partial_diagnostics(
+                observation.symbol,
+                observation.timestamp,
+                wall_present=wall is not None,
+                volume_spike=observation.volume_spike,
+            )
             return
         self._focus_on_symbol(
             observation.symbol,


### PR DESCRIPTION
## Summary
- log lost seconds for depth, trade, and ticker resync events before clearing freshness timestamps
- add configurable detailed diagnostics flag and throttle partial-condition logging in the strategy

## Testing
- python -m compileall app.py domain/strategy/strategy.py config/config.py config/models/general_settings.py

------
https://chatgpt.com/codex/tasks/task_e_690513d2e0688320b7c5756bca70a66a