### PR TITLE
Include strategy name in plot filenames

### DIFF
--- a/crypto_screener/utils/plotter.py
+++ b/crypto_screener/utils/plotter.py
@@ -258,6 +258,7 @@ def _plot_ppo(
     length = len(combined_bars)
     output_path = _resolve_output_path(
         name=data.symbol,
+        strategy_name=type(data).__name__,
         setup_name=setup_name,
         context=context,
         timeframe=data.timeframe,
@@ -387,6 +388,7 @@ def _plot_gu(
     length = len(combined_bars)
     output_path = _resolve_output_path(
         name=data.symbol,
+        strategy_name=type(data).__name__,
         setup_name=setup_name,
         context=context,
         timeframe=data.timeframe,
@@ -829,6 +831,7 @@ def _draw_entry_zones(
 
 def _resolve_output_path(
         name: str,
+        strategy_name: Optional[str],
         setup_name: Optional[str],
         context: Optional[Context],
         timeframe: Timeframe,
@@ -844,6 +847,8 @@ def _resolve_output_path(
     output_dir.mkdir(parents=True, exist_ok=True)
     resolved_name = (name or theme.default_symbol).split(":", 1)[0]
     name_parts = [resolved_name]
+    if strategy_name:
+        name_parts.append(strategy_name)
     if setup_name:
         name_parts.append(setup_name)
     if context:


### PR DESCRIPTION
### Motivation
- Ensure plot output filenames include the plotting strategy name so files from different strategies (e.g. `Ppo`, `Gu`) are easily distinguishable.
- Reduce ambiguity when multiple plotters generate images for the same symbol/timeframe and timestamp.
- Improve file organization and searchability of generated plot images.

### Description
- Pass `strategy_name=type(data).__name__` from `_plot_ppo` and `_plot_gu` when calling `_resolve_output_path`.
- Extend `_resolve_output_path` signature to accept `strategy_name: Optional[str]` and prepend it to the filename parts when present.
- Change applied in `crypto_screener/utils/plotter.py` and integrated into existing Ppo/Gu plot handlers.

### Testing
- No automated tests were run (per instruction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946eba2671483209e15c9d182e70232)