### PR TITLE
Respect trade permission during capture updates

### DIFF
--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -405,6 +405,11 @@ def run_live(
                         resistance_swings=resistance_swings,
                         support_swings=support_swings,
                     ):
+                        if trade_permission_service.has_allowance(symbol.symbol, timeframe):
+                            log.d(
+                                f"Пропущено уведомление Capture для {symbol.symbol} на {timeframe.tf} из-за активного разрешения на торговлю."
+                            )
+                            continue
                         capture_key = (symbol.symbol, timeframe)
                         message = f"Включено слежение за {symbol.symbol} на {timeframe.tf}."
                         if capture_key in capture_state.captures:

--- a/crypto_screener/execution/trade_permission_service.py
+++ b/crypto_screener/execution/trade_permission_service.py
@@ -39,3 +39,6 @@ class TradePermissionService:
             return
         self._allowed_trades.clear()
         log.d("Сброшены все разрешения на торговлю.")
+
+    def has_allowance(self, symbol: str, timeframe: Timeframe) -> bool:
+        return (symbol, timeframe) in self._allowed_trades


### PR DESCRIPTION
## Summary
- skip capture notification sending/editing when a trade permission is already active for the symbol and timeframe
- expose a helper to check active trade permissions so live processing can avoid redundant updates

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69332bf6084483208e7192a25148b110)