### PR TITLE
Refactor setup models into PPO strategy dataclasses

### DIFF
--- a/crypto_screener/domain/models/active_trade.py
+++ b/crypto_screener/domain/models/active_trade.py
@@ -8,7 +8,7 @@ from crypto_screener.domain.models.bar import Bar
 from crypto_screener.domain.models.context import Context
 from crypto_screener.domain.models.order_status import OrderStatus
 from crypto_screener.domain.models.protective_orders import ProtectiveOrders
-from crypto_screener.domain.models.setup import Buy
+from crypto_screener.domain.models.setups.ppo import Trade
 from crypto_screener.domain.models.timeframe import Timeframe
 
 
@@ -16,7 +16,7 @@ from crypto_screener.domain.models.timeframe import Timeframe
 class ActiveTrade:
     symbol: str
     timeframe: Timeframe
-    setup: Buy
+    setup: Trade
     detection_time: datetime
     context: Context
     placed_at: datetime

--- a/crypto_screener/domain/models/setups/__init__.py
+++ b/crypto_screener/domain/models/setups/__init__.py
@@ -1,0 +1,8 @@
+from crypto_screener.domain.models.setups.ppo import Capture, Setup, Trade, Unfilled
+
+__all__ = [
+    "Capture",
+    "Setup",
+    "Trade",
+    "Unfilled",
+]

--- a/crypto_screener/domain/models/setups/ppo.py
+++ b/crypto_screener/domain/models/setups/ppo.py
@@ -40,8 +40,8 @@ class Capture(Setup):
 
 
 @dataclass
-class Buy(Setup):
-    name: str = field(init=False, default="Buy")
+class Trade(Setup):
+    name: str = field(init=False, default="Trade")
     is_filled: bool = field(init=False, default=True)
     is_trade: bool = field(init=False, default=True)
 

--- a/crypto_screener/domain/setup_detector.py
+++ b/crypto_screener/domain/setup_detector.py
@@ -4,7 +4,7 @@ from crypto_screener.config.config import cfg
 from crypto_screener.domain.models.bar import Bar
 from crypto_screener.domain.models.cascade_level import CascadeLevel
 from crypto_screener.domain.models.context import Context
-from crypto_screener.domain.models.setup import Setup, Capture, Buy, Unfilled
+from crypto_screener.domain.models.setups.ppo import Capture, Setup, Trade, Unfilled
 from crypto_screener.domain.models.swing import SwingType, Swing
 from crypto_screener.domain.models.timeframe import Timeframe
 from crypto_screener.domain.models.trade_levels import TradeLevels
@@ -511,7 +511,7 @@ def detect_setup(
         partial_close_price=partial_close_price,
         breakeven_price=breakeven_price,
     )
-    setup = Buy(
+    setup = Trade(
         symbol=symbol,
         timeframe=timeframe,
         bars=bars,

--- a/crypto_screener/domain/strategies/base.py
+++ b/crypto_screener/domain/strategies/base.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 
 from crypto_screener.domain.models.bar import Bar
 from crypto_screener.domain.models.context import Context
-from crypto_screener.domain.models.setup import Setup
+from crypto_screener.domain.models.setups.ppo import Setup
 from crypto_screener.domain.models.timeframe import Timeframe
 
 

--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -18,7 +18,7 @@ from crypto_screener.domain.models.order_status import OrderStatus
 from crypto_screener.domain.models.position import Position
 from crypto_screener.domain.models.protective_order_statuses import ProtectiveOrderStatuses
 from crypto_screener.domain.models.protective_orders import ProtectiveOrders
-from crypto_screener.domain.models.setup import Capture, Buy, Unfilled
+from crypto_screener.domain.models.setups.ppo import Capture, Trade, Unfilled
 from crypto_screener.domain.models.swing import Swing
 from crypto_screener.domain.models.symbol import FuturesSymbol, set_contexts
 from crypto_screener.domain.models.timeframe import Timeframe
@@ -1315,7 +1315,7 @@ def run_live(
                             notified_once.add(capture_notification_key)
 
                     # Найден торговый сетап.
-                    case Buy(
+                    case Trade(
                         main_low_swing=main_low_swing,
                         main_high_swing=main_high_swing,
                         cascade_swings=cascade_swings,
@@ -1360,7 +1360,7 @@ def run_live(
                         capture_message_id = removed_capture.message_id if removed_capture else None
                         if removed_capture:
                             _remove_button_safe(notifier, removed_capture.message_id)
-                            log.i(f"Сетап {symbol.symbol} на {timeframe.tf} закрыт из-за сигнала Buy, кнопка удалена.")
+                            log.i(f"Сетап {symbol.symbol} на {timeframe.tf} закрыт из-за сигнала Trade, кнопка удалена.")
                             notified_once.discard((symbol.symbol, timeframe, "Capture"))
                         active_trades.add(trade_key, ActiveTrade(
                             symbol=symbol.symbol,

--- a/crypto_screener/execution/run_test_market.py
+++ b/crypto_screener/execution/run_test_market.py
@@ -5,7 +5,7 @@ from crypto_screener.data.providers.coingecko import enrich_symbols_capitalizati
 from crypto_screener.domain.exchange import Exchange
 from crypto_screener.domain.models.bar import Bar
 from crypto_screener.domain.models.mode import PlotPolicy
-from crypto_screener.domain.models.setup import Buy
+from crypto_screener.domain.models.setups.ppo import Trade
 from crypto_screener.domain.models.symbol import FuturesSymbol, set_contexts
 from crypto_screener.domain.models.timeframe import Timeframe
 from crypto_screener.domain.models.trade_result import TradeResult
@@ -153,7 +153,7 @@ def run_test_market(
                     postmortem_bars=future_bars
                 )
 
-                if not setup or not isinstance(setup, Buy):
+                if not setup or not isinstance(setup, Trade):
                     continue
 
                 if not future_bars:

--- a/crypto_screener/execution/run_test_symbol.py
+++ b/crypto_screener/execution/run_test_symbol.py
@@ -6,7 +6,7 @@ from crypto_screener.domain.exchange import Exchange
 from crypto_screener.domain.models.bar import Bar
 from crypto_screener.domain.models.mode import PlotPolicy, TestData
 from crypto_screener.domain.models.context import Context
-from crypto_screener.domain.models.setup import Setup, Buy
+from crypto_screener.domain.models.setups.ppo import Setup, Trade
 from crypto_screener.domain.models.timeframe import Timeframe
 from crypto_screener.domain.models.trade_result import TradeResult
 from crypto_screener.domain.setup_detector import default_strategy
@@ -75,7 +75,7 @@ def _run_test_symbol(
             detection_time=last_bar_time,
         )
 
-        if not setup or not isinstance(setup, Buy):
+        if not setup or not isinstance(setup, Trade):
             continue
 
         outcome = evaluate_buy(setup, future_bars)
@@ -110,7 +110,7 @@ def _plot(
         *,
         context: Context,
 ):
-    if postmortem_bars and isinstance(setup, Buy):
+    if postmortem_bars and isinstance(setup, Trade):
         output_path = plot_postmortem(
             symbol=f"{setup.symbol} ",
             timeframe=setup.timeframe,

--- a/crypto_screener/execution/test_result.py
+++ b/crypto_screener/execution/test_result.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from typing import Optional
 
 from crypto_screener.domain.models.bar import Bar
-from crypto_screener.domain.models.setup import Buy
+from crypto_screener.domain.models.setups.ppo import Trade
 from crypto_screener.domain.models.trade_result import TradeResult
 from crypto_screener.utils.logger import log
 
@@ -19,7 +19,7 @@ def _get_profit_pct(
 # endregion
 
 def evaluate_buy(
-        setup: Buy,
+        setup: Trade,
         future_bars: list[Bar]
 ) -> Optional[tuple[TradeResult, float]]:
     entry_price = setup.entry_price

--- a/crypto_screener/execution/trade_executor.py
+++ b/crypto_screener/execution/trade_executor.py
@@ -10,7 +10,7 @@ from crypto_screener.domain.models.margin_mode import MarginMode
 from crypto_screener.domain.models.order_side import OrderSide
 from crypto_screener.domain.models.order_status import OrderStatus
 from crypto_screener.domain.models.protective_orders import ProtectiveOrders
-from crypto_screener.domain.models.setup import Buy
+from crypto_screener.domain.models.setups.ppo import Trade
 from crypto_screener.domain.models.stop_realignment_result import StopRealignmentResult
 from crypto_screener.domain.notifier import Notifier, NotificationType
 from crypto_screener.utils.logger import log
@@ -33,7 +33,7 @@ class TradeExecutionService:
         self._exchange = exchange
         self.notifier = notifier
 
-    def execute_buy(self, setup: Buy, context: Context) -> Optional[ExecutionResult]:
+    def execute_buy(self, setup: Trade, context: Context) -> Optional[ExecutionResult]:
         entry_order_id: Optional[str] = None
         protective_orders = ProtectiveOrders()
         try:
@@ -59,7 +59,7 @@ class TradeExecutionService:
 
     def _determine_position_size(
             self,
-            setup: Buy,
+            setup: Trade,
             context: Context
     ) -> float:
         try:
@@ -74,7 +74,7 @@ class TradeExecutionService:
 
     def _place_entry_order(
             self,
-            setup: Buy,
+            setup: Trade,
             quantity: float
     ) -> str:
         order_id, _ = self._place_with_retries(
@@ -96,7 +96,7 @@ class TradeExecutionService:
 
     def _place_protective_bundle(
             self,
-            setup: Buy,
+            setup: Trade,
             quantity: float,
     ) -> ProtectiveOrders:
         return self._place_protective_orders(setup, quantity)
@@ -109,7 +109,7 @@ class TradeExecutionService:
 
     def _handle_execution_failure(
             self,
-            setup: Buy,
+            setup: Trade,
             context: Context,
             entry_order_id: Optional[str],
             protective_orders: ProtectiveOrders,
@@ -130,7 +130,7 @@ class TradeExecutionService:
         )
 
     @staticmethod
-    def _calculate_position_size(setup: Buy) -> float:
+    def _calculate_position_size(setup: Trade) -> float:
         entry_price = setup.entry_price
         stop_loss_price = setup.stop_loss_price
         stop_distance = entry_price - stop_loss_price
@@ -153,7 +153,7 @@ class TradeExecutionService:
 
     def _place_protective_orders(
             self,
-            setup: Buy,
+            setup: Trade,
             quantity: float,
             orders: Optional[ProtectiveOrders] = None,
     ) -> ProtectiveOrders:
@@ -165,7 +165,7 @@ class TradeExecutionService:
 
     def _place_stop_loss(
             self,
-            setup: Buy,
+            setup: Trade,
             quantity: float,
             orders: ProtectiveOrders,
     ) -> ProtectiveOrders:
@@ -185,7 +185,7 @@ class TradeExecutionService:
 
     def place_take_profit(
             self,
-            setup: Buy,
+            setup: Trade,
             quantity: float,
             orders: ProtectiveOrders,
     ) -> ProtectiveOrders:
@@ -205,7 +205,7 @@ class TradeExecutionService:
 
     def place_partial_close(
             self,
-            setup: Buy,
+            setup: Trade,
             quantity: float,
             orders: ProtectiveOrders,
     ) -> ProtectiveOrders:
@@ -275,7 +275,7 @@ class TradeExecutionService:
 
     def realign_stop_orders(
             self,
-            setup: Buy,
+            setup: Trade,
             stop_loss_order_id: Optional[str],
             breakeven_order_id: Optional[str],
             remaining_quantity: float,
@@ -343,7 +343,7 @@ class TradeExecutionService:
 
     def _handle_no_remaining_quantity(
             self,
-            setup: Buy,
+            setup: Trade,
             stop_loss_order_id: Optional[str],
             breakeven_order_id: Optional[str],
             remaining_quantity: float,
@@ -359,7 +359,7 @@ class TradeExecutionService:
 
     @staticmethod
     def _target_stop_order_details(
-            setup: Buy,
+            setup: Trade,
             move_to_breakeven: bool
     ) -> tuple[float, str, bool]:
         move_to_breakeven_target = (
@@ -373,7 +373,7 @@ class TradeExecutionService:
 
     def _place_realigned_stop(
             self,
-            setup: Buy,
+            setup: Trade,
             remaining_quantity: float,
             stop_price: float,
             label: str,
@@ -446,7 +446,7 @@ class TradeExecutionService:
 
     def _notify_failure(
             self,
-            setup: Buy,
+            setup: Trade,
             context: Context,
             message: str
     ) -> None:


### PR DESCRIPTION
## Summary
- add PPO strategy-specific setup dataclasses, replacing the old shared setup module
- migrate setup detection and execution flows to use the new Trade/Capture/Unfilled classes
- clean up imports and references to the deprecated Buy setup

## Testing
- python -m compileall .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693486bbcce083209c6cc7a7fa431b77)