### PR TITLE
Refactor strategy configuration access

### DIFF
--- a/crypto_screener/domain/models/allowed_trade_registry.py
+++ b/crypto_screener/domain/models/allowed_trade_registry.py
@@ -4,10 +4,10 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Optional
 
-from crypto_screener.config import ppo_cfg
 from crypto_screener.domain.models.allowed_trade import AllowedTrade
 from crypto_screener.domain.models.context import Context
 from crypto_screener.domain.models.timeframe import Timeframe
+from crypto_screener.domain.strategies.strategy import StrategyRuntimeConfig
 from crypto_screener.utils.time import utc_now
 
 
@@ -67,10 +67,13 @@ class AllowedTradeRegistry:
             key: AllowedTradeKey,
             message_id: str,
             context: Context,
+            runtime_config: StrategyRuntimeConfig,
             issued_at: Optional[datetime] = None,
     ) -> AllowedTrade:
         issued_at = issued_at or utc_now()
-        deadline = issued_at + timedelta(minutes=ppo_cfg.CAPTURE_TIMEOUT_MULTIPLIER * key.timeframe.minutes)
+        deadline = issued_at + timedelta(
+            minutes=runtime_config.capture_timeout_multiplier * key.timeframe.minutes,
+        )
         return AllowedTrade(
             symbol=key.symbol,
             timeframe=key.timeframe,
@@ -81,8 +84,19 @@ class AllowedTradeRegistry:
             deadline=deadline,
         )
 
-    def add(self, key: AllowedTradeKey, message_id: str, context: Context) -> tuple[AllowedTrade, bool]:
-        trade = self._build_trade(key=key, message_id=message_id, context=context)
+    def add(
+            self,
+            key: AllowedTradeKey,
+            message_id: str,
+            context: Context,
+            runtime_config: StrategyRuntimeConfig,
+    ) -> tuple[AllowedTrade, bool]:
+        trade = self._build_trade(
+            key=key,
+            message_id=message_id,
+            context=context,
+            runtime_config=runtime_config,
+        )
         replaced = self._storage.add(key, trade)
         return trade, replaced
 

--- a/crypto_screener/domain/models/ignored_symbol_registry.py
+++ b/crypto_screener/domain/models/ignored_symbol_registry.py
@@ -4,10 +4,10 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Optional
 
-from crypto_screener.config import ppo_cfg
 from crypto_screener.domain.models.allowed_trade_registry import AllowedTradeKey
 from crypto_screener.domain.models.context import Context
 from crypto_screener.domain.models.ignored_symbol import IgnoredSymbol
+from crypto_screener.domain.strategies.strategy import StrategyRuntimeConfig
 from crypto_screener.utils.time import ensure_utc, utc_now
 
 
@@ -65,10 +65,13 @@ class IgnoredSymbolRegistry:
             key: AllowedTradeKey,
             message_id: str,
             context: Context,
+            runtime_config: StrategyRuntimeConfig,
             issued_at: Optional[datetime] = None,
     ) -> IgnoredSymbol:
         issued_at = ensure_utc(issued_at) if issued_at else utc_now()
-        deadline = issued_at + timedelta(minutes=ppo_cfg.CAPTURE_TIMEOUT_MULTIPLIER * key.timeframe.minutes)
+        deadline = issued_at + timedelta(
+            minutes=runtime_config.capture_timeout_multiplier * key.timeframe.minutes,
+        )
         return IgnoredSymbol(
             symbol=key.symbol,
             timeframe=key.timeframe,
@@ -79,8 +82,19 @@ class IgnoredSymbolRegistry:
             deadline=deadline,
         )
 
-    def add(self, key: AllowedTradeKey, message_id: str, context: Context) -> tuple[IgnoredSymbol, bool]:
-        ignored_symbol = self._build_ignored_symbol(key=key, message_id=message_id, context=context)
+    def add(
+            self,
+            key: AllowedTradeKey,
+            message_id: str,
+            context: Context,
+            runtime_config: StrategyRuntimeConfig,
+    ) -> tuple[IgnoredSymbol, bool]:
+        ignored_symbol = self._build_ignored_symbol(
+            key=key,
+            message_id=message_id,
+            context=context,
+            runtime_config=runtime_config,
+        )
         replaced = self._storage.add(key, ignored_symbol)
         return ignored_symbol, replaced
 

--- a/crypto_screener/domain/strategies/ppo.py
+++ b/crypto_screener/domain/strategies/ppo.py
@@ -11,7 +11,11 @@ from crypto_screener.domain.models.swing import Swing, SwingType
 from crypto_screener.domain.models.timeframe import Timeframe
 from crypto_screener.domain.models.trade_levels import TradeLevels
 from crypto_screener.config.ppo_config import PpoConfig, ppo_cfg
-from crypto_screener.domain.strategies.strategy import Strategy, StrategyRuntimeConfig
+from crypto_screener.domain.strategies.strategy import (
+    Strategy,
+    StrategyRuntimeConfig,
+    StrategyVolumeConfig,
+)
 from crypto_screener.domain.swing_detector import add_swings
 
 
@@ -515,4 +519,11 @@ class PpoStrategy(Strategy):
             risk_per_trade_usdt=self._config.RISK_PER_TRADE_USDT,
             min_position_notional_usdt=self._config.MIN_POSITION_NOTIONAL_USDT,
             min_position_quantity=self._config.MIN_POSITION_QUANTITY,
+        )
+
+    def get_volume_config(self) -> StrategyVolumeConfig:
+        return StrategyVolumeConfig(
+            min_side_bars=self._config.VOLUME_TRIM_SIDE_BARS_MIN,
+            high_volume_factor=self._config.HIGH_VOLUME_THRESHOLD,
+            min_high_fraction=self._config.HIGH_VOLUME_FRACTION_MIN,
         )

--- a/crypto_screener/domain/strategies/strategy.py
+++ b/crypto_screener/domain/strategies/strategy.py
@@ -17,14 +17,20 @@ class StrategyRuntimeConfig:
     min_position_quantity: float
 
 
+@dataclass(frozen=True)
+class StrategyVolumeConfig:
+    min_side_bars: int
+    high_volume_factor: float
+    min_high_fraction: float
+
+
 class Strategy(ABC):
     name: str
 
-    @staticmethod
-    def trim_by_volume(bars: list[Bar]) -> list[Bar]:
-        from crypto_screener.config import ppo_cfg
+    def trim_by_volume(self, bars: list[Bar]) -> list[Bar]:
+        volume_config = self.get_volume_config()
         length = len(bars)
-        min_side_bars = ppo_cfg.VOLUME_TRIM_SIDE_BARS_MIN
+        min_side_bars = volume_config.min_side_bars
         if length < 2 * min_side_bars:
             return []
         volumes = [bar.volume for bar in bars]
@@ -33,8 +39,8 @@ class Strategy(ABC):
             prefix[i + 1] = prefix[i] + v
         best_ratio = -1.0
         best_index = -1
-        high_volume_factor = ppo_cfg.HIGH_VOLUME_THRESHOLD
-        min_high_fraction = ppo_cfg.HIGH_VOLUME_FRACTION_MIN
+        high_volume_factor = volume_config.high_volume_factor
+        min_high_fraction = volume_config.min_high_fraction
         for split in range(min_side_bars, length - min_side_bars + 1):
             left_avg = (prefix[split] - prefix[0]) / split
             if left_avg <= 0:
@@ -69,3 +75,7 @@ class Strategy(ABC):
     @abstractmethod
     def get_runtime_config(self) -> StrategyRuntimeConfig:
         """Возвращает параметры исполнения стратегии."""
+
+    @abstractmethod
+    def get_volume_config(self) -> StrategyVolumeConfig:
+        """Возвращает параметры для анализа объемов."""

--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -1211,7 +1211,7 @@ def run_live(
         return
 
     capture_state = CaptureState()
-    trade_permission_service = TradePermissionService()
+    trade_permission_service = TradePermissionService(strategies)
     trade_execution_service = TradeExecutionService(exchange, notifier)
     notifier.start_callback_handler(trade_permission_service)
     analysis_executor = ThreadPoolExecutor(max_workers=app_cfg.LIVE_MAX_WORKERS)

--- a/crypto_screener/execution/trade_permission_service.py
+++ b/crypto_screener/execution/trade_permission_service.py
@@ -9,14 +9,25 @@ from crypto_screener.domain.models.context import Context
 from crypto_screener.domain.models.ignored_symbol import IgnoredSymbol
 from crypto_screener.domain.models.ignored_symbol_registry import IgnoredSymbolRegistry
 from crypto_screener.domain.models.timeframe import Timeframe
+from crypto_screener.domain.strategies.strategy import Strategy, StrategyRuntimeConfig
 from crypto_screener.utils.logger import log
 from crypto_screener.utils.time import ensure_utc, utc_now
 
 
 class TradePermissionService:
-    def __init__(self) -> None:
+    def __init__(self, strategies: list[Strategy]) -> None:
         self._allowed_trades = AllowedTradeRegistry()
         self._ignored_symbols = IgnoredSymbolRegistry()
+        self._runtime_configs: dict[str, StrategyRuntimeConfig] = {
+            strategy.name: strategy.get_runtime_config() for strategy in strategies
+        }
+
+    def _get_runtime_config(self, strategy: str) -> StrategyRuntimeConfig | None:
+        runtime_config = self._runtime_configs.get(strategy)
+        if runtime_config:
+            return runtime_config
+        log.e(f"Неизвестная стратегия {strategy} для разрешений на торговлю.")
+        return None
 
     def allow_symbol_for_trading(
             self,
@@ -26,10 +37,14 @@ class TradePermissionService:
             message_id: str,
             context: Context,
     ) -> None:
+        runtime_config = self._get_runtime_config(strategy)
+        if not runtime_config:
+            return
         trade, replaced = self._allowed_trades.add(
             key=AllowedTradeKey(symbol, timeframe, strategy),
             message_id=message_id,
             context=context,
+            runtime_config=runtime_config,
         )
         if replaced:
             log.d(
@@ -47,10 +62,14 @@ class TradePermissionService:
             message_id: str,
             context: Context,
     ) -> None:
+        runtime_config = self._get_runtime_config(strategy)
+        if not runtime_config:
+            return
         ignored_symbol, replaced = self._ignored_symbols.add(
             key=AllowedTradeKey(symbol, timeframe, strategy),
             message_id=message_id,
             context=context,
+            runtime_config=runtime_config,
         )
         if replaced:
             log.d(


### PR DESCRIPTION
## Summary
- read volume trimming thresholds from strategy configuration instead of the global ppo config
- pass strategy runtime parameters into trade permission and ignore registries
- initialize trade permission service with strategy configs to compute deadlines

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f131568b8832081ac8dbd602b78cf)