### PR TITLE
Normalize ignored symbol deadlines and stabilize expiration handling

### DIFF
--- a/crypto_screener/domain/models/ignored_symbol_registry.py
+++ b/crypto_screener/domain/models/ignored_symbol_registry.py
@@ -8,7 +8,7 @@ from crypto_screener.config.config import AppConfig as cfg
 from crypto_screener.domain.models.allowed_trade_registry import AllowedTradeKey
 from crypto_screener.domain.models.context import Context
 from crypto_screener.domain.models.ignored_symbol import IgnoredSymbol
-from crypto_screener.utils.time import utc_now
+from crypto_screener.utils.time import ensure_utc, utc_now
 
 
 @dataclass
@@ -35,16 +35,17 @@ class IgnoredSymbolsStorage:
         ignored_symbol = self._ignored_symbols.get(key)
         if not ignored_symbol:
             return False, None
-        check_time = now or utc_now()
+        check_time = ensure_utc(now) if now else utc_now()
         if check_time >= ignored_symbol.deadline:
             expired = self._ignored_symbols.pop(key)
             return False, expired
         return True, ignored_symbol
 
     def pop_expired(self, now: datetime) -> list[tuple[AllowedTradeKey, IgnoredSymbol]]:
+        check_time = ensure_utc(now)
         expired: list[tuple[AllowedTradeKey, IgnoredSymbol]] = []
         for key, ignored_symbol in list(self._ignored_symbols.items()):
-            if now >= ignored_symbol.deadline:
+            if check_time >= ignored_symbol.deadline:
                 expired.append((key, self._ignored_symbols.pop(key)))
         return expired
 
@@ -66,7 +67,7 @@ class IgnoredSymbolRegistry:
             context: Context,
             issued_at: Optional[datetime] = None,
     ) -> IgnoredSymbol:
-        issued_at = issued_at or utc_now()
+        issued_at = ensure_utc(issued_at) if issued_at else utc_now()
         deadline = issued_at + timedelta(minutes=cfg.CAPTURE_TIMEOUT_MULTIPLIER * key.timeframe.minutes)
         return IgnoredSymbol(
             symbol=key.symbol,

--- a/crypto_screener/execution/trade_permission_service.py
+++ b/crypto_screener/execution/trade_permission_service.py
@@ -10,6 +10,7 @@ from crypto_screener.domain.models.ignored_symbol import IgnoredSymbol
 from crypto_screener.domain.models.ignored_symbol_registry import IgnoredSymbolRegistry
 from crypto_screener.domain.models.timeframe import Timeframe
 from crypto_screener.utils.logger import log
+from crypto_screener.utils.time import ensure_utc, utc_now
 
 
 class TradePermissionService:
@@ -101,9 +102,11 @@ class TradePermissionService:
     def has_ignore(
             self,
             symbol: str,
-            timeframe: Timeframe
+            timeframe: Timeframe,
+            now: Optional[datetime] = None,
     ) -> bool:
-        has_ignore, expired_ignore = self._ignored_symbols.has(AllowedTradeKey(symbol, timeframe))
+        check_time = ensure_utc(now) if now else utc_now()
+        has_ignore, expired_ignore = self._ignored_symbols.has(AllowedTradeKey(symbol, timeframe), check_time)
         if expired_ignore:
             self._log_expired_ignore(expired_ignore)
             return False
@@ -120,9 +123,10 @@ class TradePermissionService:
 
     def pop_expired_ignored(
             self,
-            now: datetime
+            now: Optional[datetime] = None,
     ) -> list[tuple[AllowedTradeKey, IgnoredSymbol]]:
-        expired = self._ignored_symbols.pop_expired(now)
+        check_time = ensure_utc(now) if now else utc_now()
+        expired = self._ignored_symbols.pop_expired(check_time)
         for _, ignored_symbol in expired:
             self._log_expired_ignore(ignored_symbol)
         return expired

--- a/crypto_screener/utils/time.py
+++ b/crypto_screener/utils/time.py
@@ -1,5 +1,12 @@
 from datetime import datetime, timezone
 
 
+def ensure_utc(dt: datetime) -> datetime:
+    """Normalize datetime to UTC to avoid timezone drift in comparisons."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
 def utc_now() -> datetime:
     return datetime.now(tz=timezone.utc)


### PR DESCRIPTION
## Summary
- normalize ignored symbol issued_at timestamps to UTC before computing deadlines to avoid early expiry
- ensure ignored symbol checks/pop operations normalize comparison time to UTC and accept optional injected timestamps
- guard expiration handling in the permission service with consistent time normalization to prevent premature removals or duplicate logs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936fd6de410832092e9d50decef8995)