### PR TITLE
Align notifier callback interface and allowed trade model

### DIFF
--- a/crypto_screener/data/notifiers/log.py
+++ b/crypto_screener/data/notifiers/log.py
@@ -37,3 +37,8 @@ class LogNotifier(Notifier):
 
     def remove_button(self, message_id: Optional[str]) -> None:
         log.d(f"Запрос на удаление кнопки у сообщения {message_id}")
+
+    def start_callback_handler(self, trade_permission_service) -> None:
+        log.d(
+            "Запрос на запуск обработчика callback-кнопок без реальной интеграции."
+        )

--- a/crypto_screener/data/notifiers/telegram.py
+++ b/crypto_screener/data/notifiers/telegram.py
@@ -1,14 +1,84 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from pathlib import Path
 from typing import Optional
 
-from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup, InputMediaPhoto
+from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup, InputMediaPhoto, Update
+from telegram.constants import UpdateType
+from telegram.ext import Application, CallbackQueryHandler, ContextTypes
 
 from crypto_screener.domain.models.context import Context
+from crypto_screener.domain.models.timeframe import Timeframe
 from crypto_screener.domain.notifier import Keyboard, Notifier, NotificationType
+from crypto_screener.execution.trade_permission_service import TradePermissionService
 from crypto_screener.utils.logger import log
+
+TRADE_CALLBACK_PREFIX = "capture-active"
+
+
+class _CallbackHandler:
+    def __init__(
+            self,
+            event_token: str,
+            trade_permission_service: TradePermissionService,
+    ) -> None:
+        self._trade_permission_service = trade_permission_service
+        self._application = Application.builder().token(event_token).build()
+        self._application.add_handler(
+            CallbackQueryHandler(
+                self._handle_trade_request,
+                pattern=fr"^{TRADE_CALLBACK_PREFIX}",
+            )
+        )
+
+    def start(self) -> None:
+        thread = threading.Thread(target=self._run_polling, name="tg-callback-handler", daemon=True)
+        thread.start()
+        log.d("Запущен обработчик callback-кнопок Telegram.")
+
+    def _run_polling(self) -> None:
+        self._application.run_polling(allowed_updates=[UpdateType.CALLBACK_QUERY])
+
+    async def _handle_trade_request(
+            self,
+            update: Update,
+            context: ContextTypes.DEFAULT_TYPE,
+    ) -> None:
+        query = update.callback_query
+        if not query:
+            return
+
+        await query.answer()
+        callback_data = (query.data or "").split(":")
+        if len(callback_data) != 4:
+            log.e(f"Не удалось разобрать callback_data: {query.data}")
+            return
+
+        _, symbol, timeframe_tf, context_value = callback_data
+        try:
+            timeframe = Timeframe.from_tf(timeframe_tf)
+            symbol_context = Context(context_value)
+        except ValueError as exception:
+            log.e(f"Некорректные данные callback {query.data}: {exception}")
+            return
+
+        message = query.message
+        if not message:
+            log.e("Отсутствует сообщение для callback торговой кнопки.")
+            return
+
+        message_id = str(message.message_id)
+        log.d(
+            f"Получен запрос на торговлю {symbol} на {timeframe.tf} с контекстом {symbol_context.value}."
+        )
+        self._trade_permission_service.allow_symbol_for_trading(
+            symbol=symbol,
+            timeframe=timeframe,
+            message_id=message_id,
+            context=symbol_context,
+        )
 
 
 class TgNotifier(Notifier):
@@ -18,9 +88,21 @@ class TgNotifier(Notifier):
             order_token: str,
             chat_id: str
     ) -> None:
+        self._event_token = event_token
         self._event_bot = Bot(token=event_token)
         self._order_bot = Bot(token=order_token)
         self._chat_id = chat_id
+        self._callback_handler: Optional[_CallbackHandler] = None
+
+    def start_callback_handler(self, trade_permission_service: TradePermissionService) -> None:
+        if self._callback_handler:
+            return
+
+        self._callback_handler = _CallbackHandler(
+            event_token=self._event_token,
+            trade_permission_service=trade_permission_service,
+        )
+        self._callback_handler.start()
 
     # region Private.
     async def _send(

--- a/crypto_screener/domain/models/allowed_trade.py
+++ b/crypto_screener/domain/models/allowed_trade.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from crypto_screener.domain.models.context import Context
+from crypto_screener.domain.models.timeframe import Timeframe
+
+
+@dataclass
+class AllowedTrade:
+    symbol: str
+    timeframe: Timeframe
+    message_id: str
+    context: Context

--- a/crypto_screener/domain/models/timeframe.py
+++ b/crypto_screener/domain/models/timeframe.py
@@ -18,3 +18,10 @@ class Timeframe(Enum):
     @property
     def minutes(self) -> int:
         return self.value[1]
+
+    @classmethod
+    def from_tf(cls, tf: str) -> "Timeframe":
+        for timeframe in cls:
+            if timeframe.tf == tf:
+                return timeframe
+        raise ValueError(f"Неизвестный таймфрейм: {tf}")

--- a/crypto_screener/domain/notifier.py
+++ b/crypto_screener/domain/notifier.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from crypto_screener.domain.models.context import Context
 
 Keyboard = list[list[tuple[str, str]]]
+
+if TYPE_CHECKING:
+    from crypto_screener.execution.trade_permission_service import TradePermissionService
 
 
 class NotificationType(Enum):
@@ -41,4 +44,8 @@ class Notifier(ABC):
 
     @abstractmethod
     def remove_button(self, message_id: Optional[str]) -> None:
+        ...
+
+    @abstractmethod
+    def start_callback_handler(self, trade_permission_service: "TradePermissionService") -> None:
         ...

--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -4,6 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
 
 from crypto_screener.config.config import AppConfig as cfg
+from crypto_screener.data.notifiers.telegram import TRADE_CALLBACK_PREFIX
 from crypto_screener.data.providers.coingecko import enrich_symbols_capitalization
 from crypto_screener.domain.capture_state import CaptureState
 from crypto_screener.domain.exchange import Exchange
@@ -15,6 +16,7 @@ from crypto_screener.domain.models.symbol import FuturesSymbol, set_contexts
 from crypto_screener.domain.models.timeframe import Timeframe
 from crypto_screener.domain.notifier import Keyboard, Notifier, NotificationType
 from crypto_screener.domain.setup_detector import detect_setup
+from crypto_screener.execution.trade_permission_service import TradePermissionService
 from crypto_screener.utils.history import calculate_limit_grid
 from crypto_screener.utils.logger import log
 from crypto_screener.utils.plotter import plot
@@ -157,6 +159,12 @@ def _edit_notification(
     return None
 
 
+def _build_trade_keyboard(symbol: str, timeframe: Timeframe, context: Context) -> Keyboard:
+    trade_text = cfg.TRADE_KEYBOARD[0][0][0] if cfg.TRADE_KEYBOARD else "Торговать"
+    callback_data = f"{TRADE_CALLBACK_PREFIX}:{symbol}:{timeframe.tf}:{context.value}"
+    return [[(trade_text, callback_data)]]
+
+
 # endregion
 
 def run_live(
@@ -189,6 +197,8 @@ def run_live(
         return
 
     capture_state = CaptureState()
+    trade_permission_service = TradePermissionService()
+    notifier.start_callback_handler(trade_permission_service)
     executor = ThreadPoolExecutor(max_workers=2)
     handle_sig(executor)
     notified_once: set[tuple[str, Timeframe, str]] = set()
@@ -203,6 +213,7 @@ def run_live(
         for (symbol_name, timeframe), active_capture in expired_captures:
             capture_state.remove_capture(symbol_name, timeframe)
             notifier.remove_button(active_capture.message_id)
+            trade_permission_service.clear_allowance(symbol_name, timeframe)
             log.i(f"Истек срок слежения за {symbol_name} на {timeframe.tf}, кнопка удалена.")
             notified_once.discard((symbol_name, timeframe, "Capture"))
             if capture_state.symbol == symbol_name and not capture_state.has_symbol_capture(symbol_name):
@@ -232,6 +243,7 @@ def run_live(
                             log.i(
                                 f"Сетап {symbol.symbol} на {timeframe.tf} потерян, кнопка удалена."
                             )
+                            trade_permission_service.clear_allowance(symbol.symbol, timeframe)
                             notified_once.discard((symbol.symbol, timeframe, "Capture"))
                         if capture_state.symbol == symbol.symbol and not capture_state.has_symbol_capture(symbol.symbol):
                             capture_state.symbol = None
@@ -266,7 +278,7 @@ def run_live(
                                     support_swings=support_swings,
                                     subdir='event',
                                     context=symbol.context,
-                                    keyboard=cfg.TRADE_KEYBOARD,
+                                    keyboard=_build_trade_keyboard(symbol.symbol, timeframe, symbol.context),
                                 ).result()
                             continue
                         if capture_state.symbol is None:
@@ -288,7 +300,7 @@ def run_live(
                                 support_swings=support_swings,
                                 subdir='event',
                                 context=symbol.context,
-                                keyboard=cfg.TRADE_KEYBOARD,
+                                keyboard=_build_trade_keyboard(symbol.symbol, timeframe, symbol.context),
                             ).result()
                             capture_state.add_capture(
                                 symbol=symbol.symbol,
@@ -308,7 +320,7 @@ def run_live(
                     ):
                         message = f"Попытка открытия позиции в {symbol.symbol} на {timeframe.tf}."
                         log.i(message)
-                        # TODO Открытие позиции на бирже.
+                        # TODO Фактическое открытие позиции на бирже.
                         executor.submit(
                             _send_notification,
                             notifier=notifier,
@@ -332,4 +344,5 @@ def run_live(
                                 f"Сетап {symbol.symbol} на {timeframe.tf} закрыт из-за сигнала Buy, кнопка удалена."
                             )
                             notified_once.discard((symbol.symbol, timeframe, "Capture"))
+                        trade_permission_service.clear_allowance(symbol.symbol, timeframe)
                         capture_state.symbol = None

--- a/crypto_screener/execution/trade_permission_service.py
+++ b/crypto_screener/execution/trade_permission_service.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+from crypto_screener.domain.models.context import Context
+from crypto_screener.domain.models.allowed_trade import AllowedTrade
+from crypto_screener.domain.models.timeframe import Timeframe
+from crypto_screener.utils.logger import log
+
+class TradePermissionService:
+    def __init__(self) -> None:
+        self._allowed_trades: Dict[Tuple[str, Timeframe], AllowedTrade] = {}
+
+    def allow_symbol_for_trading(
+            self,
+            symbol: str,
+            timeframe: Timeframe,
+            message_id: str,
+            context: Context,
+    ) -> None:
+        key = (symbol, timeframe)
+        trade = AllowedTrade(symbol=symbol, timeframe=timeframe, message_id=message_id, context=context)
+        if key in self._allowed_trades:
+            self._allowed_trades[key] = trade
+            log.d(
+                f"Обновлено разрешение на торговлю {symbol} на {timeframe.tf} без повторного уведомления."
+            )
+            return
+        self._allowed_trades[key] = trade
+        log.i(f"Разрешена торговля {symbol} на {timeframe.tf} по нажатию кнопки.")
+
+    def clear_allowance(self, symbol: str, timeframe: Timeframe) -> None:
+        removed = self._allowed_trades.pop((symbol, timeframe), None)
+        if removed:
+            log.d(f"Удалено разрешение на торговлю {symbol} на {timeframe.tf}.")
+
+    def clear_all(self) -> None:
+        if not self._allowed_trades:
+            return
+        self._allowed_trades.clear()
+        log.d("Сброшены все разрешения на торговлю.")


### PR DESCRIPTION
## Summary
- move the AllowedTrade dataclass into domain models and update the trade permission service import
- add start_callback_handler to the Notifier interface with a logging stub in LogNotifier
- invoke callback handler startup through the notifier in run_live without type checks

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933241e04b0832087dd20eef6045286)