### PR TITLE
Improve cascade level tie-break logic

### DIFF
--- a/crypto_screener/domain/setup_detector.py
+++ b/crypto_screener/domain/setup_detector.py
@@ -234,6 +234,7 @@ def get_cascade_long(
     best_level_touches = []
     best_third_touch_index = -1
     best_level_price = None
+    best_level_distance = -1
 
     for level in levels:
         if level.is_crossed:
@@ -246,6 +247,17 @@ def get_cascade_long(
             best_level_touches = touches
             best_third_touch_index = third_touch_index
             best_level_price = level.price
+            best_level_distance = level.distance
+            continue
+
+        if third_touch_index == best_third_touch_index:
+            has_more_touches = len(touches) > len(best_level_touches)
+            has_longer_distance = len(touches) == len(best_level_touches) and level.distance > best_level_distance
+            if has_more_touches or has_longer_distance:
+                best_level_touches = touches
+                best_third_touch_index = third_touch_index
+                best_level_price = level.price
+                best_level_distance = level.distance
 
     if not best_level_touches:
         return []


### PR DESCRIPTION
## Summary
- prioritize cascade levels with equal third touch index using touch count and distance as tie-breakers
- store chosen level details to reflect new preference order

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c9eb0369483209c5d6eefde48dc4d)