### PR TITLE
Handle trade button interactions

### DIFF
--- a/crypto_screener/data/notifiers/telegram.py
+++ b/crypto_screener/data/notifiers/telegram.py
@@ -99,6 +99,7 @@ class _CallbackHandler:
             message_id=message_id,
             context=symbol_context,
         )
+        await self._show_skip_only_keyboard(message, symbol, timeframe, symbol_context)
 
     # noinspection PyUnusedLocal
     async def _handle_skip_request(
@@ -119,6 +120,25 @@ class _CallbackHandler:
             message_id=message_id,
             context=symbol_context,
         )
+        self._trade_permission_service.clear_allowance(symbol, timeframe)
+
+    async def _show_skip_only_keyboard(
+            self,
+            message: MaybeInaccessibleMessage,
+            symbol: Optional[str],
+            timeframe: Optional[Timeframe],
+            symbol_context: Optional[Context],
+    ) -> None:
+        if not (symbol and timeframe and symbol_context):
+            return
+        skip_callback_data = f"{SKIP_CALLBACK_PREFIX}:{symbol}:{timeframe.tf}:{symbol_context.value}"
+        skip_keyboard = InlineKeyboardMarkup.from_button(
+            InlineKeyboardButton(text="Пропустить", callback_data=skip_callback_data)
+        )
+        try:
+            await message.edit_reply_markup(reply_markup=skip_keyboard)
+        except Exception as exception:
+            log.e(f"Не удалось обновить кнопки для {symbol} на {timeframe.tf}: {exception}")
 
 
 class TgNotifier(Notifier):


### PR DESCRIPTION
## Summary
- update trade callback handling to leave only the skip button after a trade request
- ensure skip button clears existing trade allowance when pressed

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693584da13cc8320a5e2ef34e8f93c3c)