### PR TITLE
Adjust protective orders after partial closes

### DIFF
--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -344,6 +344,7 @@ def _calculate_split_profit(
 
 def _monitor_active_trade(
         exchange: Exchange,
+        trade_execution_service: TradeExecutionService,
         active_trade: ActiveTrade,
         bars: list[Bar],
 ) -> Optional[tuple[TradeResult, float, float, list[float]]]:
@@ -401,6 +402,26 @@ def _monitor_active_trade(
                 if filled_quantity is not None:
                     remaining_quantity = (active_trade.quantity or 0) - filled_quantity
                     active_trade.remaining_quantity = max(remaining_quantity, 0)
+                    try:
+                        realigned_ids = trade_execution_service.realign_stop_orders(
+                            setup=active_trade.setup,
+                            stop_loss_order_id=active_trade.stop_loss_order_id,
+                            breakeven_order_id=active_trade.breakeven_order_id,
+                            remaining_quantity=active_trade.remaining_quantity,
+                            move_to_breakeven=active_trade.setup.breakeven_price is not None,
+                        )
+                        active_trade.stop_loss_order_id = realigned_ids.get("stop_loss_order_id")
+                        active_trade.stop_loss_order_status = (
+                            OrderStatus.NEW if realigned_ids.get("stop_loss_order_id") else None
+                        )
+                        active_trade.breakeven_order_id = realigned_ids.get("breakeven_order_id")
+                        active_trade.breakeven_order_status = (
+                            OrderStatus.NEW if realigned_ids.get("breakeven_order_id") else None
+                        )
+                    except Exception as exception:
+                        log.e(
+                            f"Не удалось обновить защитные ордера после частичного закрытия {active_trade.symbol}: {exception}"
+                        )
 
         breakeven_info = _get_order_info_safe(exchange, active_trade.symbol, active_trade.breakeven_order_id)
         if breakeven_info:
@@ -575,7 +596,7 @@ def run_live(
                         break
                 trade_key = (symbol.symbol, timeframe)
                 if trade_key in active_trades:
-                    outcome = _monitor_active_trade(exchange, active_trades[trade_key], bars)
+                    outcome = _monitor_active_trade(exchange, trade_execution_service, active_trades[trade_key], bars)
                     if outcome:
                         trade_result, profit_pct, profit_value, exit_prices = outcome
                         log.i(

--- a/crypto_screener/execution/trade_executor.py
+++ b/crypto_screener/execution/trade_executor.py
@@ -159,24 +159,6 @@ class TradeExecutionService:
                 },
             )
 
-            if setup.breakeven_price is not None:
-                ids["breakeven_order_id"] = self._place_with_retries(
-                    label="breakeven",
-                    place_order=lambda: self._exchange.place_stop_loss_order(
-                        setup.symbol,
-                        OrderSide.SELL,
-                        quantity - partial_quantity,
-                        stop_price=setup.breakeven_price,
-                        margin_mode=MarginMode.CROSS,
-                    ),
-                    symbol=setup.symbol,
-                    acceptable_statuses={
-                        OrderStatus.FILLED,
-                        OrderStatus.NEW,
-                        OrderStatus.PARTIALLY_FILLED,
-                    },
-                )
-
         return ids
 
     def _place_with_retries(
@@ -219,7 +201,57 @@ class TradeExecutionService:
 
         return order_info.status
 
-    def _cancel_order_safe(self, symbol: str, order_id: str) -> None:
+    def realign_stop_orders(
+            self,
+            setup: Buy,
+            stop_loss_order_id: Optional[str],
+            breakeven_order_id: Optional[str],
+            remaining_quantity: float,
+            move_to_breakeven: bool,
+    ) -> dict[str, Optional[str]]:
+        ids: dict[str, Optional[str]] = {
+            "stop_loss_order_id": None,
+            "breakeven_order_id": None,
+        }
+
+        self._cancel_order_safe(setup.symbol, stop_loss_order_id)
+        self._cancel_order_safe(setup.symbol, breakeven_order_id)
+
+        if remaining_quantity <= 0:
+            log.d(
+                f"Нет оставшегося объема для перестановки стоп-ордера по {setup.symbol} после частичного закрытия."
+            )
+            return ids
+
+        stop_price = setup.breakeven_price if move_to_breakeven and setup.breakeven_price is not None else setup.stop_loss_price
+        label = "breakeven" if move_to_breakeven and setup.breakeven_price is not None else "stop-loss"
+        new_stop_id = self._place_with_retries(
+            label=label,
+            place_order=lambda: self._exchange.place_stop_loss_order(
+                setup.symbol,
+                OrderSide.SELL,
+                remaining_quantity,
+                stop_price=stop_price,
+                margin_mode=MarginMode.CROSS,
+            ),
+            symbol=setup.symbol,
+            acceptable_statuses={
+                OrderStatus.FILLED,
+                OrderStatus.NEW,
+                OrderStatus.PARTIALLY_FILLED,
+            },
+        )
+
+        if move_to_breakeven and setup.breakeven_price is not None:
+            ids["breakeven_order_id"] = new_stop_id
+        else:
+            ids["stop_loss_order_id"] = new_stop_id
+
+        return ids
+
+    def _cancel_order_safe(self, symbol: str, order_id: Optional[str]) -> None:
+        if not order_id:
+            return
         try:
             self._exchange.cancel_order(symbol, order_id)
         except NotImplementedError:


### PR DESCRIPTION
## Summary
- add stop-loss realignment logic to keep protection aligned with remaining position after partial closes
- cancel and recreate stop orders when moving to breakeven to avoid exceeding position size
- update live trade monitoring to trigger stop adjustments upon partial take-profit fills

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693341dba18483209c5f5e7990d47288)