### PR TITLE
Move symbol thresholds to shared config

### DIFF
--- a/crypto_screener/config/__init__.py
+++ b/crypto_screener/config/__init__.py
@@ -1,4 +1,5 @@
 from crypto_screener.config.app_config import AppConfig, app_cfg
 from crypto_screener.config.ppo_config import PpoConfig, ppo_cfg
+from crypto_screener.config.symbol_config import SymbolConfig, symbol_cfg
 
-__all__ = ["AppConfig", "PpoConfig", "app_cfg", "ppo_cfg"]
+__all__ = ["AppConfig", "PpoConfig", "SymbolConfig", "app_cfg", "ppo_cfg", "symbol_cfg"]

--- a/crypto_screener/config/symbol_config.py
+++ b/crypto_screener/config/symbol_config.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CapitalizationThresholds:
+    LOW_MIN: float = 20_000_000
+    MIDDLE_MIN: float = 1_000_000_000
+    HIGH_MIN: float = 10_000_000_000
+
+
+@dataclass(frozen=True)
+class ContextThresholds:
+    TRADES_MIN: int = 500_000
+    VOLUME_MIN: float = 500_000_000
+
+
+@dataclass(frozen=True)
+class SymbolConfig:
+    capitalization: CapitalizationThresholds = CapitalizationThresholds()
+    context: ContextThresholds = ContextThresholds()
+
+
+symbol_cfg = SymbolConfig()

--- a/crypto_screener/data/providers/coingecko.py
+++ b/crypto_screener/data/providers/coingecko.py
@@ -4,11 +4,8 @@ from urllib.error import URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
-from crypto_screener.domain.models.symbol import (
-    FuturesSymbol,
-    assign_capitalizations,
-    extract_base_symbol,
-)
+from crypto_screener.config.symbol_config import CapitalizationThresholds, symbol_cfg
+from crypto_screener.domain.models.symbol import FuturesSymbol, assign_capitalizations, extract_base_symbol
 
 
 # region Private.
@@ -58,8 +55,12 @@ def fetch_market_caps(base_symbols: Iterable[str]) -> dict[str, float]:
     return market_caps
 
 
-def enrich_symbols_capitalization(symbols: Iterable[FuturesSymbol]) -> list[FuturesSymbol]:
+def enrich_symbols_capitalization(
+        symbols: Iterable[FuturesSymbol],
+        capitalization_thresholds: CapitalizationThresholds | None = None,
+) -> list[FuturesSymbol]:
     symbols_list = list(symbols)
     base_symbols = {extract_base_symbol(symbol.symbol) for symbol in symbols_list}
     market_caps = fetch_market_caps(base_symbols)
-    return assign_capitalizations(symbols_list, market_caps)
+    thresholds = capitalization_thresholds or symbol_cfg.capitalization
+    return assign_capitalizations(symbols_list, market_caps, thresholds)

--- a/crypto_screener/domain/models/symbol.py
+++ b/crypto_screener/domain/models/symbol.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, replace
 from datetime import datetime
 from typing import Iterable, Mapping
 
-from crypto_screener.config import ppo_cfg
+from crypto_screener.config.symbol_config import CapitalizationThresholds, ContextThresholds
 from crypto_screener.domain.models.capitalization import Capitalization
 from crypto_screener.domain.models.context import Context
 from crypto_screener.utils.time import utc_now
@@ -22,12 +22,15 @@ def extract_base_symbol(symbol: str) -> str:
     return symbol.split("/")[0].split(":")[0].lower()
 
 
-def calculate_capitalization(market_cap: float) -> Capitalization:
-    if market_cap >= ppo_cfg.CAPITALIZATION_HIGH_MIN:
+def calculate_capitalization(
+        market_cap: float,
+        capitalization_thresholds: CapitalizationThresholds,
+) -> Capitalization:
+    if market_cap >= capitalization_thresholds.HIGH_MIN:
         return Capitalization.HIGH
-    if market_cap >= ppo_cfg.CAPITALIZATION_MIDDLE_MIN:
+    if market_cap >= capitalization_thresholds.MIDDLE_MIN:
         return Capitalization.MIDDLE
-    if market_cap >= ppo_cfg.CAPITALIZATION_LOW_MIN:
+    if market_cap >= capitalization_thresholds.LOW_MIN:
         return Capitalization.LOW
     return Capitalization.LOW
 
@@ -35,12 +38,13 @@ def calculate_capitalization(market_cap: float) -> Capitalization:
 def assign_capitalizations(
         symbols: Iterable[FuturesSymbol],
         market_caps: Mapping[str, float],
+        capitalization_thresholds: CapitalizationThresholds,
 ) -> list[FuturesSymbol]:
     enriched: list[FuturesSymbol] = []
     for symbol in symbols:
         base_symbol = extract_base_symbol(symbol.symbol)
         market_cap = market_caps.get(base_symbol, 0)
-        capitalization = calculate_capitalization(market_cap)
+        capitalization = calculate_capitalization(market_cap, capitalization_thresholds)
         enriched.append(replace(symbol, capitalization=capitalization))
     return enriched
 
@@ -48,6 +52,7 @@ def assign_capitalizations(
 def set_contexts(
         symbols: list[FuturesSymbol],
         listing_period_days: int,
+        context_thresholds: ContextThresholds,
 ) -> list[FuturesSymbol]:
     symbols_list = list(symbols)
     btc_symbol = next((item for item in symbols_list if item.symbol.startswith("BTC")), None)
@@ -63,7 +68,7 @@ def set_contexts(
         elif symbol.capitalization == Capitalization.HIGH:
             if symbol.trades_24h > btc_trades and symbol.volume_usdt_24h > btc_volume:
                 context = Context.HIGH_CAP_A
-            elif symbol.volume_usdt_24h > ppo_cfg.CONTEXT_VOLUME_MIN:
+            elif symbol.volume_usdt_24h > context_thresholds.VOLUME_MIN:
                 context = Context.MIDDLE_CAP_B
             elif symbol.trades_24h > 0.5 * btc_trades:
                 context = Context.MIDDLE_CAP_C
@@ -72,7 +77,7 @@ def set_contexts(
         elif symbol.capitalization == Capitalization.MIDDLE:
             if symbol.trades_24h > btc_trades or symbol.volume_usdt_24h > btc_volume:
                 context = Context.MIDDLE_CAP_A
-            elif symbol.volume_usdt_24h > ppo_cfg.CONTEXT_VOLUME_MIN:
+            elif symbol.volume_usdt_24h > context_thresholds.VOLUME_MIN:
                 context = Context.MIDDLE_CAP_B
             elif symbol.trades_24h > 0.5 * btc_trades:
                 context = Context.MIDDLE_CAP_C
@@ -81,11 +86,11 @@ def set_contexts(
         else:
             if symbol.trades_24h > btc_trades or symbol.volume_usdt_24h > btc_volume:
                 context = Context.LOW_CAP_A
-            elif symbol.volume_usdt_24h > ppo_cfg.CONTEXT_VOLUME_MIN:
+            elif symbol.volume_usdt_24h > context_thresholds.VOLUME_MIN:
                 context = Context.LOW_CAP_B
             elif symbol.trades_24h > 0.5 * btc_trades:
                 context = Context.LOW_CAP_C
-            elif symbol.trades_24h > ppo_cfg.CONTEXT_TRADES_MIN:
+            elif symbol.trades_24h > context_thresholds.TRADES_MIN:
                 context = Context.LOW_CAP_D
             else:
                 context = Context.FROZEN

--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -9,6 +9,7 @@ from typing import Optional
 from urllib.parse import quote
 
 from crypto_screener.config import app_cfg
+from crypto_screener.config.symbol_config import symbol_cfg
 from crypto_screener.data.notifiers.telegram import SKIP_CALLBACK_PREFIX, TRADE_CALLBACK_PREFIX
 from crypto_screener.data.providers.coingecko import enrich_symbols_capitalization
 from crypto_screener.domain.capture_state import CaptureState
@@ -55,8 +56,8 @@ def _fetch_filtered_symbols(
         trades_24h_btc_ratio_min: float
 ) -> list[FuturesSymbol]:
     symbols = exchange.get_futures_symbols()
-    symbols = enrich_symbols_capitalization(symbols)
-    symbols = set_contexts(symbols, listing_period_days)
+    symbols = enrich_symbols_capitalization(symbols, symbol_cfg.capitalization)
+    symbols = set_contexts(symbols, listing_period_days, symbol_cfg.context)
     btc_trades_24h = next((symbol.trades_24h for symbol in symbols if symbol.symbol.startswith("BTC")), 0)
     filtered_symbols = _filter_symbols(
         symbols,

--- a/crypto_screener/execution/run_test_market.py
+++ b/crypto_screener/execution/run_test_market.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from datetime import timedelta
 
+from crypto_screener.config.symbol_config import symbol_cfg
 from crypto_screener.data.providers.coingecko import enrich_symbols_capitalization
 from crypto_screener.domain.exchange import Exchange
 from crypto_screener.domain.models.bar import Bar
@@ -100,8 +101,8 @@ def run_test_market(
         return
 
     symbols = exchange.get_futures_symbols()
-    symbols = enrich_symbols_capitalization(symbols)
-    symbols = set_contexts(symbols, listing_age_days_min)
+    symbols = enrich_symbols_capitalization(symbols, symbol_cfg.capitalization)
+    symbols = set_contexts(symbols, listing_age_days_min, symbol_cfg.context)
     log.d(f"Получено {len(symbols)} символов до фильтрации.")
 
     symbols = _filter_symbols(


### PR DESCRIPTION
## Summary
- move capitalization and context thresholds into a shared symbol configuration module
- update symbol processing to take threshold arguments instead of referencing strategy-specific config

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fa8320bbc8320bb2e1125e34cdbd0)