### PR TITLE
Adjust capture polling intervals

### DIFF
--- a/crypto_screener/config/config.py
+++ b/crypto_screener/config/config.py
@@ -28,6 +28,16 @@ _poll_intervals: dict[Timeframe, timedelta] = {
     Timeframe.H4: timedelta(hours=1),
 }
 
+# Интервалы опроса Capture для анализа таймфреймов.
+_capture_poll_intervals: dict[Timeframe, timedelta] = {
+    Timeframe.M1: timedelta(seconds=1),
+    Timeframe.M5: timedelta(seconds=1),
+    Timeframe.M15: timedelta(seconds=10),
+    Timeframe.M30: timedelta(seconds=20),
+    Timeframe.H1: timedelta(minutes=1),
+    Timeframe.H4: timedelta(minutes=5),
+}
+
 # Стратегия.
 _strategy = PpoStrategy()
 
@@ -110,12 +120,14 @@ class AppConfig:
     # Интервалы опроса.
     POLL_INTERVALS: dict[Timeframe, timedelta] = _poll_intervals
 
+    # Интервалы опроса для Capture.
+    CAPTURE_POLL_INTERVALS: dict[Timeframe, timedelta] = _capture_poll_intervals
+
     # Режим работы.
     MODE: Mode = _mode_live
 
     # Пул потоков.
     LIVE_MAX_WORKERS: int = 4
-    CAPTURE_PRIORITY_DIVISOR: float = 2.0
 
     # Стратегия.
     STRATEGY: Strategy = _strategy

--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -1122,12 +1122,12 @@ def _schedule_task(
 ) -> None:
     interval = cfg.POLL_INTERVALS[timeframe]
     if has_active_capture:
-        interval /= cfg.CAPTURE_PRIORITY_DIVISOR
+        interval = cfg.CAPTURE_POLL_INTERVALS.get(timeframe, interval / 2)
     heappush(
         scheduled_tasks,
         ScheduledTask(
             next_run_at=utc_now() + interval,
-            priority=-1 if has_active_capture else 0,
+            priority=-int(interval.total_seconds()) if has_active_capture else 0,
             symbol=symbol,
             timeframe=timeframe,
         )


### PR DESCRIPTION
## Summary
- add capture-specific polling intervals to configuration
- use capture polling intervals when scheduling live tasks with priority based on explicit interval

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bf1afdf108320912835ad6eb4e577)