### PR TITLE
Use close price for pullback confirmation

### DIFF
--- a/crypto_screener/domain/setup_detector.py
+++ b/crypto_screener/domain/setup_detector.py
@@ -216,7 +216,7 @@ def get_cascade_long(
                 consecutive = 0
                 max_consecutive = 0
                 for bar in pullback_bars:
-                    if bar.high <= level_price - min_pullback:
+                    if bar.close <= level_price - min_pullback:
                         consecutive += 1
                         max_consecutive = max(max_consecutive, consecutive)
                     else:


### PR DESCRIPTION
## Summary
- adjust cascade pullback validation to count consecutive closes below the pullback threshold
- keep pullback depth and minimum consecutive bar requirements unchanged while using closing prices

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c9cda97588320a16d5d3c08f5e189)