### PR TITLE
Initialize breakeven info before partial close handling

### DIFF
--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -431,6 +431,18 @@ def _monitor_active_trade(
             if stop_loss_info.average_price:
                 active_trade.exit_average_price = stop_loss_info.average_price
 
+        breakeven_info = _get_order_info_safe(exchange, active_trade.symbol, active_trade.breakeven_order_id)
+        if breakeven_info:
+            _log_status_change(
+                "breakeven",
+                active_trade.breakeven_order_status and active_trade.breakeven_order_status.value,
+                breakeven_info.status.value,
+                breakeven_info.id,
+            )
+            active_trade.breakeven_order_status = breakeven_info.status
+            if breakeven_info.average_price:
+                active_trade.exit_average_price = breakeven_info.average_price
+
         partial_close_info = _get_order_info_safe(exchange, active_trade.symbol, active_trade.partial_close_order_id)
         if partial_close_info:
             _log_status_change(
@@ -483,28 +495,18 @@ def _monitor_active_trade(
                             active_trade.breakeven_order_status = (
                                 OrderStatus.NEW if realigned_breakeven_id else None
                             )
+                            breakeven_info = None
                         elif previous_breakeven_id:
                             refreshed_breakeven_info = breakeven_info or _get_order_info_safe(
                                 exchange, active_trade.symbol, previous_breakeven_id
                             )
                             if refreshed_breakeven_info:
                                 active_trade.breakeven_order_status = refreshed_breakeven_info.status
+                                breakeven_info = refreshed_breakeven_info
                     except Exception as exception:
                         log.e(
                             f"Не удалось обновить защитные ордера после частичного закрытия {active_trade.symbol}: {exception}"
                         )
-
-        breakeven_info = _get_order_info_safe(exchange, active_trade.symbol, active_trade.breakeven_order_id)
-        if breakeven_info:
-            _log_status_change(
-                "breakeven",
-                active_trade.breakeven_order_status and active_trade.breakeven_order_status.value,
-                breakeven_info.status.value,
-                breakeven_info.id,
-            )
-            active_trade.breakeven_order_status = breakeven_info.status
-            if breakeven_info.average_price:
-                active_trade.exit_average_price = breakeven_info.average_price
 
         entry_price = active_trade.entry_average_price or active_trade.setup.entry_price
         exit_prices: list[float] = []


### PR DESCRIPTION
## Summary
- retrieve breakeven order info before processing partial close handling to ensure the variable is initialized
- reuse the initialized breakeven info when refreshing statuses after stop order realignment and reset it when new orders are created

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933e2ca29348320b5727d8f7a885881)