### PR TITLE
Refactor plotter to use setup objects

### DIFF
--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -18,7 +18,7 @@ from crypto_screener.domain.models.order_status import OrderStatus
 from crypto_screener.domain.models.position import Position
 from crypto_screener.domain.models.protective_order_statuses import ProtectiveOrderStatuses
 from crypto_screener.domain.models.protective_orders import ProtectiveOrders
-from crypto_screener.domain.models.setups.ppo import Capture, Trade, Unfilled
+from crypto_screener.domain.models.setups.ppo import Capture, Setup, Trade, Unfilled
 from crypto_screener.domain.models.swing import Swing
 from crypto_screener.domain.models.symbol import FuturesSymbol, set_contexts
 from crypto_screener.domain.models.timeframe import Timeframe
@@ -90,28 +90,14 @@ def _send_notification(
         notifier: Notifier,
         notification_type: NotificationType,
         message: str,
-        symbol: str,
-        timeframe: Timeframe,
-        bars: list[Bar],
-        main_low_swing: Optional[Swing],
-        main_high_swing: Optional[Swing],
-        cascade_swings: Optional[list[Swing]],
-        resistance_swings: Optional[list[Swing]],
-        support_swings: Optional[list[Swing]],
+        setup: Setup,
         subdir: Optional[str] = None,
         context: Optional[Context] = None,
         keyboard: Optional[Keyboard] = None,
 ) -> Optional[str]:
     try:
         image_path = plot(
-            symbol=symbol,
-            timeframe=timeframe,
-            bars=bars,
-            main_low_swing=main_low_swing,
-            main_high_swing=main_high_swing,
-            cascade_swings=cascade_swings,
-            resistance_swings=resistance_swings,
-            support_swings=support_swings,
+            setup=setup,
             subdir=subdir,
             context=context,
         )
@@ -139,28 +125,14 @@ def _edit_notification(
         notification_type: NotificationType,
         message_id: str,
         message: str,
-        symbol: str,
-        timeframe: Timeframe,
-        bars: list[Bar],
-        main_low_swing: Optional[Swing],
-        main_high_swing: Optional[Swing],
-        cascade_swings: Optional[list[Swing]],
-        resistance_swings: Optional[list[Swing]],
-        support_swings: Optional[list[Swing]],
+        setup: Setup,
         subdir: Optional[str] = None,
         context: Optional[Context] = None,
         keyboard: Optional[Keyboard] = None,
 ) -> Optional[str]:
     try:
         image_path = plot(
-            symbol=symbol,
-            timeframe=timeframe,
-            bars=bars,
-            main_low_swing=main_low_swing,
-            main_high_swing=main_high_swing,
-            cascade_swings=cascade_swings,
-            resistance_swings=resistance_swings,
-            support_swings=support_swings,
+            setup=setup,
             subdir=subdir,
             context=context,
         )
@@ -287,20 +259,11 @@ def _handle_trade_closure(
 
     try:
         postmortem_path = plot_postmortem(
-            symbol=setup.symbol,
-            timeframe=setup.timeframe,
-            bars=setup.bars,
+            setup=setup,
             detection_time=active_trade.detection_time,
-            main_low_swing=setup.main_low_swing,
-            main_high_swing=setup.main_high_swing,
-            cascade_swings=setup.cascade_swings,
-            resistance_swings=setup.resistance_swings,
-            support_swings=setup.support_swings,
             subdir='order',
             postmortem_bars=active_trade.postmortem_bars,
-            trade_levels=trade_levels,
             context=active_trade.context,
-            setup_name=setup.name,
         )
     except Exception as exception:
         log.e(f"Ошибка при построении postmortem графика: {exception}")
@@ -1272,14 +1235,7 @@ def run_live(
                                     notification_type=NotificationType.EVENT,
                                     message_id=active_capture.message_id,
                                     message=message,
-                                    symbol=symbol.symbol,
-                                    timeframe=timeframe,
-                                    bars=bars,
-                                    main_low_swing=main_low_swing,
-                                    main_high_swing=main_high_swing,
-                                    cascade_swings=cascade_swings,
-                                    resistance_swings=resistance_swings,
-                                    support_swings=support_swings,
+                                    setup=setup,
                                     subdir='event',
                                     context=symbol.context,
                                     keyboard=_build_trade_keyboard(symbol.symbol, timeframe, symbol.context),
@@ -1294,14 +1250,7 @@ def run_live(
                                 notifier=notifier,
                                 notification_type=NotificationType.EVENT,
                                 message=message,
-                                symbol=symbol.symbol,
-                                timeframe=timeframe,
-                                bars=bars,
-                                main_low_swing=main_low_swing,
-                                main_high_swing=main_high_swing,
-                                cascade_swings=cascade_swings,
-                                resistance_swings=resistance_swings,
-                                support_swings=support_swings,
+                                setup=setup,
                                 subdir='event',
                                 context=symbol.context,
                                 keyboard=_build_trade_keyboard(symbol.symbol, timeframe, symbol.context),
@@ -1344,14 +1293,7 @@ def run_live(
                             notifier=notifier,
                             notification_type=NotificationType.ORDER,
                             message=success_message,
-                            symbol=symbol.symbol,
-                            timeframe=timeframe,
-                            bars=bars,
-                            main_low_swing=main_low_swing,
-                            main_high_swing=main_high_swing,
-                            cascade_swings=cascade_swings,
-                            resistance_swings=resistance_swings,
-                            support_swings=support_swings,
+                            setup=setup,
                             subdir='order',
                             context=symbol.context
                         ).result()

--- a/crypto_screener/execution/run_test_symbol.py
+++ b/crypto_screener/execution/run_test_symbol.py
@@ -112,34 +112,17 @@ def _plot(
 ):
     if postmortem_bars and isinstance(setup, Trade):
         output_path = plot_postmortem(
-            symbol=f"{setup.symbol} ",
-            timeframe=setup.timeframe,
-            bars=setup.bars,
+            setup=setup,
             detection_time=detection_time,
-            main_low_swing=setup.main_low_swing,
-            main_high_swing=setup.main_high_swing,
-            cascade_swings=setup.cascade_swings,
-            resistance_swings=setup.resistance_swings,
-            support_swings=setup.support_swings,
             subdir=subdir,
-            setup_name=setup.name.capitalize(),
             postmortem_bars=postmortem_bars,
-            trade_levels=setup.trade_levels,
             context=context,
         )
     else:
         output_path = plot(
-            symbol=f"{setup.symbol} {setup.name.capitalize()} ",
-            timeframe=setup.timeframe,
-            bars=setup.bars,
+            setup=setup,
             detection_time=detection_time,
-            main_low_swing=setup.main_low_swing,
-            main_high_swing=setup.main_high_swing,
-            cascade_swings=setup.cascade_swings,
-            resistance_swings=setup.resistance_swings,
-            support_swings=setup.support_swings,
             subdir=subdir,
-            setup_name=setup.name.capitalize(),
             context=context,
         )
     log.d(f"График {setup.symbol} сохранен (контекст {context.value}) в {output_path}".strip())

--- a/crypto_screener/utils/plotter.py
+++ b/crypto_screener/utils/plotter.py
@@ -8,6 +8,7 @@ import numpy as np
 from matplotlib.figure import Figure
 
 from crypto_screener.domain.models.context import Context
+from crypto_screener.domain.models.setups.ppo import Capture, Setup, Trade, Unfilled
 from crypto_screener.domain.models.trade_levels import TradeLevels
 from crypto_screener.domain.swing_detector import add_swings
 
@@ -445,23 +446,51 @@ def _resolve_output_path(
 # endregion
 
 def _plot(
-        symbol: str,
-        timeframe: Timeframe,
-        bars: list[Bar],
+        setup: Setup,
         *,
         postmortem_bars: Optional[list[Bar]],
         detection_time: Optional[datetime],
         context: Optional[Context],
-        main_high_swing: Optional[Swing],
-        main_low_swing: Optional[Swing],
-        cascade_swings: Optional[list[Swing]],
-        resistance_swings: Optional[list[Swing]],
-        support_swings: Optional[list[Swing]],
         subdir: Optional[str],
-        setup_name: Optional[str],
-        trade_levels: Optional[TradeLevels],
         draw_entry_zones: bool,
 ):
+    match setup:
+        case Trade(
+            symbol=symbol,
+            timeframe=timeframe,
+            bars=bars,
+            main_high_swing=main_high_swing,
+            main_low_swing=main_low_swing,
+            cascade_swings=cascade_swings,
+            resistance_swings=resistance_swings,
+            support_swings=support_swings,
+            trade_levels=trade_levels,
+        ):
+            setup_name = setup.name
+        case Capture(
+            symbol=symbol,
+            timeframe=timeframe,
+            bars=bars,
+            main_high_swing=main_high_swing,
+            main_low_swing=main_low_swing,
+            cascade_swings=cascade_swings,
+            resistance_swings=resistance_swings,
+            support_swings=support_swings,
+        ) | Unfilled(
+            symbol=symbol,
+            timeframe=timeframe,
+            bars=bars,
+            main_high_swing=main_high_swing,
+            main_low_swing=main_low_swing,
+            cascade_swings=cascade_swings,
+            resistance_swings=resistance_swings,
+            support_swings=support_swings,
+        ):
+            setup_name = setup.name
+            trade_levels = None
+        case _:
+            raise TypeError(f"Неизвестный тип сетапа: {type(setup).__name__}")
+
     if not symbol or not bars:
         raise ValueError("Недостаточно данных для построения графика.")
 
@@ -631,69 +660,33 @@ def _plot(
 
 
 def plot(
-        symbol: str,
-        timeframe: Timeframe,
-        bars: list[Bar],
+        setup: Setup,
         detection_time: Optional[datetime] = None,
         context: Optional[Context] = None,
-        main_high_swing: Optional[Swing] = None,
-        main_low_swing: Optional[Swing] = None,
-        cascade_swings: Optional[list[Swing]] = None,
-        resistance_swings: Optional[list[Swing]] = None,
-        support_swings: Optional[list[Swing]] = None,
         subdir: Optional[str] = None,
-        setup_name: Optional[str] = None,
 ):
     return _plot(
-        symbol=symbol,
-        timeframe=timeframe,
-        bars=bars,
+        setup=setup,
         postmortem_bars=None,
         detection_time=detection_time,
         context=context,
-        main_high_swing=main_high_swing,
-        main_low_swing=main_low_swing,
-        cascade_swings=cascade_swings,
-        resistance_swings=resistance_swings,
-        support_swings=support_swings,
         subdir=subdir,
-        setup_name=setup_name,
-        trade_levels=None,
         draw_entry_zones=False,
     )
 
 
 def plot_postmortem(
-        symbol: str,
-        timeframe: Timeframe,
-        bars: list[Bar],
+        setup: Setup,
         postmortem_bars: Optional[list[Bar]] = None,
         detection_time: Optional[datetime] = None,
         context: Optional[Context] = None,
-        main_high_swing: Optional[Swing] = None,
-        main_low_swing: Optional[Swing] = None,
-        cascade_swings: Optional[list[Swing]] = None,
-        resistance_swings: Optional[list[Swing]] = None,
-        support_swings: Optional[list[Swing]] = None,
         subdir: Optional[str] = None,
-        setup_name: Optional[str] = None,
-        *,
-        trade_levels: TradeLevels,
 ):
     return _plot(
-        symbol=symbol,
-        timeframe=timeframe,
-        bars=bars,
+        setup=setup,
         postmortem_bars=postmortem_bars,
         detection_time=detection_time,
         context=context,
-        main_high_swing=main_high_swing,
-        main_low_swing=main_low_swing,
-        cascade_swings=cascade_swings,
-        resistance_swings=resistance_swings,
-        support_swings=support_swings,
         subdir=subdir,
-        setup_name=setup_name,
-        trade_levels=trade_levels,
         draw_entry_zones=True,
     )


### PR DESCRIPTION
## Summary
- refactor plotter APIs to accept Setup instances and unpack their fields via structural pattern matching
- update plotting helpers in live and test execution paths to pass setups instead of individual parameters

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693487f8e37c8320b3091bb1a847fc59)