### PR TITLE
Include primary cascade swing for GU cascade plotting

### DIFF
--- a/crypto_screener/domain/strategies/gu.py
+++ b/crypto_screener/domain/strategies/gu.py
@@ -672,20 +672,23 @@ class GuStrategy(Strategy):
                 duration = bars[last_index].time - bars[first_index].time
                 last_time = bars[last_index].time
                 if best_duration is None or duration > best_duration:
-                    best_candidate = (touch_indices, level_price)
+                    best_candidate = (touch_indices, level_price, first_swing)
                     best_duration = duration
                     best_last_time = last_time
                 elif duration == best_duration and best_last_time is not None and last_time > best_last_time:
-                    best_candidate = (touch_indices, level_price)
+                    best_candidate = (touch_indices, level_price, first_swing)
                     best_duration = duration
                     best_last_time = last_time
 
             if not best_candidate:
                 continue
 
-            touch_indices, level_price = best_candidate
-            cascade_swings = []
+            touch_indices, level_price, first_swing = best_candidate
+            cascade_swings = [first_swing]
+            first_index = touch_indices[0]
             for touch_index in touch_indices:
+                if touch_index == first_index:
+                    continue
                 bar = bars[touch_index]
                 cascade_swings.append(Swing(
                     time=bar.time,

--- a/crypto_screener/utils/plotter.py
+++ b/crypto_screener/utils/plotter.py
@@ -548,8 +548,10 @@ def _draw_cascade_level(
     if not cascade_swings or not bars:
         return
 
-    level_price = np.mean([swing.extremum_price for swing in cascade_swings])
-    start_time = cascade_swings[0].time
+    start_swing = cascade_swings[0]
+    level_swings = cascade_swings[1:] if len(cascade_swings) > 1 else cascade_swings
+    level_price = np.mean([swing.extremum_price for swing in level_swings])
+    start_time = start_swing.time
     start_index = next((index for index, bar in enumerate(bars) if bar.time == start_time), None)
     if start_index is None:
         return


### PR DESCRIPTION
### Motivation
- Ensure the primary (initial) extremum that starts a GU cascade is preserved in the cascade data so plotting and downstream logic can reference the true starting swing. 
- Prevent the cascade level price from being skewed by that initial extremum while still anchoring the drawn horizontal line at the cascade start. 
- Avoid duplicating the first touch when building cascade swings. 

### Description
- In `crypto_screener/domain/strategies/gu.py` the best candidate now returns the `first_swing` and the cascade builder prepends that `first_swing` to the returned `cascade_swings` while skipping the duplicate first touch. 
- In `crypto_screener/utils/plotter.py` `_draw_cascade_level` now treats the first swing as the start anchor but computes `level_price` as the mean of the remaining level swings (or the only swing if there is one) to avoid skewing the horizontal level. 
- The cascade drawing still finds the `start_index` by the start swing time and still limits the horizontal line end by checking bars after that index against the computed `level_price`, preserving the existing endpoint limiting logic. 

### Testing
- No automated tests were run for this change. 
- Code changes were compiled/committed locally without running a test suite. 
- No new unit tests were added per repository instructions. 
- Manual inspection verifies that `cascade_swings` now includes the initial swing and that plotting uses the initial swing as the start anchor while computing the level from subsequent touches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946e6ced8748320abb7831c4fa86301)