### PR TITLE
Adjust stream subscription burst capacity

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -25,6 +25,11 @@ from config.models import (
 )
 
 MAX_ACTIVE_STREAMS: Final[int] = 300
+# MAX_NEW_SUBSCRIPTIONS must not exceed the per-cycle capacity derived from
+# config/stream_limits.json. With three stream buckets and a Binance limit of
+# up to 10 subscription messages per second (50 per 5 seconds), a
+# burst_per_5s of 24 keeps our effective cap at eight new subscriptions while
+# leaving ample safety margin.
 MAX_NEW_SUBSCRIPTIONS: Final[int] = 8
 MAX_RESUBSCRIBE_PER_CYCLE: Final[int] = 5
 POLICY_VIOLATION_STREAM_COOLDOWN_S: Final[int] = 10

--- a/config/stream_limits.json
+++ b/config/stream_limits.json
@@ -1,21 +1,21 @@
 {
   "depth": {
     "steady_per_min": 60,
-    "burst_per_5s": 12,
+    "burst_per_5s": 24,
     "max_symbols": 120,
     "resubscribe_buffer": 10,
     "max_weight": 100
   },
   "trades": {
     "steady_per_min": 60,
-    "burst_per_5s": 12,
+    "burst_per_5s": 24,
     "max_symbols": 120,
     "resubscribe_buffer": 10,
     "max_weight": 100
   },
   "book_ticker": {
     "steady_per_min": 60,
-    "burst_per_5s": 12,
+    "burst_per_5s": 24,
     "max_symbols": 120,
     "resubscribe_buffer": 10,
     "max_weight": 100

--- a/uptick_bot_instructions.md
+++ b/uptick_bot_instructions.md
@@ -65,6 +65,10 @@ utils/
 - `RECENT_BAND_S = 5`
 - `RECENT_BAND_S_VOL_BOOST = 8`
 - `VOL_SPIKE_MULT = 2.0`
+- `MAX_NEW_SUBSCRIPTIONS = 8`  
+  Связан с `config/stream_limits.json`: значение должно оставаться ≤ `burst_per_5s / len(limit_map)`.
+  При лимите Binance до 10 подписок в секунду (50 за 5 секунд) текущий буфер `burst_per_5s = 24`
+  гарантирует восемь новых подписок за цикл без риска превышения.
 
 ### Обороты (отбор монет)
 


### PR DESCRIPTION
## Summary
- raise stream burst limits to support eight new subscriptions per cycle without exceeding Binance websocket guidance
- document the relationship between MAX_NEW_SUBSCRIPTIONS and stream_limits for operators

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f996fee58832082583e183bf5f45d)