### PR TITLE
Clamp history fetch to requested window

### DIFF
--- a/crypto_screener/execution/run_test_market.py
+++ b/crypto_screener/execution/run_test_market.py
@@ -52,7 +52,11 @@ def _accumulate_history(
     bars: list[Bar] = []
 
     while True:
-        batch = exchange.get_ohlcv(symbol=symbol, timeframe=timeframe, limit=batch_limit, end=end)
+        remaining_minutes = (end - history_start).total_seconds() // 60
+        remaining_bars = max(1, int(remaining_minutes // timeframe.minutes))
+        limit = min(batch_limit, remaining_bars)
+
+        batch = exchange.get_ohlcv(symbol=symbol, timeframe=timeframe, limit=limit, end=end)
         if not batch:
             break
 


### PR DESCRIPTION
## Summary
- limit OHLCV batch requests to the remaining history window to avoid fetching outdated candles

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941b68d25f083208c6e1521e0ba2d6f)