### PR TITLE
Ensure stop order placement reports success

### DIFF
--- a/app.py
+++ b/app.py
@@ -178,8 +178,8 @@ class TradingAdapterRouter(TradingAdapter):
         stop_price: float,
         quantity: float,
         trigger: StopTrigger,
-    ) -> None:
-        self._resolve().place_stop_market(side, stop_price, quantity, trigger)
+    ) -> bool:
+        return self._resolve().place_stop_market(side, stop_price, quantity, trigger)
 
 
 class Application:

--- a/application/trading.py
+++ b/application/trading.py
@@ -58,8 +58,8 @@ class NoopTradingAdapter(TradingAdapter):
         stop_price: float,
         quantity: float,
         trigger: StopTrigger,
-    ) -> None:
-        return
+    ) -> bool:
+        return True
 
 
 __all__ = ["NoopTradingAdapter"]

--- a/data/exchanges/__init__.py
+++ b/data/exchanges/__init__.py
@@ -213,7 +213,7 @@ class IExchangeTrade(Protocol):
         stop_price: float,
         quantity: float,
         trigger: StopTrigger,
-    ) -> None: ...
+    ) -> bool: ...
 
 
 class BinanceTradingAdapter(IExchangeTrade):
@@ -239,12 +239,50 @@ class BinanceTradingAdapter(IExchangeTrade):
         )
         self._market_reduce_only = settings.reduce_only
         self._stop_close_position = settings.close_position
+        self._last_stop_order_id: Optional[str] = None
+        self._last_stop_client_id: Optional[str] = None
 
     def _log(self, message: str) -> None:
         try:
             self._log_writer(message)
         except Exception:  # pragma: no cover - logging sink errors are ignored
             pass
+
+    def _cancel_previous_stop_order(self, *, timeout: float) -> None:
+        order_id = self._last_stop_order_id
+        client_id = self._last_stop_client_id
+        if not order_id and not client_id:
+            return
+
+        params: dict[str, Any] = {"symbol": self._symbol}
+        if order_id:
+            params["orderId"] = order_id
+        elif client_id:
+            params["origClientOrderId"] = client_id
+
+        try:
+            self._signed_request(
+                "/fapi/v1/order",
+                params=params,
+                timeout=timeout,
+                context="cancel stop order",
+                method="DELETE",
+            )
+            identifier = order_id or client_id or "UNKNOWN"
+            self._log(
+                f"[INFO] Binance cancelled previous stop order for {self._symbol}: id={identifier}"
+            )
+        except Exception as exc:  # pragma: no cover - network errors
+            identifier = order_id or client_id or "UNKNOWN"
+            self._log(
+                (
+                    f"[WARNING] Binance cancel stop order failed for {self._symbol} "
+                    f"id={identifier}: {exc}"
+                )
+            )
+        finally:
+            self._last_stop_order_id = None
+            self._last_stop_client_id = None
 
     def _signed_request(
         self,
@@ -391,8 +429,9 @@ class BinanceTradingAdapter(IExchangeTrade):
         stop_price: float,
         quantity: float,
         trigger: StopTrigger,
-    ) -> None:
+    ) -> bool:
         timeout_s = getattr(CONFIG.general, "orderbook_snapshot_timeout_s", 5.0)
+        self._cancel_previous_stop_order(timeout=timeout_s)
         params: dict[str, Any] = {
             "symbol": self._symbol,
             "side": "BUY" if side is Side.BID else "SELL",
@@ -412,21 +451,41 @@ class BinanceTradingAdapter(IExchangeTrade):
             method="POST",
         )
         payload = self._decode_payload(response_text, context="create stop order")
-        order_id = str(payload.get("orderId") or payload.get("clientOrderId") or "").strip()
+        order_id = str(payload.get("orderId") or "").strip()
+        client_order_id = str(payload.get("clientOrderId") or "").strip()
         status = str(payload.get("status") or "").strip()
         order_type = str(payload.get("type") or "").strip()
-        if not order_id:
-            order_id = "UNKNOWN"
+        identifier = order_id or client_order_id or "UNKNOWN"
         if not status:
             status = "UNKNOWN"
         if not order_type:
             order_type = "STOP_MARKET"
+        normalized_status = status.upper()
+        allowed_statuses = {
+            "NEW",
+            "PENDING_NEW",
+            "ACCEPTED",
+            "PENDING",
+            "FILLED",
+            "PARTIALLY_FILLED",
+        }
+        if normalized_status not in allowed_statuses:
+            self._log(
+                (
+                    f"[ERROR] Binance stop order rejected for {self._symbol}: "
+                    f"id={identifier} type={order_type} status={status}"
+                )
+            )
+            return False
+        self._last_stop_order_id = order_id or None
+        self._last_stop_client_id = client_order_id or None
         self._log(
             (
                 f"[INFO] Binance stop order ack for {self._symbol}: "
-                f"id={order_id} type={order_type} status={status}"
+                f"id={identifier} type={order_type} status={status}"
             )
         )
+        return True
 
     @staticmethod
     def _sanitize_identifier(value: Optional[str]) -> Optional[str]:
@@ -601,12 +660,53 @@ class BybitTradingAdapter(IExchangeTrade):
         self._timeout = getattr(CONFIG.general, "orderbook_snapshot_timeout_s", 5.0)
         self._log_writer: LogSink = log_writer or (lambda message: None)
         self._rest_client: Optional[_BybitPrivateRestClient] = None
+        self._last_stop_order_id: Optional[str] = None
+        self._last_stop_link_id: Optional[str] = None
 
     def _log(self, message: str) -> None:
         try:
             self._log_writer(message)
         except Exception:  # pragma: no cover - logging sink errors are ignored
             pass
+
+    def _cancel_previous_stop_order(self) -> None:
+        order_id = self._last_stop_order_id
+        link_id = self._last_stop_link_id
+        if not order_id and not link_id:
+            return
+
+        body = {
+            "category": "linear",
+            "symbol": self._symbol,
+        }
+        if order_id:
+            body["orderId"] = order_id
+        if link_id:
+            body["orderLinkId"] = link_id
+
+        client = self._client()
+        try:
+            payload = client.post(
+                "/v5/order/cancel",
+                body=body,
+                context="cancel stop order",
+            )
+            self._extract_result(payload, context="cancel stop order")
+            identifier = order_id or link_id or "UNKNOWN"
+            self._log(
+                f"[INFO] Bybit cancelled previous stop order for {self._symbol}: id={identifier}"
+            )
+        except Exception as exc:  # pragma: no cover - network errors
+            identifier = order_id or link_id or "UNKNOWN"
+            self._log(
+                (
+                    f"[WARNING] Bybit cancel stop order failed for {self._symbol} "
+                    f"id={identifier}: {exc}"
+                )
+            )
+        finally:
+            self._last_stop_order_id = None
+            self._last_stop_link_id = None
 
     def _ensure_credentials(self, *, context: str) -> None:
         if self._api_key and self._api_secret:
@@ -899,8 +999,9 @@ class BybitTradingAdapter(IExchangeTrade):
         stop_price: float,
         quantity: float,
         trigger: StopTrigger,
-    ) -> None:
+    ) -> bool:
         client = self._client()
+        self._cancel_previous_stop_order()
         trigger_map = {
             StopTrigger.MARK: "MarkPrice",
             StopTrigger.LAST: "LastPrice",
@@ -930,7 +1031,41 @@ class BybitTradingAdapter(IExchangeTrade):
             body=body,
             context="create stop order",
         )
-        self._extract_result(payload, context="create stop order")
+        result, _ = self._extract_result(payload, context="create stop order")
+        order_id = str(result.get("orderId") or result.get("orderID") or "").strip()
+        link_id = str(result.get("orderLinkId") or result.get("orderLinkID") or "").strip()
+        status = str(result.get("orderStatus") or result.get("status") or "").strip()
+        order_type = str(result.get("orderType") or "").strip() or "Market"
+        identifier = order_id or link_id or "UNKNOWN"
+        normalized_status = status.upper() if status else "UNKNOWN"
+        allowed_statuses = {
+            "NEW",
+            "CREATED",
+            "ACCEPTED",
+            "UNTRIGGERED",
+            "TRIGGERED",
+            "PENDING",
+            "PENDING_NEW",
+            "FILLED",
+            "PARTIALLY_FILLED",
+        }
+        if normalized_status not in allowed_statuses:
+            self._log(
+                (
+                    f"[ERROR] Bybit stop order rejected for {self._symbol}: "
+                    f"id={identifier} type={order_type} status={normalized_status}"
+                )
+            )
+            return False
+        self._last_stop_order_id = order_id or None
+        self._last_stop_link_id = link_id or None
+        self._log(
+            (
+                f"[INFO] Bybit stop order ack for {self._symbol}: "
+                f"id={identifier} type={order_type} status={normalized_status}"
+            )
+        )
+        return True
 
 
 __all__ = [

--- a/domain/execution.py
+++ b/domain/execution.py
@@ -107,7 +107,7 @@ def create_execution_handlers(
         signal: Signal,
     ) -> bool:
         try:
-            trading.place_stop_market(side, stop_price, quantity, stop_trigger)
+            success = trading.place_stop_market(side, stop_price, quantity, stop_trigger)
         except Exception as exc:
             logger.error(
                 "Stop order failed: %s %s qty=%.8f stop=%.8f signal=%s: %s",
@@ -117,6 +117,16 @@ def create_execution_handlers(
                 stop_price,
                 signal.name,
                 exc,
+            )
+            return False
+        if not success:
+            logger.error(
+                "Stop order rejected: %s %s qty=%.8f stop=%.8f signal=%s",
+                symbol,
+                side.name,
+                quantity,
+                stop_price,
+                signal.name,
             )
             return False
         logger.info(
@@ -184,13 +194,22 @@ def create_execution_handlers(
         current_quantity = executed_quantity
         stop_price: float = _compute_stop_price(signal, wall.price, filters)
         stop_side: Side = _signal_to_exit_side(signal)
-        place_stop_market(
+        stop_success = place_stop_market(
             stop_side,
             stop_price,
             current_quantity,
             symbol=symbol,
             signal=signal,
         )
+        if not stop_success:
+            logger.error(
+                "Initial stop order placement failed: %s %s qty=%.8f stop=%.8f signal=%s",
+                symbol,
+                stop_side.name,
+                current_quantity,
+                stop_price,
+                signal.name,
+            )
         return True
 
     def exit(symbol: str, reason: str) -> bool:
@@ -225,13 +244,23 @@ def create_execution_handlers(
         filters: SymbolFilters = filters_provider(symbol)
         stop_price = _compute_stop_price(current_signal, wall_price, filters)
         stop_side: Side = _signal_to_exit_side(current_signal)
-        return place_stop_market(
+        success = place_stop_market(
             stop_side,
             stop_price,
             current_quantity,
             symbol=symbol,
             signal=current_signal,
         )
+        if not success:
+            logger.error(
+                "Stop move failed: %s %s qty=%.8f stop=%.8f signal=%s",
+                symbol,
+                stop_side.name,
+                current_quantity,
+                stop_price,
+                current_signal.name,
+            )
+        return success
 
     return enter, exit, move_stop
 

--- a/domain/trading_adapter.py
+++ b/domain/trading_adapter.py
@@ -27,7 +27,7 @@ class TradingAdapter(Protocol):
         stop_price: float,
         quantity: float,
         trigger: StopTrigger,
-    ) -> None:
+    ) -> bool:
         ...
 
 


### PR DESCRIPTION
## Summary
- update Binance and Bybit stop order placement to return success flags, log REST failures, and cancel any previous stop orders before placing a new one
- propagate boolean stop placement results through the trading adapter interface and execution handlers so failed moves can be logged
- adjust router and noop trading adapters to the new stop-order contract

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6909b5de6eb0832099f9aa1cc11b5145