### PR TITLE
Implement L timeframe pipeline and swings adapter

### DIFF
--- a/domain/models/symbol_state.py
+++ b/domain/models/symbol_state.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
 
+from .band import Band
 from .level import Level
 from .pump import Pump
 from .scenario_status import ScenarioStatus
@@ -17,6 +18,7 @@ class SymbolState:
     cooldown_until: Optional[datetime]
     last_pump: Optional[Pump]
     last_level: Optional[Level]
+    last_band: Optional[Band]
     l_pullback: Optional[float]
     h_main: Optional[float]
 

--- a/integrations/__init__.py
+++ b/integrations/__init__.py
@@ -1,0 +1,17 @@
+"""Integration adapters used to bridge external services with domain models."""
+
+from .swings import (
+    RawBand,
+    RawSwing,
+    RawSwingsOutput,
+    SwingsAdapter,
+    SwingsExtractor,
+)
+
+__all__ = [
+    "RawBand",
+    "RawSwing",
+    "RawSwingsOutput",
+    "SwingsAdapter",
+    "SwingsExtractor",
+]

--- a/integrations/swings.py
+++ b/integrations/swings.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Protocol, Sequence, TypedDict, overload
+
+from domain.models import Band, Candle, SwingsOutput, SwingHigh
+
+
+class RawSwing(TypedDict):
+    """Raw representation of a swing high returned by the external module."""
+
+    price: float
+    timestamp: int | float | datetime
+    index: int
+
+
+class RawBand(TypedDict):
+    """Raw representation of a consolidation band."""
+
+    low: float
+    high: float
+    start_timestamp: int | float | datetime
+    end_timestamp: int | float | datetime
+
+
+class RawSwingsOutput(TypedDict):
+    """Raw payload describing extracted swings on the low timeframe."""
+
+    swings: list[RawSwing]
+    has_consolidation: bool
+    consolidation_band: RawBand | None
+
+
+class SwingsExtractor(Protocol):
+    """Protocol describing the expected swings extraction interface."""
+
+    def extract(self, candles: Sequence[Candle]) -> RawSwingsOutput:
+        """Return swings identified on the provided ``candles``."""
+
+
+@dataclass
+class SwingsAdapter:
+    """Adapter converting raw swings payloads into domain models."""
+
+    extractor: SwingsExtractor
+
+    def extract_swings(self, candles: Sequence[Candle]) -> SwingsOutput:
+        """Extract swings and convert them into domain objects."""
+
+        raw_output = self.extractor.extract(candles)
+        swings = [_convert_raw_swing(raw_swing) for raw_swing in raw_output["swings"]]
+        band = _convert_raw_band(raw_output.get("consolidation_band"))
+        return SwingsOutput(
+            swings=swings,
+            has_consolidation=raw_output["has_consolidation"],
+            consolidation_band=band,
+        )
+
+
+def _convert_raw_swing(raw: RawSwing) -> SwingHigh:
+    return SwingHigh(
+        price=float(raw["price"]),
+        timestamp=_normalise_datetime(raw["timestamp"]),
+        index=int(raw["index"]),
+    )
+
+
+def _convert_raw_band(raw: RawBand | None) -> Band | None:
+    if raw is None:
+        return None
+    return Band(
+        low=float(raw["low"]),
+        high=float(raw["high"]),
+        start_timestamp=_normalise_datetime(raw["start_timestamp"]),
+        end_timestamp=_normalise_datetime(raw["end_timestamp"]),
+    )
+
+
+@overload
+def _normalise_datetime(value: datetime) -> datetime:
+    ...
+
+
+@overload
+def _normalise_datetime(value: int | float) -> datetime:
+    ...
+
+
+def _normalise_datetime(value: datetime | int | float) -> datetime:
+    """Normalise ``value`` into a timezone-aware ``datetime`` instance."""
+
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    if not isinstance(value, (int, float)):
+        raise TypeError("timestamp должен быть datetime, int или float")
+
+    timestamp = float(value)
+    # ``Swings`` may emit timestamps either in seconds or milliseconds.
+    if timestamp > 1_000_000_000_000:
+        timestamp /= 1_000.0
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc)
+
+
+__all__ = [
+    "RawBand",
+    "RawSwing",
+    "RawSwingsOutput",
+    "SwingsAdapter",
+    "SwingsExtractor",
+]

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,12 +1,23 @@
 """Trading strategy utilities."""
 
+from .breakout import RiskRewardResult, check_breakout, compute_rr
 from .htf_pipeline import HtfPipeline, HtfPipelineResult
+from .level_builder import LevelBuildResult, build_level
+from .ltf_pipeline import BreakoutSignal, LtfPipeline, LtfPipelineResult
 from .pump_detection import detect_pump_candle_on_H
 from .pullback import PullbackCancelReason, PullbackValidationResult, validate_pullback_on_H
 
 __all__ = [
+    "BreakoutSignal",
     "HtfPipeline",
     "HtfPipelineResult",
+    "LevelBuildResult",
+    "LtfPipeline",
+    "LtfPipelineResult",
+    "RiskRewardResult",
+    "build_level",
+    "check_breakout",
+    "compute_rr",
     "detect_pump_candle_on_H",
     "PullbackCancelReason",
     "PullbackValidationResult",

--- a/strategies/breakout.py
+++ b/strategies/breakout.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RiskRewardResult:
+    """Detailed result of risk-reward evaluation."""
+
+    rr: float
+    meets_min_rr: bool
+    meets_min_tp: bool
+    tp1: float
+    tp2: float
+
+
+def check_breakout(last_price: float, level_top: float) -> bool:
+    """Return ``True`` when ``last_price`` breaks above ``level_top``."""
+
+    return last_price >= level_top
+
+
+def compute_rr(
+    entry_price: float,
+    l_pullback: float,
+    h_main: float,
+    *,
+    min_rr: float,
+    min_tp_pct: float,
+) -> RiskRewardResult:
+    """Compute risk-reward metrics and validate thresholds."""
+
+    if entry_price <= 0:
+        raise ValueError("entry_price должен быть положительным")
+    if min_rr < 0:
+        raise ValueError("min_rr не может быть отрицательным")
+    if min_tp_pct < 0:
+        raise ValueError("min_tp_pct не может быть отрицательным")
+
+    stop_distance = entry_price - l_pullback
+    if stop_distance <= 0:
+        raise ValueError("entry_price должен быть больше L_pullback")
+
+    profit_distance = h_main - entry_price
+    rr = profit_distance / stop_distance
+
+    tp1 = h_main
+    tp2 = h_main + (2.0 / 3.0) * (h_main - l_pullback)
+
+    meets_min_rr = rr > min_rr or abs(rr - min_rr) < 1e-9
+    min_tp_value = (tp1 - entry_price) / entry_price
+    meets_min_tp = min_tp_value >= min_tp_pct
+
+    return RiskRewardResult(
+        rr=rr,
+        meets_min_rr=meets_min_rr,
+        meets_min_tp=meets_min_tp,
+        tp1=tp1,
+        tp2=tp2,
+    )
+
+
+__all__ = ["RiskRewardResult", "check_breakout", "compute_rr"]

--- a/strategies/level_builder.py
+++ b/strategies/level_builder.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from domain.models import Band, Level, LevelPattern, SwingsOutput, SwingHigh
+
+_EPSILON = 1e-9
+
+
+@dataclass(frozen=True)
+class LevelBuildResult:
+    """Result of building a level from swings."""
+
+    level: Level
+    used_swings: tuple[SwingHigh, ...]
+    swings_above_level: tuple[SwingHigh, ...]
+    consolidation_band: Band | None
+
+
+def build_level(swings_output: SwingsOutput, atr_h: float) -> LevelBuildResult | None:
+    """Build a level from the provided swings output.
+
+    The function implements templates (A) and (B) defined by the strategy
+    specification. The resulting level must satisfy the following constraints:
+
+    * Width strictly less than ``atr_h``.
+    * For template (A) at least two swings are required.
+    * For template (B) a single swing accompanied by a consolidation band is
+      required.
+    * No more than one swing high is allowed above the computed ``level_top``.
+    """
+
+    if atr_h <= 0:
+        raise ValueError("atr_h должен быть положительным")
+
+    swings = tuple(swings_output.swings)
+    if not swings:
+        return None
+
+    if len(swings) >= 2:
+        result = _build_template_a(swings, atr_h)
+        if result is not None:
+            return result
+
+    if len(swings) == 1 and swings_output.has_consolidation:
+        result = _build_template_b(swings[0], swings_output, atr_h)
+        if result is not None:
+            return result
+
+    return None
+
+
+def _build_template_a(swings: Sequence[SwingHigh], atr_h: float) -> LevelBuildResult | None:
+    swings_by_price = sorted(swings, key=lambda swing: swing.price)
+    total = len(swings_by_price)
+
+    # We may exclude the highest swing to tolerate a single fake breakout
+    # above the level (constraint §8.6).
+    for excluded in range(0, min(2, total)):
+        subset = swings_by_price[: total - excluded]
+        if len(subset) < 2:
+            break
+
+        level_low = subset[0].price
+        level_top = subset[-1].price
+        width = level_top - level_low
+        if width >= atr_h - _EPSILON:
+            continue
+
+        level = Level(
+            level_low=level_low,
+            level_top=level_top,
+            width=width,
+            pattern=LevelPattern.MULTIPLE_SWINGS,
+        )
+
+        used_swings = _preserve_original_order(swings, subset)
+        swings_above = tuple(swing for swing in swings if swing.price > level_top + _EPSILON)
+        if len(swings_above) > 1:
+            continue
+
+        return LevelBuildResult(
+            level=level,
+            used_swings=used_swings,
+            swings_above_level=swings_above,
+            consolidation_band=None,
+        )
+
+    return None
+
+
+def _build_template_b(
+    swing: SwingHigh,
+    swings_output: SwingsOutput,
+    atr_h: float,
+) -> LevelBuildResult | None:
+    band = swings_output.consolidation_band
+    if band is None:
+        return None
+
+    level_low = band.low
+    level_top = swing.price
+    width = level_top - level_low
+    if width >= atr_h - _EPSILON:
+        return None
+    if band.high < level_top - _EPSILON:
+        return None
+
+    level = Level(
+        level_low=level_low,
+        level_top=level_top,
+        width=width,
+        pattern=LevelPattern.SINGLE_WITH_CONSOLIDATION,
+    )
+
+    swings_above = tuple(sw for sw in swings_output.swings if sw.price > level_top + _EPSILON)
+    if len(swings_above) > 1:
+        return None
+
+    return LevelBuildResult(
+        level=level,
+        used_swings=(swing,),
+        swings_above_level=swings_above,
+        consolidation_band=band,
+    )
+
+
+def _preserve_original_order(
+    original: Sequence[SwingHigh],
+    subset: Iterable[SwingHigh],
+) -> tuple[SwingHigh, ...]:
+    subset_set = set(subset)
+    return tuple(swing for swing in original if swing in subset_set)
+
+
+__all__ = ["LevelBuildResult", "build_level"]

--- a/strategies/ltf_pipeline.py
+++ b/strategies/ltf_pipeline.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from typing import Callable, Sequence
+
+from config.config import AppConfig, MinTakeProfitConfig, RiskRewardConfig
+from data_providers.ccxt_client import OHLCV
+from domain.models import Band, Candle, Level, ScenarioStatus, SymbolState, SwingsOutput
+from integrations import SwingsAdapter
+from strategies.breakout import RiskRewardResult, check_breakout, compute_rr
+from strategies.level_builder import LevelBuildResult, build_level
+
+
+@dataclass(frozen=True)
+class BreakoutSignal:
+    """Signal instructing the system to place breakout orders."""
+
+    level: Level
+    band: Band | None
+    entry_price: float
+    stop_loss: float
+    take_profit_1: float
+    take_profit_2: float
+    rr: float
+
+
+@dataclass(frozen=True)
+class LtfPipelineResult:
+    """Detailed outcome of the low timeframe analysis."""
+
+    swings_output: SwingsOutput | None
+    level_result: LevelBuildResult | None
+    breakout_triggered: bool
+    risk_reward: RiskRewardResult | None
+    signal: BreakoutSignal | None
+    state: SymbolState
+
+
+@dataclass
+class LtfPipeline:
+    """Pipeline responsible for processing low timeframe data."""
+
+    swings_adapter: SwingsAdapter
+    risk_reward_config: RiskRewardConfig
+    min_tp_config: MinTakeProfitConfig
+    now_factory: Callable[[], datetime] = lambda: datetime.now(tz=timezone.utc)
+
+    @classmethod
+    def from_config(
+        cls,
+        config: AppConfig,
+        swings_adapter: SwingsAdapter,
+        *,
+        now_factory: Callable[[], datetime] | None = None,
+    ) -> LtfPipeline:
+        return cls(
+            swings_adapter=swings_adapter,
+            risk_reward_config=config.risk_reward,
+            min_tp_config=config.min_take_profit,
+            now_factory=now_factory or (lambda: datetime.now(tz=timezone.utc)),
+        )
+
+    def run(
+        self,
+        state: SymbolState,
+        ltf_candles: Sequence[OHLCV],
+        *,
+        atr_h: float,
+        h_main: float,
+        l_pullback: float,
+        last_price: float,
+    ) -> LtfPipelineResult:
+        """Execute the pipeline for the provided symbol state and data."""
+
+        if not ltf_candles:
+            updated_state = replace(
+                state,
+                h_main=h_main,
+                l_pullback=l_pullback,
+            )
+            return LtfPipelineResult(
+                swings_output=None,
+                level_result=None,
+                breakout_triggered=False,
+                risk_reward=None,
+                signal=None,
+                state=updated_state,
+            )
+
+        candles = [_convert_ohlcv(candle) for candle in ltf_candles]
+        swings_output = self.swings_adapter.extract_swings(candles)
+
+        level_result = build_level(swings_output, atr_h)
+
+        new_status = state.status
+        if level_result is not None and not state.has_open_position:
+            new_status = ScenarioStatus.MONITORING
+
+        updated_state = replace(
+            state,
+            h_main=h_main,
+            l_pullback=l_pullback,
+            last_level=level_result.level if level_result is not None else None,
+            last_band=level_result.consolidation_band if level_result is not None else None,
+            status=new_status,
+        )
+
+        breakout_detected = False
+        risk_reward_result: RiskRewardResult | None = None
+        signal: BreakoutSignal | None = None
+
+        if level_result is not None and not state.has_open_position:
+            breakout_detected = check_breakout(last_price, level_result.level.level_top)
+            if breakout_detected:
+                risk_reward_result = compute_rr(
+                    entry_price=level_result.level.level_top,
+                    l_pullback=l_pullback,
+                    h_main=h_main,
+                    min_rr=self.risk_reward_config.rr_min,
+                    min_tp_pct=self.min_tp_config.min_tp_pct,
+                )
+                if risk_reward_result.meets_min_rr and risk_reward_result.meets_min_tp:
+                    signal = BreakoutSignal(
+                        level=level_result.level,
+                        band=level_result.consolidation_band,
+                        entry_price=level_result.level.level_top,
+                        stop_loss=l_pullback,
+                        take_profit_1=risk_reward_result.tp1,
+                        take_profit_2=risk_reward_result.tp2,
+                        rr=risk_reward_result.rr,
+                    )
+                    updated_state = replace(updated_state, status=ScenarioStatus.ACTIVE)
+
+        return LtfPipelineResult(
+            swings_output=swings_output,
+            level_result=level_result,
+            breakout_triggered=breakout_detected,
+            risk_reward=risk_reward_result,
+            signal=signal,
+            state=updated_state,
+        )
+
+
+def _convert_ohlcv(ohlcv: OHLCV) -> Candle:
+    timestamp = _normalise_timestamp(ohlcv["timestamp"])
+    return Candle(
+        open=ohlcv["open"],
+        high=ohlcv["high"],
+        low=ohlcv["low"],
+        close=ohlcv["close"],
+        volume=ohlcv["volume"],
+        timestamp=timestamp,
+    )
+
+
+def _normalise_timestamp(value: int | float) -> datetime:
+    timestamp = float(value)
+    if timestamp > 1_000_000_000_000:
+        timestamp /= 1_000.0
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc)
+
+
+__all__ = ["BreakoutSignal", "LtfPipeline", "LtfPipelineResult"]


### PR DESCRIPTION
## Summary
- add an adapter that converts raw swings output into domain models
- add level construction logic covering multi-swing and consolidation templates with breakout RR helpers
- implement the L-timeframe pipeline that updates symbol state and emits breakout order signals

## Testing
- python -m compileall integrations strategies domain

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69108ba6984483208fe636f4b3c8e3e7)