### PR TITLE
Register GuStrategy and introduce GuConfig/gu_cfg

### DIFF
--- a/crypto_screener/config/gu_config.py
+++ b/crypto_screener/config/gu_config.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
-class PuConfig:
+class GuConfig:
     # region Контекст.
     CONTEXT_TRADES_MIN: int = 500_000
     CONTEXT_VOLUME_MIN: float = 500_000_000
@@ -104,4 +104,5 @@ class PuConfig:
     # endregion
 
 
-pu_cfg = PuConfig()
+gu_cfg = GuConfig()
+pu_cfg = gu_cfg

--- a/crypto_screener/config/strategy_registry.py
+++ b/crypto_screener/config/strategy_registry.py
@@ -1,9 +1,11 @@
+from crypto_screener.config.gu_config import gu_cfg
 from crypto_screener.config.ppo_config import ppo_cfg
+from crypto_screener.domain.strategies.gu import GuStrategy
 from crypto_screener.domain.strategies.ppo import PpoStrategy
 from crypto_screener.domain.strategies.strategy import Strategy
 
 # Стратегии, активированные через конфигурацию приложения.
-DEFAULT_STRATEGIES: list[Strategy] = [PpoStrategy()]
+DEFAULT_STRATEGIES: list[Strategy] = [PpoStrategy(), GuStrategy()]
 
 # Конфигурации стратегий.
-DEFAULT_STRATEGY_CONFIGS: dict[str, object] = {"ppo": ppo_cfg}
+DEFAULT_STRATEGY_CONFIGS: dict[str, object] = {"ppo": ppo_cfg, "gu": gu_cfg}

--- a/crypto_screener/domain/strategies/__init__.py
+++ b/crypto_screener/domain/strategies/__init__.py
@@ -1,5 +1,7 @@
+from crypto_screener.domain.strategies.gu import GuStrategy
 from crypto_screener.domain.strategies.ppo import PpoStrategy
 
 __all__ = [
+    "GuStrategy",
     "PpoStrategy",
 ]

--- a/crypto_screener/domain/strategies/gu.py
+++ b/crypto_screener/domain/strategies/gu.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from crypto_screener.config.gu_config import PuConfig, pu_cfg
+from crypto_screener.config.gu_config import GuConfig, gu_cfg
 from crypto_screener.domain.models.bar import Bar
 from crypto_screener.domain.models.cascade_type import CascadeType
 from crypto_screener.domain.models.context import Context
@@ -38,7 +38,7 @@ class Cascade:
 class GuStrategy(Strategy):
     name = "ГУ"
 
-    def __init__(self, config: PuConfig = pu_cfg) -> None:
+    def __init__(self, config: GuConfig = gu_cfg) -> None:
         self._config = config
 
     def detect_setup(


### PR DESCRIPTION
### Motivation
- Make the `GuStrategy` available as a default runtime strategy.
- Provide a clear, named config type for the GU strategy (`GuConfig`) and a `gu_cfg` default instance.
- Preserve backward compatibility by keeping `pu_cfg` as an alias to the new `gu_cfg` instance.

### Description
- Registered `GuStrategy()` in `DEFAULT_STRATEGIES` and added the GU config to `DEFAULT_STRATEGY_CONFIGS` in `crypto_screener/config/strategy_registry.py` (now imports `gu_cfg` and `GuStrategy`).
- Renamed the GU config class from `PuConfig` to `GuConfig` in `crypto_screener/config/gu_config.py` and created `gu_cfg = GuConfig()` with `pu_cfg = gu_cfg` to maintain compatibility.
- Updated `crypto_screener/domain/strategies/gu.py` to use the new `GuConfig` type and `gu_cfg` as the default config for `GuStrategy`.
- Exported `GuStrategy` from the strategies package by adding it to `crypto_screener/domain/strategies/__init__.py` (`__all__`).

### Testing
- No automated tests were executed for these changes.
- No automated test failures (no tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457d16490c8320adf9c033de5043dd)