### PR TITLE
Use datetime typing for rolling time window groups in GuStrategy

### DIFF
--- a/crypto_screener/domain/strategies/gu.py
+++ b/crypto_screener/domain/strategies/gu.py
@@ -436,7 +436,7 @@ class GuStrategy(Strategy):
     ) -> list[tuple[int, int, datetime, datetime]]:
         if not bars:
             return []
-        groups: list[tuple[int, int, object, object]] = []
+        groups: list[tuple[int, int, datetime, datetime]] = []
         start_index = 0
         while start_index < len(bars):
             start_time = bars[start_index].time


### PR DESCRIPTION
### Motivation
- Clarify and align local typing with actual runtime values: window start/end are `datetime` objects, not generic `object`.
- Improve static typing and aid type checkers/readers when working with rolling window grouping logic.

### Description
- Changed the local variable annotation in `_group_bars_by_time_window` from `list[tuple[int, int, object, object]]` to `list[tuple[int, int, datetime, datetime]]`.
- No runtime behavior altered — the function still computes and returns `(start_index, end_index, window_start, window_end)` tuples where `window_start`/`window_end` are `datetime` values.
- Ensured consistency with the `_get_window_extremes` signature which expects `time_groups: list[tuple[int, int, datetime, datetime]]`.

### Testing
- No automated tests were run for this change.
- Change is annotation-only and does not modify logic or outputs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945969d7f1483208d86f52f3a3f2a08)