### PR TITLE
Refactor capture state handling

### DIFF
--- a/crypto_screener/domain/capture_state.py
+++ b/crypto_screener/domain/capture_state.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Optional
+from typing import Iterable, Optional
 
 from crypto_screener.domain.models.active_capture import ActiveCapture
 from crypto_screener.domain.models.capture_registry import CaptureKey, CaptureRegistry
@@ -11,8 +11,19 @@ from crypto_screener.utils.time import utc_now
 @dataclass
 class CaptureState:
     def __init__(self) -> None:
-        self.symbol: Optional[str] = None
         self.captures: CaptureRegistry = CaptureRegistry()
+
+    def _filtered_items(
+            self,
+            symbol: Optional[str] = None,
+            timeframe: Optional[Timeframe] = None,
+    ) -> Iterable[tuple[CaptureKey, ActiveCapture]]:
+        return (
+            (capture_key, capture)
+            for capture_key, capture in self.captures.items()
+            if (symbol is None or capture_key.symbol == symbol)
+            and (timeframe is None or capture_key.timeframe == timeframe)
+        )
 
     def add_capture(
             self,
@@ -33,14 +44,24 @@ class CaptureState:
 
     def remove_capture(
             self,
-            symbol: str,
-            timeframe: Timeframe
+            capture_key: CaptureKey,
     ) -> Optional[ActiveCapture]:
-        capture_key = CaptureKey(symbol, timeframe)
         return self.captures.remove(capture_key)
 
-    def has_symbol_capture(
-            self,
-            symbol: str
-    ) -> bool:
-        return self.captures.has_symbol(symbol)
+    def has_capture(self, capture_key: CaptureKey) -> bool:
+        return self.captures.has(capture_key)
+
+    def captures_for_symbol(self, symbol: str) -> list[tuple[CaptureKey, ActiveCapture]]:
+        return list(self._filtered_items(symbol=symbol))
+
+    def captures_for_timeframe(self, timeframe: Timeframe) -> list[tuple[CaptureKey, ActiveCapture]]:
+        return list(self._filtered_items(timeframe=timeframe))
+
+    def get_capture(self, capture_key: CaptureKey) -> Optional[ActiveCapture]:
+        return self.captures.get(capture_key)
+
+    def has_symbol_capture(self, symbol: str) -> bool:
+        return any(self._filtered_items(symbol=symbol))
+
+    def is_empty(self) -> bool:
+        return not any(self.captures.items())

--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -1136,22 +1136,21 @@ def run_live(
             if now >= active_capture.deadline
         ]
         for capture_key, active_capture in expired_captures:
-            capture_state.remove_capture(capture_key.symbol, capture_key.timeframe)
+            capture_state.remove_capture(capture_key)
             _remove_button(notifier, active_capture.message_id)
             trade_permission_service.clear_allowance(capture_key.symbol, capture_key.timeframe)
             log.i(f"Истек срок слежения за {capture_key.symbol} на {capture_key.timeframe.tf}.")
             notified_once.discard((capture_key.symbol, capture_key.timeframe, "Capture"))
-            if capture_state.symbol == capture_key.symbol and not capture_state.has_symbol_capture(capture_key.symbol):
-                capture_state.symbol = None
 
-        if not capture_state.symbol:
+        if capture_state.is_empty():
             log.d("Запуск цикла анализа отобранных монет.")
 
-        active_symbols = [symbol for symbol in filtered_symbols
-                          if not capture_state.symbol
-                          or capture_state.symbol == symbol.symbol]
-        for symbol in active_symbols:
+        for symbol in filtered_symbols:
             for timeframe in timeframes:
+                capture_key = CaptureKey(symbol.symbol, timeframe)
+                active_capture = capture_state.get_capture(capture_key)
+                if active_capture and now < active_capture.deadline:
+                    log.d(f"Продолжаем мониторинг Capture {symbol.symbol} на {timeframe.tf}.")
                 if trade_permission_service.has_ignore(symbol.symbol, timeframe):
                     log.d(f"Пропущен анализ {symbol.symbol} на {timeframe.tf} из-за активного игнорирования.")
                     continue
@@ -1191,20 +1190,16 @@ def run_live(
                             exchange_name=exchange_name,
                         )
                         trade_permission_service.clear_allowance(symbol.symbol, timeframe)
-                        capture_state.symbol = None
                         continue
                 match setup:
                     # Сетап не найден.
                     case Unfilled():
-                        removed_capture = capture_state.remove_capture(symbol.symbol, timeframe)
+                        removed_capture = capture_state.remove_capture(capture_key)
                         if removed_capture:
                             _remove_button(notifier, removed_capture.message_id)
                             log.i(f"Сетап {symbol.symbol} на {timeframe.tf} потерян, кнопка удалена.")
                             trade_permission_service.clear_allowance(symbol.symbol, timeframe)
                             notified_once.discard((symbol.symbol, timeframe, "Capture"))
-                        if (capture_state.symbol == symbol.symbol and
-                                not capture_state.has_symbol_capture(symbol.symbol)):
-                            capture_state.symbol = None
                         continue
 
                     # Найден базовый сетап.
@@ -1230,8 +1225,6 @@ def run_live(
                                     keyboard=_build_keyboard(symbol.symbol, timeframe, symbol.context),
                                 ).result()
                             continue
-                        if capture_state.symbol is None:
-                            capture_state.symbol = symbol.symbol
                         capture_notification_key = (symbol.symbol, timeframe, setup.name)
                         if capture_notification_key not in notified_once:
                             message_id = executor.submit(
@@ -1280,7 +1273,7 @@ def run_live(
                             context=symbol.context
                         ).result()
                         detection_time = bars[-1].time if bars else utc_now()
-                        removed_capture = capture_state.remove_capture(symbol.symbol, timeframe)
+                        removed_capture = capture_state.remove_capture(capture_key)
                         capture_message_id = removed_capture.message_id if removed_capture else None
                         if removed_capture:
                             _remove_button(notifier, removed_capture.message_id)
@@ -1302,4 +1295,3 @@ def run_live(
                         )
                         active_trades.add(trade_key, trade)
                         trade_permission_service.clear_allowance(symbol.symbol, timeframe)
-                        capture_state.symbol = None


### PR DESCRIPTION
## Summary
- remove the global capture symbol flag and add filtering helpers around capture keys
- adjust capture handling in run_live to work per symbol/timeframe instead of global flag
- update expired and removed capture processing to operate on multiple entries

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bcec1bbf08320ae6d557a42054a32)