### PR TITLE
Implement swing detection for bars

### DIFF
--- a/crypto_screener/domain/swing_detector.py
+++ b/crypto_screener/domain/swing_detector.py
@@ -1,7 +1,49 @@
+from dataclasses import replace
+
 from crypto_screener.domain.models.bar import Bar
-from crypto_screener.domain.models.swing import Swing
+from crypto_screener.domain.models.swing import Swing, SwingType
 
 
 def add_swings(bars: list[Bar]) -> list[Bar]:
-    # TODO Реализовать позже.
-    return []
+    if not bars:
+        return []
+
+    enriched: list[Bar] = []
+    total = len(bars)
+
+    for idx, bar in enumerate(bars):
+        swing = bar.swing
+
+        if 0 < idx < total - 1:
+            prev_bar = bars[idx - 1]
+            next_bar = bars[idx + 1]
+
+            if bar.low < prev_bar.low and bar.low < next_bar.low:
+                swing_price = bar.low
+                swing = Swing(
+                    ts=bar.ts,
+                    price=swing_price,
+                    type=SwingType.LOW,
+                    is_open=_is_swing_open(swing_price, bars[idx + 1 :]),
+                )
+            elif bar.high > prev_bar.high and bar.high > next_bar.high:
+                swing_price = bar.high
+                swing = Swing(
+                    ts=bar.ts,
+                    price=swing_price,
+                    type=SwingType.HIGH,
+                    is_open=_is_swing_open(swing_price, bars[idx + 1 :]),
+                )
+
+        enriched.append(replace(bar, swing=swing))
+
+    return enriched
+
+
+def _is_swing_open(price: float, future_bars: list[Bar]) -> bool:
+    for bar in future_bars:
+        body_low = min(bar.open, bar.close)
+        body_high = max(bar.open, bar.close)
+        if body_low <= price <= body_high:
+            return False
+    return True


### PR DESCRIPTION
## Summary
- add swing detection for highs and lows based on neighbouring bars
- mark swing open state when no subsequent candle body covers the swing price
- return enriched bars without mutating the originals

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69178a0d8c508320a2a1d6ce3880fe7a)