### PR TITLE
GU: implement TP/SL, reward-risk checks and support short TradeLevels

### DIFF
--- a/crypto_screener/config/gu_config.py
+++ b/crypto_screener/config/gu_config.py
@@ -79,6 +79,10 @@ class PuConfig:
     PROFIT_PCT_MIN: float = 3
     # Минимальное расстояние Entry-SL.
     LOSS_PCT_MIN: float = 0.3
+    # Множитель ширины каскада для TP в top-контексте или при повышенном объеме.
+    TP_MULTIPLIER_TOP_HIGH_VOLUME: float = 2.0
+    # Множитель ширины каскада для TP в остальных случаях.
+    TP_MULTIPLIER_DEFAULT: float = 2 / 3
     # Минимальное расстояние от Entry и TP до PC при частичном закрытии позиции.
     PARTIAL_CLOSE_SIDE_PCT_MIN: float = 2.0
     # Соотношение цены участков Entry-BE и Entry-PC при частичном закрытии позиции.

--- a/crypto_screener/domain/models/trade_levels.py
+++ b/crypto_screener/domain/models/trade_levels.py
@@ -33,9 +33,18 @@ class TradeLevels:
         if breakeven_price is not None and breakeven_price <= 0:
             raise ValueError(f"Цена BE должна быть положительной ({breakeven_price}).")
 
+        is_long = stop_loss_price < entry_price < take_profit_price
+        is_short = stop_loss_price > entry_price > take_profit_price
+
         if partial_close_price is not None and breakeven_price is not None:
-            if not stop_loss_price < entry_price < breakeven_price < partial_close_price < take_profit_price:
-                raise ValueError("Неправильное соотношение цен SL -> BE -> PC -> TP.")
+            if is_long:
+                if not stop_loss_price < entry_price < breakeven_price < partial_close_price < take_profit_price:
+                    raise ValueError("Неправильное соотношение цен SL -> BE -> PC -> TP.")
+            elif is_short:
+                if not stop_loss_price > entry_price > breakeven_price > partial_close_price > take_profit_price:
+                    raise ValueError("Неправильное соотношение цен SL -> BE -> PC -> TP.")
+            else:
+                raise ValueError("Неправильное соотношение цен SL -> TP.")
         else:
-            if not stop_loss_price < entry_price < take_profit_price:
+            if not (is_long or is_short):
                 raise ValueError("Неправильное соотношение цен SL -> TP.")

--- a/crypto_screener/domain/strategies/gu.py
+++ b/crypto_screener/domain/strategies/gu.py
@@ -205,10 +205,40 @@ class GuStrategy(Strategy):
         )
 
         # Анализ риска и вознаграждения.
-        todo() # сделать блок. потенциалы:
-        # TP для top-контекстов и has_high_volume - 2 * ширина каскада (считается как top-bottom на участке от первого свинга каскада до текущей свечи)
-        # TP для остальных случаем - 2/3 * ширина каскада
-        # SL всегда support_swing.extremum_price
+        highs = [bar.high for bar in cascade_bars]
+        lows = [bar.low for bar in cascade_bars]
+        cascade_range = max(highs) - min(lows) if highs and lows else 0.0
+        if cascade_range <= 0:
+            return setup
+        entry_price = target_swing.extremum_price
+        is_tp_top = context.is_top or has_high_volume
+        tp_multiplier = (
+            self._config.TP_MULTIPLIER_TOP_HIGH_VOLUME
+            if is_tp_top
+            else self._config.TP_MULTIPLIER_DEFAULT
+        )
+        if cascade.is_long:
+            profit_price = entry_price + tp_multiplier * cascade_range
+            loss_price = support_swing.extremum_price
+            profit_pct = 100 * (profit_price - entry_price) / entry_price
+            loss_pct = 100 * (loss_price - entry_price) / entry_price
+        else:
+            profit_price = entry_price - tp_multiplier * cascade_range
+            loss_price = support_swing.extremum_price
+            profit_pct = 100 * (entry_price - profit_price) / entry_price
+            loss_pct = 100 * (loss_price - entry_price) / entry_price
+        if loss_pct == 0:
+            return setup
+        is_loss_valid = abs(loss_pct) > self._config.LOSS_PCT_MIN
+        if not is_loss_valid:
+            return setup
+        is_profit_valid = profit_pct > self._config.PROFIT_PCT_MIN
+        if not is_profit_valid:
+            return setup
+        reward_risk = abs(profit_pct / loss_pct)
+        is_reward_risk_valid = reward_risk >= self._config.REWARD_RISK_RATIO_MIN
+        if not is_reward_risk_valid and not context.is_test:
+            return setup
 
         # Анализ пробоя каскада.
         if cascade.is_long:


### PR DESCRIPTION
### Motivation
- Implement TP/SL calculation and risk filtering for GU setups according to strategy comments (different TP rules for top/high-volume vs others, SL at support swing).
- Enforce minimum `PROFIT_PCT`, `LOSS_PCT` and `REWARD_RISK_RATIO_MIN` thresholds before entering a trade.
- Allow `TradeLevels` validation to accept both long and short price ordering.

### Description
- Implemented TP/SL computation in `GuStrategy.detect_setup`:
  - Compute `cascade_range` from `cascade_bars` and derive `profit_price` and `loss_price` using multipliers.
  - Select TP multiplier based on `context.is_top` or `has_high_volume` using new config values `TP_MULTIPLIER_TOP_HIGH_VOLUME` and `TP_MULTIPLIER_DEFAULT`.
  - Compute `profit_pct`, `loss_pct`, and `reward_risk` and validate against `PROFIT_PCT_MIN`, `LOSS_PCT_MIN`, and `REWARD_RISK_RATIO_MIN` (skip reward-risk check in test context).
  - Use resulting `profit_price` and `loss_price` when building `TradeLevels` for `Trade`.
- Added new config parameters to `crypto_screener/config/gu_config.py`: `TP_MULTIPLIER_TOP_HIGH_VOLUME` and `TP_MULTIPLIER_DEFAULT`.
- Extended `TradeLevels.__post_init__` validation in `crypto_screener/domain/models/trade_levels.py` to allow correct price ordering for short trades (mirror of long checks) and to properly validate PC/BE ordering for both long and short.
- Minor guards: check for non-positive `cascade_range` and avoid division by zero on loss percentage.

### Testing
- No automated tests were executed for this change.
- Static checks / linters were not run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457bcc84748320bf4fa4c3291210b8)