### PR TITLE
Use lists for strategy configuration defaults

### DIFF
--- a/crypto_screener/config/app_config.py
+++ b/crypto_screener/config/app_config.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
+from typing import Mapping
 from zoneinfo import ZoneInfo
 
-from crypto_screener.config.ppo_config import PpoConfig, ppo_cfg
+from crypto_screener.config.strategy_registry import DEFAULT_STRATEGIES, DEFAULT_STRATEGY_CONFIGS
 from crypto_screener.domain.models.mode import Live, Mode, TestMarket, PlotPolicy, TestSymbols, TestData
 from crypto_screener.domain.models.timeframe import Timeframe
-from crypto_screener.domain.strategies.ppo import PpoStrategy
 from crypto_screener.domain.strategies.strategy import Strategy
 
 # Временная зона.
@@ -37,9 +37,6 @@ _capture_poll_intervals: dict[Timeframe, timedelta] = {
     Timeframe.H1: timedelta(minutes=1),
     Timeframe.H4: timedelta(minutes=5),
 }
-
-# Стратегия.
-_strategy = PpoStrategy()
 
 # Данные для тестирования конкретных символов.
 _test_data: list[TestData] = [
@@ -130,11 +127,11 @@ class AppConfig:
     # Пул потоков.
     LIVE_MAX_WORKERS: int = 1
 
-    # Стратегия.
-    STRATEGY: Strategy = _strategy
+    # Стратегии.
+    STRATEGIES: list[Strategy] = field(default_factory=lambda: list(DEFAULT_STRATEGIES))
 
-    # Конфигурация стратегии.
-    STRATEGY_CONFIG: PpoConfig = field(default_factory=lambda: ppo_cfg)
+    # Конфигурации стратегий.
+    STRATEGY_CONFIGS: Mapping[str, object] = field(default_factory=lambda: DEFAULT_STRATEGY_CONFIGS.copy())
 
 
 app_cfg = AppConfig()

--- a/crypto_screener/config/strategy_registry.py
+++ b/crypto_screener/config/strategy_registry.py
@@ -1,0 +1,9 @@
+from crypto_screener.config.ppo_config import ppo_cfg
+from crypto_screener.domain.strategies.ppo import PpoStrategy
+from crypto_screener.domain.strategies.strategy import Strategy
+
+# Стратегии, активированные через конфигурацию приложения.
+DEFAULT_STRATEGIES: list[Strategy] = [PpoStrategy()]
+
+# Конфигурации стратегий.
+DEFAULT_STRATEGY_CONFIGS: dict[str, object] = {"ppo": ppo_cfg}

--- a/crypto_screener/main.py
+++ b/crypto_screener/main.py
@@ -43,7 +43,10 @@ def _initialize_notifier() -> Notifier:
 def main() -> None:
     load_dotenv()
     exchange = _initialize_exchange()
-    strategy = app_cfg.STRATEGY
+    strategies = app_cfg.STRATEGIES
+    if not strategies:
+        raise ValueError("В конфигурации не задано ни одной стратегии.")
+    strategy = strategies[0]
     mode: Mode = app_cfg.MODE
     match mode:
         # Работа с актуальным рынком.


### PR DESCRIPTION
## Summary
- update AppConfig to store configured strategies as a list
- align strategy registry defaults to provide a list of strategy instances

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f01d799e8832080945523c7a2a59d)