### PR TITLE
Preserve stop order statuses during realignment

### DIFF
--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -596,6 +596,8 @@ def _process_filled_partial_close(
             setup=active_trade.setup,
             stop_loss_order_id=context.protective_orders.stop_loss_id,
             breakeven_order_id=context.protective_orders.breakeven_id,
+            stop_loss_status=context.protective_orders.stop_loss_status,
+            breakeven_status=context.protective_orders.breakeven_status,
             remaining_quantity=context.remaining_quantity,
             move_to_breakeven=active_trade.setup.breakeven_price is not None,
         )

--- a/crypto_screener/execution/trade_executor.py
+++ b/crypto_screener/execution/trade_executor.py
@@ -262,9 +262,15 @@ class TradeExecutionService:
             breakeven_order_id: Optional[str],
             remaining_quantity: float,
             move_to_breakeven: bool,
+            stop_loss_status: Optional[OrderStatus] = None,
+            breakeven_status: Optional[OrderStatus] = None,
     ) -> StopRealignmentResult:
         current_ids = self._current_stop_orders_result(
-            stop_loss_order_id, breakeven_order_id
+            setup.symbol,
+            stop_loss_order_id,
+            breakeven_order_id,
+            stop_loss_status,
+            breakeven_status,
         )
 
         early_exit_result = self._handle_no_remaining_quantity(
@@ -292,14 +298,27 @@ class TradeExecutionService:
 
     def _current_stop_orders_result(
             self,
+            symbol: str,
             stop_loss_order_id: Optional[str],
             breakeven_order_id: Optional[str],
+            stop_loss_status: Optional[OrderStatus],
+            breakeven_status: Optional[OrderStatus],
     ) -> StopRealignmentResult:
+        stop_loss_status = stop_loss_status or (
+            self._get_order_status(symbol, stop_loss_order_id)
+            if stop_loss_order_id
+            else None
+        )
+        breakeven_status = breakeven_status or (
+            self._get_order_status(symbol, breakeven_order_id)
+            if breakeven_order_id
+            else None
+        )
         return StopRealignmentResult(
             stop_loss_id=stop_loss_order_id,
             breakeven_id=breakeven_order_id,
-            stop_loss_status=OrderStatus.NEW if stop_loss_order_id else None,
-            breakeven_status=OrderStatus.NEW if breakeven_order_id else None,
+            stop_loss_status=stop_loss_status,
+            breakeven_status=breakeven_status,
         )
 
     def _handle_no_remaining_quantity(


### PR DESCRIPTION
## Summary
- allow stop-order realignment to receive known order statuses and resolve existing ones
- keep previous stop statuses when no new stop orders are placed instead of resetting to NEW

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69340bb6c6248320bf9c24fa2823b866)