### PR TITLE
Support strategy-specific timeout multipliers for trade permissions

### DIFF
--- a/crypto_screener/domain/models/allowed_trade_registry.py
+++ b/crypto_screener/domain/models/allowed_trade_registry.py
@@ -7,7 +7,6 @@ from typing import Optional
 from crypto_screener.domain.models.allowed_trade import AllowedTrade
 from crypto_screener.domain.models.context import Context
 from crypto_screener.domain.models.timeframe import Timeframe
-from crypto_screener.domain.strategies.strategy import StrategyRuntimeConfig
 from crypto_screener.utils.time import utc_now
 
 
@@ -67,12 +66,12 @@ class AllowedTradeRegistry:
             key: AllowedTradeKey,
             message_id: str,
             context: Context,
-            runtime_config: StrategyRuntimeConfig,
+            timeout_multiplier: int,
             issued_at: Optional[datetime] = None,
     ) -> AllowedTrade:
         issued_at = issued_at or utc_now()
         deadline = issued_at + timedelta(
-            minutes=runtime_config.capture_timeout_multiplier * key.timeframe.minutes,
+            minutes=timeout_multiplier * key.timeframe.minutes,
         )
         return AllowedTrade(
             symbol=key.symbol,
@@ -89,13 +88,13 @@ class AllowedTradeRegistry:
             key: AllowedTradeKey,
             message_id: str,
             context: Context,
-            runtime_config: StrategyRuntimeConfig,
+            timeout_multiplier: int,
     ) -> tuple[AllowedTrade, bool]:
         trade = self._build_trade(
             key=key,
             message_id=message_id,
             context=context,
-            runtime_config=runtime_config,
+            timeout_multiplier=timeout_multiplier,
         )
         replaced = self._storage.add(key, trade)
         return trade, replaced

--- a/crypto_screener/domain/models/ignored_symbol_registry.py
+++ b/crypto_screener/domain/models/ignored_symbol_registry.py
@@ -7,7 +7,6 @@ from typing import Optional
 from crypto_screener.domain.models.allowed_trade_registry import AllowedTradeKey
 from crypto_screener.domain.models.context import Context
 from crypto_screener.domain.models.ignored_symbol import IgnoredSymbol
-from crypto_screener.domain.strategies.strategy import StrategyRuntimeConfig
 from crypto_screener.utils.time import ensure_utc, utc_now
 
 
@@ -65,12 +64,12 @@ class IgnoredSymbolRegistry:
             key: AllowedTradeKey,
             message_id: str,
             context: Context,
-            runtime_config: StrategyRuntimeConfig,
+            timeout_multiplier: int,
             issued_at: Optional[datetime] = None,
     ) -> IgnoredSymbol:
         issued_at = ensure_utc(issued_at) if issued_at else utc_now()
         deadline = issued_at + timedelta(
-            minutes=runtime_config.capture_timeout_multiplier * key.timeframe.minutes,
+            minutes=timeout_multiplier * key.timeframe.minutes,
         )
         return IgnoredSymbol(
             symbol=key.symbol,
@@ -87,13 +86,13 @@ class IgnoredSymbolRegistry:
             key: AllowedTradeKey,
             message_id: str,
             context: Context,
-            runtime_config: StrategyRuntimeConfig,
+            timeout_multiplier: int,
     ) -> tuple[IgnoredSymbol, bool]:
         ignored_symbol = self._build_ignored_symbol(
             key=key,
             message_id=message_id,
             context=context,
-            runtime_config=runtime_config,
+            timeout_multiplier=timeout_multiplier,
         )
         replaced = self._storage.add(key, ignored_symbol)
         return ignored_symbol, replaced

--- a/crypto_screener/execution/trade_permission_service.py
+++ b/crypto_screener/execution/trade_permission_service.py
@@ -29,6 +29,12 @@ class TradePermissionService:
         log.e(f"Неизвестная стратегия {strategy} для разрешений на торговлю.")
         return None
 
+    def _get_timeout_multiplier(self, strategy: str) -> int | None:
+        runtime_config = self._get_runtime_config(strategy)
+        if not runtime_config:
+            return None
+        return runtime_config.capture_timeout_multiplier
+
     def allow_symbol_for_trading(
             self,
             symbol: str,
@@ -37,14 +43,14 @@ class TradePermissionService:
             message_id: str,
             context: Context,
     ) -> None:
-        runtime_config = self._get_runtime_config(strategy)
-        if not runtime_config:
+        timeout_multiplier = self._get_timeout_multiplier(strategy)
+        if timeout_multiplier is None:
             return
         trade, replaced = self._allowed_trades.add(
             key=AllowedTradeKey(symbol, timeframe, strategy),
             message_id=message_id,
             context=context,
-            runtime_config=runtime_config,
+            timeout_multiplier=timeout_multiplier,
         )
         if replaced:
             log.d(
@@ -62,14 +68,14 @@ class TradePermissionService:
             message_id: str,
             context: Context,
     ) -> None:
-        runtime_config = self._get_runtime_config(strategy)
-        if not runtime_config:
+        timeout_multiplier = self._get_timeout_multiplier(strategy)
+        if timeout_multiplier is None:
             return
         ignored_symbol, replaced = self._ignored_symbols.add(
             key=AllowedTradeKey(symbol, timeframe, strategy),
             message_id=message_id,
             context=context,
-            runtime_config=runtime_config,
+            timeout_multiplier=timeout_multiplier,
         )
         if replaced:
             log.d(


### PR DESCRIPTION
## Summary
- update allowed and ignored registries to accept explicit timeout multipliers when creating entries
- fetch multipliers from each strategy's runtime configuration inside TradePermissionService to honor per-strategy settings

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fa69c38ac8320aaa3f97e3ffe1514)