### PR TITLE
Center GU analysis on cascade start and add directional support/resistance detection

### DIFF
--- a/crypto_screener/domain/strategies/gu.py
+++ b/crypto_screener/domain/strategies/gu.py
@@ -85,20 +85,44 @@ class GuStrategy(Strategy):
         setup.data.cascade_swings = cascade.swings
 
         # Центрирование относительно начала каскада.
-        todo()
+        first_touch_index = next(
+            (index for index, bar in enumerate(bars) if bar.time == cascade.swings[0].time),
+            None,
+        )
+        if first_touch_index is None:
+            return setup
+        start_index = max(0, first_touch_index - (len(bars) - first_touch_index - 1))
+        bars = bars[start_index:]
+        setup.data.bars = bars
+        first_touch_index -= start_index
+
+        cascade_bars = bars[first_touch_index:]
+        if not cascade_bars:
+            return setup
 
         # Анализ поддержки под каскадом.
-        todo() # переписать этот блок правильно с учетом типа каскада (лонговый или шортовый - определить по свингам в нем).
-        todo() # блок должен определить свинги, относящиеся к поддержке этого каскада на финальном участке
         initial_swing = cascade.swings[0]
         support_swing = None
         target_swing = cascade.swings[-1]
-        open_low_swings: list[Swing] = []
+        support_swings: list[Swing] = []
         if cascade.is_long:
-            todo()
-            consolidation_range = initial_swing.extremum_price - cascade_low_swing.extremum_price
             open_low_swings = self._get_open_swings(cascade_bars, SwingType.LOW)
-            setup.data.support_swings = open_low_swings
+            cascade_low_swing = min(open_low_swings, key=lambda swing: swing.extremum_price, default=None)
+            if not cascade_low_swing:
+                lowest_bar = min(cascade_bars, key=lambda bar: bar.low, default=None)
+                if not lowest_bar:
+                    return setup
+                cascade_low_swing = Swing(
+                    time=lowest_bar.time,
+                    extremum_price=lowest_bar.low,
+                    close_price=lowest_bar.close,
+                    type=SwingType.LOW,
+                    is_open=True,
+                )
+            consolidation_range = initial_swing.extremum_price - cascade_low_swing.extremum_price
+            if consolidation_range <= 0:
+                return setup
+            support_swings = open_low_swings
 
             support_price_min = cascade_low_swing.extremum_price + consolidation_range * self._config.SUPPORT_CONSOLIDATION_RATIO_MIN
             support_price_max = target_swing.extremum_price
@@ -116,7 +140,43 @@ class GuStrategy(Strategy):
                     is_open=True
                 )
         elif cascade.is_short:
-            todo()
+            open_high_swings = self._get_open_swings(cascade_bars, SwingType.HIGH)
+            cascade_high_swing = max(open_high_swings, key=lambda swing: swing.extremum_price, default=None)
+            if not cascade_high_swing:
+                highest_bar = max(cascade_bars, key=lambda bar: bar.high, default=None)
+                if not highest_bar:
+                    return setup
+                cascade_high_swing = Swing(
+                    time=highest_bar.time,
+                    extremum_price=highest_bar.high,
+                    close_price=highest_bar.close,
+                    type=SwingType.HIGH,
+                    is_open=True,
+                )
+            consolidation_range = cascade_high_swing.extremum_price - initial_swing.extremum_price
+            if consolidation_range <= 0:
+                return setup
+            support_swings = open_high_swings
+
+            resistance_price_min = target_swing.extremum_price
+            resistance_price_max = cascade_high_swing.extremum_price - consolidation_range * self._config.SUPPORT_CONSOLIDATION_RATIO_MIN
+            if resistance_price_min < resistance_price_max:
+                open_high_swings = self._filter_by_price(open_high_swings, resistance_price_min, resistance_price_max)
+            else:
+                open_high_swings = []
+            support_swing = open_high_swings[-1] if open_high_swings else None
+            if not support_swing:
+                last_green_bar = next((bar for bar in reversed(cascade_bars) if bar.close > bar.open), None)
+                if not last_green_bar:
+                    return setup
+                support_swing = Swing(
+                    time=last_green_bar.time,
+                    extremum_price=last_green_bar.high,
+                    close_price=last_green_bar.close,
+                    type=SwingType.HIGH,
+                    is_open=True
+                )
+        setup.data.support_swings = support_swings
         has_support = support_swing is not None
         if not has_support:
             return setup
@@ -124,7 +184,6 @@ class GuStrategy(Strategy):
         # Анализ пробоя поддержки каскада.
         current_bar = bars[-1]
         current_price = current_bar.close
-        todo() # надо нормально реализовать is_long и is_short
         if cascade.is_long:
             has_breakout_short = current_price < support_swing.extremum_price
             if has_breakout_short:
@@ -141,7 +200,7 @@ class GuStrategy(Strategy):
                 timeframe=timeframe,
                 bars=bars,
                 cascade_swings=cascade.swings,
-                support_swings=open_low_swings
+                support_swings=support_swings
             )
         )
 
@@ -180,7 +239,7 @@ class GuStrategy(Strategy):
                 timeframe=timeframe,
                 bars=bars,
                 cascade_swings=cascade.swings,
-                support_swings=open_low_swings,
+                support_swings=support_swings,
             ),
             trade_levels=trade_levels,
         )


### PR DESCRIPTION
### Motivation
- Align GU cascade handling with existing PPO logic: center the analysis window relative to the first cascade touch so the final segment is analyzed symmetrically.
- Properly detect support for long cascades and mirror detection of resistance/support for short cascades on the final segment.
- Provide robust fallbacks when open swings are missing (use lowest/highest bar as synthetic swing).
- Persist direction-aware support swings in `Gu` setup data for downstream processing.

### Description
- Center the bars window around the first cascade touch using `first_touch_index` and slice `bars` accordingly (`bars = bars[start_index:]`).
- For longs:
  - Collect `open_low_swings = _get_open_swings(cascade_bars, SwingType.LOW)` and pick `cascade_low_swing` as the minimum extremum (fallback to lowest bar if none).
  - Compute `consolidation_range` and filter `open_low_swings` by price range via `_filter_by_price` to select `support_swing`.
  - Fallback to last red bar low as `support_swing` if no suitable swing is found.
- For shorts (mirrored):
  - Use `open_high_swings = _get_open_swings(cascade_bars, SwingType.HIGH)` and select `cascade_high_swing` (fallback to highest bar if none).
  - Compute mirrored `consolidation_range`, determine resistance price window and select `support_swing` for short (fallback to last green bar high if needed).
- Store the list of direction-aware swings in `setup.data.support_swings` (previously used `open_low_swings` unconditionally).
- Keep existing breakout and trade-logic checks; removed several `todo()` placeholders in the support-detection block.

### Testing
- No automated tests were executed for this change.
- Static code paths were exercised by running the repository commands during development, but no unit/integration tests were run.
- Further automated test coverage is recommended (not included here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69454c4fcbf88320ae420ada6fdd56a9)