### PR TITLE
Add CCXT data providers and periodic market scanner

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ import os
 import time
 
 from config.config import AppConfig, load_config, load_env
+from services.market_scan import build_market_scanner
 
 
 def configure_logging() -> None:
@@ -30,7 +31,13 @@ def configure() -> AppConfig:
 
 
 def start_symbol_monitoring(config: AppConfig) -> None:
-    logging.info("Мониторинг символов ещё не реализован для %s", config.exchange.name)
+    scanner = build_market_scanner(config)
+    logging.info(
+        "Запуск мониторинга символов для %s с периодом %s ч",
+        config.exchange.name,
+        config.scan.market_scan_interval_h,
+    )
+    scanner.run_forever()
 
 
 def main() -> None:

--- a/data_providers/__init__.py
+++ b/data_providers/__init__.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Data providers used by the application."""
+
+from .ccxt_client import (
+    CcxtClient,
+    CcxtClientConfig,
+    OHLCV,
+    TradingStats,
+)
+from .symbol_filter import (
+    ListingAge,
+    SymbolFilter,
+    SymbolFilterResult,
+)
+
+__all__ = [
+    "CcxtClient",
+    "CcxtClientConfig",
+    "OHLCV",
+    "TradingStats",
+    "ListingAge",
+    "SymbolFilter",
+    "SymbolFilterResult",
+]

--- a/data_providers/ccxt_client.py
+++ b/data_providers/ccxt_client.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Final, Mapping, MutableMapping, Optional, Sequence, TypedDict
+
+import ccxt
+
+
+class OHLCV(TypedDict):
+    """Normalized OHLCV candle returned by CCXT."""
+
+    timestamp: int
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+
+class TradingStats(TypedDict, total=False):
+    """Trading statistics derived from CCXT ticker payload."""
+
+    symbol: str
+    last_price: float
+    price_change_percent: float
+    avg_daily_volume_usdt: float
+    trades_24h: int
+
+
+class _CcxtMarketInfo(TypedDict, total=False):
+    """Subset of raw market information needed by the application."""
+
+    symbol: str
+    swap: bool
+    future: bool
+    active: bool
+    info: "_CcxtExchangeSpecific"
+
+
+class _CcxtExchangeSpecific(TypedDict, total=False):
+    onboardDate: int
+
+
+@dataclass(frozen=True)
+class CcxtClientConfig:
+    """Configuration required to bootstrap the CCXT client wrapper."""
+
+    exchange_name: str
+    api_key: str | None
+    api_secret: str | None
+    htf: str
+    ltf: str
+    rest_htf: bool
+    rest_ltf: bool
+
+
+class CcxtClient:
+    """Thin wrapper around CCXT tailored for the application's needs."""
+
+    _DEFAULT_LIMIT: Final[int] = 150
+
+    def __init__(self, config: CcxtClientConfig) -> None:
+        self._config = config
+        self._exchange = self._create_exchange()
+        self._markets: MutableMapping[str, _CcxtMarketInfo] | None = None
+
+    def _create_exchange(self) -> ccxt.Exchange:
+        exchange_class = getattr(ccxt, self._config.exchange_name)
+        exchange: ccxt.Exchange = exchange_class({
+            "apiKey": self._config.api_key,
+            "secret": self._config.api_secret,
+            "enableRateLimit": True,
+        })
+        return exchange
+
+    # ------------------------------------------------------------------
+    # Market helpers
+    # ------------------------------------------------------------------
+    def _ensure_markets_loaded(self) -> None:
+        if self._markets is None:
+            raw_markets = self._exchange.load_markets()
+            self._markets = {symbol: _CcxtMarketInfo(**market) for symbol, market in raw_markets.items()}
+
+    def get_futures_symbols(self) -> list[str]:
+        """Return a sorted list of futures (swap) symbols available on the exchange."""
+
+        self._ensure_markets_loaded()
+        assert self._markets is not None
+        symbols: list[str] = []
+        for symbol, market in self._markets.items():
+            if not market.get("active", True):
+                continue
+            if market.get("swap") or market.get("future"):
+                symbols.append(symbol)
+        symbols.sort()
+        return symbols
+
+    def get_market(self, symbol: str) -> _CcxtMarketInfo:
+        """Return cached market metadata for ``symbol``."""
+
+        self._ensure_markets_loaded()
+        assert self._markets is not None
+        market = self._markets.get(symbol)
+        if market is None:
+            raise KeyError(f"Маркет {symbol} не найден")
+        return market
+
+    # ------------------------------------------------------------------
+    # Candles
+    # ------------------------------------------------------------------
+    def _normalize_ohlcv(self, raw: Sequence[float | int]) -> OHLCV:
+        if len(raw) < 6:
+            raise ValueError("CCXT вернул некорректную свечу")
+        timestamp, open_, high, low, close, volume = raw[:6]
+        return OHLCV(
+            timestamp=int(timestamp),
+            open=float(open_),
+            high=float(high),
+            low=float(low),
+            close=float(close),
+            volume=float(volume),
+        )
+
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        timeframe: str,
+        *,
+        since: Optional[int] = None,
+        limit: int | None = None,
+    ) -> list[OHLCV]:
+        """Fetch OHLCV candles and normalise them into dictionaries."""
+
+        raw_candles = self._exchange.fetch_ohlcv(symbol, timeframe=timeframe, since=since, limit=limit or self._DEFAULT_LIMIT)
+        return [self._normalize_ohlcv(candle) for candle in raw_candles]
+
+    def fetch_htf_ohlcv(self, symbol: str, *, since: Optional[int] = None, limit: int | None = None) -> list[OHLCV]:
+        """Fetch OHLCV candles for the configured high timeframe."""
+
+        if not self._config.rest_htf:
+            return []
+        return self.fetch_ohlcv(symbol, self._config.htf, since=since, limit=limit)
+
+    def fetch_ltf_ohlcv(self, symbol: str, *, since: Optional[int] = None, limit: int | None = None) -> list[OHLCV]:
+        """Fetch OHLCV candles for the configured low timeframe."""
+
+        if not self._config.rest_ltf:
+            return []
+        return self.fetch_ohlcv(symbol, self._config.ltf, since=since, limit=limit)
+
+    def fetch_daily_ohlcv(self, symbol: str, *, limit: int) -> list[OHLCV]:
+        """Fetch daily candles used for averaging volume statistics."""
+
+        if limit <= 0:
+            raise ValueError("limit должен быть положительным")
+        raw_candles = self._exchange.fetch_ohlcv(symbol, timeframe="1d", limit=limit)
+        return [self._normalize_ohlcv(candle) for candle in raw_candles]
+
+    # ------------------------------------------------------------------
+    # Trading stats
+    # ------------------------------------------------------------------
+    def fetch_trading_stats(self, symbol: str, *, avg_days: int) -> TradingStats:
+        """Return lightweight trading statistics for ``symbol``."""
+
+        if avg_days <= 0:
+            raise ValueError("avg_days должен быть положительным")
+
+        ticker: Mapping[str, Any] = self._exchange.fetch_ticker(symbol)
+        info = ticker.get("info", {}) if isinstance(ticker, Mapping) else {}
+
+        last_price = float(ticker.get("last", info.get("lastPrice", 0.0))) if isinstance(ticker, Mapping) else 0.0
+        change_percent = float(ticker.get("percentage", info.get("priceChangePercent", 0.0))) if isinstance(ticker, Mapping) else 0.0
+
+        quote_volume_raw = ticker.get("quoteVolume") if isinstance(ticker, Mapping) else None
+        if quote_volume_raw is None:
+            quote_volume_raw = info.get("quoteVolume") if isinstance(info, Mapping) else 0.0
+        quote_volume = float(quote_volume_raw or 0.0)
+
+        trades_raw: Any = info.get("count") if isinstance(info, Mapping) else None
+        if trades_raw is None and isinstance(ticker, Mapping):
+            trades_raw = ticker.get("trades")
+        trades = int(trades_raw or 0)
+
+        daily_candles = self.fetch_daily_ohlcv(symbol, limit=avg_days)
+        if not daily_candles:
+            avg_daily_volume = quote_volume
+        else:
+            total_quote_volume = 0.0
+            for candle in daily_candles:
+                total_quote_volume += candle["close"] * candle["volume"]
+            avg_daily_volume = total_quote_volume / len(daily_candles)
+
+        return TradingStats(
+            symbol=symbol,
+            last_price=last_price,
+            price_change_percent=change_percent,
+            avg_daily_volume_usdt=avg_daily_volume,
+            trades_24h=trades,
+        )
+
+
+__all__ = [
+    "CcxtClient",
+    "CcxtClientConfig",
+    "OHLCV",
+    "TradingStats",
+]

--- a/data_providers/symbol_filter.py
+++ b/data_providers/symbol_filter.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Callable, Optional, Protocol, TypedDict
+
+from config.config import SymbolFiltersConfig
+
+from .ccxt_client import TradingStats
+
+
+class ListingAge(TypedDict, total=False):
+    """Represents the calculated listing age for a symbol."""
+
+    days: float
+    source_timestamp: int
+
+
+class _CcxtMarketInfo(TypedDict, total=False):
+    """Subset of CCXT market payload used for filtering."""
+
+    symbol: str
+    info: "_CcxtExchangeSpecific"
+
+
+class _CcxtExchangeSpecific(TypedDict, total=False):
+    onboardDate: int
+
+
+class SymbolFilterResult(TypedDict):
+    """Outcome of the symbol filtering pipeline."""
+
+    symbol: str
+    allowed: bool
+    is_new_listing: bool
+    listing_age: ListingAge | None
+
+
+class SymbolFilterProtocol(Protocol):
+    def evaluate(self, symbol: str, market: _CcxtMarketInfo, stats: TradingStats) -> SymbolFilterResult:
+        ...
+
+
+@dataclass
+class SymbolFilter(SymbolFilterProtocol):
+    """Filter symbols based on listing age and trading activity thresholds."""
+
+    config: SymbolFiltersConfig
+    now_factory: Callable[[], datetime] = field(default=lambda: datetime.now(tz=timezone.utc))
+
+    def _extract_onboard_timestamp(self, market: _CcxtMarketInfo) -> Optional[int]:
+        info = market.get("info")
+        if info is None:
+            return None
+        onboard = info.get("onboardDate")
+        if onboard is None:
+            return None
+        try:
+            return int(onboard)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Невозможно преобразовать onboardDate в int") from exc
+
+    def _calculate_listing_age(self, market: _CcxtMarketInfo) -> ListingAge | None:
+        onboard_timestamp = self._extract_onboard_timestamp(market)
+        if onboard_timestamp is None:
+            return None
+
+        onboard_dt = datetime.fromtimestamp(onboard_timestamp / 1000, tz=timezone.utc)
+        now = self.now_factory()
+        age_seconds = (now - onboard_dt).total_seconds()
+        age_days = max(age_seconds / 86400, 0.0)
+        return ListingAge(days=age_days, source_timestamp=onboard_timestamp)
+
+    def evaluate(self, symbol: str, market: _CcxtMarketInfo, stats: TradingStats) -> SymbolFilterResult:
+        listing_age = self._calculate_listing_age(market)
+        is_new_listing = False
+        volume_threshold = self.config.min_volume_established
+        trades_threshold = self.config.min_trades_established
+
+        if listing_age is not None and listing_age["days"] < self.config.n_avg_days:
+            is_new_listing = True
+            volume_threshold = self.config.min_volume_new_listing
+            trades_threshold = 0
+
+        avg_daily_volume = float(stats.get("avg_daily_volume_usdt", 0.0))
+        trades_24h = int(stats.get("trades_24h", 0))
+
+        allowed = avg_daily_volume >= volume_threshold and trades_24h >= trades_threshold
+
+        return SymbolFilterResult(
+            symbol=symbol,
+            allowed=allowed,
+            is_new_listing=is_new_listing,
+            listing_age=listing_age,
+        )
+
+
+__all__ = [
+    "ListingAge",
+    "SymbolFilter",
+    "SymbolFilterResult",
+]

--- a/services/market_scan.py
+++ b/services/market_scan.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Callable, Dict, Iterable, List
+
+from config.config import AppConfig, RestDataConfig, ScanConfig, SymbolFiltersConfig
+from data_providers import (
+    CcxtClient,
+    CcxtClientConfig,
+    ListingAge,
+    SymbolFilter,
+    SymbolFilterResult,
+    TradingStats,
+)
+
+from data_providers.ccxt_client import OHLCV
+
+
+@dataclass
+class SymbolMarketSnapshot:
+    """Snapshot of the latest market data tracked for a symbol."""
+
+    symbol: str
+    listing_age: ListingAge | None
+    stats: TradingStats
+    htf_candles: List[OHLCV]
+    ltf_candles: List[OHLCV]
+    extended_mode: bool
+    last_updated: datetime
+
+
+@dataclass
+class MarketScanState:
+    """Mutable state of all symbols observed by the market scanner."""
+
+    symbols: Dict[str, SymbolMarketSnapshot] = field(default_factory=dict)
+
+    def update_symbol(self, snapshot: SymbolMarketSnapshot) -> None:
+        self.symbols[snapshot.symbol] = snapshot
+
+    def remove_symbols(self, symbols: Iterable[str]) -> None:
+        for symbol in symbols:
+            self.symbols.pop(symbol, None)
+
+
+@dataclass
+class MarketScanner:
+    """Iterative scanner that runs filters and collects market data."""
+
+    client: CcxtClient
+    symbol_filter: SymbolFilter
+    scan_config: ScanConfig
+    rest_config: RestDataConfig
+    symbol_filters_config: SymbolFiltersConfig
+    now_factory: Callable[[], datetime] = field(default=lambda: datetime.now(tz=timezone.utc))
+    logger: logging.Logger = logging.getLogger(__name__)
+    state: MarketScanState = field(default_factory=MarketScanState)
+
+    def _should_enable_extended_mode(self, filter_result: SymbolFilterResult, stats: TradingStats) -> bool:
+        if not self.rest_config.fetch_ltf:
+            return False
+        if filter_result["is_new_listing"]:
+            return False
+        trades = int(stats.get("trades_24h", 0))
+        return trades >= self.symbol_filters_config.min_trades_established
+
+    def _collect_symbol_data(self, symbol: str, filter_result: SymbolFilterResult, stats: TradingStats) -> SymbolMarketSnapshot:
+        htf_candles = self.client.fetch_htf_ohlcv(symbol)
+        extended_mode = self._should_enable_extended_mode(filter_result, stats)
+        ltf_candles = self.client.fetch_ltf_ohlcv(symbol) if extended_mode else []
+        snapshot = SymbolMarketSnapshot(
+            symbol=symbol,
+            listing_age=filter_result["listing_age"],
+            stats=stats,
+            htf_candles=htf_candles,
+            ltf_candles=ltf_candles,
+            extended_mode=extended_mode,
+            last_updated=self.now_factory(),
+        )
+        return snapshot
+
+    def _run_filters(self, symbol: str) -> tuple[bool, SymbolFilterResult, TradingStats]:
+        market = self.client.get_market(symbol)
+        stats = self.client.fetch_trading_stats(symbol, avg_days=self.symbol_filters_config.n_avg_days)
+        filter_result = self.symbol_filter.evaluate(symbol, market, stats)
+        return filter_result["allowed"], filter_result, stats
+
+    def scan_once(self) -> MarketScanState:
+        futures_symbols = self.client.get_futures_symbols()
+        observed_now: set[str] = set()
+        for symbol in futures_symbols:
+            allowed, filter_result, stats = self._run_filters(symbol)
+            if not allowed:
+                self.state.remove_symbols([symbol])
+                continue
+            observed_now.add(symbol)
+            snapshot = self._collect_symbol_data(symbol, filter_result, stats)
+            self.state.update_symbol(snapshot)
+
+        stale_symbols = [symbol for symbol in self.state.symbols if symbol not in observed_now]
+        if stale_symbols:
+            self.state.remove_symbols(stale_symbols)
+        return self.state
+
+    def run_forever(self) -> None:
+        interval_seconds = max(self.scan_config.market_scan_interval_h, 1) * 3600
+        while True:
+            start = self.now_factory()
+            self.logger.info("Запуск сканирования рынка")
+            try:
+                self.scan_once()
+            except Exception as exc:  # pragma: no cover - safeguard for runtime
+                self.logger.exception("Ошибка сканирования рынка: %s", exc)
+            elapsed = (self.now_factory() - start).total_seconds()
+            sleep_for = max(interval_seconds - elapsed, 0.0)
+            if sleep_for:
+                time.sleep(sleep_for)
+
+
+def build_market_scanner(config: AppConfig) -> MarketScanner:
+    client_config = CcxtClientConfig(
+        exchange_name=config.exchange.name,
+        api_key=config.exchange.api_key,
+        api_secret=config.exchange.api_secret,
+        htf=config.timeframes.htf,
+        ltf=config.timeframes.ltf,
+        rest_htf=config.rest_data.fetch_htf,
+        rest_ltf=config.rest_data.fetch_ltf,
+    )
+    client = CcxtClient(client_config)
+    symbol_filter = SymbolFilter(config.symbol_filters)
+    return MarketScanner(
+        client=client,
+        symbol_filter=symbol_filter,
+        scan_config=config.scan,
+        rest_config=config.rest_data,
+        symbol_filters_config=config.symbol_filters,
+    )
+
+
+__all__ = [
+    "MarketScanner",
+    "MarketScanState",
+    "SymbolMarketSnapshot",
+    "build_market_scanner",
+]


### PR DESCRIPTION
## Summary
- wrap CCXT for the configured exchange to expose futures metadata, OHLCV access, and trading statistics
- implement symbol filtering that evaluates listing age and volume/trade thresholds via typed CCXT payloads
- add a market scanning service that orchestrates periodic polling and wire it into the app entrypoint

## Testing
- python -m compileall app data_providers services

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910879e46e48320825ad747b75a49c8)