### PR TITLE
Prefer detection time for entry shading

### DIFF
--- a/crypto_screener/utils/plotter.py
+++ b/crypto_screener/utils/plotter.py
@@ -194,10 +194,10 @@ def _format_volume_ax(ax: Axes, volumes: list[float]):
 
 
 def _get_entry_time(postmortem_bars: Optional[list[Bar]], detection_time: Optional[datetime], bars: list[Bar]) -> datetime:
-    if postmortem_bars:
-        return postmortem_bars[0].time
     if detection_time:
         return detection_time
+    if postmortem_bars:
+        return postmortem_bars[0].time
     return bars[-1].time
 
 


### PR DESCRIPTION
## Summary
- prioritize detection_time over postmortem bars when determining entry start time
- keep postmortem fallback for entry shading when detection time is unavailable

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c22df7b888320b3ba62cc2f190673)