### PR TITLE
Add allowed trade registry to manage permissions

### DIFF
--- a/crypto_screener/domain/models/allowed_trade_registry.py
+++ b/crypto_screener/domain/models/allowed_trade_registry.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Optional
+
+from crypto_screener.config.config import AppConfig as cfg
+from crypto_screener.domain.models.allowed_trade import AllowedTrade
+from crypto_screener.domain.models.context import Context
+from crypto_screener.domain.models.timeframe import Timeframe
+from crypto_screener.utils.time import utc_now
+
+
+@dataclass(frozen=True)
+class AllowedTradeKey:
+    symbol: str
+    timeframe: Timeframe
+
+
+@dataclass
+class AllowedTradeRegistry:
+    _allowed_trades: dict[AllowedTradeKey, AllowedTrade] = field(default_factory=dict)
+
+    def _build_trade(
+            self,
+            key: AllowedTradeKey,
+            message_id: str,
+            context: Context,
+            issued_at: Optional[datetime] = None,
+    ) -> AllowedTrade:
+        issued_at = issued_at or utc_now()
+        deadline = issued_at + timedelta(minutes=cfg.CAPTURE_TIMEOUT_MULTIPLIER * key.timeframe.minutes)
+        return AllowedTrade(
+            symbol=key.symbol,
+            timeframe=key.timeframe,
+            message_id=message_id,
+            context=context,
+            issued_at=issued_at,
+            deadline=deadline,
+        )
+
+    def add(self, key: AllowedTradeKey, message_id: str, context: Context) -> tuple[AllowedTrade, bool]:
+        trade = self._build_trade(key=key, message_id=message_id, context=context)
+        replaced = key in self._allowed_trades
+        self._allowed_trades[key] = trade
+        return trade, replaced
+
+    def get(self, key: AllowedTradeKey) -> Optional[AllowedTrade]:
+        return self._allowed_trades.get(key)
+
+    def remove(self, key: AllowedTradeKey) -> Optional[AllowedTrade]:
+        return self._allowed_trades.pop(key, None)
+
+    def has(self, key: AllowedTradeKey, now: Optional[datetime] = None) -> tuple[bool, Optional[AllowedTrade]]:
+        allowance = self._allowed_trades.get(key)
+        if not allowance:
+            return False, None
+        check_time = now or utc_now()
+        if check_time >= allowance.deadline:
+            expired = self._allowed_trades.pop(key)
+            return False, expired
+        return True, allowance
+
+    def pop_expired(self, now: datetime) -> list[tuple[AllowedTradeKey, AllowedTrade]]:
+        expired: list[tuple[AllowedTradeKey, AllowedTrade]] = []
+        for key, allowance in list(self._allowed_trades.items()):
+            if now >= allowance.deadline:
+                expired.append((key, self._allowed_trades.pop(key)))
+        return expired
+
+    def clear(self) -> None:
+        self._allowed_trades.clear()
+
+    def is_empty(self) -> bool:
+        return not self._allowed_trades

--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -920,12 +920,12 @@ def run_live(
     while True:
         now = utc_now()
         expired_permissions = trade_permission_service.pop_expired(now)
-        for (symbol_name, timeframe), expired_permission in expired_permissions:
+        for permission_key, expired_permission in expired_permissions:
             _remove_button_safe(notifier, expired_permission.message_id)
             log.i(
-                f"Истекло разрешение на торговлю {symbol_name} на {timeframe.tf}, кнопка удалена."
+                f"Истекло разрешение на торговлю {permission_key.symbol} на {permission_key.timeframe.tf}, кнопка удалена."
             )
-            notified_once.discard((symbol_name, timeframe, "Capture"))
+            notified_once.discard((permission_key.symbol, permission_key.timeframe, "Capture"))
         expired_captures = [
             (capture_key, active_capture)
             for capture_key, active_capture in capture_state.captures.items()

--- a/crypto_screener/execution/trade_permission_service.py
+++ b/crypto_screener/execution/trade_permission_service.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
-from typing import Dict, Tuple, Optional
+from datetime import datetime
+from typing import Optional
 
-from crypto_screener.config.config import AppConfig as cfg
 from crypto_screener.domain.models.context import Context
 from crypto_screener.domain.models.allowed_trade import AllowedTrade
+from crypto_screener.domain.models.allowed_trade_registry import AllowedTradeKey, AllowedTradeRegistry
 from crypto_screener.domain.models.timeframe import Timeframe
 from crypto_screener.utils.logger import log
-from crypto_screener.utils.time import utc_now
 
 class TradePermissionService:
     def __init__(self) -> None:
-        self._allowed_trades: Dict[Tuple[str, Timeframe], AllowedTrade] = {}
+        self._allowed_trades = AllowedTradeRegistry()
 
     def allow_symbol_for_trading(
             self,
@@ -21,28 +20,20 @@ class TradePermissionService:
             message_id: str,
             context: Context,
     ) -> None:
-        key = (symbol, timeframe)
-        issued_at = utc_now()
-        deadline = issued_at + timedelta(minutes=cfg.CAPTURE_TIMEOUT_MULTIPLIER * timeframe.minutes)
-        trade = AllowedTrade(
-            symbol=symbol,
-            timeframe=timeframe,
+        trade, replaced = self._allowed_trades.add(
+            key=AllowedTradeKey(symbol, timeframe),
             message_id=message_id,
             context=context,
-            issued_at=issued_at,
-            deadline=deadline,
         )
-        if key in self._allowed_trades:
-            self._allowed_trades[key] = trade
+        if replaced:
             log.d(
                 f"Обновлено разрешение на торговлю {symbol} на {timeframe.tf} без повторного уведомления."
             )
             return
-        self._allowed_trades[key] = trade
         log.i(f"Разрешена торговля {symbol} на {timeframe.tf} по нажатию кнопки.")
 
     def clear_allowance(self, symbol: str, timeframe: Timeframe) -> Optional[AllowedTrade]:
-        removed = self._allowed_trades.pop((symbol, timeframe), None)
+        removed = self._allowed_trades.remove(AllowedTradeKey(symbol, timeframe))
         if removed:
             log.d(
                 f"Удалено разрешение на торговлю {symbol} на {timeframe.tf}. "
@@ -51,34 +42,27 @@ class TradePermissionService:
         return removed
 
     def clear_all(self) -> None:
-        if not self._allowed_trades:
+        if self._allowed_trades.is_empty():
             return
         self._allowed_trades.clear()
         log.d("Сброшены все разрешения на торговлю.")
 
     def has_allowance(self, symbol: str, timeframe: Timeframe) -> bool:
-        allowance = self._allowed_trades.get((symbol, timeframe))
-        if not allowance:
+        has_allowance, expired_allowance = self._allowed_trades.has(
+            AllowedTradeKey(symbol, timeframe)
+        )
+        if expired_allowance:
+            self._log_expired_allowance(expired_allowance)
             return False
-        if utc_now() >= allowance.deadline:
-            self._expire_allowance((symbol, timeframe), allowance)
-            return False
-        return True
+        return has_allowance
 
-    def pop_expired(self, now: datetime) -> list[tuple[Tuple[str, Timeframe], AllowedTrade]]:
-        expired: list[tuple[Tuple[str, Timeframe], AllowedTrade]] = []
-        for key, allowance in list(self._allowed_trades.items()):
-            if now >= allowance.deadline:
-                self._expire_allowance(key, allowance)
-                expired.append((key, allowance))
+    def pop_expired(self, now: datetime) -> list[tuple[AllowedTradeKey, AllowedTrade]]:
+        expired = self._allowed_trades.pop_expired(now)
+        for _, allowance in expired:
+            self._log_expired_allowance(allowance)
         return expired
 
-    def _expire_allowance(
-            self,
-            key: Tuple[str, Timeframe],
-            allowance: AllowedTrade,
-    ) -> None:
-        self._allowed_trades.pop(key, None)
+    def _log_expired_allowance(self, allowance: AllowedTrade) -> None:
         log.i(
             f"Истекло разрешение на торговлю {allowance.symbol} на {allowance.timeframe.tf}. "
             f"Выдано: {allowance.issued_at.isoformat()}, дедлайн: {allowance.deadline.isoformat()}."


### PR DESCRIPTION
## Summary
- add an AllowedTradeRegistry dataclass to encapsulate trade permissions and deadline calculations
- refactor the trade permission service to rely on the registry for allowance lifecycle management
- update live monitoring to consume expired permissions through the registry interface

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933f6052cdc8320a25ccb9c27ae161d)