### PR TITLE
Fix cascade strategy method and runtime plot checks

### DIFF
--- a/crypto_screener/domain/strategies/ppo.py
+++ b/crypto_screener/domain/strategies/ppo.py
@@ -375,8 +375,8 @@ class PpoStrategy(Strategy):
 
         return [(min_low_index, main_low_swing), main_high]
 
-    @staticmethod
     def _get_cascade_long(
+            self,
             bars: list[Bar],
             price_min: float,
             price_max: float,

--- a/crypto_screener/utils/plotter.py
+++ b/crypto_screener/utils/plotter.py
@@ -2,7 +2,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, Optional, Protocol, Type
+from typing import Callable, Optional, Protocol, Type, runtime_checkable
 
 import matplotlib
 import numpy as np
@@ -42,6 +42,7 @@ PlotHandler = Callable[
 ]
 
 
+@runtime_checkable
 class PlotData(Protocol):
     symbol: str
     timeframe: Timeframe


### PR DESCRIPTION
## Summary
- convert cascade cascade detection helper to an instance method so configuration access works
- make PlotData protocol runtime checkable to allow isinstance checks when selecting plot strategies

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fe995971c8320ba20fe953d4a45b7)