### PR TITLE
Add strategy abstraction for setup detection

### DIFF
--- a/crypto_screener/domain/setup_detector.py
+++ b/crypto_screener/domain/setup_detector.py
@@ -3,12 +3,13 @@ import numpy as np
 from crypto_screener.config.config import cfg
 from crypto_screener.domain.models.bar import Bar
 from crypto_screener.domain.models.cascade_level import CascadeLevel
+from crypto_screener.domain.models.context import Context
 from crypto_screener.domain.models.setup import Setup, Capture, Buy, Unfilled
 from crypto_screener.domain.models.swing import SwingType, Swing
-from crypto_screener.domain.models.symbol import Context
 from crypto_screener.domain.models.timeframe import Timeframe
 from crypto_screener.domain.models.trade_levels import TradeLevels
 from crypto_screener.domain.swing_detector import add_swings
+from crypto_screener.domain.strategies.base import Strategy
 
 
 # region Private.
@@ -523,3 +524,19 @@ def detect_setup(
     )
 
     return setup
+
+
+class DefaultStrategy(Strategy):
+    name = "default"
+
+    def detect_setup(
+            self,
+            symbol: str,
+            bars: list[Bar],
+            timeframe: Timeframe,
+            context: Context,
+    ) -> Setup:
+        return detect_setup(symbol, bars, timeframe, context)
+
+
+default_strategy = DefaultStrategy()

--- a/crypto_screener/domain/strategies/base.py
+++ b/crypto_screener/domain/strategies/base.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from crypto_screener.domain.models.bar import Bar
+from crypto_screener.domain.models.context import Context
+from crypto_screener.domain.models.setup import Setup
+from crypto_screener.domain.models.timeframe import Timeframe
+
+
+class Strategy(ABC):
+    name: str
+
+    @abstractmethod
+    def detect_setup(
+            self,
+            symbol: str,
+            bars: list[Bar],
+            timeframe: Timeframe,
+            context: Context,
+    ) -> Setup:
+        """Определяет сетап для заданного символа."""

--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -24,7 +24,7 @@ from crypto_screener.domain.models.symbol import FuturesSymbol, set_contexts
 from crypto_screener.domain.models.timeframe import Timeframe
 from crypto_screener.domain.models.trade_result import TradeResult
 from crypto_screener.domain.notifier import Keyboard, Notifier, NotificationType
-from crypto_screener.domain.setup_detector import detect_setup
+from crypto_screener.domain.setup_detector import default_strategy
 from crypto_screener.execution.trade_executor import TradeExecutionService
 from crypto_screener.execution.trade_permission_service import TradePermissionService
 from crypto_screener.utils.history import calculate_limit_grid
@@ -1208,7 +1208,7 @@ def run_live(
                 bars = []
                 for timeframe_limit in calculate_limit_grid(limit, timeframe):
                     bars = exchange.get_ohlcv(symbol.symbol, timeframe, timeframe_limit)
-                    setup = detect_setup(symbol.symbol, bars, timeframe, symbol.context)
+                    setup = default_strategy.detect_setup(symbol.symbol, bars, timeframe, symbol.context)
                     if setup:
                         break
                 trade_key = ActiveTradeKey(symbol.symbol, timeframe)

--- a/crypto_screener/execution/run_test_symbol.py
+++ b/crypto_screener/execution/run_test_symbol.py
@@ -5,11 +5,11 @@ from typing import Optional
 from crypto_screener.domain.exchange import Exchange
 from crypto_screener.domain.models.bar import Bar
 from crypto_screener.domain.models.mode import PlotPolicy, TestData
+from crypto_screener.domain.models.context import Context
 from crypto_screener.domain.models.setup import Setup, Buy
-from crypto_screener.domain.models.symbol import Context
 from crypto_screener.domain.models.timeframe import Timeframe
 from crypto_screener.domain.models.trade_result import TradeResult
-from crypto_screener.domain.setup_detector import detect_setup
+from crypto_screener.domain.setup_detector import default_strategy
 from crypto_screener.execution.test_result import evaluate_buy, log_test_summary
 from crypto_screener.utils.history import calculate_limit_grid
 from crypto_screener.utils.logger import log
@@ -96,7 +96,7 @@ def _detect_setup(
         timeframe: Timeframe,
         context: Context
 ) -> Setup:
-    setup = detect_setup(symbol, bars, timeframe, context)
+    setup = default_strategy.detect_setup(symbol, bars, timeframe, context)
     if setup.is_filled:
         log.d(f"На {symbol} ({timeframe.tf}) обнаружен {setup.name.capitalize()}-сетап.")
     return setup


### PR DESCRIPTION
## Summary
- add a base `Strategy` abstraction with the setup detection contract
- expose a default strategy wrapping the existing detector
- update callers to use the strategy instance and align context typing imports

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693485e4289c8320aab55c71636a2961)