### PR TITLE
Fix Binance futures symbol retrieval

### DIFF
--- a/crypto_screener/data/exchanges/binance.py
+++ b/crypto_screener/data/exchanges/binance.py
@@ -19,18 +19,21 @@ class Binance(Exchange):
             {
                 "apiKey": api_key,
                 "secret": api_secret,
-                "options": {"defaultType": "future"},
+                "options": {"defaultType": "swap", "defaultSubType": "linear"},
                 "enableRateLimit": True,
             }
         )
 
     def get_futures_symbols(self) -> Iterable[FuturesSymbol]:
-        markets = self._client.load_markets()
-        tickers = self._client.fetch_tickers()
+        markets = self._client.load_markets(params={"type": "swap"})
+        tickers = self._client.fetch_tickers(params={"type": "swap"})
         symbols: list[FuturesSymbol] = []
 
         for market in markets.values():
-            if not market.get("future"):
+            if not market.get("contract"):
+                continue
+
+            if market.get("settle") != "USDT" and market.get("quote") != "USDT":
                 continue
 
             symbol = market["symbol"]


### PR DESCRIPTION
## Summary
- switch the Binance client to use swap markets so USDT-margined perpetual futures are loaded
- filter markets to include only USDT-settled contracts when building the futures symbol list

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69183a3f426c83208eac87a891127184)