### PR TITLE
Add Cascade dataclass and cascade-direction handling to GU strategy

### DIFF
--- a/crypto_screener/domain/strategies/gu.py
+++ b/crypto_screener/domain/strategies/gu.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import numpy as np
 
 from crypto_screener.config.gu_config import PuConfig, pu_cfg
@@ -17,6 +19,20 @@ from crypto_screener.domain.strategies.strategy import (
     StrategyVolumeConfig,
 )
 from crypto_screener.domain.swing_detector import add_swings
+
+
+@dataclass(frozen=True)
+class Cascade:
+    swings: list[Swing]
+    direction: CascadeType
+
+    @property
+    def is_long(self) -> bool:
+        return self.direction is CascadeType.LONG
+
+    @property
+    def is_short(self) -> bool:
+        return self.direction is CascadeType.SHORT
 
 
 class GuStrategy(Strategy):
@@ -66,7 +82,7 @@ class GuStrategy(Strategy):
         if not cascade:
             return setup
 
-        setup.data.cascade_swings = cascade
+        setup.data.cascade_swings = cascade.swings
 
         # Центрирование относительно начала каскада.
         todo()
@@ -74,14 +90,15 @@ class GuStrategy(Strategy):
         # Анализ поддержки под каскадом.
         todo() # переписать этот блок правильно с учетом типа каскада (лонговый или шортовый - определить по свингам в нем).
         todo() # блок должен определить свинги, относящиеся к поддержке этого каскада на финальном участке
-        initial_swing = cascade_long[0]
+        initial_swing = cascade.swings[0]
         support_swing = None
+        target_swing = cascade.swings[-1]
+        open_low_swings: list[Swing] = []
         if cascade.is_long:
             todo()
             consolidation_range = initial_swing.extremum_price - cascade_low_swing.extremum_price
             open_low_swings = self._get_open_swings(cascade_bars, SwingType.LOW)
             setup.data.support_swings = open_low_swings
-            target_swing = cascade_long[-1]
 
             support_price_min = cascade_low_swing.extremum_price + consolidation_range * self._config.SUPPORT_CONSOLIDATION_RATIO_MIN
             support_price_max = target_swing.extremum_price
@@ -123,7 +140,7 @@ class GuStrategy(Strategy):
                 symbol=symbol,
                 timeframe=timeframe,
                 bars=bars,
-                cascade_swings=cascade,
+                cascade_swings=cascade.swings,
                 support_swings=open_low_swings
             )
         )
@@ -162,7 +179,7 @@ class GuStrategy(Strategy):
                 symbol=symbol,
                 timeframe=timeframe,
                 bars=bars,
-                cascade_swings=cascade,
+                cascade_swings=cascade.swings,
                 support_swings=open_low_swings,
             ),
             trade_levels=trade_levels,
@@ -270,14 +287,33 @@ class GuStrategy(Strategy):
     def _get_cascade_long(
             self,
             bars: list[Bar]
-    ) -> list[Swing]:
-        return self._get_cascade(bars, cascade_type=CascadeType.LONG)
+    ) -> Cascade | None:
+        swings = self._get_cascade(bars, cascade_type=CascadeType.LONG)
+        if not swings:
+            return None
+        return Cascade(swings=swings, direction=CascadeType.LONG)
 
     def _get_cascade_short(
             self,
             bars: list[Bar]
-    ) -> list[Swing]:
-        return self._get_cascade(bars, cascade_type=CascadeType.SHORT)
+    ) -> Cascade | None:
+        swings = self._get_cascade(bars, cascade_type=CascadeType.SHORT)
+        if not swings:
+            return None
+        return Cascade(swings=swings, direction=CascadeType.SHORT)
+
+    @staticmethod
+    def _longest(*cascades: Cascade | None) -> Cascade | None:
+        candidates = [cascade for cascade in cascades if cascade and cascade.swings]
+        if not candidates:
+            return None
+
+        def key(cascade: Cascade) -> tuple[float, object]:
+            duration = cascade.swings[-1].time - cascade.swings[0].time
+            last_time = cascade.swings[-1].time
+            return duration, last_time
+
+        return max(candidates, key=key)
 
     @staticmethod
     def _group_bars_by_day(bars: list[Bar]) -> list[tuple[int, int]]:


### PR DESCRIPTION
### Motivation
- Represent cascade as a single object carrying both `swings` and its `direction` so downstream logic can reliably inspect whether a cascade is long or short.
- Replace scattered boolean assumptions and `cascade.is_long/is_short` placeholders with a typed interface that encapsulates direction.
- Ensure target swing selection, storage in `Setup.data`, and later checks use the correct cascade swings and direction.

### Description
- Added a frozen dataclass `Cascade` with fields `swings: list[Swing]` and `direction: CascadeType`, and convenience properties `is_long` / `is_short`.
- Updated `_get_cascade_long` and `_get_cascade_short` to return `Cascade | None` (wraps the existing swings with a direction) instead of raw lists.
- Implemented `_longest` static helper to choose the longest (by duration, tiebreaker by last time) cascade among candidates.
- Updated `detect_setup` to use `cascade.swings` where cascade swings are stored in `Setup.data`, and to use `cascade.is_long` / `cascade.is_short` for directional checks; also initialized `target_swing` and `open_low_swings` appropriately.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69454affb2088320b8f2529f5072e61f)