### PR TITLE
Use list return type for get_futures_symbols in Binance and Bybit

### DIFF
--- a/crypto_screener/data/exchanges/binance.py
+++ b/crypto_screener/data/exchanges/binance.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Iterable, Optional
+from typing import Optional
 
 import ccxt
 
@@ -38,7 +38,7 @@ class Binance(Exchange):
     def get_name() -> str:
         return "Binance"
 
-    def get_futures_symbols(self) -> Iterable[FuturesSymbol]:
+    def get_futures_symbols(self) -> list[FuturesSymbol]:
         try:
             markets = self._client.load_markets()
             tickers = self._client.fetch_tickers()

--- a/crypto_screener/data/exchanges/bybit.py
+++ b/crypto_screener/data/exchanges/bybit.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Iterable, Optional
+from typing import Optional
 
 import ccxt  # type: ignore
 
@@ -38,7 +38,7 @@ class Bybit(Exchange):
     def get_name() -> str:
         return "Bybit"
 
-    def get_futures_symbols(self) -> Iterable[FuturesSymbol]:
+    def get_futures_symbols(self) -> list[FuturesSymbol]:
         try:
             markets = self._client.load_markets()
             tickers = self._client.fetch_tickers()


### PR DESCRIPTION
### Motivation
- Align concrete implementations with the base interface in `crypto_screener/domain/exchange.py` which expects `get_futures_symbols` to return `list[FuturesSymbol]`.
- Remove the now-unused `Iterable` import after switching to `list[...]`.

### Description
- Updated function annotations in `crypto_screener/data/exchanges/binance.py` and `crypto_screener/data/exchanges/bybit.py` from `Iterable[FuturesSymbol]` to `list[FuturesSymbol]` (`def get_futures_symbols(self) -> list[FuturesSymbol]:`).
- Removed `Iterable` from the imports in both files.
- No logic changes to return values — both methods already return `symbols` or `[]`, so runtime behavior is unchanged.

### Testing
- No automated tests were run for this change.
- Static typing/checking (if any) should now be consistent with the base class signature.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694592d53f048320811bcc8cd2c3af1f)