### PR TITLE
Align rolling-window extremes with daily extremes in GuStrategy

### DIFF
--- a/crypto_screener/domain/strategies/gu.py
+++ b/crypto_screener/domain/strategies/gu.py
@@ -454,25 +454,20 @@ class GuStrategy(Strategy):
             cascade_type: CascadeType,
     ) -> list[dict[str, float]]:
         window_extremes: list[dict[str, float]] = []
-        for start_index, end_index, window_start, window_end in time_groups:
-            candidate_indices = [
-                index
-                for index in range(start_index, end_index + 1)
-                if window_start <= bars[index].time <= window_end
-            ]
-            if start_index not in candidate_indices:
-                candidate_indices.insert(0, start_index)
-            if not candidate_indices:
+        for start_index, end_index, _window_start, _window_end in time_groups:
+            # Экстремумы окна: лонг — максимум окна, шорт — минимум окна (аналогично дневным экстремумам).
+            window_indices = list(range(start_index, end_index + 1))
+            if not window_indices:
                 continue
             if cascade_type is CascadeType.LONG:
-                window_price = max(bars[index].high for index in candidate_indices)
-                for index in candidate_indices:
+                window_price = max(bars[index].high for index in window_indices)
+                for index in window_indices:
                     if bars[index].high == window_price:
                         window_extremes.append({"index": float(index), "price": float(window_price)})
                         break
             else:
-                window_price = min(bars[index].low for index in candidate_indices)
-                for index in candidate_indices:
+                window_price = min(bars[index].low for index in window_indices)
+                for index in window_indices:
                     if bars[index].low == window_price:
                         window_extremes.append({"index": float(index), "price": float(window_price)})
                         break


### PR DESCRIPTION
### Motivation
- Implement the intended rule for window-level extremes: for longs the window maximum, for shorts the window minimum (same semantics as daily extremes).
- Ensure rolling-window grouping produces the same type of extremum points as calendar daily grouping so downstream logic for `touch_indices`, pullbacks and squeeze remains compatible.
- Clarify the code with an inline comment and remove unnecessary time filtering logic.

### Description
- Updated `_get_window_extremes` in `GuStrategy` to consider the full window range when computing extremes instead of filtering candidates by the `window_start`/`window_end` timestamps.
- For long cascades the function now selects the window `max(bar.high)`; for short cascades it selects the window `min(bar.low)` (matching the daily extremes behavior).
- Removed insertion of `start_index` into candidate list and replaced `candidate_indices` with `window_indices = list(range(start_index, end_index + 1))`.
- Added an inline Russian comment documenting the window-extremes rule and renamed unused tuple variables to `_window_start`/`_window_end`.

### Testing
- No automated tests were executed (per instructions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945869eaf4083209bb78dd937c73ee0)