### PR TITLE
Add scheduling queue for live analysis

### DIFF
--- a/crypto_screener/config/config.py
+++ b/crypto_screener/config/config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from crypto_screener.domain.models.mode import Live, Mode, TestMarket, PlotPolicy, TestSymbols, \
@@ -13,6 +13,10 @@ _timezone: ZoneInfo = ZoneInfo("Europe/Belgrade")
 
 # Таймфреймы.
 _timeframes: list[Timeframe] = [Timeframe.H1, Timeframe.M30, Timeframe.M15, Timeframe.M5]
+_timeframe_intervals: dict[Timeframe, timedelta] = {
+    timeframe: timedelta(minutes=timeframe.minutes)
+    for timeframe in Timeframe
+}
 
 # Стратегия.
 _strategy = PpoStrategy()
@@ -89,6 +93,9 @@ class AppConfig:
 
     # Временная зона.
     TIMEZONE: ZoneInfo = _timezone
+
+    # Интервалы таймфреймов.
+    TIMEFRAME_INTERVALS: dict[Timeframe, timedelta] = _timeframe_intervals
 
     # Режим работы.
     MODE: Mode = _mode_live

--- a/crypto_screener/domain/models/scheduled_task.py
+++ b/crypto_screener/domain/models/scheduled_task.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from crypto_screener.domain.models.symbol import FuturesSymbol
+from crypto_screener.domain.models.timeframe import Timeframe
+
+
+@dataclass(order=True)
+class ScheduledTask:
+    next_run_at: datetime
+    symbol: FuturesSymbol = field(compare=False)
+    timeframe: Timeframe = field(compare=False)

--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from heapq import heapify, heappop, heappush
+from time import sleep
 from typing import Optional
 from urllib.parse import quote
 
@@ -38,6 +41,18 @@ from crypto_screener.utils.logger import log
 from crypto_screener.utils.plotter import plot, plot_postmortem
 from crypto_screener.utils.signals import handle_sig
 from crypto_screener.utils.time import utc_now
+
+TIMEFRAME_INTERVALS: dict[Timeframe, timedelta] = {
+    timeframe: timedelta(minutes=timeframe.minutes)
+    for timeframe in Timeframe
+}
+
+
+@dataclass(order=True)
+class ScheduledTask:
+    next_run_at: datetime
+    symbol: FuturesSymbol = field(compare=False)
+    timeframe: Timeframe = field(compare=False)
 
 # region Private.
 def _fetch_filtered_symbols(
@@ -1119,6 +1134,13 @@ def run_live(
     notified_once: set[tuple[str, Timeframe, str]] = set()
     active_trades = ActiveTrades()
 
+    scheduled_tasks = [
+        ScheduledTask(next_run_at=utc_now(), symbol=symbol, timeframe=timeframe)
+        for symbol in filtered_symbols
+        for timeframe in timeframes
+    ]
+    heapify(scheduled_tasks)
+
     while True:
         now = utc_now()
         expired_permissions = trade_permission_service.pop_expired(now)
@@ -1142,11 +1164,17 @@ def run_live(
             log.i(f"Истек срок слежения за {capture_key.symbol} на {capture_key.timeframe.tf}.")
             notified_once.discard((capture_key.symbol, capture_key.timeframe, "Capture"))
 
-        if capture_state.is_empty():
-            log.d("Запуск цикла анализа отобранных монет.")
+        cycle_started = False
+        while scheduled_tasks and scheduled_tasks[0].next_run_at <= now:
+            task = heappop(scheduled_tasks)
+            symbol = task.symbol
+            timeframe = task.timeframe
 
-        for symbol in filtered_symbols:
-            for timeframe in timeframes:
+            if capture_state.is_empty() and not cycle_started:
+                log.d("Запуск цикла анализа отобранных монет.")
+                cycle_started = True
+
+            try:
                 capture_key = CaptureKey(symbol.symbol, timeframe)
                 active_capture = capture_state.get_capture(capture_key)
                 if active_capture and now < active_capture.deadline:
@@ -1295,3 +1323,19 @@ def run_live(
                         )
                         active_trades.add(trade_key, trade)
                         trade_permission_service.clear_allowance(symbol.symbol, timeframe)
+            finally:
+                next_run_at = utc_now() + TIMEFRAME_INTERVALS[timeframe]
+                heappush(
+                    scheduled_tasks,
+                    ScheduledTask(
+                        next_run_at=next_run_at,
+                        symbol=symbol,
+                        timeframe=timeframe,
+                    )
+                )
+                now = utc_now()
+
+        if scheduled_tasks:
+            sleep_seconds = max(0.0, (scheduled_tasks[0].next_run_at - now).total_seconds())
+            if sleep_seconds > 0:
+                sleep(min(sleep_seconds, 60))

--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass, field
-from datetime import datetime, timedelta
 from heapq import heapify, heappop, heappush
 from time import sleep
 from typing import Optional
@@ -23,6 +21,7 @@ from crypto_screener.domain.models.position import Position
 from crypto_screener.domain.models.protective_order_statuses import ProtectiveOrderStatuses
 from crypto_screener.domain.models.protective_orders import ProtectiveOrders
 from crypto_screener.domain.models.setup import Capture, Setup, Trade, Unfilled
+from crypto_screener.domain.models.scheduled_task import ScheduledTask
 from crypto_screener.domain.models.symbol import FuturesSymbol, set_contexts
 from crypto_screener.domain.models.timeframe import Timeframe
 from crypto_screener.domain.models.trade_result import TradeResult
@@ -41,18 +40,6 @@ from crypto_screener.utils.logger import log
 from crypto_screener.utils.plotter import plot, plot_postmortem
 from crypto_screener.utils.signals import handle_sig
 from crypto_screener.utils.time import utc_now
-
-TIMEFRAME_INTERVALS: dict[Timeframe, timedelta] = {
-    timeframe: timedelta(minutes=timeframe.minutes)
-    for timeframe in Timeframe
-}
-
-
-@dataclass(order=True)
-class ScheduledTask:
-    next_run_at: datetime
-    symbol: FuturesSymbol = field(compare=False)
-    timeframe: Timeframe = field(compare=False)
 
 # region Private.
 def _fetch_filtered_symbols(
@@ -1324,7 +1311,7 @@ def run_live(
                         active_trades.add(trade_key, trade)
                         trade_permission_service.clear_allowance(symbol.symbol, timeframe)
             finally:
-                next_run_at = utc_now() + TIMEFRAME_INTERVALS[timeframe]
+                next_run_at = utc_now() + cfg.TIMEFRAME_INTERVALS[timeframe]
                 heappush(
                     scheduled_tasks,
                     ScheduledTask(


### PR DESCRIPTION
## Summary
- add timeframe interval table and scheduled task structure for live analysis
- process live analysis tasks via priority queue by next runtime, updating schedule after each run
- pause the loop until the next task is due instead of iterating eagerly

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bd9e0bdc48320b829188697e92be3)