### PR TITLE
Add trade execution service and integrate live flow

### DIFF
--- a/crypto_screener/config/config.py
+++ b/crypto_screener/config/config.py
@@ -142,6 +142,16 @@ class AppConfig:
     PARTIAL_CLOSE_SIDE_PCT_MIN: float = 2.0
     # Соотношение цены участков Entry-BE и Entry-PC при частичном закрытии позиции.
     BREAKEVEN_PARTIAL_CLOSE_RATIO: float = 0.5
+    # Размер риска на сделку в USDT.
+    RISK_PER_TRADE_USDT: float = 20.0
+    # Минимальная нотация позиции в USDT.
+    MIN_POSITION_NOTIONAL_USDT: float = 10.0
+    # Минимальное количество монет в позиции.
+    MIN_POSITION_QUANTITY: float = 0.001
+    # Количество повторных попыток размещения ордеров.
+    ORDER_MAX_RETRIES: int = 3
+    # Пауза между повторными попытками размещения ордеров.
+    ORDER_RETRY_DELAY_SECONDS: float = 1.0
     # endregion
 
     # region Построение графиков.

--- a/crypto_screener/data/exchanges/binance.py
+++ b/crypto_screener/data/exchanges/binance.py
@@ -115,3 +115,25 @@ class Binance(Exchange):
 
     def get_position(self, symbol: str) -> Optional[Position]:
         raise NotImplementedError("Position retrieval is not implemented for Binance yet")
+
+    def place_stop_loss_order(
+            self,
+            symbol: str,
+            side: OrderSide,
+            quantity: float,
+            stop_price: float,
+            reduce_only: bool = True,
+            margin_mode: Optional[MarginMode] = None,
+    ) -> str:
+        raise NotImplementedError("Stop-loss orders are not implemented for Binance yet")
+
+    def place_take_profit_order(
+            self,
+            symbol: str,
+            side: OrderSide,
+            quantity: float,
+            price: float,
+            reduce_only: bool = True,
+            margin_mode: Optional[MarginMode] = None,
+    ) -> str:
+        raise NotImplementedError("Take-profit orders are not implemented for Binance yet")

--- a/crypto_screener/data/exchanges/bybit.py
+++ b/crypto_screener/data/exchanges/bybit.py
@@ -112,3 +112,25 @@ class Bybit(Exchange):
 
     def get_position(self, symbol: str) -> Optional[Position]:
         raise NotImplementedError("Position retrieval is not implemented for Bybit yet")
+
+    def place_stop_loss_order(
+            self,
+            symbol: str,
+            side: OrderSide,
+            quantity: float,
+            stop_price: float,
+            reduce_only: bool = True,
+            margin_mode: Optional[MarginMode] = None,
+    ) -> str:
+        raise NotImplementedError("Stop-loss orders are not implemented for Bybit yet")
+
+    def place_take_profit_order(
+            self,
+            symbol: str,
+            side: OrderSide,
+            quantity: float,
+            price: float,
+            reduce_only: bool = True,
+            margin_mode: Optional[MarginMode] = None,
+    ) -> str:
+        raise NotImplementedError("Take-profit orders are not implemented for Bybit yet")

--- a/crypto_screener/domain/exchange.py
+++ b/crypto_screener/domain/exchange.py
@@ -49,3 +49,27 @@ class Exchange(ABC):
         ...
 
     @abstractmethod
+    def place_stop_loss_order(
+            self,
+            symbol: str,
+            side: OrderSide,
+            quantity: float,
+            stop_price: float,
+            reduce_only: bool = True,
+            margin_mode: Optional[MarginMode] = None,
+    ) -> str:
+        ...
+
+    @abstractmethod
+    def place_take_profit_order(
+            self,
+            symbol: str,
+            side: OrderSide,
+            quantity: float,
+            price: float,
+            reduce_only: bool = True,
+            margin_mode: Optional[MarginMode] = None,
+    ) -> str:
+        ...
+
+    @abstractmethod

--- a/crypto_screener/domain/models/active_trade.py
+++ b/crypto_screener/domain/models/active_trade.py
@@ -19,3 +19,9 @@ class ActiveTrade:
     context: Context
     capture_message_id: Optional[str] = None
     postmortem_bars: list[Bar] = field(default_factory=list)
+    entry_order_id: Optional[str] = None
+    stop_loss_order_id: Optional[str] = None
+    take_profit_order_id: Optional[str] = None
+    partial_close_order_id: Optional[str] = None
+    breakeven_order_id: Optional[str] = None
+    position_id: Optional[str] = None

--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -19,6 +19,7 @@ from crypto_screener.domain.notifier import Keyboard, Notifier, NotificationType
 from crypto_screener.domain.models.trade_result import TradeResult
 from crypto_screener.domain.setup_detector import detect_setup
 from crypto_screener.execution.trade_permission_service import TradePermissionService
+from crypto_screener.execution.trade_executor import TradeExecutionService
 from crypto_screener.utils.history import calculate_limit_grid
 from crypto_screener.utils.logger import log
 from crypto_screener.utils.plotter import plot, plot_postmortem
@@ -327,6 +328,7 @@ def run_live(
 
     capture_state = CaptureState()
     trade_permission_service = TradePermissionService()
+    trade_execution_service = TradeExecutionService(exchange, notifier)
     notifier.start_callback_handler(trade_permission_service)
     executor = ThreadPoolExecutor(max_workers=2)
     handle_sig(executor)
@@ -485,12 +487,22 @@ def run_live(
                             continue
                         message = f"Попытка открытия позиции в {symbol.symbol} на {timeframe.tf}."
                         log.i(message)
-                        # TODO Фактическое открытие позиции на бирже.
+                        execution_result = trade_execution_service.execute_buy(setup, symbol.context)
+                        if not execution_result:
+                            trade_permission_service.clear_allowance(symbol.symbol, timeframe)
+                            continue
+                        success_message = (
+                            f"Открыта позиция в {symbol.symbol} на {timeframe.tf}.\n"
+                            f"Entry order: {execution_result.entry_order_id}\n"
+                            f"SL order: {execution_result.stop_loss_order_id}\n"
+                            f"TP order: {execution_result.take_profit_order_id}"
+                        )
+                        log.i(success_message)
                         executor.submit(
                             _send_notification,
                             notifier=notifier,
                             notification_type=NotificationType.ORDER,
-                            message=message,
+                            message=success_message,
                             symbol=symbol.symbol,
                             timeframe=timeframe,
                             bars=bars,
@@ -518,6 +530,12 @@ def run_live(
                             detection_time=detection_time,
                             context=symbol.context,
                             capture_message_id=capture_message_id,
+                            entry_order_id=execution_result.entry_order_id,
+                            stop_loss_order_id=execution_result.stop_loss_order_id,
+                            take_profit_order_id=execution_result.take_profit_order_id,
+                            partial_close_order_id=execution_result.partial_close_order_id,
+                            breakeven_order_id=execution_result.breakeven_order_id,
+                            position_id=execution_result.position_id,
                         )
                         trade_permission_service.clear_allowance(symbol.symbol, timeframe)
                         capture_state.symbol = None

--- a/crypto_screener/execution/trade_executor.py
+++ b/crypto_screener/execution/trade_executor.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from crypto_screener.config.config import AppConfig as cfg
+from crypto_screener.domain.exchange import Exchange
+from crypto_screener.domain.models.context import Context
+from crypto_screener.domain.models.margin_mode import MarginMode
+from crypto_screener.domain.models.order_side import OrderSide
+from crypto_screener.domain.models.order_status import OrderStatus
+from crypto_screener.domain.models.setup import Buy
+from crypto_screener.domain.notifier import Notifier, NotificationType
+from crypto_screener.utils.logger import log
+
+
+@dataclass
+class ExecutionResult:
+    quantity: float
+    entry_order_id: str
+    stop_loss_order_id: Optional[str]
+    take_profit_order_id: Optional[str]
+    partial_close_order_id: Optional[str]
+    breakeven_order_id: Optional[str]
+    position_id: Optional[str]
+
+
+class TradeExecutionService:
+    def __init__(
+            self,
+            exchange: Exchange,
+            notifier: Notifier,
+            max_retries: int = cfg.ORDER_MAX_RETRIES,
+            retry_delay_seconds: float = cfg.ORDER_RETRY_DELAY_SECONDS,
+    ) -> None:
+        self._exchange = exchange
+        self._notifier = notifier
+        self._max_retries = max_retries
+        self._retry_delay_seconds = retry_delay_seconds
+
+    def execute_buy(self, setup: Buy, context: Context) -> Optional[ExecutionResult]:
+        try:
+            quantity = self._calculate_position_size(setup)
+        except Exception as exception:
+            self._notify_failure(
+                setup,
+                context,
+                f"Не удалось рассчитать размер позиции: {exception}",
+            )
+            return None
+
+        entry_order_id: Optional[str] = None
+        try:
+            entry_order_id = self._place_with_retries(
+                label="entry",
+                place_order=lambda: self._exchange.place_market_order(
+                    setup.symbol,
+                    OrderSide.BUY,
+                    quantity,
+                    margin_mode=MarginMode.CROSS,
+                ),
+                symbol=setup.symbol,
+            )
+            protective_order_ids = self._place_protective_orders(setup, quantity)
+            position_id = self._fetch_position_id(setup.symbol)
+            return ExecutionResult(
+                quantity=quantity,
+                entry_order_id=entry_order_id,
+                position_id=position_id,
+                **protective_order_ids,
+            )
+        except Exception as exception:
+            if entry_order_id:
+                self._cancel_order_safe(setup.symbol, entry_order_id)
+            self._notify_failure(
+                setup,
+                context,
+                f"Не удалось разместить ордера: {exception}",
+            )
+            return None
+
+    def _calculate_position_size(self, setup: Buy) -> float:
+        entry_price = setup.entry_price
+        stop_loss_price = setup.stop_loss_price
+        stop_distance = entry_price - stop_loss_price
+        if stop_distance <= 0:
+            raise ValueError(
+                f"Некорректная дистанция до стоп-лосса: Entry {entry_price}, SL {stop_loss_price}"
+            )
+
+        risk_amount = cfg.RISK_PER_TRADE_USDT
+        min_notional = cfg.MIN_POSITION_NOTIONAL_USDT
+        min_quantity = cfg.MIN_POSITION_QUANTITY
+
+        quantity_by_risk = risk_amount / stop_distance
+        quantity_by_notional = min_notional / entry_price
+        quantity = max(quantity_by_risk, quantity_by_notional, min_quantity)
+
+        log.d(
+            f"Рассчитан размер позиции: {quantity:.6f} ({quantity * entry_price:.2f} USDT) "
+            f"при риске {risk_amount} USDT и SL-расстоянии {stop_distance:.4f}."
+        )
+        return quantity
+
+    def _place_protective_orders(self, setup: Buy, quantity: float) -> dict[str, Optional[str]]:
+        ids: dict[str, Optional[str]] = {
+            "stop_loss_order_id": None,
+            "take_profit_order_id": None,
+            "partial_close_order_id": None,
+            "breakeven_order_id": None,
+        }
+
+        ids["stop_loss_order_id"] = self._place_with_retries(
+            label="stop-loss",
+            place_order=lambda: self._exchange.place_stop_loss_order(
+                setup.symbol,
+                OrderSide.SELL,
+                quantity,
+                stop_price=setup.stop_loss_price,
+                margin_mode=MarginMode.CROSS,
+            ),
+            symbol=setup.symbol,
+        )
+
+        ids["take_profit_order_id"] = self._place_with_retries(
+            label="take-profit",
+            place_order=lambda: self._exchange.place_take_profit_order(
+                setup.symbol,
+                OrderSide.SELL,
+                quantity,
+                price=setup.take_profit_price,
+                margin_mode=MarginMode.CROSS,
+            ),
+            symbol=setup.symbol,
+        )
+
+        if setup.partial_close_price is not None:
+            partial_quantity = quantity * 0.5
+            ids["partial_close_order_id"] = self._place_with_retries(
+                label="partial-close",
+                place_order=lambda: self._exchange.place_take_profit_order(
+                    setup.symbol,
+                    OrderSide.SELL,
+                    partial_quantity,
+                    price=setup.partial_close_price,
+                    margin_mode=MarginMode.CROSS,
+                ),
+                symbol=setup.symbol,
+            )
+
+            if setup.breakeven_price is not None:
+                ids["breakeven_order_id"] = self._place_with_retries(
+                    label="breakeven",
+                    place_order=lambda: self._exchange.place_stop_loss_order(
+                        setup.symbol,
+                        OrderSide.SELL,
+                        quantity - partial_quantity,
+                        stop_price=setup.breakeven_price,
+                        margin_mode=MarginMode.CROSS,
+                    ),
+                    symbol=setup.symbol,
+                )
+
+        return ids
+
+    def _place_with_retries(
+            self,
+            label: str,
+            place_order: Callable[[], str],
+            symbol: str,
+    ) -> str:
+        last_error: Optional[Exception] = None
+        for attempt in range(1, self._max_retries + 1):
+            try:
+                order_id = place_order()
+                if self._is_filled(symbol, order_id):
+                    return order_id
+                log.d(
+                    f"Ордер {label} {order_id} для {symbol} не исполнен полностью, попытка {attempt}."
+                )
+                self._cancel_order_safe(symbol, order_id)
+            except Exception as exception:
+                last_error = exception
+                log.e(
+                    f"Ошибка при размещении {label} для {symbol} (попытка {attempt}/{self._max_retries}):"
+                    f" {exception}"
+                )
+            time.sleep(self._retry_delay_seconds)
+
+        raise RuntimeError(
+            f"Не удалось разместить {label} для {symbol} после {self._max_retries} попыток: {last_error}"
+        )
+
+    def _is_filled(self, symbol: str, order_id: str) -> bool:
+        try:
+            order_info = self._exchange.get_order_status(symbol, order_id)
+        except NotImplementedError:
+            return True
+
+        if order_info.status == OrderStatus.FILLED:
+            return True
+        if order_info.status == OrderStatus.CANCELED:
+            raise RuntimeError(f"Ордер {order_id} для {symbol} отменен биржей")
+        return False
+
+    def _cancel_order_safe(self, symbol: str, order_id: str) -> None:
+        try:
+            self._exchange.cancel_order(symbol, order_id)
+        except NotImplementedError:
+            log.d(f"Отмена ордера {order_id} для {symbol} не поддерживается биржей.")
+        except Exception as exception:
+            log.e(f"Не удалось отменить ордер {order_id} для {symbol}: {exception}")
+
+    def _fetch_position_id(self, symbol: str) -> Optional[str]:
+        try:
+            position = self._exchange.get_position(symbol)
+            return position.symbol if position else None
+        except NotImplementedError:
+            return None
+        except Exception as exception:
+            log.e(f"Не удалось получить позицию {symbol}: {exception}")
+            return None
+
+    def _notify_failure(self, setup: Buy, context: Context, message: str) -> None:
+        full_message = (
+            f"Ошибка открытия позиции {setup.symbol} на {setup.timeframe.tf}: {message}\n"
+            f"Уровни: Entry {setup.entry_price:.4f}, SL {setup.stop_loss_price:.4f}, "
+            f"TP {setup.take_profit_price:.4f}"
+        )
+        log.e(full_message)
+        try:
+            self._notifier.notify(
+                notification_type=NotificationType.ORDER,
+                message=full_message,
+                context=context,
+            )
+        except Exception as exception:
+            log.e(f"Не удалось отправить уведомление об ошибке сделки: {exception}")


### PR DESCRIPTION
## Summary
- add a trade execution service to size positions, place linked orders, and notify about failures
- extend exchange abstractions and configuration with risk and retry parameters
- update live trading loop to execute buy setups, persist order identifiers, and clear permissions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69333746758883209c7e0b6a57dcb622)