### PR TITLE
Scale history parameters based on timeframe

### DIFF
--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -11,6 +11,7 @@ from crypto_screener.domain.models.swing import Swing
 from crypto_screener.domain.models.timeframe import Timeframe
 from crypto_screener.domain.notifier import Notifier, NotificationType
 from crypto_screener.domain.setup_detector import detect_setup
+from crypto_screener.utils.history import calculate_limit
 from crypto_screener.utils.logger import log
 from crypto_screener.utils.plotter import plot
 from crypto_screener.utils.signals import handle_sig
@@ -141,7 +142,8 @@ def run_live(
                           or capture_state.symbol == symbol.symbol]
         for symbol in active_symbols:
             for timeframe in timeframes:
-                bars = exchange.get_ohlcv(symbol.symbol, timeframe, limit)
+                timeframe_limit = calculate_limit(limit, timeframe)
+                bars = exchange.get_ohlcv(symbol.symbol, timeframe, timeframe_limit)
                 setup = detect_setup(symbol.symbol, bars, timeframe)
                 match setup:
                     # Сетап не найден.

--- a/crypto_screener/execution/run_test_market.py
+++ b/crypto_screener/execution/run_test_market.py
@@ -4,6 +4,7 @@ from crypto_screener.domain.exchange import Exchange, FuturesSymbol
 from crypto_screener.domain.models.mode import PlotPolicy
 from crypto_screener.domain.models.timeframe import Timeframe
 from crypto_screener.execution.run_test_symbol import run_test_bars
+from crypto_screener.utils.history import calculate_limit, calculate_window
 from crypto_screener.utils.logger import log
 from crypto_screener.utils.time import utc_now
 
@@ -47,7 +48,7 @@ def run_test_market(
     if not timeframes:
         log.e("Не заданы таймфреймы.")
         return
-    if limit <= 0 or window <= 0 or window > limit:
+    if limit <= 0 or window <= 0:
         log.e("Некорректные данные для количества свеч.")
         return
 
@@ -65,12 +66,14 @@ def run_test_market(
 
     for symbol in symbols:
         for timeframe in timeframes:
-            log.d(f"Проверка {symbol.symbol} на {timeframe.tf}")
+            timeframe_limit = calculate_limit(limit, timeframe)
+            timeframe_window = calculate_window(window, timeframe, timeframe_limit)
+            log.d(f"Проверка {symbol.symbol} на {timeframe.tf} (limit={timeframe_limit}, window={timeframe_window})")
             try:
                 bars = exchange.get_ohlcv(
                     symbol=symbol.symbol,
                     timeframe=timeframe,
-                    limit=limit,
+                    limit=timeframe_limit,
                     end=utc_now(),
                 )
             except Exception as exception:
@@ -81,12 +84,12 @@ def run_test_market(
                 log.e(f"{symbol.symbol} {timeframe.tf}: не удалось получить свечи.")
                 continue
 
-            if len(bars) < window:
-                log.e(f"{symbol.symbol} {timeframe.tf}: для теста нужно минимум {window} свечей, получено {len(bars)}.")
+            if len(bars) < timeframe_window:
+                log.e(f"{symbol.symbol} {timeframe.tf}: для теста нужно минимум {timeframe_window} свечей, получено {len(bars)}.")
                 continue
 
-            for i in range(window - 1, len(bars)):
-                window_bars = bars[i - window + 1:i + 1]
+            for i in range(timeframe_window - 1, len(bars)):
+                window_bars = bars[i - timeframe_window + 1:i + 1]
                 run_test_bars(
                     symbol=symbol.symbol,
                     timeframe=timeframe,

--- a/crypto_screener/execution/run_test_symbol.py
+++ b/crypto_screener/execution/run_test_symbol.py
@@ -7,6 +7,7 @@ from crypto_screener.domain.models.mode import PlotPolicy, TestData
 from crypto_screener.domain.models.setup import Setup
 from crypto_screener.domain.models.timeframe import Timeframe
 from crypto_screener.domain.setup_detector import detect_setup
+from crypto_screener.utils.history import calculate_limit
 from crypto_screener.utils.logger import log
 from crypto_screener.utils.plotter import plot
 
@@ -21,7 +22,8 @@ def _run_test_symbol(
         plot_policy: PlotPolicy
 ) -> None:
     log.d(f"Проверка {symbol} на {timeframe.tf}")
-    bars = exchange.get_ohlcv(symbol, timeframe, limit, end)
+    timeframe_limit = calculate_limit(limit, timeframe)
+    bars = exchange.get_ohlcv(symbol, timeframe, timeframe_limit, end)
     run_test_bars(
         symbol=symbol,
         timeframe=timeframe,

--- a/crypto_screener/utils/history.py
+++ b/crypto_screener/utils/history.py
@@ -1,0 +1,29 @@
+from crypto_screener.domain.models.timeframe import Timeframe
+
+
+_REFERENCE_TIMEFRAME_MINUTES = Timeframe.M5.minutes
+_MIN_LIMIT = 100
+_MIN_WINDOW = 40
+
+
+def _scale_by_timeframe(base_value: int, timeframe: Timeframe, minimum: int) -> int:
+    coverage_minutes = base_value * _REFERENCE_TIMEFRAME_MINUTES
+    scaled_value = max(minimum, coverage_minutes // timeframe.minutes)
+
+    if timeframe.minutes < _REFERENCE_TIMEFRAME_MINUTES:
+        return min(base_value, scaled_value)
+
+    return scaled_value
+
+
+def calculate_limit(base_limit: int, timeframe: Timeframe) -> int:
+    """Подбирает limit на основе таймфрейма так, чтобы сохранять одинаковую глубину истории."""
+
+    return _scale_by_timeframe(base_limit, timeframe, _MIN_LIMIT)
+
+
+def calculate_window(base_window: int, timeframe: Timeframe, limit: int) -> int:
+    """Подбирает window на основе таймфрейма, не позволяя окну превышать limit."""
+
+    window = _scale_by_timeframe(base_window, timeframe, _MIN_WINDOW)
+    return min(window, limit)


### PR DESCRIPTION
## Summary
- add helper to scale history depth and sliding window sizes by timeframe minutes
- adjust live and test runners to request timeframe-specific history limits
- scale test windows per timeframe to reduce unnecessary data fetching on higher intervals

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e3157e1d8832089484f346424da57)