### PR TITLE
Encapsulate active trade registry

### DIFF
--- a/crypto_screener/domain/models/active_trade_registry.py
+++ b/crypto_screener/domain/models/active_trade_registry.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from crypto_screener.domain.models.active_trade import ActiveTrade
+from crypto_screener.domain.models.timeframe import Timeframe
+
+
+@dataclass(frozen=True)
+class ActiveTradeKey:
+    symbol: str
+    timeframe: Timeframe
+
+
+@dataclass
+class ActiveTradeRegistry:
+    trades: dict[ActiveTradeKey, ActiveTrade] = field(default_factory=dict)
+
+    def get(self, key: ActiveTradeKey) -> Optional[ActiveTrade]:
+        return self.trades.get(key)
+
+    def set(self, key: ActiveTradeKey, trade: ActiveTrade) -> None:
+        self.trades[key] = trade
+
+    def pop(self, key: ActiveTradeKey) -> Optional[ActiveTrade]:
+        return self.trades.pop(key, None)
+
+    def has(self, key: ActiveTradeKey) -> bool:
+        return key in self.trades

--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -10,6 +10,7 @@ from crypto_screener.data.providers.coingecko import enrich_symbols_capitalizati
 from crypto_screener.domain.capture_state import CaptureState
 from crypto_screener.domain.exchange import Exchange
 from crypto_screener.domain.models.active_trade import ActiveTrade
+from crypto_screener.domain.models.active_trade_registry import ActiveTradeKey, ActiveTradeRegistry
 from crypto_screener.domain.models.bar import Bar
 from crypto_screener.domain.models.context import Context
 from crypto_screener.domain.models.order_status import OrderStatus
@@ -762,7 +763,7 @@ def run_live(
     executor = ThreadPoolExecutor(max_workers=2)
     handle_sig(executor)
     notified_once: set[tuple[str, Timeframe, str]] = set()
-    active_trades: dict[tuple[str, Timeframe], ActiveTrade] = {}
+    active_trades = ActiveTradeRegistry()
 
     while True:
         now = utc_now()
@@ -802,9 +803,10 @@ def run_live(
                     setup = detect_setup(symbol.symbol, bars, timeframe, symbol.context)
                     if setup:
                         break
-                trade_key = (symbol.symbol, timeframe)
-                if trade_key in active_trades:
-                    outcome = _monitor_active_trade(exchange, trade_execution_service, active_trades[trade_key], bars)
+                trade_key = ActiveTradeKey(symbol.symbol, timeframe)
+                active_trade = active_trades.get(trade_key)
+                if active_trade:
+                    outcome = _monitor_active_trade(exchange, trade_execution_service, active_trade, bars)
                     if outcome:
                         trade_result, profit_pct, profit_value, exit_prices = outcome
                         log.i(
@@ -956,7 +958,7 @@ def run_live(
                                 f"Сетап {symbol.symbol} на {timeframe.tf} закрыт из-за сигнала Buy, кнопка удалена."
                             )
                             notified_once.discard((symbol.symbol, timeframe, "Capture"))
-                        active_trades[trade_key] = ActiveTrade(
+                        active_trades.set(trade_key, ActiveTrade(
                             symbol=symbol.symbol,
                             timeframe=timeframe,
                             setup=setup,
@@ -969,6 +971,6 @@ def run_live(
                             entry_order_id=execution_result.entry_order_id,
                             protective_orders=execution_result.protective_orders,
                             position_id=execution_result.position_id,
-                        )
+                        ))
                         trade_permission_service.clear_allowance(symbol.symbol, timeframe)
                         capture_state.symbol = None


### PR DESCRIPTION
## Summary
- add ActiveTradeRegistry and ActiveTradeKey dataclasses to manage active trades with typed keys
- update live execution flow to use the registry instead of a raw dictionary

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933ebf77d5483209d53abcad24ae9ea)