### PR TITLE
Handle optional end timestamp for OHLCV mapping

### DIFF
--- a/crypto_screener/data/mappers.py
+++ b/crypto_screener/data/mappers.py
@@ -1,16 +1,20 @@
 from datetime import datetime, timezone
+from typing import Optional
 
 from crypto_screener.domain.models.bar import Bar
 
 
 def map_ohlcv(
         raw: list[list[float]],
-        end: datetime
+        end: Optional[datetime] = None,
 ) -> list[Bar]:
     mapped: list[Bar] = []
+    end_ms = (
+        int(end.astimezone(timezone.utc).timestamp() * 1000)
+        if end else None
+    )
     for ts_ms, o, h, l, c, v in raw:
-        end_ms = int(end.astimezone(timezone.utc).timestamp() * 1000)
-        if ts_ms <= end_ms:
+        if end_ms is None or ts_ms <= end_ms:
             time = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
             mapped.append(
                 Bar(


### PR DESCRIPTION
## Summary
- make the end parameter optional when mapping OHLCV data
- accept all returned OHLCV entries when no end timestamp is provided

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c2446b7e4832082818fd01a2fd085)