### PR TITLE
Use filled quantity for partially-filled entry orders

### DIFF
--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -530,7 +530,10 @@ def _update_entry_status(
         )
         active_trade.entry_order_status = entry_info.status
         active_trade.entry_average_price = entry_info.average_price or active_trade.entry_average_price
-        active_trade.quantity = entry_info.quantity or active_trade.quantity
+        if entry_info.status == OrderStatus.PARTIALLY_FILLED:
+            active_trade.quantity = entry_info.filled or entry_info.quantity or active_trade.quantity
+        else:
+            active_trade.quantity = entry_info.quantity or active_trade.quantity
         active_trade.status = entry_info.status
 
     if active_trade.entry_order_status not in (OrderStatus.FILLED, OrderStatus.PARTIALLY_FILLED):


### PR DESCRIPTION
### Motivation
- Обеспечить, чтобы расчёты `remaining_quantity` и перестановка стоп-ордеров опирались на фактически исполненный объём, если входной ордер частично заполнен.
- Исправить присвоение размера сделки, которое ранее использовало поле `quantity` ордера вместо реально `filled` объёма для частичных заполнений.

### Description
- Внутри ` _update_entry_status` при `entry_info.status == OrderStatus.PARTIALLY_FILLED` теперь устанавливается `active_trade.quantity = entry_info.filled or entry_info.quantity or active_trade.quantity`.
- Для остальных статусов поведение сохранено и используется прежняя логика с запасным вариантом на `entry_info.quantity` и существующее `active_trade.quantity`.
- Изменение гарантирует, что дальнейшие вызовы, в том числе `_get_remaining_quantity` и `realign_stop_orders`, будут оперировать актуальным исполненным объёмом.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69465423b6248320a13eb34f232e40a7)