### PR TITLE
Implement execution pipeline for breakout orders

### DIFF
--- a/domain/__init__.py
+++ b/domain/__init__.py
@@ -1,9 +1,11 @@
 from .models import (
+    ActiveOrder,
     Band,
     Candle,
     Level,
     LevelPattern,
     OrderParams,
+    OrderRole,
     Pump,
     ScenarioStatus,
     SymbolState,
@@ -12,11 +14,13 @@ from .models import (
 )
 
 __all__ = [
+    "ActiveOrder",
     "Band",
     "Candle",
     "Level",
     "LevelPattern",
     "OrderParams",
+    "OrderRole",
     "Pump",
     "ScenarioStatus",
     "SymbolState",

--- a/domain/models/__init__.py
+++ b/domain/models/__init__.py
@@ -1,8 +1,10 @@
+from .active_order import ActiveOrder
 from .band import Band
 from .candle import Candle
 from .level import Level
 from .level_pattern import LevelPattern
 from .order_params import OrderParams
+from .order_role import OrderRole
 from .pump import Pump
 from .scenario_status import ScenarioStatus
 from .symbol_state import SymbolState
@@ -10,11 +12,13 @@ from .swing_high import SwingHigh
 from .swings_output import SwingsOutput
 
 __all__ = [
+    "ActiveOrder",
     "Band",
     "Candle",
     "Level",
     "LevelPattern",
     "OrderParams",
+    "OrderRole",
     "Pump",
     "ScenarioStatus",
     "SymbolState",

--- a/domain/models/active_order.py
+++ b/domain/models/active_order.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ActiveOrder:
+    """Order tracked by the execution layer."""
+
+    order_id: str
+    quantity: float
+    filled: float = 0.0
+
+    def register_fill(self, filled: float) -> float:
+        """Update filled quantity and return the delta executed since last update."""
+
+        if filled < 0:
+            raise ValueError("filled не может быть отрицательным")
+        delta = max(filled - self.filled, 0.0)
+        self.filled += delta
+        return delta
+
+
+__all__ = ["ActiveOrder"]

--- a/domain/models/order_role.py
+++ b/domain/models/order_role.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class OrderRole(str, Enum):
+    """Logical role of an order within the breakout strategy."""
+
+    ENTRY = "entry"
+    STOP_LOSS = "stop_loss"
+    TAKE_PROFIT_1 = "take_profit_1"
+    TAKE_PROFIT_2 = "take_profit_2"
+
+
+__all__ = ["OrderRole"]

--- a/domain/models/symbol_state.py
+++ b/domain/models/symbol_state.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Optional
+from typing import Dict, Optional
 
+from .active_order import ActiveOrder
 from .band import Band
 from .level import Level
+from .order_params import OrderParams
+from .order_role import OrderRole
 from .pump import Pump
 from .scenario_status import ScenarioStatus
 
@@ -21,6 +24,9 @@ class SymbolState:
     last_band: Optional[Band]
     l_pullback: Optional[float]
     h_main: Optional[float]
+    active_orders: Dict[OrderRole, ActiveOrder] = field(default_factory=dict)
+    last_order_params: Optional[OrderParams] = None
+    open_quantity: float = 0.0
 
 
 __all__ = ["SymbolState"]

--- a/execution/__init__.py
+++ b/execution/__init__.py
@@ -1,0 +1,10 @@
+"""Execution layer responsible for order placement and event processing."""
+
+from .event_handler import ExecutionEventHandler, OrderUpdateEvent
+from .order_manager import OrderManager
+
+__all__ = [
+    "ExecutionEventHandler",
+    "OrderManager",
+    "OrderUpdateEvent",
+]

--- a/execution/event_handler.py
+++ b/execution/event_handler.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Optional
+
+from domain.models import ActiveOrder, OrderRole, ScenarioStatus, SymbolState
+
+from .order_manager import OrderManager
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+@dataclass(frozen=True)
+class OrderUpdateEvent:
+    """Normalized order update event emitted by the exchange."""
+
+    symbol: str
+    order_id: str
+    status: str
+    filled: float
+    remaining: float
+    average_price: Optional[float] = None
+    timestamp: Optional[datetime] = None
+
+
+@dataclass
+class ExecutionEventHandler:
+    """React to order execution events and update symbol state."""
+
+    order_manager: OrderManager
+    cooldown_minutes: int
+    now_factory: Callable[[], datetime] = field(default_factory=lambda: _utc_now)
+    logger: logging.Logger = field(default_factory=lambda: logging.getLogger(__name__))
+
+    def handle_order_update(self, state: SymbolState, event: OrderUpdateEvent) -> SymbolState:
+        role, active_order = self._find_active_order(state, event.order_id)
+        if active_order is None:
+            self.logger.debug("Получено событие по неизвестному ордеру %s", event.order_id)
+            return state
+
+        delta = active_order.register_fill(event.filled)
+        status = event.status.lower()
+
+        if role == OrderRole.ENTRY and delta > 0:
+            state.open_quantity += delta
+            state.has_open_position = state.open_quantity > 0
+            state.status = ScenarioStatus.ACTIVE
+        elif role in {OrderRole.STOP_LOSS, OrderRole.TAKE_PROFIT_1, OrderRole.TAKE_PROFIT_2} and delta > 0:
+            state.open_quantity = max(state.open_quantity - delta, 0.0)
+
+        if role == OrderRole.TAKE_PROFIT_1 and status == "closed":
+            self._handle_take_profit_one(symbol=event.symbol, state=state)
+        elif role in {OrderRole.STOP_LOSS, OrderRole.TAKE_PROFIT_2} and status == "closed":
+            self._handle_position_closed(symbol=event.symbol, state=state, completed_role=role)
+
+        if status in {"closed", "canceled"}:
+            state.active_orders.pop(role, None)
+
+        if role == OrderRole.ENTRY and status == "canceled":
+            self._handle_entry_canceled(symbol=event.symbol, state=state)
+
+        state.has_open_position = state.open_quantity > 0.0
+        if not state.has_open_position and role != OrderRole.ENTRY and status == "closed":
+            state.status = ScenarioStatus.IDLE
+
+        return state
+
+    def handle_scenario_cancelled(self, state: SymbolState, symbol: str, reason: str | None = None) -> SymbolState:
+        if state.active_orders:
+            self.order_manager.cancel_orders(symbol, [order.order_id for order in state.active_orders.values()])
+            state.active_orders.clear()
+        state.open_quantity = 0.0
+        state.has_open_position = False
+        state.last_order_params = None
+        state.status = ScenarioStatus.IDLE
+        self.logger.info("Сценарий по %s отменён%s", symbol, f": {reason}" if reason else "")
+        return state
+
+    def handle_order_error(self, state: SymbolState, symbol: str, error: Exception) -> SymbolState:
+        self.logger.error("Ошибка размещения ордеров по %s: %s", symbol, error)
+        cooldown_until = self.now_factory() + timedelta(minutes=self.cooldown_minutes)
+        state.cooldown_until = cooldown_until
+        state.status = ScenarioStatus.COOLDOWN
+        state.active_orders.clear()
+        state.open_quantity = 0.0
+        state.has_open_position = False
+        state.last_order_params = None
+        return state
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _find_active_order(self, state: SymbolState, order_id: str) -> tuple[OrderRole | None, ActiveOrder | None]:
+        for role, active in state.active_orders.items():
+            if active.order_id == order_id:
+                return role, active
+        return None, None
+
+    def _handle_take_profit_one(self, symbol: str, state: SymbolState) -> None:
+        params = state.last_order_params
+        stop_order = state.active_orders.get(OrderRole.STOP_LOSS)
+        if params is None or stop_order is None:
+            return
+        remaining_quantity = max(state.open_quantity, 0.0)
+        if remaining_quantity <= 0:
+            return
+        break_even_price = (params.entry_price + params.take_profit_1) / 2.0
+        try:
+            new_stop_id = self.order_manager.replace_stop_loss(
+                symbol,
+                stop_order.order_id,
+                quantity=remaining_quantity,
+                new_stop_price=break_even_price,
+            )
+        except Exception as exc:  # pragma: no cover - network interaction
+            self.logger.error("Не удалось перенести стоп по %s в безубыток: %s", symbol, exc)
+            return
+        state.active_orders[OrderRole.STOP_LOSS] = ActiveOrder(order_id=new_stop_id, quantity=remaining_quantity)
+
+    def _handle_position_closed(
+        self,
+        symbol: str,
+        state: SymbolState,
+        *,
+        completed_role: OrderRole,
+    ) -> None:
+        to_cancel = [
+            order.order_id
+            for role, order in state.active_orders.items()
+            if role != completed_role
+        ]
+        if to_cancel:
+            self.order_manager.cancel_orders(symbol, to_cancel)
+        state.active_orders.clear()
+        state.open_quantity = 0.0
+        state.has_open_position = False
+        state.last_order_params = None
+        state.status = ScenarioStatus.IDLE
+
+    def _handle_entry_canceled(self, symbol: str, state: SymbolState) -> None:
+        to_cancel = [
+            order.order_id
+            for role, order in state.active_orders.items()
+            if role != OrderRole.ENTRY
+        ]
+        if to_cancel:
+            self.order_manager.cancel_orders(symbol, to_cancel)
+        state.active_orders.clear()
+        state.open_quantity = 0.0
+        state.has_open_position = False
+        state.last_order_params = None
+        state.status = ScenarioStatus.IDLE
+
+
+__all__ = ["ExecutionEventHandler", "OrderUpdateEvent"]

--- a/execution/order_manager.py
+++ b/execution/order_manager.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from decimal import Decimal, ROUND_DOWN
+from typing import Any, Dict, Iterable, Mapping
+
+import ccxt
+
+from config.config import OrderConfig, PositioningConfig
+from domain.models import ActiveOrder, OrderParams, OrderRole
+from utils.precision import (
+    apply_min_notional,
+    apply_min_qty,
+    calculate_position_size,
+    round_price_to_tick,
+    round_quantity_to_step,
+)
+
+
+@dataclass(frozen=True)
+class MarketPrecision:
+    """Precision and trading limits extracted from the exchange metadata."""
+
+    tick_size: float
+    step_size: float
+    min_qty: float
+    min_notional: float
+
+
+@dataclass
+class OrderManager:
+    """Place and manage bracket orders on the exchange."""
+
+    exchange: ccxt.Exchange
+    order_config: OrderConfig
+    positioning_config: PositioningConfig
+    quote_currency: str = "USDT"
+    logger: logging.Logger = field(default_factory=lambda: logging.getLogger(__name__))
+
+    def __post_init__(self) -> None:
+        self._precision_cache: Dict[str, MarketPrecision] = {}
+        self._ensure_markets_loaded()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def create_order_params(self, symbol: str, params: OrderParams) -> OrderParams:
+        """Return order parameters rounded according to market precision."""
+
+        precision = self._get_precision(symbol)
+        entry_price = round_price_to_tick(params.entry_price, precision.tick_size)
+        stop_loss = self._apply_stop_trigger(
+            round_price_to_tick(params.stop_loss, precision.tick_size),
+            precision,
+        )
+        tp1_price = round_price_to_tick(params.take_profit_1, precision.tick_size)
+        tp2_price = round_price_to_tick(params.take_profit_2, precision.tick_size)
+
+        balance = self._get_available_balance()
+        position_value = calculate_position_size(
+            balance,
+            self.positioning_config.position_fraction,
+            self.positioning_config.position_min_usdt,
+        )
+        if entry_price <= 0:
+            raise ValueError("Цена входа должна быть положительной")
+        raw_quantity = position_value / entry_price
+        quantity = round_quantity_to_step(raw_quantity, precision.step_size)
+        effective_min_qty = max(precision.min_qty, 2.0 * precision.step_size)
+        quantity = apply_min_qty(quantity, effective_min_qty, precision.step_size)
+        quantity = apply_min_notional(
+            quantity,
+            entry_price,
+            precision.min_notional,
+            precision.step_size,
+        )
+        quantity = apply_min_qty(quantity, effective_min_qty, precision.step_size)
+        if quantity <= 0:
+            raise ValueError("Размер позиции должен быть положительным после округления")
+
+        return OrderParams(
+            entry_price=entry_price,
+            stop_loss=stop_loss,
+            take_profit_1=tp1_price,
+            take_profit_2=tp2_price,
+            position_size=quantity,
+        )
+
+    def place_bracket_orders(self, symbol: str, params: OrderParams) -> Dict[OrderRole, ActiveOrder]:
+        """Create entry, stop-loss and take-profit orders for a breakout setup."""
+
+        precision = self._get_precision(symbol)
+        tp1_quantity, tp2_quantity = self._split_take_profit_quantities(
+            params.position_size,
+            precision.step_size,
+        )
+
+        created_orders: list[tuple[OrderRole, str]] = []
+        try:
+            entry_id = self._create_limit_order(
+                symbol=symbol,
+                side="buy",
+                quantity=params.position_size,
+                price=params.entry_price,
+                reduce_only=False,
+            )
+            created_orders.append((OrderRole.ENTRY, entry_id))
+
+            stop_id = self._create_stop_order(
+                symbol=symbol,
+                quantity=params.position_size,
+                price=params.stop_loss,
+            )
+            created_orders.append((OrderRole.STOP_LOSS, stop_id))
+
+            tp1_id = self._create_limit_order(
+                symbol=symbol,
+                side="sell",
+                quantity=tp1_quantity,
+                price=params.take_profit_1,
+                reduce_only=True,
+            )
+            created_orders.append((OrderRole.TAKE_PROFIT_1, tp1_id))
+
+            tp2_id = self._create_limit_order(
+                symbol=symbol,
+                side="sell",
+                quantity=tp2_quantity,
+                price=params.take_profit_2,
+                reduce_only=True,
+            )
+            created_orders.append((OrderRole.TAKE_PROFIT_2, tp2_id))
+        except Exception:
+            self.logger.error("Ошибка размещения ордеров по %s", symbol, exc_info=True)
+            self.cancel_orders(symbol, [order_id for _, order_id in created_orders])
+            raise
+
+        self.logger.info(
+            "Размещены ордера %s: entry=%s, stop=%s, tp1=%s, tp2=%s, qty=%s",
+            symbol,
+            entry_id,
+            stop_id,
+            tp1_id,
+            tp2_id,
+            params.position_size,
+        )
+
+        return {
+            OrderRole.ENTRY: ActiveOrder(order_id=entry_id, quantity=params.position_size),
+            OrderRole.STOP_LOSS: ActiveOrder(order_id=stop_id, quantity=params.position_size),
+            OrderRole.TAKE_PROFIT_1: ActiveOrder(order_id=tp1_id, quantity=tp1_quantity),
+            OrderRole.TAKE_PROFIT_2: ActiveOrder(order_id=tp2_id, quantity=tp2_quantity),
+        }
+
+    def replace_stop_loss(
+        self,
+        symbol: str,
+        old_order_id: str,
+        *,
+        quantity: float,
+        new_stop_price: float,
+    ) -> str:
+        """Cancel the existing stop-loss order and place a new one."""
+
+        precision = self._get_precision(symbol)
+        adjusted_price = self._apply_stop_trigger(
+            round_price_to_tick(new_stop_price, precision.tick_size),
+            precision,
+        )
+        self.cancel_orders(symbol, [old_order_id])
+        new_order_id = self._create_stop_order(symbol, quantity=quantity, price=adjusted_price)
+        self.logger.info(
+            "Стоп-лосс для %s перенесён: старый=%s, новый=%s по цене %.8f",
+            symbol,
+            old_order_id,
+            new_order_id,
+            adjusted_price,
+        )
+        return new_order_id
+
+    def cancel_orders(self, symbol: str, order_ids: Iterable[str]) -> None:
+        """Cancel orders for ``symbol`` ignoring failures."""
+
+        for order_id in order_ids:
+            if not order_id:
+                continue
+            try:
+                self.exchange.cancel_order(order_id, symbol)
+            except ccxt.BaseError as exc:  # pragma: no cover - network failures
+                self.logger.warning("Не удалось отменить ордер %s по %s: %s", order_id, symbol, exc)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_markets_loaded(self) -> None:
+        try:
+            self.exchange.load_markets()
+        except ccxt.BaseError as exc:  # pragma: no cover - network failures
+            self.logger.error("Не удалось загрузить рынки: %s", exc)
+            raise
+
+    def _get_available_balance(self) -> float:
+        balance = self.exchange.fetch_balance()
+        free = balance.get("free") if isinstance(balance, Mapping) else None
+        if isinstance(free, Mapping) and self.quote_currency in free:
+            return float(free[self.quote_currency])
+        value = balance.get(self.quote_currency) if isinstance(balance, Mapping) else None
+        return float(value or 0.0)
+
+    def _get_market(self, symbol: str) -> Mapping[str, Any]:
+        return self.exchange.market(symbol)
+
+    def _get_precision(self, symbol: str) -> MarketPrecision:
+        if symbol not in self._precision_cache:
+            market = self._get_market(symbol)
+            self._precision_cache[symbol] = self._extract_precision(market)
+        return self._precision_cache[symbol]
+
+    def _extract_precision(self, market: Mapping[str, Any]) -> MarketPrecision:
+        info = market.get("info", {}) if isinstance(market, Mapping) else {}
+        tick_size = self._extract_tick_size(market, info)
+        step_size, min_qty = self._extract_step_size_and_min_qty(market, info)
+        min_notional = self._extract_min_notional(market, info)
+        if tick_size <= 0 or step_size <= 0:
+            raise ValueError("Биржа вернула некорректные параметры точности")
+        if min_qty <= 0 or min_notional <= 0:
+            raise ValueError("Биржа вернула некорректные лимиты объёма")
+        return MarketPrecision(
+            tick_size=tick_size,
+            step_size=step_size,
+            min_qty=min_qty,
+            min_notional=min_notional,
+        )
+
+    def _extract_tick_size(self, market: Mapping[str, Any], info: Mapping[str, Any]) -> float:
+        filters = info.get("filters") if isinstance(info, Mapping) else None
+        if isinstance(filters, list):
+            for item in filters:
+                if isinstance(item, Mapping) and item.get("filterType") == "PRICE_FILTER":
+                    value = item.get("tickSize")
+                    if value is not None:
+                        return float(value)
+        precision = market.get("precision") if isinstance(market, Mapping) else None
+        if isinstance(precision, Mapping):
+            price_precision = precision.get("price")
+            if price_precision is not None:
+                decimals = int(price_precision)
+                return float(Decimal(1) / (Decimal(10) ** decimals))
+        limits = market.get("limits") if isinstance(market, Mapping) else None
+        if isinstance(limits, Mapping):
+            price_limits = limits.get("price")
+            if isinstance(price_limits, Mapping):
+                min_price = price_limits.get("min")
+                if min_price is not None:
+                    return float(min_price)
+        raise ValueError("tickSize не найден в описании маркета")
+
+    def _extract_step_size_and_min_qty(
+        self,
+        market: Mapping[str, Any],
+        info: Mapping[str, Any],
+    ) -> tuple[float, float]:
+        filters = info.get("filters") if isinstance(info, Mapping) else None
+        step_size = None
+        min_qty = None
+        if isinstance(filters, list):
+            for item in filters:
+                if not isinstance(item, Mapping):
+                    continue
+                if item.get("filterType") == "LOT_SIZE":
+                    step_raw = item.get("stepSize")
+                    min_raw = item.get("minQty")
+                    if step_raw is not None:
+                        step_size = float(step_raw)
+                    if min_raw is not None:
+                        min_qty = float(min_raw)
+                    break
+        limits = market.get("limits") if isinstance(market, Mapping) else None
+        if (step_size is None or min_qty is None) and isinstance(limits, Mapping):
+            amount_limits = limits.get("amount")
+            if isinstance(amount_limits, Mapping):
+                if step_size is None and amount_limits.get("step") is not None:
+                    step_size = float(amount_limits["step"])
+                if min_qty is None and amount_limits.get("min") is not None:
+                    min_qty = float(amount_limits["min"])
+        if step_size is None:
+            precision = market.get("precision") if isinstance(market, Mapping) else None
+            if isinstance(precision, Mapping):
+                amount_precision = precision.get("amount")
+                if amount_precision is not None:
+                    decimals = int(amount_precision)
+                    step_size = float(Decimal(1) / (Decimal(10) ** decimals))
+        if step_size is None or step_size <= 0:
+            raise ValueError("stepSize не найден в описании маркета")
+        if min_qty is None or min_qty <= 0:
+            min_qty = step_size
+        return step_size, min_qty
+
+    def _extract_min_notional(self, market: Mapping[str, Any], info: Mapping[str, Any]) -> float:
+        filters = info.get("filters") if isinstance(info, Mapping) else None
+        if isinstance(filters, list):
+            for item in filters:
+                if isinstance(item, Mapping) and item.get("filterType") == "MIN_NOTIONAL":
+                    value = item.get("notional") or item.get("minNotional")
+                    if value is not None:
+                        return float(value)
+        limits = market.get("limits") if isinstance(market, Mapping) else None
+        if isinstance(limits, Mapping):
+            cost_limits = limits.get("cost")
+            if isinstance(cost_limits, Mapping):
+                min_cost = cost_limits.get("min")
+                if min_cost is not None:
+                    return float(min_cost)
+        raise ValueError("minNotional не найден в описании маркета")
+
+    def _split_take_profit_quantities(self, total: float, step_size: float) -> tuple[float, float]:
+        if total <= 0:
+            raise ValueError("Размер позиции должен быть положительным")
+        step_dec = Decimal(str(step_size))
+        units = (Decimal(str(total)) / step_dec).to_integral_value(rounding=ROUND_DOWN)
+        units_int = int(units)
+        if units_int < 2:
+            raise ValueError("Недостаточный размер позиции для двух тейк-профитов")
+        tp1_units = units_int // 2
+        tp2_units = units_int - tp1_units
+        if tp1_units <= 0 or tp2_units <= 0:
+            raise ValueError("Недостаточный размер позиции для двух тейк-профитов")
+        tp1 = float(Decimal(tp1_units) * step_dec)
+        tp2 = float(Decimal(tp2_units) * step_dec)
+        return tp1, tp2
+
+    def _create_limit_order(
+        self,
+        *,
+        symbol: str,
+        side: str,
+        quantity: float,
+        price: float,
+        reduce_only: bool,
+    ) -> str:
+        params: Dict[str, Any] = {}
+        if reduce_only:
+            params["reduceOnly"] = True
+        order = self.exchange.create_order(
+            symbol,
+            "limit",
+            side,
+            quantity,
+            price,
+            params,
+        )
+        return self._extract_order_id(order)
+
+    def _create_stop_order(self, symbol: str, *, quantity: float, price: float) -> str:
+        params: Dict[str, Any] = {"stopPrice": price, "reduceOnly": True}
+        order = self.exchange.create_order(
+            symbol,
+            "stop_market",
+            "sell",
+            quantity,
+            None,
+            params,
+        )
+        return self._extract_order_id(order)
+
+    def _extract_order_id(self, order: Mapping[str, Any]) -> str:
+        order_id = order.get("id") if isinstance(order, Mapping) else None
+        if not order_id:
+            raise ValueError("Биржа вернула ответ без идентификатора ордера")
+        return str(order_id)
+
+    def _apply_stop_trigger(self, stop_price: float, precision: MarketPrecision) -> float:
+        adjusted = stop_price + self.order_config.stop_trigger
+        if adjusted <= 0:
+            raise ValueError("Стоп-лосс должен быть положительным")
+        return round_price_to_tick(adjusted, precision.tick_size)
+
+
+__all__ = ["OrderManager", "MarketPrecision"]

--- a/services/signal_executor.py
+++ b/services/signal_executor.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+import ccxt
+
+from config.config import AppConfig, MinTakeProfitConfig, RiskRewardConfig
+from domain.models import OrderParams, ScenarioStatus, SymbolState
+from execution import ExecutionEventHandler, OrderManager
+from strategies.ltf_pipeline import BreakoutSignal
+
+
+@dataclass
+class SignalExecutor:
+    """Bridge between LTF signals and the order management layer."""
+
+    order_manager: OrderManager
+    event_handler: ExecutionEventHandler
+    risk_reward_config: RiskRewardConfig
+    min_tp_config: MinTakeProfitConfig
+    logger: logging.Logger = field(default_factory=lambda: logging.getLogger(__name__))
+
+    @classmethod
+    def from_config(
+        cls,
+        exchange: ccxt.Exchange,
+        config: AppConfig,
+        *,
+        quote_currency: str = "USDT",
+    ) -> SignalExecutor:
+        order_manager = OrderManager(
+            exchange=exchange,
+            order_config=config.order,
+            positioning_config=config.positioning,
+            quote_currency=quote_currency,
+        )
+        event_handler = ExecutionEventHandler(
+            order_manager=order_manager,
+            cooldown_minutes=config.cooldown.minutes,
+        )
+        return cls(
+            order_manager=order_manager,
+            event_handler=event_handler,
+            risk_reward_config=config.risk_reward,
+            min_tp_config=config.min_take_profit,
+        )
+
+    def execute_breakout_signal(self, symbol: str, state: SymbolState, signal: BreakoutSignal) -> SymbolState:
+        if state.has_open_position:
+            self.logger.debug("Пропуск %s: уже есть открытая позиция", symbol)
+            return state
+        if state.active_orders:
+            self.logger.debug("Пропуск %s: уже есть активные ордера", symbol)
+            return state
+        if self._is_in_cooldown(state):
+            self.logger.info("Пропуск %s: действует кулдаун", symbol)
+            return state
+        if not self._meets_thresholds(signal):
+            self.logger.debug("Пропуск %s: сигнал не удовлетворяет RR/MIN_TP", symbol)
+            return state
+
+        raw_params = OrderParams(
+            entry_price=signal.entry_price,
+            stop_loss=signal.stop_loss,
+            take_profit_1=signal.take_profit_1,
+            take_profit_2=signal.take_profit_2,
+            position_size=0.0,
+        )
+
+        try:
+            order_params = self.order_manager.create_order_params(symbol, raw_params)
+            active_orders = self.order_manager.place_bracket_orders(symbol, order_params)
+        except (ccxt.BaseError, ValueError) as exc:
+            return self.event_handler.handle_order_error(state, symbol, exc)
+
+        state.active_orders = dict(active_orders)
+        state.last_order_params = order_params
+        state.open_quantity = 0.0
+        state.has_open_position = False
+        state.status = ScenarioStatus.ACTIVE
+        self.logger.info(
+            "Размещён сетап по %s: entry=%.4f, stop=%.4f, tp1=%.4f, tp2=%.4f",
+            symbol,
+            order_params.entry_price,
+            order_params.stop_loss,
+            order_params.take_profit_1,
+            order_params.take_profit_2,
+        )
+        return state
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _meets_thresholds(self, signal: BreakoutSignal) -> bool:
+        if signal.rr < self.risk_reward_config.rr_min:
+            return False
+        min_tp_value = (signal.take_profit_1 - signal.entry_price) / signal.entry_price
+        return min_tp_value >= self.min_tp_config.min_tp_pct
+
+    def _is_in_cooldown(self, state: SymbolState) -> bool:
+        if state.cooldown_until is None:
+            return False
+        return state.cooldown_until > self.event_handler.now_factory()
+
+
+__all__ = ["SignalExecutor"]


### PR DESCRIPTION
## Summary
- add domain models for order tracking to capture active orders and roles
- implement a CCXT-backed order manager that prepares bracket orders with rounding and position sizing
- add execution event handling and a signal executor to manage state updates and breakout order placement

## Testing
- python -m compileall domain execution services

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69108de3de288320a18cee33e81e89ae)