### PR TITLE
Add shared command limiter for Binance stream sessions

### DIFF
--- a/data/exchanges/binance.py
+++ b/data/exchanges/binance.py
@@ -1099,6 +1099,7 @@ class BinanceStreamManager:
             "trades": self._limits.trades,
             "book_ticker": self._limits.book_ticker,
         }
+        self._global_command_budget = CommandBudget(self._build_global_limit())
         self._exchange_data: Dict[str, BinanceExchangeData] = {}
         self._streams: Dict[str, BinanceSymbolStreams] = {}
         self._profiles: Dict[str, TradingProfile] = {}
@@ -1119,12 +1120,33 @@ class BinanceStreamManager:
             session = self._create_session(name)
             self._sessions[name] = [session]
 
+    def _build_global_limit(self) -> StreamLimit:
+        steady_values = [
+            limit.steady_per_min for limit in self._limit_map.values() if limit.steady_per_min > 0
+        ]
+        burst_values = [
+            limit.burst_per_5s for limit in self._limit_map.values() if limit.burst_per_5s > 0
+        ]
+        steady = min(steady_values) if steady_values else 0
+        burst = min(burst_values) if burst_values else 0
+        reserve_total = sum(
+            max(limit.resubscribe_buffer, 0) for limit in self._limit_map.values()
+        )
+        return StreamLimit(
+            steady_per_min=steady,
+            burst_per_5s=burst,
+            max_symbols=0,
+            resubscribe_buffer=reserve_total,
+            max_weight=0.0,
+        )
+
     def _create_session(self, stream: str) -> BinanceStreamSession:
         session = BinanceStreamSession(
             stream=stream,
             limit=self._limit_map[stream],
             silence_timeout_ms=self._silence_timeout_ms,
             log_writer=self._log_writer,
+            command_limiter=self._global_command_budget,
         )
         session.start()
         return session
@@ -1189,6 +1211,9 @@ class BinanceStreamManager:
         burst_capacity = min(burst_limits) if burst_limits else float("inf")
         steady_capacity = min(steady_limits) if steady_limits else float("inf")
         command_capacity = min(burst_capacity, steady_capacity)
+        global_budget_capacity = self._global_command_budget.available()
+        if not math.isinf(global_budget_capacity):
+            command_capacity = min(command_capacity, global_budget_capacity)
         if math.isinf(command_capacity):
             max_new_batch: Optional[int] = None
         else:

--- a/data/exchanges/binance_session.py
+++ b/data/exchanges/binance_session.py
@@ -17,7 +17,7 @@ from config.config import (
 )
 from data.logger import LogSink
 from .binance_websocket import WebSocketClientProtocol, websockets
-from .command_budget import CommandBudget
+from .command_budget import CommandBudget, CommandBudgetToken
 from .limits import StreamLimit
 from .stream_consumer import StreamConsumer
 from .stream_subscription import StreamLimitError, StreamSubscription
@@ -61,12 +61,14 @@ class BinanceStreamSession:
             limit: StreamLimit,
             silence_timeout_ms: int,
             log_writer: LogSink,
+            command_limiter: CommandBudget | None = None,
     ) -> None:
         self._stream = stream
         self._limit = limit
         self._log = log_writer
         self._silence_timeout_s = max(float(silence_timeout_ms) / 1000.0, 1.0)
         self._budget = CommandBudget(limit)
+        self._global_budget = command_limiter
         self._max_weight = float(limit.max_weight)
         self._stop_event = threading.Event()
         self._thread = threading.Thread(
@@ -339,7 +341,32 @@ class BinanceStreamSession:
             self._command_queue.sort()
             score, seq, command = self._command_queue[0]
             budget_priority = "resync" if command.use_reserve else "normal"
-            if not self._budget.consume(priority=budget_priority):
+            global_token: CommandBudgetToken | None = None
+            local_token: CommandBudgetToken | None = None
+            if self._global_budget is not None:
+                global_token = self._global_budget.acquire(priority=budget_priority)
+                if global_token is None:
+                    delay = self._global_budget.failure_delay()
+                    now = time.monotonic()
+                    if now - self._last_rate_limit_log > 30.0:
+                        symbol = getattr(command.consumer, "symbol", "unknown")
+                        queue_len = len(self._command_queue)
+                        budget_state = self._global_budget.debug_state()
+                        log_msg = (
+                            f"[{self._stream}] Global rate limit: {command.method} для {symbol} "
+                            f"заблокирован на {delay:.1f}с. "
+                            f"В очереди {queue_len} команд(а/ы). "
+                            f"Глобальный бюджет: {budget_state}. "
+                        )
+                        self._log(log_msg)
+                        self._last_rate_limit_log = now
+                    if delay > 0.0:
+                        await asyncio.sleep(delay)
+                    break
+            local_token = self._budget.acquire(priority=budget_priority)
+            if local_token is None:
+                if self._global_budget is not None and global_token is not None:
+                    self._global_budget.release(global_token)
                 delay = self._budget.failure_delay()
                 now = time.monotonic()
                 if now - self._last_rate_limit_log > 30.0:
@@ -365,7 +392,14 @@ class BinanceStreamSession:
                 "method": command.method,
                 "params": list(command.params),
             }
-            await ws.send(json.dumps(payload))
+            try:
+                await ws.send(json.dumps(payload))
+            except Exception:
+                self._budget.release(local_token)
+                if self._global_budget is not None:
+                    self._global_budget.release(global_token)
+                self._inflight.pop(command_id, None)
+                raise
             self._inflight[command_id] = command
             try:
                 queue_len = len(self._command_queue)

--- a/data/exchanges/command_budget.py
+++ b/data/exchanges/command_budget.py
@@ -43,6 +43,23 @@ class RateLimiter:
         self._trim(timestamp)
         return max(self.limit - len(self._events), 0)
 
+    def revert(self, timestamp: datetime) -> None:
+        """Revert a previously committed event if it is still tracked."""
+
+        if self.limit <= 0:
+            return
+        self._trim(timestamp)
+        for index in range(len(self._events) - 1, -1, -1):
+            if self._events[index] == timestamp:
+                del self._events[index]
+                break
+
+
+@dataclass(slots=True)
+class CommandBudgetToken:
+    timestamp: datetime
+    reserve_delta: int = 0
+
 
 class CommandBudget:
     """Enforces Binance command rate limits across shared sessions."""
@@ -64,8 +81,16 @@ class CommandBudget:
         self._lock = Lock()
         self._failure_delay = 0.0
 
-    def consume(self, *, priority: str = "normal") -> bool:
-        """Consume from the configured budget."""
+    def _calculate_failure_delay(self) -> float:
+        wait = 0.0
+        if self._steady.limit > 0:
+            wait = max(wait, self._steady.window.total_seconds())
+        if self._burst.limit > 0:
+            wait = max(wait, self._burst.window.total_seconds())
+        return wait
+
+    def can_consume(self, *, priority: str = "normal") -> bool:
+        """Check whether a consume operation would succeed without mutating state."""
 
         use_reserve = priority != "normal"
         now = datetime.now(tz=timezone.utc)
@@ -73,36 +98,71 @@ class CommandBudget:
             steady_ok = self._steady.has_capacity(now)
             burst_ok = self._burst.has_capacity(now)
             if not steady_ok or not burst_ok:
-                wait = 0.0
-                if not steady_ok and self._steady.limit > 0:
-                    wait = max(wait, self._steady.window.total_seconds())
-                if not burst_ok and self._burst.limit > 0:
-                    wait = max(wait, self._burst.window.total_seconds())
-                self._failure_delay = wait
                 return False
+            if use_reserve and self._reserve_limit > 0:
+                return self._reserve_used < self._reserve_limit
+            return True
+
+    def acquire(self, *, priority: str = "normal") -> CommandBudgetToken | None:
+        """Attempt to reserve quota from the configured budget."""
+
+        use_reserve = priority != "normal"
+        now = datetime.now(tz=timezone.utc)
+        with self._lock:
+            steady_ok = self._steady.has_capacity(now)
+            burst_ok = self._burst.has_capacity(now)
+            if not steady_ok or not burst_ok:
+                self._failure_delay = self._calculate_failure_delay()
+                return None
+            if use_reserve and self._reserve_limit > 0 and self._reserve_used >= self._reserve_limit:
+                self._failure_delay = self._calculate_failure_delay()
+                return None
             self._steady.commit(now)
             self._burst.commit(now)
-            self._failure_delay = 0.0
+            reserve_delta = 0
             if use_reserve and self._reserve_used < self._reserve_limit:
                 self._reserve_used += 1
+                reserve_delta = 1
             elif not use_reserve and self._reserve_used > 0:
                 self._reserve_used -= 1
-            return True
+                reserve_delta = -1
+            self._failure_delay = 0.0
+            return CommandBudgetToken(timestamp=now, reserve_delta=reserve_delta)
+
+    def release(self, token: CommandBudgetToken | None) -> None:
+        if token is None:
+            return
+        with self._lock:
+            self._steady.revert(token.timestamp)
+            self._burst.revert(token.timestamp)
+            if token.reserve_delta == 1:
+                self._reserve_used = max(self._reserve_used - 1, 0)
+            elif token.reserve_delta == -1:
+                if self._reserve_limit > 0:
+                    self._reserve_used = min(self._reserve_used + 1, self._reserve_limit)
+
+    def consume(self, *, priority: str = "normal") -> bool:
+        """Consume from the configured budget."""
+
+        token = self.acquire(priority=priority)
+        return token is not None
 
     def failure_delay(self) -> float:
         with self._lock:
             if self._failure_delay > 0.0:
                 return self._failure_delay
-            waits: list[float] = []
-            if self._steady.limit > 0:
-                waits.append(self._steady.window.total_seconds())
-            if self._burst.limit > 0:
-                waits.append(self._burst.window.total_seconds())
-            return max(waits) if waits else 0.0
+            return self._calculate_failure_delay()
 
     def reserve_remaining(self) -> int:
         with self._lock:
             return max(self._reserve_limit - self._reserve_used, 0)
+
+    def available(self) -> float:
+        now = datetime.now(tz=timezone.utc)
+        with self._lock:
+            steady_remaining = self._steady.remaining(now)
+            burst_remaining = self._burst.remaining(now)
+        return float(min(steady_remaining, burst_remaining))
 
     def debug_state(self) -> Dict[str, float]:
         now = datetime.now(tz=timezone.utc)
@@ -122,4 +182,4 @@ class CommandBudget:
         }
 
 
-__all__ = ["RateLimiter", "CommandBudget"]
+__all__ = ["RateLimiter", "CommandBudget", "CommandBudgetToken"]


### PR DESCRIPTION
## Summary
- add a global command budget in the Binance stream manager and share it with every session
- update BinanceStreamSession to respect the shared limiter when flushing commands
- extend CommandBudget with token-based acquire/release helpers and expose available capacity for planning

## Testing
- python -m compileall data/exchanges/command_budget.py data/exchanges/binance_session.py data/exchanges/binance.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f9dcb8afc83208a9b91b26a5bb665)