### PR TITLE
Add ATR-based minimum pullback depth for GU cascades

### DIFF
--- a/crypto_screener/config/gu_config.py
+++ b/crypto_screener/config/gu_config.py
@@ -39,6 +39,8 @@ class GuConfig:
     CASCADE_PULLBACK_NEXT_RATIO_MIN: float = 0.1
     # Максимальная доля отката после третьего и далее относительно второго.
     CASCADE_PULLBACK_NEXT_RATIO_MAX: float = 0.9
+    # Минимальная глубина первых откатов в долях ATR.
+    CASCADE_MIN_PULLBACK_NATR: float = 2.5
     # Минимальное соотношение отступа поддержки от низа проторговки к размеру проторговки.
     SUPPORT_CONSOLIDATION_RATIO_MIN: float = 0.3
     # Минимальная длительность окна группировки каскадов.

--- a/crypto_screener/domain/strategies/gu.py
+++ b/crypto_screener/domain/strategies/gu.py
@@ -560,12 +560,16 @@ class GuStrategy(Strategy):
     def _passes_pullback_rules(
             self,
             pullbacks: list[tuple[float, float]],
+            avg_range: float,
     ) -> bool:
         if len(pullbacks) < 2:
             return False
         first_depth = pullbacks[0][0]
         second_depth = pullbacks[1][0]
         if first_depth <= 0 or second_depth <= 0:
+            return False
+        min_pullback = self._config.CASCADE_MIN_PULLBACK_NATR * avg_range
+        if first_depth < min_pullback or second_depth < min_pullback:
             return False
         ratio = second_depth / first_depth
         if not (
@@ -673,7 +677,7 @@ class GuStrategy(Strategy):
                 )
                 if not pullbacks:
                     continue
-                if not self._passes_pullback_rules(pullbacks):
+                if not self._passes_pullback_rules(pullbacks, avg_range):
                     continue
                 if not self._is_price_squeezed(pullbacks, cascade_type=cascade_type):
                     continue


### PR DESCRIPTION
### Motivation
- Reduce false-positive cascade detections by requiring the first two pullbacks to have meaningful depth relative to ATR. 
- Make pullback depth threshold configurable via the strategy configuration for easier tuning. 

### Description
- Added `CASCADE_MIN_PULLBACK_NATR: float = 2.5` to `GuConfig` to express the minimum pullback depth in ATR multiples. 
- Updated `_passes_pullback_rules` signature to `def _passes_pullback_rules(self, pullbacks: list[tuple[float, float]], avg_range: float) -> bool` and added a check that the first and second pullback depths are at least `self._config.CASCADE_MIN_PULLBACK_NATR * avg_range`. 
- Passed `avg_range` (computed in `_get_cascade`) into `_passes_pullback_rules` where pullbacks are validated so the new ATR-based check can be applied. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946ed9a97808320b9e091a8872e5cdb)