### PR TITLE
Handle canceled entries without positions

### DIFF
--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -379,6 +379,27 @@ def _monitor_active_trade(
                 position = None
 
             if not position or position.entry_price is None or position.quantity is None:
+                if active_trade.entry_order_status in (OrderStatus.NEW, OrderStatus.CANCELED):
+                    log.i(
+                        f"Входной ордер {active_trade.entry_order_id} в статусе "
+                        f"{active_trade.entry_order_status.value if active_trade.entry_order_status else 'неизвестно'} "
+                        "и позиция не найдена — завершаем сделку и отменяем связанные ордера."
+                    )
+                    trade_execution_service._cancel_order_safe(
+                        active_trade.symbol, active_trade.stop_loss_order_id
+                    )
+                    trade_execution_service._cancel_order_safe(
+                        active_trade.symbol, active_trade.take_profit_order_id
+                    )
+                    trade_execution_service._cancel_order_safe(
+                        active_trade.symbol, active_trade.partial_close_order_id
+                    )
+                    trade_execution_service._cancel_order_safe(
+                        active_trade.symbol, active_trade.breakeven_order_id
+                    )
+                    active_trade.status = OrderStatus.CANCELED
+                    return TradeResult.MANUAL, 0.0, 0.0, []
+
                 return None
 
             active_trade.entry_order_status = OrderStatus.FILLED


### PR DESCRIPTION
## Summary
- add forced closure handling when entry order is canceled or new but no position exists
- cancel related protective orders and mark trade as canceled
- log forced completion and return manual result for cleanup

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933e092798083209ff1c9040024872d)