### PR TITLE
Allow acceptable statuses for entry market orders

### DIFF
--- a/crypto_screener/execution/trade_executor.py
+++ b/crypto_screener/execution/trade_executor.py
@@ -56,6 +56,11 @@ class TradeExecutionService:
                     margin_mode=MarginMode.CROSS,
                 ),
                 symbol=setup.symbol,
+                acceptable_statuses={
+                    OrderStatus.FILLED,
+                    OrderStatus.NEW,
+                    OrderStatus.PARTIALLY_FILLED,
+                },
             )
             protective_order_ids = self._place_protective_orders(setup, quantity)
             position_id = self._fetch_position_id(setup.symbol)


### PR DESCRIPTION
## Summary
- pass acceptable statuses when placing entry market orders to avoid cancelling valid states

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933434bdfd08320b069649a8328e46f)