### PR TITLE
Pass main low swing to live plots

### DIFF
--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -77,6 +77,7 @@ def _send_notification(
         symbol: str,
         timeframe: Timeframe,
         bars: list[Bar],
+        main_low_swing: Optional[Swing],
         main_high_swing: Optional[Swing],
         cascade_swings: Optional[list[Swing]],
         resistance_swings: Optional[list[Swing]],
@@ -88,6 +89,7 @@ def _send_notification(
             symbol=symbol,
             timeframe=timeframe,
             bars=bars,
+            main_low_swing=main_low_swing,
             main_high_swing=main_high_swing,
             cascade_swings=cascade_swings,
             resistance_swings=resistance_swings,
@@ -160,6 +162,7 @@ def run_live(
 
                     # Найден базовый сетап.
                     case Capture(
+                        main_low_swing=main_low_swing,
                         main_high_swing=main_high_swing,
                         cascade_swings=cascade_swings,
                         resistance_swings=resistance_swings,
@@ -179,6 +182,7 @@ def run_live(
                                 symbol=symbol.symbol,
                                 timeframe=timeframe,
                                 bars=bars,
+                                main_low_swing=main_low_swing,
                                 main_high_swing=main_high_swing,
                                 cascade_swings=cascade_swings,
                                 resistance_swings=resistance_swings,
@@ -188,6 +192,7 @@ def run_live(
 
                     # Найден торговый сетап.
                     case buy_setup @ Buy(
+                        main_low_swing=main_low_swing,
                         main_high_swing=main_high_swing,
                         cascade_swings=cascade_swings,
                         resistance_swings=resistance_swings,
@@ -205,6 +210,7 @@ def run_live(
                             symbol=symbol.symbol,
                             timeframe=timeframe,
                             bars=bars,
+                            main_low_swing=main_low_swing,
                             main_high_swing=main_high_swing,
                             cascade_swings=cascade_swings,
                             resistance_swings=resistance_swings,


### PR DESCRIPTION
## Summary
- bind main_low_swing from Capture and Buy setups in live execution
- forward main_low_swing to notifications so plots can render growth phase shading

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c20d5ef3c8320917fe8975d361f32)