### PR TITLE
Configure leverage during application bootstrap

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,8 +4,11 @@ import logging
 import os
 import time
 
+import ccxt
+
 from config.config import AppConfig, load_config, load_env
 from infrastructure import setup_logging
+from services.exchange import set_leverage
 from services.market_scan import build_market_scanner
 
 
@@ -31,8 +34,20 @@ def configure() -> AppConfig:
     return config
 
 
-def start_symbol_monitoring(config: AppConfig) -> None:
-    scanner = build_market_scanner(config)
+def create_exchange(config: AppConfig) -> ccxt.Exchange:
+    exchange_class = getattr(ccxt, config.exchange.name)
+    exchange: ccxt.Exchange = exchange_class(
+        {
+            "apiKey": config.exchange.api_key,
+            "secret": config.exchange.api_secret,
+            "enableRateLimit": True,
+        }
+    )
+    return exchange
+
+
+def start_symbol_monitoring(config: AppConfig, exchange: ccxt.Exchange) -> None:
+    scanner = build_market_scanner(config, exchange=exchange)
     logging.info(
         "Запуск мониторинга символов для %s с периодом %s ч",
         config.exchange.name,
@@ -43,7 +58,16 @@ def start_symbol_monitoring(config: AppConfig) -> None:
 
 def main() -> None:
     config = configure()
-    start_symbol_monitoring(config)
+    exchange = create_exchange(config)
+    leverage_applied = set_leverage(config.leverage.leverage, config.leverage.margin_mode, exchange)
+    if not leverage_applied:
+        logging.warning(
+            "Не удалось установить плечо %s и режим маржи %s на бирже %s",
+            config.leverage.leverage,
+            config.leverage.margin_mode,
+            config.exchange.name,
+        )
+    start_symbol_monitoring(config, exchange)
 
 
 if __name__ == "__main__":

--- a/data_providers/ccxt_client.py
+++ b/data_providers/ccxt_client.py
@@ -59,9 +59,9 @@ class CcxtClient:
 
     _DEFAULT_LIMIT: Final[int] = 150
 
-    def __init__(self, config: CcxtClientConfig) -> None:
+    def __init__(self, config: CcxtClientConfig, *, exchange: ccxt.Exchange | None = None) -> None:
         self._config = config
-        self._exchange = self._create_exchange()
+        self._exchange = exchange if exchange is not None else self._create_exchange()
         self._markets: MutableMapping[str, _CcxtMarketInfo] | None = None
 
     def _create_exchange(self) -> ccxt.Exchange:

--- a/services/exchange.py
+++ b/services/exchange.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from typing import Final
 
+import ccxt
+
 
 DEFAULT_MARGIN_MODE: Final[str] = "isolated"
 
 
-def set_leverage(leverage: int, margin_mode: str) -> bool:
+def set_leverage(leverage: int, margin_mode: str, exchange: ccxt.Exchange) -> bool:
     """Set leverage on the exchange.
 
     This placeholder should be replaced with integration against the selected
@@ -16,6 +18,13 @@ def set_leverage(leverage: int, margin_mode: str) -> bool:
         raise ValueError("leverage должен быть положительным")
     if not margin_mode:
         raise ValueError("margin_mode не может быть пустым")
+
+    try:
+        exchange.set_margin_mode(margin_mode)
+        exchange.set_leverage(leverage)
+    except ccxt.BaseError:
+        return False
+
     return True
 
 

--- a/services/market_scan.py
+++ b/services/market_scan.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Callable, Dict, Iterable, List
 
+import ccxt
+
 from config.config import AppConfig, RestDataConfig, ScanConfig, SymbolFiltersConfig
 from data_providers import (
     CcxtClient,
@@ -120,7 +122,7 @@ class MarketScanner:
                 time.sleep(sleep_for)
 
 
-def build_market_scanner(config: AppConfig) -> MarketScanner:
+def build_market_scanner(config: AppConfig, *, exchange: ccxt.Exchange | None = None) -> MarketScanner:
     client_config = CcxtClientConfig(
         exchange_name=config.exchange.name,
         api_key=config.exchange.api_key,
@@ -130,7 +132,7 @@ def build_market_scanner(config: AppConfig) -> MarketScanner:
         rest_htf=config.rest_data.fetch_htf,
         rest_ltf=config.rest_data.fetch_ltf,
     )
-    client = CcxtClient(client_config)
+    client = CcxtClient(client_config, exchange=exchange)
     symbol_filter = SymbolFilter(config.symbol_filters)
     return MarketScanner(
         client=client,


### PR DESCRIPTION
## Summary
- update the exchange service to set margin mode and leverage on a ccxt client while handling ccxt errors gracefully
- create a shared ccxt exchange during application startup, apply leverage, and warn when the configuration cannot be applied
- reuse the pre-created ccxt exchange when building the market scanner to avoid duplicate REST clients

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69109871aa58832083d59f7f4ce6d45a)