### PR TITLE
Add configurable poll intervals for live analysis

### DIFF
--- a/crypto_screener/config/config.py
+++ b/crypto_screener/config/config.py
@@ -18,6 +18,16 @@ _timeframe_intervals: dict[Timeframe, timedelta] = {
     for timeframe in Timeframe
 }
 
+# Интервалы опроса для анализа таймфреймов.
+_poll_intervals: dict[Timeframe, timedelta] = {
+    Timeframe.M1: timedelta(seconds=30),
+    Timeframe.M5: timedelta(minutes=2),
+    Timeframe.M15: timedelta(minutes=5),
+    Timeframe.M30: timedelta(minutes=10),
+    Timeframe.H1: timedelta(minutes=15),
+    Timeframe.H4: timedelta(hours=1),
+}
+
 # Стратегия.
 _strategy = PpoStrategy()
 
@@ -96,6 +106,9 @@ class AppConfig:
 
     # Интервалы таймфреймов.
     TIMEFRAME_INTERVALS: dict[Timeframe, timedelta] = _timeframe_intervals
+
+    # Интервалы опроса.
+    POLL_INTERVALS: dict[Timeframe, timedelta] = _poll_intervals
 
     # Режим работы.
     MODE: Mode = _mode_live

--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -1120,7 +1120,7 @@ def _schedule_task(
         timeframe: Timeframe,
         has_active_capture: bool,
 ) -> None:
-    interval = cfg.TIMEFRAME_INTERVALS[timeframe]
+    interval = cfg.POLL_INTERVALS[timeframe]
     if has_active_capture:
         interval /= cfg.CAPTURE_PRIORITY_DIVISOR
     heappush(
@@ -1157,6 +1157,12 @@ def run_live(
 
     if not timeframes:
         log.e("Не заданы таймфреймы.")
+        return
+
+    missing_intervals = [timeframe for timeframe in timeframes if timeframe not in cfg.POLL_INTERVALS]
+    if missing_intervals:
+        missing_labels = ", ".join(sorted(timeframe.tf for timeframe in missing_intervals))
+        log.e(f"Не заданы интервалы опроса для таймфреймов: {missing_labels}.")
         return
 
     filtered_symbols = _fetch_filtered_symbols(


### PR DESCRIPTION
## Summary
- add explicit poll intervals for each timeframe to control analysis frequency independently
- use the configured poll intervals when scheduling live tasks and validate their presence before starting

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bef405d7c8320b5ddd3df285e7fbc)