### PR TITLE
Add guard when fallback support swing red bar missing

### DIFF
--- a/crypto_screener/domain/setup_detector.py
+++ b/crypto_screener/domain/setup_detector.py
@@ -414,6 +414,8 @@ def detect_setup(
     support_swing = open_low_swings[-1] if open_low_swings else None
     if not support_swing:
         last_red_bar = next((bar for bar in reversed(correction_bars) if bar.close < bar.open), None)
+        if not last_red_bar:
+            return setup
         support_swing = Swing(
             time=last_red_bar.time,
             price=last_red_bar.low,


### PR DESCRIPTION
## Summary
- add a safety check to short-circuit when no red bar exists before creating a fallback support swing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931da8f44e88320b30d5a004d4067cd)