### PR TITLE
Guard optional Swings dependency and use explicit CCXT exchange registry

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from infrastructure import TelegramNotifier, setup_logging
 from integrations import RealSwingsExtractor, SwingsAdapter
 from services.exchange import set_leverage
 from services import build_trading_loop
+from data_providers.ccxt_client import get_exchange_class
 
 
 def configure_logging() -> None:
@@ -36,7 +37,7 @@ def configure() -> AppConfig:
 
 
 def create_exchange(config: AppConfig) -> ccxt.Exchange:
-    exchange_class = getattr(ccxt, config.exchange.name)
+    exchange_class = get_exchange_class(config.exchange.name)
     exchange: ccxt.Exchange = exchange_class(
         {
             "apiKey": config.exchange.api_key,

--- a/data_providers/ccxt_client.py
+++ b/data_providers/ccxt_client.py
@@ -5,6 +5,21 @@ from typing import Any, Final, Mapping, MutableMapping, Optional, Sequence, Type
 
 import ccxt
 
+SUPPORTED_EXCHANGES: Mapping[str, type[ccxt.Exchange]] = {
+    "binance": ccxt.binance,
+    "binanceusdm": ccxt.binanceusdm,
+}
+
+
+def get_exchange_class(name: str) -> type[ccxt.Exchange]:
+    exchange_class = SUPPORTED_EXCHANGES.get(name)
+    if exchange_class is None:
+        supported = ", ".join(sorted(SUPPORTED_EXCHANGES)) or "<не настроены>"
+        raise ValueError(
+            f"Биржа {name!r} не поддерживается. Доступные варианты: {supported}"
+        )
+    return exchange_class
+
 
 class OHLCV(TypedDict):
     """Normalized OHLCV candle returned by CCXT."""
@@ -65,7 +80,7 @@ class CcxtClient:
         self._markets: MutableMapping[str, _CcxtMarketInfo] | None = None
 
     def _create_exchange(self) -> ccxt.Exchange:
-        exchange_class = getattr(ccxt, self._config.exchange_name)
+        exchange_class = get_exchange_class(self._config.exchange_name)
         exchange: ccxt.Exchange = exchange_class({
             "apiKey": self._config.api_key,
             "secret": self._config.api_secret,

--- a/integrations/swings.py
+++ b/integrations/swings.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+import importlib.util
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass, is_dataclass
 from datetime import datetime, timezone
 from typing import Any, Protocol, Sequence, TypedDict, overload
 
 from domain.models import Band, Candle, SwingsOutput, SwingHigh
+
+
+if importlib.util.find_spec("swings") is not None:  # pragma: no cover - optional dependency
+    from swings import Swings  # type: ignore import-not-found
+else:  # pragma: no cover - optional dependency
+    Swings = None  # type: ignore[assignment]
 
 
 class RawSwing(TypedDict):
@@ -63,12 +70,10 @@ class RealSwingsExtractor(SwingsExtractor):
     """Extractor that relies on the external ``Swings`` module."""
 
     def __init__(self) -> None:
-        try:
-            from swings import Swings  # type: ignore import-not-found
-        except ImportError as exc:  # pragma: no cover - integration guard
+        if Swings is None:
             raise RuntimeError(
                 "Модуль Swings недоступен. Установите зависимость, чтобы извлекать свинги."
-            ) from exc
+            )
 
         self._swings = Swings()
 


### PR DESCRIPTION
## Summary
- add a CCXT exchange registry and helper that validates configured exchange names
- update the application entrypoint to resolve exchanges via the shared registry
- import Swings at module load with an explicit runtime check for the optional dependency

## Testing
- python -m compileall app/main.py data_providers/ccxt_client.py integrations/swings.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910ace3f6c483208dc2b61fd21968f1)