### PR TITLE
Allow plot handlers and plot functions to return Optional[Path]

### DIFF
--- a/crypto_screener/utils/plotter.py
+++ b/crypto_screener/utils/plotter.py
@@ -38,7 +38,7 @@ PlotHandler = Callable[
         bool,
         PlotTheme,
     ],
-    Path,
+    Optional[Path],
 ]
 
 
@@ -65,7 +65,7 @@ def _plot(
         context: Optional[Context],
         subdir: Optional[str],
         draw_entry_zones: bool,
-):
+) -> Optional[Path]:
     match setup:
         case Trade(data=data, trade_levels=trade_levels):
             setup_name = setup.name
@@ -730,7 +730,7 @@ def plot(
         detection_time: Optional[datetime] = None,
         context: Optional[Context] = None,
         subdir: Optional[str] = None,
-):
+) -> Optional[Path]:
     return _plot(
         setup=setup,
         postmortem_bars=None,
@@ -747,7 +747,7 @@ def plot_postmortem(
         detection_time: Optional[datetime] = None,
         context: Optional[Context] = None,
         subdir: Optional[str] = None,
-):
+) -> Optional[Path]:
     return _plot(
         setup=setup,
         postmortem_bars=postmortem_bars,


### PR DESCRIPTION
### Motivation
- Make the plotter API express that plotting can fail to produce a file by allowing `None` as a valid return.
- Align `PlotHandler` and public/internal plot functions with optional output semantics.
- Preserve existing runtime behavior; only type annotations are adjusted.

### Description
- Changed `PlotHandler` return type from `Path` to `Optional[Path]`.
- Annotated `_plot` with `-> Optional[Path]` and updated `plot` and `plot_postmortem` signatures to return `Optional[Path]`.
- No functional logic changes; `Optional` was already available from `typing` in the module.

### Testing
- No automated tests were executed for this change.
- No test failures reported (no tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69459361c0a08320a29cce6f5f102d65)