### PR TITLE
Handle trade permission expiry

### DIFF
--- a/crypto_screener/domain/models/allowed_trade.py
+++ b/crypto_screener/domain/models/allowed_trade.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 
 from crypto_screener.domain.models.context import Context
 from crypto_screener.domain.models.timeframe import Timeframe
@@ -12,3 +13,5 @@ class AllowedTrade:
     timeframe: Timeframe
     message_id: str
     context: Context
+    issued_at: datetime
+    deadline: datetime

--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -335,6 +335,13 @@ def run_live(
 
     while True:
         now = utc_now()
+        expired_permissions = trade_permission_service.pop_expired(now)
+        for (symbol_name, timeframe), expired_permission in expired_permissions:
+            _remove_button_safe(notifier, expired_permission.message_id)
+            log.i(
+                f"Истекло разрешение на торговлю {symbol_name} на {timeframe.tf}, кнопка удалена."
+            )
+            notified_once.discard((symbol_name, timeframe, "Capture"))
         expired_captures = [
             (symbol_timeframe, active_capture)
             for symbol_timeframe, active_capture in capture_state.captures.items()

--- a/crypto_screener/execution/trade_permission_service.py
+++ b/crypto_screener/execution/trade_permission_service.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from typing import Dict, Tuple
+from datetime import datetime, timedelta
+from typing import Dict, Tuple, Optional
 
+from crypto_screener.config.config import AppConfig as cfg
 from crypto_screener.domain.models.context import Context
 from crypto_screener.domain.models.allowed_trade import AllowedTrade
 from crypto_screener.domain.models.timeframe import Timeframe
 from crypto_screener.utils.logger import log
+from crypto_screener.utils.time import utc_now
 
 class TradePermissionService:
     def __init__(self) -> None:
@@ -19,7 +22,16 @@ class TradePermissionService:
             context: Context,
     ) -> None:
         key = (symbol, timeframe)
-        trade = AllowedTrade(symbol=symbol, timeframe=timeframe, message_id=message_id, context=context)
+        issued_at = utc_now()
+        deadline = issued_at + timedelta(minutes=cfg.CAPTURE_TIMEOUT_MULTIPLIER * timeframe.minutes)
+        trade = AllowedTrade(
+            symbol=symbol,
+            timeframe=timeframe,
+            message_id=message_id,
+            context=context,
+            issued_at=issued_at,
+            deadline=deadline,
+        )
         if key in self._allowed_trades:
             self._allowed_trades[key] = trade
             log.d(
@@ -29,10 +41,14 @@ class TradePermissionService:
         self._allowed_trades[key] = trade
         log.i(f"Разрешена торговля {symbol} на {timeframe.tf} по нажатию кнопки.")
 
-    def clear_allowance(self, symbol: str, timeframe: Timeframe) -> None:
+    def clear_allowance(self, symbol: str, timeframe: Timeframe) -> Optional[AllowedTrade]:
         removed = self._allowed_trades.pop((symbol, timeframe), None)
         if removed:
-            log.d(f"Удалено разрешение на торговлю {symbol} на {timeframe.tf}.")
+            log.d(
+                f"Удалено разрешение на торговлю {symbol} на {timeframe.tf}. "
+                f"Выдано: {removed.issued_at.isoformat()}, дедлайн: {removed.deadline.isoformat()}."
+            )
+        return removed
 
     def clear_all(self) -> None:
         if not self._allowed_trades:
@@ -41,4 +57,29 @@ class TradePermissionService:
         log.d("Сброшены все разрешения на торговлю.")
 
     def has_allowance(self, symbol: str, timeframe: Timeframe) -> bool:
-        return (symbol, timeframe) in self._allowed_trades
+        allowance = self._allowed_trades.get((symbol, timeframe))
+        if not allowance:
+            return False
+        if utc_now() >= allowance.deadline:
+            self._expire_allowance((symbol, timeframe), allowance)
+            return False
+        return True
+
+    def pop_expired(self, now: datetime) -> list[tuple[Tuple[str, Timeframe], AllowedTrade]]:
+        expired: list[tuple[Tuple[str, Timeframe], AllowedTrade]] = []
+        for key, allowance in list(self._allowed_trades.items()):
+            if now >= allowance.deadline:
+                self._expire_allowance(key, allowance)
+                expired.append((key, allowance))
+        return expired
+
+    def _expire_allowance(
+            self,
+            key: Tuple[str, Timeframe],
+            allowance: AllowedTrade,
+    ) -> None:
+        self._allowed_trades.pop(key, None)
+        log.i(
+            f"Истекло разрешение на торговлю {allowance.symbol} на {allowance.timeframe.tf}. "
+            f"Выдано: {allowance.issued_at.isoformat()}, дедлайн: {allowance.deadline.isoformat()}."
+        )


### PR DESCRIPTION
## Summary
- track issuance time and deadlines for trade permissions and log their expiration
- clear expired permissions during live runs, removing related buttons and allowing capture notifications again
- include timing data when clearing permissions after other events

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69332ebb925883209f68305445e22e20)