### PR TITLE
Handle capture expiration scheduling

### DIFF
--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -1187,12 +1187,30 @@ def run_live(
             for capture_key, active_capture in capture_state.captures.items()
             if now >= active_capture.deadline
         ]
+        expired_capture_keys: set[tuple[str, Timeframe]] = set()
+        if expired_captures:
+            log.i(
+                f"Истекло Capture событий: {len(expired_captures)}. "
+                "Возвращаем интервалы опроса к базовым значениям."
+            )
         for capture_key, active_capture in expired_captures:
+            expired_capture_keys.add((capture_key.symbol, capture_key.timeframe))
             capture_state.remove_capture(capture_key)
             _remove_button(notifier, active_capture.message_id)
             trade_permission_service.clear_allowance(capture_key.symbol, capture_key.timeframe)
             log.i(f"Истек срок слежения за {capture_key.symbol} на {capture_key.timeframe.tf}.")
             notified_once.discard((capture_key.symbol, capture_key.timeframe, "Capture"))
+            scheduler.downgrade_capture(capture_key.symbol, capture_key.timeframe, now=now)
+
+        if expired_capture_keys:
+            retained_ready_heap: list[ScheduledTask] = []
+            while ready_heap:
+                task = heappop(ready_heap)
+                if (task.symbol.symbol, task.timeframe) in expired_capture_keys:
+                    scheduler.reschedule(task, has_active_capture=False)
+                else:
+                    heappush(retained_ready_heap, task)
+            ready_heap = retained_ready_heap
 
         free_slots = cfg.LIVE_MAX_WORKERS - len(pending_tasks) - len(ready_heap)
         capacity = max(0, free_slots)

--- a/crypto_screener/execution/scheduler.py
+++ b/crypto_screener/execution/scheduler.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from datetime import datetime
 from heapq import heapify, heappop, heappush
 from typing import Optional
 
 from crypto_screener.config.config import AppConfig as cfg
 from crypto_screener.domain.models.scheduled_task import ScheduledTask
+from crypto_screener.domain.models.timeframe import Timeframe
 from crypto_screener.utils.time import utc_now
 
 
@@ -38,6 +40,25 @@ class Scheduler:
         task.next_run_at = base_time + interval
         task.due_at = None
         self.push(task)
+
+    def downgrade_capture(
+            self,
+            symbol: str,
+            timeframe: Timeframe,
+            now: Optional[datetime] = None,
+    ) -> None:
+        now = now or utc_now()
+        interval = cfg.POLL_INTERVALS[timeframe]
+        base_tasks = False
+        for task in self._tasks:
+            if task.symbol.symbol == symbol and task.timeframe == timeframe:
+                task.priority = 0
+                base_time = max(now, task.due_at or task.next_run_at)
+                task.next_run_at = base_time + interval
+                task.due_at = None
+                base_tasks = True
+        if base_tasks:
+            heapify(self._tasks)
 
     def get_next_sleep_timeout(self) -> float:
         if not self._tasks:


### PR DESCRIPTION
## Summary
- add scheduler helper to downgrade tasks to base poll intervals when captures expire
- requeue ready tasks after capture expiry and log bulk capture resets to observe load changes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c03bc57dc8320b0e984e9222f2c0e)