### PR TITLE
Handle multiple strategies in execution runners

### DIFF
--- a/crypto_screener/data/notifiers/telegram.py
+++ b/crypto_screener/data/notifiers/telegram.py
@@ -56,22 +56,24 @@ class _CallbackHandler:
         Optional[MaybeInaccessibleMessage],
         Optional[Timeframe],
         Optional[Context],
+        Optional[str],
     ]:
         symbol = None
         message = None
         timeframe = None
         symbol_context = None
+        strategy = None
         query = update.callback_query
         if not query:
-            return symbol, message, timeframe, symbol_context
+            return symbol, message, timeframe, symbol_context, strategy
 
         await query.answer()
-        callback_data = (query.data or "").split(":", 3)
-        if len(callback_data) != 4:
+        callback_data = (query.data or "").split(":", 4)
+        if len(callback_data) != 5:
             log.e(f"Не удалось разобрать callback_data: {query.data}")
-            return symbol, message, timeframe, symbol_context
+            return symbol, message, timeframe, symbol_context, strategy
 
-        _, encoded_symbol, timeframe_tf, encoded_context = callback_data
+        _, encoded_symbol, timeframe_tf, encoded_context, strategy = callback_data
         symbol = unquote(encoded_symbol)
         context_value = unquote(encoded_context)
         try:
@@ -79,10 +81,10 @@ class _CallbackHandler:
             symbol_context = Context(context_value)
         except ValueError as exception:
             log.e(f"Некорректные данные callback {query.data}: {exception}")
-            return symbol, message, timeframe, symbol_context
+            return symbol, message, timeframe, symbol_context, strategy
 
         message = query.message
-        return symbol, message, timeframe, symbol_context
+        return symbol, message, timeframe, symbol_context, strategy
 
     # noinspection PyUnusedLocal
     async def _handle_trade_request(
@@ -90,20 +92,24 @@ class _CallbackHandler:
             update: Update,
             context: ContextTypes.DEFAULT_TYPE,
     ) -> None:
-        symbol, message, timeframe, symbol_context = await self._get_message_data(update)
+        symbol, message, timeframe, symbol_context, strategy = await self._get_message_data(update)
         if not message:
             log.e("Отсутствует сообщение для callback торговой кнопки.")
             return
 
         message_id = str(message.message_id)
-        log.d(f"Получен запрос на торговлю {symbol} на {timeframe.tf} с контекстом {symbol_context.value}.")
+        log.d(
+            f"Получен запрос на торговлю {symbol} на {timeframe.tf} "
+            f"с контекстом {symbol_context.value} для стратегии {strategy}."
+        )
         self._trade_permission_service.allow_symbol_for_trading(
             symbol=symbol,
             timeframe=timeframe,
+            strategy=strategy or "",
             message_id=message_id,
             context=symbol_context,
         )
-        await self._show_skip_only_keyboard(message, symbol, timeframe, symbol_context)
+        await self._show_skip_only_keyboard(message, symbol, timeframe, symbol_context, strategy or "")
 
     # noinspection PyUnusedLocal
     async def _handle_skip_request(
@@ -111,20 +117,24 @@ class _CallbackHandler:
             update: Update,
             context: ContextTypes.DEFAULT_TYPE,
     ) -> None:
-        symbol, message, timeframe, symbol_context = await self._get_message_data(update)
+        symbol, message, timeframe, symbol_context, strategy = await self._get_message_data(update)
         if not message:
             log.e("Отсутствует сообщение для callback кнопки игнорирования.")
             return
 
         message_id = str(message.message_id)
-        log.d(f"Получен запрос на игнорирование {symbol} на {timeframe.tf} с контекстом {symbol_context.value}.")
+        log.d(
+            f"Получен запрос на игнорирование {symbol} на {timeframe.tf} "
+            f"с контекстом {symbol_context.value} для стратегии {strategy}."
+        )
         self._trade_permission_service.ignore_symbol(
             symbol=symbol,
             timeframe=timeframe,
+            strategy=strategy or "",
             message_id=message_id,
             context=symbol_context,
         )
-        self._trade_permission_service.clear_allowance(symbol, timeframe)
+        self._trade_permission_service.clear_allowance(symbol, timeframe, strategy or "")
 
     @staticmethod
     async def _show_skip_only_keyboard(
@@ -132,10 +142,11 @@ class _CallbackHandler:
             symbol: Optional[str],
             timeframe: Optional[Timeframe],
             symbol_context: Optional[Context],
+            strategy: str,
     ) -> None:
         if not (symbol and timeframe and symbol_context):
             return
-        skip_callback_data = f"{SKIP_CALLBACK_PREFIX}:{symbol}:{timeframe.tf}:{symbol_context.value}"
+        skip_callback_data = f"{SKIP_CALLBACK_PREFIX}:{symbol}:{timeframe.tf}:{symbol_context.value}:{strategy}"
         skip_keyboard = InlineKeyboardMarkup.from_button(
             InlineKeyboardButton(
                 text="Пропустить",

--- a/crypto_screener/domain/capture_state.py
+++ b/crypto_screener/domain/capture_state.py
@@ -29,12 +29,13 @@ class CaptureState:
             self,
             symbol: str,
             timeframe: Timeframe,
+            strategy: str,
             message_id: Optional[str],
             timeout_multiplier: int
     ) -> None:
         added_at = utc_now()
         deadline = added_at + timedelta(minutes=timeout_multiplier * timeframe.minutes)
-        capture_key = CaptureKey(symbol, timeframe)
+        capture_key = CaptureKey(symbol, timeframe, strategy)
         self.captures.add(capture_key, ActiveCapture(
             added_at=added_at,
             deadline=deadline,
@@ -62,6 +63,12 @@ class CaptureState:
 
     def has_symbol_capture(self, symbol: str) -> bool:
         return any(self._filtered_items(symbol=symbol))
+
+    def has_timeframe_capture(self, symbol: str, timeframe: Timeframe) -> bool:
+        return any(
+            capture_key.symbol == symbol and capture_key.timeframe == timeframe
+            for capture_key, _ in self.captures.items()
+        )
 
     def is_empty(self) -> bool:
         return not any(self.captures.items())

--- a/crypto_screener/domain/models/active_trade.py
+++ b/crypto_screener/domain/models/active_trade.py
@@ -16,6 +16,7 @@ from crypto_screener.domain.models.timeframe import Timeframe
 class ActiveTrade:
     symbol: str
     timeframe: Timeframe
+    strategy: str
     setup: Trade
     detection_time: datetime
     context: Context

--- a/crypto_screener/domain/models/active_trade_registry.py
+++ b/crypto_screener/domain/models/active_trade_registry.py
@@ -12,6 +12,7 @@ from crypto_screener.domain.models.timeframe import Timeframe
 class ActiveTradeKey:
     symbol: str
     timeframe: Timeframe
+    strategy: str
 
 
 @dataclass

--- a/crypto_screener/domain/models/allowed_trade.py
+++ b/crypto_screener/domain/models/allowed_trade.py
@@ -11,6 +11,7 @@ from crypto_screener.domain.models.timeframe import Timeframe
 class AllowedTrade:
     symbol: str
     timeframe: Timeframe
+    strategy: str
     message_id: str
     context: Context
     issued_at: datetime

--- a/crypto_screener/domain/models/allowed_trade_registry.py
+++ b/crypto_screener/domain/models/allowed_trade_registry.py
@@ -15,6 +15,7 @@ from crypto_screener.utils.time import utc_now
 class AllowedTradeKey:
     symbol: str
     timeframe: Timeframe
+    strategy: str
 
 
 @dataclass
@@ -73,6 +74,7 @@ class AllowedTradeRegistry:
         return AllowedTrade(
             symbol=key.symbol,
             timeframe=key.timeframe,
+            strategy=key.strategy,
             message_id=message_id,
             context=context,
             issued_at=issued_at,

--- a/crypto_screener/domain/models/capture_registry.py
+++ b/crypto_screener/domain/models/capture_registry.py
@@ -12,6 +12,7 @@ from crypto_screener.domain.models.timeframe import Timeframe
 class CaptureKey:
     symbol: str
     timeframe: Timeframe
+    strategy: str
 
 
 @dataclass

--- a/crypto_screener/domain/models/ignored_symbol.py
+++ b/crypto_screener/domain/models/ignored_symbol.py
@@ -11,6 +11,7 @@ from crypto_screener.domain.models.timeframe import Timeframe
 class IgnoredSymbol:
     symbol: str
     timeframe: Timeframe
+    strategy: str
     message_id: str
     context: Context
     issued_at: datetime

--- a/crypto_screener/domain/models/ignored_symbol_registry.py
+++ b/crypto_screener/domain/models/ignored_symbol_registry.py
@@ -72,6 +72,7 @@ class IgnoredSymbolRegistry:
         return IgnoredSymbol(
             symbol=key.symbol,
             timeframe=key.timeframe,
+            strategy=key.strategy,
             message_id=message_id,
             context=context,
             issued_at=issued_at,

--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -100,14 +100,16 @@ def _filter_symbols(
 def _build_keyboard(
         symbol: str,
         timeframe: Timeframe,
-        context: Context
+        context: Context,
+        strategy: Strategy,
 ) -> Keyboard:
     trade_text = "Торговать"
     skip_text = "Пропустить"
     encoded_symbol = quote(symbol, safe="")
     encoded_context = quote(context.value, safe="")
-    callback_data = f"{TRADE_CALLBACK_PREFIX}:{encoded_symbol}:{timeframe.tf}:{encoded_context}"
-    skip_callback_data = f"{SKIP_CALLBACK_PREFIX}:{encoded_symbol}:{timeframe.tf}:{encoded_context}"
+    encoded_strategy = quote(strategy.name, safe="")
+    callback_data = f"{TRADE_CALLBACK_PREFIX}:{encoded_symbol}:{timeframe.tf}:{encoded_context}:{encoded_strategy}"
+    skip_callback_data = f"{SKIP_CALLBACK_PREFIX}:{encoded_symbol}:{timeframe.tf}:{encoded_context}:{encoded_strategy}"
     return [[(trade_text, callback_data), (skip_text, skip_callback_data)]]
 
 
@@ -258,6 +260,7 @@ def _notify_trade_closure(
         profit_value: float,
         exit_prices: list[float],
         exchange_name: str,
+        strategy_name: str | None = None,
 ) -> None:
     setup = active_trade.setup
     trade_levels = setup.trade_levels
@@ -274,6 +277,7 @@ def _notify_trade_closure(
         exit_prices=actual_exit_prices,
         actual_entry_price=actual_entry_price,
         exchange_name=exchange_name,
+        strategy_name=strategy_name,
     )
     log.i(message)
 
@@ -366,12 +370,14 @@ def _notify_protective_recovery(
         active_trade: ActiveTrade,
         reason: str,
         exchange_name: str,
+        strategy_name: str | None = None,
 ) -> None:
     log.d(reason)
     message = build_protective_recovery_message(
         active_trade=active_trade,
         reason=reason,
         exchange_name=exchange_name,
+        strategy_name=strategy_name,
     )
     try:
         trade_execution_service.notifier.notify(
@@ -582,6 +588,7 @@ def _refresh_protective_orders(
                 active_trade,
                 f"Take-profit {take_profit_info.id} по {active_trade.symbol} отменен — восстанавливаем защиту.",
                 exchange_name,
+                strategy_name=active_trade.strategy,
             )
             _restore_limit_orders(
                 trade_execution_service=trade_execution_service,
@@ -610,6 +617,7 @@ def _refresh_protective_orders(
                 active_trade,
                 f"Stop-loss {stop_loss_info.id} по {active_trade.symbol} отменен — переставляем защиту.",
                 exchange_name,
+                strategy_name=active_trade.strategy,
             )
             _restore_stop_orders(
                 trade_execution_service=trade_execution_service,
@@ -638,6 +646,7 @@ def _refresh_protective_orders(
                 active_trade,
                 f"Breakeven {breakeven_info.id} по {active_trade.symbol} отменен — восстанавливаем защиту.",
                 exchange_name,
+                strategy_name=active_trade.strategy,
             )
             _restore_stop_orders(
                 trade_execution_service=trade_execution_service,
@@ -666,6 +675,7 @@ def _refresh_protective_orders(
                 active_trade,
                 f"Partial-close {partial_close_info.id} по {active_trade.symbol} отменен — пробуем восстановить.",
                 exchange_name,
+                strategy_name=active_trade.strategy,
             )
             _restore_limit_orders(
                 trade_execution_service=trade_execution_service,
@@ -1085,36 +1095,54 @@ def _monitor_active_trade(
 
 # endregion
 
+@dataclass
+class AnalysisResult:
+    strategy_name: str
+    bars: list[Bar]
+    setup: Optional[Setup]
+    outcome: Optional[tuple[TradeResult, float, float, list[float]]]
+
+
 def _run_analysis_task(
         symbol: FuturesSymbol,
         timeframe: Timeframe,
         limit: int,
-        strategy: Strategy,
+        strategies: list[Strategy],
         exchange: Exchange,
-        active_trade: Optional[ActiveTrade],
+        active_trades: dict[str, Optional[ActiveTrade]],
         trade_execution_service: TradeExecutionService,
         exchange_name: str,
 ):
-    bars: list[Bar] = []
-    setup: Optional[Setup] = None
-    outcome = None
+    results: list[AnalysisResult] = []
+    bars_cache: dict[int, list[Bar]] = {}
     try:
-        for timeframe_limit in calculate_limit_grid(limit, timeframe):
-            bars = exchange.get_ohlcv(symbol.symbol, timeframe, timeframe_limit)
-            setup = strategy.detect_setup(symbol.symbol, bars, timeframe, symbol.context)
-            if setup:
-                break
-        if active_trade:
-            outcome = _monitor_active_trade(
-                exchange,
-                trade_execution_service,
-                active_trade,
-                bars,
-                exchange_name,
-            )
+        for strategy in strategies:
+            bars: list[Bar] = []
+            setup: Optional[Setup] = None
+            outcome = None
+            for timeframe_limit in calculate_limit_grid(limit, timeframe):
+                bars = bars_cache.get(timeframe_limit) or exchange.get_ohlcv(
+                    symbol.symbol,
+                    timeframe,
+                    timeframe_limit,
+                )
+                bars_cache[timeframe_limit] = bars
+                setup = strategy.detect_setup(symbol.symbol, bars, timeframe, symbol.context)
+                if setup:
+                    break
+            active_trade = active_trades.get(strategy.name)
+            if active_trade:
+                outcome = _monitor_active_trade(
+                    exchange,
+                    trade_execution_service,
+                    active_trade,
+                    bars,
+                    exchange_name,
+                )
+            results.append(AnalysisResult(strategy.name, bars, setup, outcome))
     except Exception as exception:
         log.e(f"Ошибка в задаче анализа {symbol.symbol} на {timeframe.tf}: {exception}")
-    return bars, setup, outcome
+    return results
 
 
 def _ready_task_priority_key(task: ScheduledTask) -> tuple[int, datetime]:
@@ -1123,7 +1151,7 @@ def _ready_task_priority_key(task: ScheduledTask) -> tuple[int, datetime]:
 
 
 def run_live(
-        strategy: Strategy,
+        strategies: list[Strategy],
         exchange: Exchange,
         notifier: Notifier,
         timeframes: list[Timeframe],
@@ -1137,6 +1165,9 @@ def run_live(
     exchange_name = exchange.get_name()
     log.d(f"Запуск в живом режиме на бирже {exchange_name}.")
 
+    if not strategies:
+        log.e("Не заданы стратегии.")
+        return
     if not timeframes:
         log.e("Не заданы таймфреймы.")
         return
@@ -1147,6 +1178,7 @@ def run_live(
         log.e(f"Не заданы интервалы опроса для таймфреймов: {missing_labels}.")
         return
 
+    strategy_by_name = {strategy.name: strategy for strategy in strategies}
     filtered_symbols = _fetch_filtered_symbols(
         exchange,
         listing_period_days,
@@ -1166,7 +1198,7 @@ def run_live(
     analysis_executor = ThreadPoolExecutor(max_workers=app_cfg.LIVE_MAX_WORKERS)
     notification_executor = ThreadPoolExecutor(max_workers=2)
     handle_sig(analysis_executor)
-    notified_once: set[tuple[str, Timeframe, str]] = set()
+    notified_once: set[tuple[str, Timeframe, str, str]] = set()
     active_trades = ActiveTrades()
 
     scheduler = Scheduler([
@@ -1184,31 +1216,55 @@ def run_live(
         expired_permissions = trade_permission_service.pop_expired(now)
         for permission_key, expired_permission in expired_permissions:
             _remove_button(notifier, expired_permission.message_id)
-            log.i(f"Истекло разрешение на торговлю {permission_key.symbol} на {permission_key.timeframe.tf}.")
-            notified_once.discard((permission_key.symbol, permission_key.timeframe, "Capture"))
+            log.i(
+                f"Истекло разрешение на торговлю {permission_key.symbol} на {permission_key.timeframe.tf} "
+                f"по стратегии {permission_key.strategy}."
+            )
+            notified_once.discard((
+                permission_key.symbol,
+                permission_key.timeframe,
+                permission_key.strategy,
+                "Capture",
+            ))
         expired_ignored = trade_permission_service.pop_expired_ignored(now)
         for ignored_key, expired_ignore in expired_ignored:
             _remove_button(notifier, expired_ignore.message_id)
-            log.i(f"Истек срок игнорирования {ignored_key.symbol} на {ignored_key.timeframe.tf}.")
+            log.i(
+                f"Истек срок игнорирования {ignored_key.symbol} на {ignored_key.timeframe.tf} "
+                f"по стратегии {ignored_key.strategy}."
+            )
         expired_captures = [
             (capture_key, active_capture)
             for capture_key, active_capture in capture_state.captures.items()
             if now >= active_capture.deadline
         ]
-        expired_capture_keys: set[tuple[str, Timeframe]] = set()
+        expired_capture_keys: set[CaptureKey] = set()
         if expired_captures:
             log.i(
                 f"Истекло Capture событий: {len(expired_captures)}. "
                 "Возвращаем интервалы опроса к базовым значениям."
             )
         for capture_key, active_capture in expired_captures:
-            expired_capture_keys.add((capture_key.symbol, capture_key.timeframe))
+            expired_capture_keys.add(capture_key)
             capture_state.remove_capture(capture_key)
             _remove_button(notifier, active_capture.message_id)
-            trade_permission_service.clear_allowance(capture_key.symbol, capture_key.timeframe)
-            log.i(f"Истек срок слежения за {capture_key.symbol} на {capture_key.timeframe.tf}.")
-            notified_once.discard((capture_key.symbol, capture_key.timeframe, "Capture"))
-            scheduler.downgrade_capture(capture_key.symbol, capture_key.timeframe, now=now)
+            trade_permission_service.clear_allowance(
+                capture_key.symbol,
+                capture_key.timeframe,
+                capture_key.strategy,
+            )
+            log.i(
+                f"Истек срок слежения за {capture_key.symbol} на {capture_key.timeframe.tf} "
+                f"по стратегии {capture_key.strategy}."
+            )
+            notified_once.discard((
+                capture_key.symbol,
+                capture_key.timeframe,
+                capture_key.strategy,
+                "Capture",
+            ))
+            if not capture_state.has_timeframe_capture(capture_key.symbol, capture_key.timeframe):
+                scheduler.downgrade_capture(capture_key.symbol, capture_key.timeframe, now=now)
 
         if not capture_state.is_empty():
             cycle_started = False
@@ -1217,7 +1273,10 @@ def run_live(
             retained_ready_heap: list[ScheduledTask] = []
             while ready_heap:
                 task = heappop(ready_heap)
-                if (task.symbol.symbol, task.timeframe) in expired_capture_keys:
+                if any(
+                    capture_key.symbol == task.symbol.symbol and capture_key.timeframe == task.timeframe
+                    for capture_key in expired_capture_keys
+                ) and not capture_state.has_timeframe_capture(task.symbol.symbol, task.timeframe):
                     scheduler.reschedule(task, has_active_capture=False)
                 else:
                     heappush(retained_ready_heap, task)
@@ -1225,161 +1284,202 @@ def run_live(
 
         done_futures = [future for future in list(pending_tasks.keys()) if future.done()]
         for future in done_futures:
-            task, capture_key = pending_tasks.pop(future)
+            task, _ = pending_tasks.pop(future)
             symbol = task.symbol
             timeframe = task.timeframe
-            bars: list[Bar] = []
-            setup: Optional[Setup] = None
-            outcome = None
 
             try:
-                bars, setup, outcome = future.result()
+                analysis_results = future.result()
             except Exception as exception:
                 log.e(f"Не удалось обработать задачу {symbol.symbol} на {timeframe.tf}: {exception}")
+                scheduler.reschedule(
+                    task,
+                    has_active_capture=capture_state.has_timeframe_capture(symbol.symbol, timeframe),
+                )
+                continue
 
-            active_capture = capture_state.get_capture(capture_key)
-            if active_capture and now < active_capture.deadline:
-                log.d(f"Продолжаем мониторинг Capture {symbol.symbol} на {timeframe.tf}.")
+            for result in analysis_results:
+                bars = result.bars
+                setup = result.setup
+                outcome = result.outcome
+                strategy_name = result.strategy_name
+                strategy = strategy_by_name.get(strategy_name)
 
-            trade_key = ActiveTradeKey(symbol.symbol, timeframe)
-
-            try:
-                if outcome:
-                    trade_result, profit_pct, profit_value, exit_prices = outcome
-                    log.i(
-                        f"Завершена сделка {symbol.symbol} {timeframe.tf}: "
-                        f"{trade_result.value} ({profit_pct:+.2f}%)"
+                capture_key = CaptureKey(symbol.symbol, timeframe, strategy_name)
+                active_capture = capture_state.get_capture(capture_key)
+                if active_capture and now < active_capture.deadline:
+                    log.d(
+                        f"Продолжаем мониторинг Capture {symbol.symbol} на {timeframe.tf} "
+                        f"({strategy_name})."
                     )
-                    active_trade = active_trades.remove(trade_key)
-                    active_trade.exit_average_price = active_trade.exit_average_price or (
-                        exit_prices[0] if exit_prices else None)
-                    _notify_trade_closure(
-                        notifier=notifier,
-                        active_trade=active_trade,
-                        trade_result=trade_result,
-                        profit_pct=profit_pct,
-                        profit_value=profit_value,
-                        exit_prices=exit_prices,
-                        exchange_name=exchange_name,
-                    )
-                    trade_permission_service.clear_allowance(symbol.symbol, timeframe)
-                    continue
 
-                match setup:
-                    # Сетап не найден.
-                    case Unfilled():
-                        removed_capture = capture_state.remove_capture(capture_key)
-                        if removed_capture:
-                            _remove_button(notifier, removed_capture.message_id)
-                            log.i(f"Сетап {symbol.symbol} на {timeframe.tf} потерян, кнопка удалена.")
-                            trade_permission_service.clear_allowance(symbol.symbol, timeframe)
-                            notified_once.discard((symbol.symbol, timeframe, "Capture"))
+                trade_key = ActiveTradeKey(symbol.symbol, timeframe, strategy_name)
+
+                try:
+                    if outcome:
+                        trade_result, profit_pct, profit_value, exit_prices = outcome
+                        log.i(
+                            f"Завершена сделка {symbol.symbol} {timeframe.tf} ({strategy_name}): "
+                            f"{trade_result.value} ({profit_pct:+.2f}%)"
+                        )
+                        active_trade = active_trades.remove(trade_key)
+                        if not active_trade:
+                            continue
+                        active_trade.exit_average_price = active_trade.exit_average_price or (
+                            exit_prices[0] if exit_prices else None)
+                        _notify_trade_closure(
+                            notifier=notifier,
+                            active_trade=active_trade,
+                            trade_result=trade_result,
+                            profit_pct=profit_pct,
+                            profit_value=profit_value,
+                            exit_prices=exit_prices,
+                            exchange_name=exchange_name,
+                            strategy_name=strategy_name,
+                        )
+                        trade_permission_service.clear_allowance(symbol.symbol, timeframe, strategy_name)
                         continue
 
-                    # Найден базовый сетап.
-                    case Capture():
-                        if trade_permission_service.has_allowance(symbol.symbol, timeframe):
-                            log.d(
-                                f"Пропущено уведомление Capture для {symbol.symbol} на {timeframe.tf} "
-                                f"из-за активного разрешения на торговлю."
-                            )
+                    match setup:
+                        case Unfilled():
+                            removed_capture = capture_state.remove_capture(capture_key)
+                            if removed_capture:
+                                _remove_button(notifier, removed_capture.message_id)
+                                log.i(
+                                    f"Сетап {symbol.symbol} на {timeframe.tf} ({strategy_name}) потерян, кнопка удалена."
+                                )
+                                trade_permission_service.clear_allowance(symbol.symbol, timeframe, strategy_name)
+                                notified_once.discard((symbol.symbol, timeframe, strategy_name, "Capture"))
                             continue
-                        message = build_capture_message(symbol, timeframe, exchange_name)
-                        if capture_key in capture_state.captures:
-                            active_capture = capture_state.captures.get(capture_key)
-                            if active_capture and active_capture.message_id:
-                                notification_executor.submit(
-                                    _edit_notification,
+
+                        case Capture():
+                            if trade_permission_service.has_allowance(symbol.symbol, timeframe, strategy_name):
+                                log.d(
+                                    f"Пропущено уведомление Capture для {symbol.symbol} на {timeframe.tf} "
+                                    f"({strategy_name}) из-за активного разрешения на торговлю."
+                                )
+                                continue
+                            message = build_capture_message(
+                                symbol,
+                                timeframe,
+                                exchange_name,
+                                strategy_name=strategy_name,
+                            )
+                            if capture_key in capture_state.captures:
+                                active_capture = capture_state.captures.get(capture_key)
+                                if active_capture and active_capture.message_id:
+                                    notification_executor.submit(
+                                        _edit_notification,
+                                        notifier=notifier,
+                                        notification_type=NotificationType.EVENT,
+                                        message_id=active_capture.message_id,
+                                        message=message,
+                                        setup=setup,
+                                        subdir='event',
+                                        context=symbol.context,
+                                        keyboard=_build_keyboard(
+                                            symbol.symbol,
+                                            timeframe,
+                                            symbol.context,
+                                            strategy or strategy_by_name.get(strategy_name) or strategies[0],
+                                        ),
+                                    ).result()
+                                continue
+                            capture_notification_key = (symbol.symbol, timeframe, strategy_name, "Capture")
+                            if capture_notification_key not in notified_once:
+                                message_id = notification_executor.submit(
+                                    _send_notification,
                                     notifier=notifier,
                                     notification_type=NotificationType.EVENT,
-                                    message_id=active_capture.message_id,
                                     message=message,
                                     setup=setup,
                                     subdir='event',
                                     context=symbol.context,
-                                    keyboard=_build_keyboard(symbol.symbol, timeframe, symbol.context),
+                                    keyboard=_build_keyboard(
+                                        symbol.symbol,
+                                        timeframe,
+                                        symbol.context,
+                                        strategy or strategy_by_name.get(strategy_name) or strategies[0],
+                                    ),
                                 ).result()
-                            continue
-                        capture_notification_key = (symbol.symbol, timeframe, setup.name)
-                        if capture_notification_key not in notified_once:
-                            message_id = notification_executor.submit(
+                                capture_state.add_capture(
+                                    symbol=symbol.symbol,
+                                    timeframe=timeframe,
+                                    strategy=strategy_name,
+                                    message_id=message_id,
+                                    timeout_multiplier=ppo_cfg.CAPTURE_TIMEOUT_MULTIPLIER,
+                                )
+                                cycle_started = False
+                                notified_once.add(capture_notification_key)
+
+                        case Trade():
+                            if not trade_permission_service.has_allowance(symbol.symbol, timeframe, strategy_name):
+                                log.i(
+                                    f"Отказ в открытии сделки {symbol.symbol} на {timeframe.tf} ({strategy_name}): "
+                                    f"отсутствует разрешение на торговлю."
+                                )
+                                continue
+                            log.i(
+                                f"Попытка открытия позиции в {symbol.symbol} на {timeframe.tf} ({strategy_name})."
+                            )
+                            execution_result = trade_execution_service.execute_buy(setup, symbol.context)
+                            if not execution_result:
+                                trade_permission_service.clear_allowance(symbol.symbol, timeframe, strategy_name)
+                                continue
+                            success_message = build_trade_opened_message(
+                                setup=setup,
+                                timeframe=timeframe,
+                                execution_result=execution_result,
+                                exchange_name=exchange_name,
+                                strategy_name=strategy_name,
+                            )
+                            log.i(success_message)
+                            notification_executor.submit(
                                 _send_notification,
                                 notifier=notifier,
-                                notification_type=NotificationType.EVENT,
-                                message=message,
+                                notification_type=NotificationType.ORDER,
+                                message=success_message,
                                 setup=setup,
-                                subdir='event',
-                                context=symbol.context,
-                                keyboard=_build_keyboard(symbol.symbol, timeframe, symbol.context),
+                                subdir='order',
+                                context=symbol.context
                             ).result()
-                            capture_state.add_capture(
+                            detection_time = bars[-1].time if bars else utc_now()
+                            removed_capture = capture_state.remove_capture(capture_key)
+                            capture_message_id = removed_capture.message_id if removed_capture else None
+                            if removed_capture:
+                                _remove_button(notifier, removed_capture.message_id)
+                                log.i(
+                                    f"Сетап {symbol.symbol} на {timeframe.tf} ({strategy_name}) закрыт из-за сигнала Trade, "
+                                    f"кнопка удалена."
+                                )
+                                notified_once.discard((symbol.symbol, timeframe, strategy_name, "Capture"))
+                            trade = ActiveTrade(
                                 symbol=symbol.symbol,
                                 timeframe=timeframe,
-                                message_id=message_id,
-                                timeout_multiplier=ppo_cfg.CAPTURE_TIMEOUT_MULTIPLIER,
+                                strategy=strategy_name,
+                                setup=setup,
+                                detection_time=detection_time,
+                                context=symbol.context,
+                                placed_at=utc_now(),
+                                quantity=execution_result.quantity,
+                                entry_order_status=OrderStatus.NEW,
+                                capture_message_id=capture_message_id,
+                                entry_order_id=execution_result.entry_order_id,
+                                protective_orders=execution_result.protective_orders,
+                                position_id=execution_result.position_id,
                             )
-                            cycle_started = False
-                            notified_once.add(capture_notification_key)
+                            active_trades.add(trade_key, trade)
+                            trade_permission_service.clear_allowance(symbol.symbol, timeframe, strategy_name)
+                except Exception as exception:
+                    log.e(
+                        f"Ошибка при обработке результата {symbol.symbol} {timeframe.tf} ({strategy_name}): "
+                        f"{exception}"
+                    )
 
-                    # Найден торговый сетап.
-                    case Trade():
-                        if not trade_permission_service.has_allowance(symbol.symbol, timeframe):
-                            log.i(
-                                f"Отказ в открытии сделки {symbol.symbol} на {timeframe.tf}: "
-                                f"отсутствует разрешение на торговлю."
-                            )
-                            continue
-                        log.i(f"Попытка открытия позиции в {symbol.symbol} на {timeframe.tf}.")
-                        execution_result = trade_execution_service.execute_buy(setup, symbol.context)
-                        if not execution_result:
-                            trade_permission_service.clear_allowance(symbol.symbol, timeframe)
-                            continue
-                        success_message = build_trade_opened_message(
-                            setup=setup,
-                            timeframe=timeframe,
-                            execution_result=execution_result,
-                            exchange_name=exchange_name,
-                        )
-                        log.i(success_message)
-                        notification_executor.submit(
-                            _send_notification,
-                            notifier=notifier,
-                            notification_type=NotificationType.ORDER,
-                            message=success_message,
-                            setup=setup,
-                            subdir='order',
-                            context=symbol.context
-                        ).result()
-                        detection_time = bars[-1].time if bars else utc_now()
-                        removed_capture = capture_state.remove_capture(capture_key)
-                        capture_message_id = removed_capture.message_id if removed_capture else None
-                        if removed_capture:
-                            _remove_button(notifier, removed_capture.message_id)
-                            log.i(
-                                f"Сетап {symbol.symbol} на {timeframe.tf} закрыт из-за сигнала Trade, кнопка удалена."
-                            )
-                            notified_once.discard((symbol.symbol, timeframe, "Capture"))
-                        trade = ActiveTrade(
-                            symbol=symbol.symbol,
-                            timeframe=timeframe,
-                            setup=setup,
-                            detection_time=detection_time,
-                            context=symbol.context,
-                            placed_at=utc_now(),
-                            quantity=execution_result.quantity,
-                            entry_order_status=OrderStatus.NEW,
-                            capture_message_id=capture_message_id,
-                            entry_order_id=execution_result.entry_order_id,
-                            protective_orders=execution_result.protective_orders,
-                            position_id=execution_result.position_id,
-                        )
-                        active_trades.add(trade_key, trade)
-                        trade_permission_service.clear_allowance(symbol.symbol, timeframe)
-            finally:
-                scheduler.reschedule(
-                    task,
-                    has_active_capture=bool(capture_state.get_capture(capture_key)),
-                )
+            scheduler.reschedule(
+                task,
+                has_active_capture=capture_state.has_timeframe_capture(symbol.symbol, timeframe),
+            )
 
         free_workers = app_cfg.LIVE_MAX_WORKERS - len(pending_tasks)
         ready_capacity = app_cfg.LIVE_MAX_WORKERS
@@ -1408,33 +1508,44 @@ def run_live(
             task = heappop(ready_heap)
             symbol = task.symbol
             timeframe = task.timeframe
-            capture_key = CaptureKey(symbol.symbol, timeframe)
-            active_capture = capture_state.get_capture(capture_key)
 
             if capture_state.is_empty() and not cycle_started:
                 log.d("Запуск цикла анализа отобранных монет.")
                 cycle_started = True
 
-            if trade_permission_service.has_ignore(symbol.symbol, timeframe):
-                log.d(f"Пропущен анализ {symbol.symbol} на {timeframe.tf} из-за активного игнорирования.")
-                scheduler.reschedule(task, has_active_capture=bool(active_capture))
+            strategies_to_run = [
+                strategy
+                for strategy in strategies
+                if not trade_permission_service.has_ignore(symbol.symbol, timeframe, strategy.name, now)
+            ]
+            if not strategies_to_run:
+                log.d(
+                    f"Пропущен анализ {symbol.symbol} на {timeframe.tf} из-за активного игнорирования всех стратегий."
+                )
+                scheduler.reschedule(
+                    task,
+                    has_active_capture=capture_state.has_timeframe_capture(symbol.symbol, timeframe),
+                )
                 continue
 
             log.d(f"Проверяем {extract_base_symbol(symbol.symbol).upper()} на {timeframe.tf}.")
 
-            active_trade = active_trades.get(ActiveTradeKey(symbol.symbol, timeframe))
+            active_trades_map = {
+                strategy.name: active_trades.get(ActiveTradeKey(symbol.symbol, timeframe, strategy.name))
+                for strategy in strategies_to_run
+            }
             future = analysis_executor.submit(
                 _run_analysis_task,
                 symbol,
                 timeframe,
                 limit,
-                strategy,
+                strategies_to_run,
                 exchange,
-                active_trade,
+                active_trades_map,
                 trade_execution_service,
                 exchange_name,
             )
-            pending_tasks[future] = (task, capture_key)
+            pending_tasks[future] = (task, None)
 
         sleep_time = 0.1 if pending_tasks or ready_heap else scheduler.get_next_sleep_timeout()
         sleep(sleep_time)

--- a/crypto_screener/execution/run_test_market.py
+++ b/crypto_screener/execution/run_test_market.py
@@ -73,7 +73,7 @@ def _accumulate_history(
 # endregion
 
 def run_test_market(
-        strategy: Strategy,
+        strategies: list[Strategy],
         exchange: Exchange,
         timeframes: list[Timeframe],
         limit: int,
@@ -86,6 +86,9 @@ def run_test_market(
 ) -> None:
     log.d("Запуск тестирования рынка.")
 
+    if not strategies:
+        log.e("Не заданы стратегии.")
+        return
     if not timeframes:
         log.e("Не заданы таймфреймы.")
         return
@@ -142,34 +145,38 @@ def run_test_market(
                 log.e(f"{symbol.symbol} {timeframe.tf}: нужно {timeframe_window} свечей, получено {len(bars)}.")
                 continue
 
-            for i in range(timeframe_window - 1, len(bars)):
-                window_bars = bars[i - timeframe_window + 1:i + 1]
-                future_bars = bars[i + 1:]
-                setup = run_test_bars(
-                    strategy,
-                    symbol=symbol.symbol,
-                    timeframe=timeframe,
-                    bars=window_bars,
-                    plot_policy=plot_policy,
-                    context=symbol.context,
-                    subdir='test_market',
-                    postmortem_bars=future_bars
-                )
+            for strategy in strategies:
+                for i in range(timeframe_window - 1, len(bars)):
+                    window_bars = bars[i - timeframe_window + 1:i + 1]
+                    future_bars = bars[i + 1:]
+                    setup = run_test_bars(
+                        strategy,
+                        symbol=symbol.symbol,
+                        timeframe=timeframe,
+                        bars=window_bars,
+                        plot_policy=plot_policy,
+                        context=symbol.context,
+                        subdir='test_market',
+                        postmortem_bars=future_bars
+                    )
 
-                if not setup or not isinstance(setup, Trade):
-                    continue
+                    if not setup or not isinstance(setup, Trade):
+                        continue
 
-                if not future_bars:
-                    continue
+                    if not future_bars:
+                        continue
 
-                outcome = evaluate_buy(setup, future_bars)
-                if not outcome:
-                    continue
+                    outcome = evaluate_buy(setup, future_bars)
+                    if not outcome:
+                        continue
 
-                trade_result, profit_pct = outcome
-                trade_outcomes[trade_result] += 1
-                trade_results.append(profit_pct)
-                log.i(f"{symbol.symbol} {timeframe.tf}: {trade_result.value} ({profit_pct:+.2f}%)")
+                    trade_result, profit_pct = outcome
+                    trade_outcomes[trade_result] += 1
+                    trade_results.append(profit_pct)
+                    log.i(
+                        f"{symbol.symbol} {timeframe.tf} ({strategy.name}): "
+                        f"{trade_result.value} ({profit_pct:+.2f}%)"
+                    )
 
     log_test_summary(trade_outcomes, trade_results)
 

--- a/crypto_screener/execution/run_test_symbol.py
+++ b/crypto_screener/execution/run_test_symbol.py
@@ -161,7 +161,7 @@ def run_test_bars(
 
 
 def run_test_symbols(
-        strategy: Strategy,
+        strategies: list[Strategy],
         exchange: Exchange,
         test_data: list[TestData],
         limit: int,
@@ -170,19 +170,20 @@ def run_test_symbols(
     trade_results: list[float] = []
     trade_outcomes: defaultdict[TradeResult, int] = defaultdict(int)
 
-    for data in test_data:
-        symbol_results, symbol_outcomes = _run_test_symbol(
-            strategy,
-            exchange,
-            data.symbol,
-            data.timeframe,
-            limit,
-            data.end,
-            plot_policy,
-        )
-        trade_results.extend(symbol_results)
-        for result, count in symbol_outcomes.items():
-            trade_outcomes[result] += count
+    for strategy in strategies:
+        for data in test_data:
+            symbol_results, symbol_outcomes = _run_test_symbol(
+                strategy,
+                exchange,
+                data.symbol,
+                data.timeframe,
+                limit,
+                data.end,
+                plot_policy,
+            )
+            trade_results.extend(symbol_results)
+            for result, count in symbol_outcomes.items():
+                trade_outcomes[result] += count
 
     log_test_summary(trade_outcomes, trade_results)
     log.d("Тест завершен.")

--- a/crypto_screener/execution/trade_permission_service.py
+++ b/crypto_screener/execution/trade_permission_service.py
@@ -22,45 +22,56 @@ class TradePermissionService:
             self,
             symbol: str,
             timeframe: Timeframe,
+            strategy: str,
             message_id: str,
             context: Context,
     ) -> None:
         trade, replaced = self._allowed_trades.add(
-            key=AllowedTradeKey(symbol, timeframe),
+            key=AllowedTradeKey(symbol, timeframe, strategy),
             message_id=message_id,
             context=context,
         )
         if replaced:
-            log.d(f"Обновлено разрешение на торговлю {symbol} на {timeframe.tf} без повторного уведомления.")
+            log.d(
+                f"Обновлено разрешение на торговлю {symbol} на {timeframe.tf} "
+                f"({strategy}) без повторного уведомления."
+            )
             return
-        log.i(f"Разрешена торговля {symbol} на {timeframe.tf} по нажатию кнопки.")
+        log.i(f"Разрешена торговля {symbol} на {timeframe.tf} ({strategy}) по нажатию кнопки.")
 
     def ignore_symbol(
             self,
             symbol: str,
             timeframe: Timeframe,
+            strategy: str,
             message_id: str,
             context: Context,
     ) -> None:
         ignored_symbol, replaced = self._ignored_symbols.add(
-            key=AllowedTradeKey(symbol, timeframe),
+            key=AllowedTradeKey(symbol, timeframe, strategy),
             message_id=message_id,
             context=context,
         )
         if replaced:
-            log.d(f"Обновлено игнорирование {symbol} на {timeframe.tf} без повторного уведомления.")
+            log.d(
+                f"Обновлено игнорирование {symbol} на {timeframe.tf} ({strategy}) без повторного уведомления."
+            )
             return
-        log.i(f"Добавлен запрет на анализ {ignored_symbol.symbol} на {ignored_symbol.timeframe.tf} по нажатию кнопки.")
+        log.i(
+            f"Добавлен запрет на анализ {ignored_symbol.symbol} на {ignored_symbol.timeframe.tf} "
+            f"({strategy}) по нажатию кнопки."
+        )
 
     def clear_allowance(
             self,
             symbol: str,
-            timeframe: Timeframe
+            timeframe: Timeframe,
+            strategy: str,
     ) -> Optional[AllowedTrade]:
-        removed = self._allowed_trades.remove(AllowedTradeKey(symbol, timeframe))
+        removed = self._allowed_trades.remove(AllowedTradeKey(symbol, timeframe, strategy))
         if removed:
             log.d(
-                f"Удалено разрешение на торговлю {symbol} на {timeframe.tf}. "
+                f"Удалено разрешение на торговлю {symbol} на {timeframe.tf} ({strategy}). "
                 f"Выдано: {removed.issued_at.isoformat()}, дедлайн: {removed.deadline.isoformat()}."
             )
         return removed
@@ -68,12 +79,13 @@ class TradePermissionService:
     def clear_ignore(
             self,
             symbol: str,
-            timeframe: Timeframe
+            timeframe: Timeframe,
+            strategy: str,
     ) -> Optional[IgnoredSymbol]:
-        removed = self._ignored_symbols.remove(AllowedTradeKey(symbol, timeframe))
+        removed = self._ignored_symbols.remove(AllowedTradeKey(symbol, timeframe, strategy))
         if removed:
             log.d(
-                f"Удалено игнорирование {symbol} на {timeframe.tf}. "
+                f"Удалено игнорирование {symbol} на {timeframe.tf} ({strategy}). "
                 f"Выдано: {removed.issued_at.isoformat()}, дедлайн: {removed.deadline.isoformat()}."
             )
         return removed
@@ -89,10 +101,11 @@ class TradePermissionService:
     def has_allowance(
             self,
             symbol: str,
-            timeframe: Timeframe
+            timeframe: Timeframe,
+            strategy: str,
     ) -> bool:
         has_allowance, expired_allowance = self._allowed_trades.has(
-            AllowedTradeKey(symbol, timeframe)
+            AllowedTradeKey(symbol, timeframe, strategy)
         )
         if expired_allowance:
             self._log_expired_allowance(expired_allowance)
@@ -103,10 +116,14 @@ class TradePermissionService:
             self,
             symbol: str,
             timeframe: Timeframe,
+            strategy: str,
             now: Optional[datetime] = None,
     ) -> bool:
         check_time = ensure_utc(now) if now else utc_now()
-        has_ignore, expired_ignore = self._ignored_symbols.has(AllowedTradeKey(symbol, timeframe), check_time)
+        has_ignore, expired_ignore = self._ignored_symbols.has(
+            AllowedTradeKey(symbol, timeframe, strategy),
+            check_time,
+        )
         if expired_ignore:
             self._log_expired_ignore(expired_ignore)
             return False
@@ -134,14 +151,16 @@ class TradePermissionService:
     @staticmethod
     def _log_expired_allowance(allowance: AllowedTrade) -> None:
         log.i(
-            f"Истекло разрешение на торговлю {allowance.symbol} на {allowance.timeframe.tf}. "
+            f"Истекло разрешение на торговлю {allowance.symbol} на {allowance.timeframe.tf} "
+            f"по стратегии {allowance.strategy}. "
             f"Выдано: {allowance.issued_at.isoformat()}, дедлайн: {allowance.deadline.isoformat()}."
         )
 
     @staticmethod
     def _log_expired_ignore(ignored_symbol: IgnoredSymbol) -> None:
         log.i(
-            f"Истек срок игнорирования {ignored_symbol.symbol} на {ignored_symbol.timeframe.tf}. "
+            f"Истек срок игнорирования {ignored_symbol.symbol} на {ignored_symbol.timeframe.tf} "
+            f"по стратегии {ignored_symbol.strategy}. "
             f"Выдано: {ignored_symbol.issued_at.isoformat()}, "
             f"дедлайн: {ignored_symbol.deadline.isoformat()}."
         )

--- a/crypto_screener/main.py
+++ b/crypto_screener/main.py
@@ -46,7 +46,6 @@ def main() -> None:
     strategies = app_cfg.STRATEGIES
     if not strategies:
         raise ValueError("В конфигурации не задано ни одной стратегии.")
-    strategy = strategies[0]
     mode: Mode = app_cfg.MODE
     match mode:
         # Работа с актуальным рынком.
@@ -61,7 +60,7 @@ def main() -> None:
         ):
             notifier = _initialize_notifier()
             run_live(
-                strategy,
+                strategies,
                 exchange,
                 notifier,
                 timeframes,
@@ -85,7 +84,7 @@ def main() -> None:
             listing_age_days_min=listing_age_days_min
         ):
             run_test_market(
-                strategy,
+                strategies,
                 exchange,
                 timeframes,
                 limit,
@@ -103,7 +102,7 @@ def main() -> None:
             limit=limit,
             plot_policy=plot_policy
         ):
-            run_test_symbols(strategy, exchange, test_data, limit, plot_policy)
+            run_test_symbols(strategies, exchange, test_data, limit, plot_policy)
 
         case _:
             # noinspection PyUnreachableCode

--- a/crypto_screener/utils/telegram_messages.py
+++ b/crypto_screener/utils/telegram_messages.py
@@ -76,12 +76,14 @@ def _trade_levels_block(setup: Trade) -> str:
 def build_capture_message(
         symbol: FuturesSymbol,
         timeframe: Timeframe,
-        exchange_name: str
+        exchange_name: str,
+        strategy_name: str | None = None,
 ) -> str:
     link = _tradingview_link(symbol.symbol, exchange_name)
     lines = [
         "<b>Включено слежение</b>",
         f"Инструмент: {link}",
+        f"Стратегия: {escape(strategy_name or '')}",
         f"Биржа: {escape(exchange_name)}",
         f"Таймфрейм: {escape(timeframe.tf)}",
         f"Контекст: {escape(symbol.context.value)}",
@@ -97,12 +99,14 @@ def build_trade_opened_message(
         timeframe: Timeframe,
         execution_result: ExecutionResult,
         exchange_name: str,
+        strategy_name: str | None = None,
 ) -> str:
     link = _tradingview_link(setup.data.symbol, exchange_name)
     trade_levels = setup.trade_levels
     lines = [
         "<b>Позиция открыта</b>",
         f"Инструмент: {link}",
+        f"Стратегия: {escape(strategy_name or '')}",
         f"Биржа: {escape(exchange_name)}",
         f"Таймфрейм: {escape(timeframe.tf)}",
         f"Количество: {execution_result.quantity:.4f}",
@@ -135,6 +139,7 @@ def build_trade_closure_message(
         exit_prices: Iterable[float],
         actual_entry_price: float,
         exchange_name: str,
+        strategy_name: str | None = None,
 ) -> str:
     link = _tradingview_link(active_trade.symbol, exchange_name)
     exit_prices_text = ", ".join(f"{price:.4f}" for price in exit_prices) if exit_prices else "—"
@@ -142,6 +147,7 @@ def build_trade_closure_message(
     lines = [
         "<b>Сделка закрыта</b>",
         f"Инструмент: {link} ({escape(active_trade.timeframe.tf)})",
+        f"Стратегия: {escape(strategy_name or '')}",
         f"Результат: {escape(trade_result.value)} — {escape(exit_label)}",
         f"P&L: {profit_value:+.4f} ({profit_pct:+.2f}%)",
         f"Выходные цены: {exit_prices_text}",
@@ -156,13 +162,15 @@ def build_trade_closure_message(
 def build_protective_recovery_message(
         active_trade: ActiveTrade,
         reason: str,
-        exchange_name: str
+        exchange_name: str,
+        strategy_name: str | None = None,
 ) -> str:
     link = _tradingview_link(active_trade.symbol, exchange_name)
     return "\n".join(
         [
             "<b>Восстановление защиты</b>",
             f"Инструмент: {link} ({escape(active_trade.timeframe.tf)})",
+            f"Стратегия: {escape(strategy_name or '')}",
             f"Причина: {escape(reason)}",
         ]
     )


### PR DESCRIPTION
## Summary
- update application entrypoint and runners to iterate over configured strategies
- scope trade permissions, captures, and active trades by strategy and include strategy details in notifications
- extend Telegram callbacks and notifier messages to carry strategy identifiers alongside context

## Testing
- python -m compileall execution/run_live.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f08cf292883209de4bacc2445b244)