### PR TITLE
Recalculate cascade level price from touches

### DIFF
--- a/crypto_screener/domain/strategies/gu.py
+++ b/crypto_screener/domain/strategies/gu.py
@@ -645,6 +645,16 @@ class GuStrategy(Strategy):
                 if len(touch_indices) < min_touches:
                     continue
 
+                if is_long:
+                    touch_prices = [bars[index].high for index in touch_indices]
+                else:
+                    touch_prices = [bars[index].low for index in touch_indices]
+                if not touch_prices:
+                    continue
+                level_price = float(np.median(touch_prices))
+                if any(abs(price - level_price) > touch_tolerance for price in touch_prices):
+                    continue
+
                 first_index = touch_indices[0]
                 first_swing = bars[first_index].swing
                 if (


### PR DESCRIPTION
### Motivation
- Improve accuracy of cascade horizontal `level_price` by recalculating it from actual touch prices rather than the initial window extreme.  
- Use the central tendency of touch prices to reduce sensitivity to single-bar extremes.  
- Ensure that the set of touch prices is consistent with `touch_tolerance` before accepting a cascade candidate.  

### Description
- In `_get_cascade` collect touch prices from `bars` for each candidate using `high` for longs and `low` for shorts and compute `level_price = float(np.median(touch_prices))`.  
- Validate that every touch price lies within `touch_tolerance` of the recomputed `level_price` and skip the candidate otherwise.  
- Keep the remainder of the candidate validation (first swing checks, pullback rules, squeezing rules) unchanged and continue to build `cascade_swings` using the validated `level_price`.  

### Testing
- No automated tests were executed for this change.  
- The change was limited to `_get_cascade` logic and committed after local edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946e9304be48320abce334c4809fdb7)