### PR TITLE
Use strategy runtime config for trade and capture parameters

### DIFF
--- a/crypto_screener/domain/strategies/ppo.py
+++ b/crypto_screener/domain/strategies/ppo.py
@@ -10,12 +10,16 @@ from crypto_screener.domain.models.setup_data import Ppo
 from crypto_screener.domain.models.swing import Swing, SwingType
 from crypto_screener.domain.models.timeframe import Timeframe
 from crypto_screener.domain.models.trade_levels import TradeLevels
-from crypto_screener.domain.strategies.strategy import Strategy
+from crypto_screener.config.ppo_config import PpoConfig, ppo_cfg
+from crypto_screener.domain.strategies.strategy import Strategy, StrategyRuntimeConfig
 from crypto_screener.domain.swing_detector import add_swings
 
 
 class PpoStrategy(Strategy):
     name = "ППО"
+
+    def __init__(self, config: PpoConfig = ppo_cfg) -> None:
+        self._config = config
 
     def detect_setup(
             self,
@@ -24,8 +28,6 @@ class PpoStrategy(Strategy):
             timeframe: Timeframe,
             context: Context,
     ) -> Setup:
-        from crypto_screener.config import ppo_cfg
-
         setup = Unfilled(
             data=Ppo(
                 symbol=symbol,
@@ -48,7 +50,7 @@ class PpoStrategy(Strategy):
 
         # Анализ теней.
         shadows_pct = self._get_shadow_range_pct(bars)
-        if shadows_pct > ppo_cfg.SHADOW_RANGE_PCT_MAX:
+        if shadows_pct > self._config.SHADOW_RANGE_PCT_MAX:
             return setup
 
         bars = add_swings(bars, timeframe)
@@ -89,8 +91,8 @@ class PpoStrategy(Strategy):
                 max_retrace = max(max_retrace, retrace_ratio)
         is_rise_valid = (
                 rise > 0 and
-                rise_pct >= ppo_cfg.PRICE_RISE_PCT_MIN and
-                max_retrace <= ppo_cfg.MAX_RETRACE_RATIO
+                rise_pct >= self._config.PRICE_RISE_PCT_MIN and
+                max_retrace <= self._config.MAX_RETRACE_RATIO
         )
 
         if not is_rise_valid:
@@ -104,7 +106,7 @@ class PpoStrategy(Strategy):
         correction_bars_count = len(correction_bars)
         rise_correction_ratio = (rise_bars_count / correction_bars_count
                                  if correction_bars_count > 0 else 0)
-        is_rise_age_valid = rise_correction_ratio < ppo_cfg.RISE_AGE_LIMIT_MULTIPLIER
+        is_rise_age_valid = rise_correction_ratio < self._config.RISE_AGE_LIMIT_MULTIPLIER
         if not is_rise_age_valid:
             return setup
         correction_low = self._get_first_open_swing_indexed(correction_bars, SwingType.LOW)
@@ -113,7 +115,7 @@ class PpoStrategy(Strategy):
         correction_low_index, correction_low_swing = correction_low
         retrace_range = main_high_swing.extremum_price - correction_low_swing.extremum_price
         retrace_ratio = retrace_range / rise
-        is_retrace_valid = retrace_range >= 0 and retrace_ratio <= ppo_cfg.RETRACE_RATIO_MAX
+        is_retrace_valid = retrace_range >= 0 and retrace_ratio <= self._config.RETRACE_RATIO_MAX
         if not is_retrace_valid:
             return setup
 
@@ -126,12 +128,12 @@ class PpoStrategy(Strategy):
                     sum(1 for bar in pre_low_window if bar.low > correction_low_swing.extremum_price) / len(pre_low_window)
             )
             is_pre_low_above_correction_low_valid = (pre_low_above_correction_low_fraction <=
-                                                     ppo_cfg.PRE_LOW_ABOVE_CORRECTION_LOW_FRACTION_MAX)
+                                                     self._config.PRE_LOW_ABOVE_CORRECTION_LOW_FRACTION_MAX)
             if not is_pre_low_above_correction_low_valid:
                 return setup
 
         # Анализ лонгового каскада.
-        cascade_price_min = correction_low_swing.close_price + retrace_range * ppo_cfg.CASCADE_RETRACE_RATIO_MIN
+        cascade_price_min = correction_low_swing.close_price + retrace_range * self._config.CASCADE_RETRACE_RATIO_MIN
         cascade_price_max = main_high_swing.close_price
         cascade_long = self._get_cascade_long(
             correction_bars,
@@ -141,7 +143,7 @@ class PpoStrategy(Strategy):
         if not cascade_long:
             return setup
         cascade_top = max(cascade_long, key=lambda swing: swing.extremum_price).extremum_price
-        resistance_gap = retrace_range * ppo_cfg.RESISTANCE_GAP_RATIO_MIN
+        resistance_gap = retrace_range * self._config.RESISTANCE_GAP_RATIO_MIN
         open_high_swings = self._get_open_swings(correction_bars, SwingType.HIGH)
         open_high_swings = self._filter_by_price(open_high_swings, cascade_price_min, cascade_price_max)
         extra_cascade_swings = [
@@ -155,14 +157,14 @@ class PpoStrategy(Strategy):
 
         # Анализ сопротивления над каскадом.
         cascade_top = max(cascade_long, key=lambda swing: swing.extremum_price).extremum_price
-        resistance_gap = retrace_range * ppo_cfg.RESISTANCE_GAP_RATIO_MIN
+        resistance_gap = retrace_range * self._config.RESISTANCE_GAP_RATIO_MIN
         resistance_price_min = cascade_top + resistance_gap
         resistance_price_max = main_high_swing.extremum_price - resistance_gap
         resistance_swings = []
         if resistance_price_min < resistance_price_max:
             resistance_swings = self._filter_by_price(open_high_swings, resistance_price_min, resistance_price_max)
         setup.data.resistance_swings = resistance_swings
-        has_resistance = len(resistance_swings) > ppo_cfg.RESISTANCE_COUNT_MAX
+        has_resistance = len(resistance_swings) > self._config.RESISTANCE_COUNT_MAX
         if has_resistance:
             return setup
 
@@ -173,7 +175,7 @@ class PpoStrategy(Strategy):
         setup.data.support_swings = open_low_swings
         target_swing = cascade_long[-1]
 
-        support_price_min = correction_low_swing.extremum_price + consolidation_range * ppo_cfg.SUPPORT_CONSOLIDATION_RATIO_MIN
+        support_price_min = correction_low_swing.extremum_price + consolidation_range * self._config.SUPPORT_CONSOLIDATION_RATIO_MIN
         support_price_max = target_swing.extremum_price
         open_low_swings = self._filter_by_price(open_low_swings, support_price_min, support_price_max)
         support_swing = open_low_swings[-1] if open_low_swings else None
@@ -208,15 +210,15 @@ class PpoStrategy(Strategy):
             profit_price = profit_price + (main_high_swing.close_price - correction_low_swing.close_price)
         loss_price = support_swing.extremum_price
         loss_pct = 100 * (loss_price - current_price) / loss_price
-        is_loss_valid = abs(loss_pct) > ppo_cfg.LOSS_PCT_MIN
+        is_loss_valid = abs(loss_pct) > self._config.LOSS_PCT_MIN
         if not is_loss_valid:
             return setup
         profit_pct = 100 * (profit_price - current_price) / current_price
-        is_profit_valid = profit_pct > ppo_cfg.PROFIT_PCT_MIN
+        is_profit_valid = profit_pct > self._config.PROFIT_PCT_MIN
         if not is_profit_valid:
             return setup
         reward_risk = abs(profit_pct / loss_pct)
-        is_reward_risk_valid = reward_risk >= ppo_cfg.REWARD_RISK_RATIO_MIN
+        is_reward_risk_valid = reward_risk >= self._config.REWARD_RISK_RATIO_MIN
         if not is_reward_risk_valid and not context.is_test:
             return setup
 
@@ -242,21 +244,21 @@ class PpoStrategy(Strategy):
         # Пробой лонгового каскада.
         partial_close_price = None
         breakeven_price = None
-        partial_close_side_pct = ppo_cfg.PARTIAL_CLOSE_SIDE_PCT_MIN
+        partial_close_side_pct = self._config.PARTIAL_CLOSE_SIDE_PCT_MIN
         if resistance_swings:
             nearest_resistance_price = resistance_swings[-1].extremum_price
             nearest_resistance_distance_pct = 100 * (nearest_resistance_price - current_price) / current_price
             has_partial_close = partial_close_side_pct <= nearest_resistance_distance_pct < profit_pct - partial_close_side_pct
             if has_partial_close:
                 partial_close_price = nearest_resistance_price if has_partial_close else None
-                breakeven_price = current_price + ppo_cfg.BREAKEVEN_PARTIAL_CLOSE_RATIO * (partial_close_price - current_price)
+                breakeven_price = current_price + self._config.BREAKEVEN_PARTIAL_CLOSE_RATIO * (partial_close_price - current_price)
         elif context.is_top:
             main_high_distance_pct = 100 * (main_high_swing.extremum_price - current_price) / current_price
             has_partial_close = partial_close_side_pct <= main_high_distance_pct < profit_pct - partial_close_side_pct
             if has_partial_close:
                 partial_close_price = main_high_swing.extremum_price
-                breakeven_price = current_price + ppo_cfg.BREAKEVEN_PARTIAL_CLOSE_RATIO * (partial_close_price - current_price)
-        entry_slippage_ratio = 1 + ppo_cfg.TEST_SLIPPAGE_PCT / 100 if context.is_test else 1
+                breakeven_price = current_price + self._config.BREAKEVEN_PARTIAL_CLOSE_RATIO * (partial_close_price - current_price)
+        entry_slippage_ratio = 1 + self._config.TEST_SLIPPAGE_PCT / 100 if context.is_test else 1
         trade_levels = TradeLevels(
             entry_price=target_swing.extremum_price * entry_slippage_ratio,
             take_profit_price=profit_price,
@@ -388,11 +390,11 @@ class PpoStrategy(Strategy):
             ranges = [bar.high - bar.low for bar in bars[-window:]]
             return float(np.mean(ranges)) if ranges else 0.0
 
-        avg_range = calculate_average_range(ppo_cfg.CASCADE_ATR_WINDOW)
-        touch_tolerance = max(ppo_cfg.CASCADE_TOUCH_EPS_NATR * avg_range, 0.0)
-        min_pullback = max(ppo_cfg.CASCADE_MIN_PULLBACK_NATR * avg_range, 0.0)
-        min_pullback_bars = ppo_cfg.CASCADE_MIN_PULLBACK_BARS
-        min_gap_bars = ppo_cfg.CASCADE_MIN_GAP_BARS
+        avg_range = calculate_average_range(self._config.CASCADE_ATR_WINDOW)
+        touch_tolerance = max(self._config.CASCADE_TOUCH_EPS_NATR * avg_range, 0.0)
+        min_pullback = max(self._config.CASCADE_MIN_PULLBACK_NATR * avg_range, 0.0)
+        min_pullback_bars = self._config.CASCADE_MIN_PULLBACK_BARS
+        min_gap_bars = self._config.CASCADE_MIN_GAP_BARS
         levels: list[CascadeLevel] = []
         bar_data = [(i, bar.high, bar.open, bar.close)
                     for i, bar in enumerate(bars)
@@ -484,7 +486,7 @@ class PpoStrategy(Strategy):
                 best_level_touches_count = touches_count
                 best_level_price = level.price
 
-        if not best_level_touches or best_level_touches_count < ppo_cfg.CASCADE_LENGTH_MIN:
+        if not best_level_touches or best_level_touches_count < self._config.CASCADE_LENGTH_MIN:
             return []
         first_touch_index = min(best_level_touches)
         last_touch_index = max(best_level_touches)
@@ -506,3 +508,11 @@ class PpoStrategy(Strategy):
             cascade_swings.append(swing)
 
         return cascade_swings
+
+    def get_runtime_config(self) -> StrategyRuntimeConfig:
+        return StrategyRuntimeConfig(
+            capture_timeout_multiplier=self._config.CAPTURE_TIMEOUT_MULTIPLIER,
+            risk_per_trade_usdt=self._config.RISK_PER_TRADE_USDT,
+            min_position_notional_usdt=self._config.MIN_POSITION_NOTIONAL_USDT,
+            min_position_quantity=self._config.MIN_POSITION_QUANTITY,
+        )

--- a/crypto_screener/domain/strategies/strategy.py
+++ b/crypto_screener/domain/strategies/strategy.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 
 from crypto_screener.domain.models.bar import Bar
 from crypto_screener.domain.models.context import Context
 from crypto_screener.domain.models.setup import Setup
 from crypto_screener.domain.models.timeframe import Timeframe
+
+
+@dataclass(frozen=True)
+class StrategyRuntimeConfig:
+    capture_timeout_multiplier: int
+    risk_per_trade_usdt: float
+    min_position_notional_usdt: float
+    min_position_quantity: float
 
 
 class Strategy(ABC):
@@ -56,3 +65,7 @@ class Strategy(ABC):
             context: Context,
     ) -> Setup:
         """Определяет сетап для заданного символа."""
+
+    @abstractmethod
+    def get_runtime_config(self) -> StrategyRuntimeConfig:
+        """Возвращает параметры исполнения стратегии."""

--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -8,7 +8,7 @@ from time import sleep
 from typing import Optional
 from urllib.parse import quote
 
-from crypto_screener.config import app_cfg, ppo_cfg
+from crypto_screener.config import app_cfg
 from crypto_screener.data.notifiers.telegram import SKIP_CALLBACK_PREFIX, TRADE_CALLBACK_PREFIX
 from crypto_screener.data.providers.coingecko import enrich_symbols_capitalization
 from crypto_screener.domain.capture_state import CaptureState
@@ -28,7 +28,7 @@ from crypto_screener.domain.models.symbol import FuturesSymbol, set_contexts, ex
 from crypto_screener.domain.models.timeframe import Timeframe
 from crypto_screener.domain.models.trade_result import TradeResult
 from crypto_screener.domain.notifier import Keyboard, Notifier, NotificationType
-from crypto_screener.domain.strategies.strategy import Strategy
+from crypto_screener.domain.strategies.strategy import Strategy, StrategyRuntimeConfig
 from crypto_screener.execution.scheduler import Scheduler
 from crypto_screener.execution.trade_executor import TradeExecutionService
 from crypto_screener.execution.trade_permission_service import TradePermissionService
@@ -111,6 +111,25 @@ def _build_keyboard(
     callback_data = f"{TRADE_CALLBACK_PREFIX}:{encoded_symbol}:{timeframe.tf}:{encoded_context}:{encoded_strategy}"
     skip_callback_data = f"{SKIP_CALLBACK_PREFIX}:{encoded_symbol}:{timeframe.tf}:{encoded_context}:{encoded_strategy}"
     return [[(trade_text, callback_data), (skip_text, skip_callback_data)]]
+
+
+def _resolve_strategy(
+        strategy: Strategy | None,
+        strategy_by_name: dict[str, Strategy],
+        strategies: list[Strategy],
+        strategy_name: str,
+) -> Strategy:
+    return strategy or strategy_by_name.get(strategy_name) or strategies[0]
+
+
+def _get_runtime_config(
+        strategy: Strategy | None,
+        strategy_by_name: dict[str, Strategy],
+        strategies: list[Strategy],
+        strategy_name: str,
+) -> StrategyRuntimeConfig:
+    resolved_strategy = _resolve_strategy(strategy, strategy_by_name, strategies, strategy_name)
+    return resolved_strategy.get_runtime_config()
 
 
 def _send_notification(
@@ -1304,6 +1323,13 @@ def run_live(
                 outcome = result.outcome
                 strategy_name = result.strategy_name
                 strategy = strategy_by_name.get(strategy_name)
+                resolved_strategy = _resolve_strategy(
+                    strategy,
+                    strategy_by_name,
+                    strategies,
+                    strategy_name,
+                )
+                runtime_config = resolved_strategy.get_runtime_config()
 
                 capture_key = CaptureKey(symbol.symbol, timeframe, strategy_name)
                 active_capture = capture_state.get_capture(capture_key)
@@ -1381,7 +1407,7 @@ def run_live(
                                             symbol.symbol,
                                             timeframe,
                                             symbol.context,
-                                            strategy or strategy_by_name.get(strategy_name) or strategies[0],
+                                            resolved_strategy,
                                         ),
                                     ).result()
                                 continue
@@ -1399,7 +1425,7 @@ def run_live(
                                         symbol.symbol,
                                         timeframe,
                                         symbol.context,
-                                        strategy or strategy_by_name.get(strategy_name) or strategies[0],
+                                        resolved_strategy,
                                     ),
                                 ).result()
                                 capture_state.add_capture(
@@ -1407,7 +1433,7 @@ def run_live(
                                     timeframe=timeframe,
                                     strategy=strategy_name,
                                     message_id=message_id,
-                                    timeout_multiplier=ppo_cfg.CAPTURE_TIMEOUT_MULTIPLIER,
+                                    timeout_multiplier=runtime_config.capture_timeout_multiplier,
                                 )
                                 cycle_started = False
                                 notified_once.add(capture_notification_key)
@@ -1422,7 +1448,11 @@ def run_live(
                             log.i(
                                 f"Попытка открытия позиции в {symbol.symbol} на {timeframe.tf} ({strategy_name})."
                             )
-                            execution_result = trade_execution_service.execute_buy(setup, symbol.context)
+                            execution_result = trade_execution_service.execute_buy(
+                                setup,
+                                symbol.context,
+                                runtime_config,
+                            )
                             if not execution_result:
                                 trade_permission_service.clear_allowance(symbol.symbol, timeframe, strategy_name)
                                 continue

--- a/crypto_screener/execution/trade_executor.py
+++ b/crypto_screener/execution/trade_executor.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Optional
 
-from crypto_screener.config import ppo_cfg
 from crypto_screener.domain.exchange import Exchange
 from crypto_screener.domain.models.context import Context
 from crypto_screener.domain.models.margin_mode import MarginMode
@@ -13,6 +12,7 @@ from crypto_screener.domain.models.protective_orders import ProtectiveOrders
 from crypto_screener.domain.models.setup import Trade
 from crypto_screener.domain.models.stop_realignment_result import StopRealignmentResult
 from crypto_screener.domain.notifier import Notifier, NotificationType
+from crypto_screener.domain.strategies.strategy import StrategyRuntimeConfig
 from crypto_screener.utils.logger import log
 
 
@@ -33,11 +33,11 @@ class TradeExecutionService:
         self._exchange = exchange
         self.notifier = notifier
 
-    def execute_buy(self, setup: Trade, context: Context) -> Optional[ExecutionResult]:
+    def execute_buy(self, setup: Trade, context: Context, runtime_config: StrategyRuntimeConfig) -> Optional[ExecutionResult]:
         entry_order_id: Optional[str] = None
         protective_orders = ProtectiveOrders()
         try:
-            quantity = self._determine_position_size(setup, context)
+            quantity = self._determine_position_size(setup, context, runtime_config)
         except Exception:
             return None
 
@@ -60,10 +60,11 @@ class TradeExecutionService:
     def _determine_position_size(
             self,
             setup: Trade,
-            context: Context
+            context: Context,
+            runtime_config: StrategyRuntimeConfig,
     ) -> float:
         try:
-            return self._calculate_position_size(setup)
+            return self._calculate_position_size(setup, runtime_config)
         except Exception as exception:
             self._notify_failure(
                 setup,
@@ -130,16 +131,16 @@ class TradeExecutionService:
         )
 
     @staticmethod
-    def _calculate_position_size(setup: Trade) -> float:
+    def _calculate_position_size(setup: Trade, runtime_config: StrategyRuntimeConfig) -> float:
         entry_price = setup.entry_price
         stop_loss_price = setup.stop_loss_price
         stop_distance = entry_price - stop_loss_price
         if stop_distance <= 0:
             raise ValueError(f"Некорректная дистанция до стоп-лосса: Entry {entry_price}, SL {stop_loss_price}")
 
-        risk_amount = ppo_cfg.RISK_PER_TRADE_USDT
-        min_notional = ppo_cfg.MIN_POSITION_NOTIONAL_USDT
-        min_quantity = ppo_cfg.MIN_POSITION_QUANTITY
+        risk_amount = runtime_config.risk_per_trade_usdt
+        min_notional = runtime_config.min_position_notional_usdt
+        min_quantity = runtime_config.min_position_quantity
 
         quantity_by_risk = risk_amount / stop_distance
         quantity_by_notional = min_notional / entry_price


### PR DESCRIPTION
## Summary
- add StrategyRuntimeConfig interface and implement it in PpoStrategy
- use strategy runtime configuration for capture timeouts instead of global PPO config
- pass strategy-provided risk parameters into TradeExecutionService to size positions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f0c6827f48320a1d17fafe0f81b26)