### PR TITLE
Add swing extremes to cascade detection

### DIFF
--- a/crypto_screener/domain/strategies/gu.py
+++ b/crypto_screener/domain/strategies/gu.py
@@ -503,6 +503,36 @@ class GuStrategy(Strategy):
                         break
         return daily_extremes
 
+    @staticmethod
+    def _get_swing_extremes(
+            bars: list[Bar],
+            *,
+            cascade_type: CascadeType,
+    ) -> list[CascadeExtreme]:
+        swing_type = SwingType.HIGH if cascade_type is CascadeType.LONG else SwingType.LOW
+        swing_extremes: list[CascadeExtreme] = []
+        for index, bar in enumerate(bars):
+            swing = bar.swing
+            if swing is None:
+                continue
+            if not swing.is_open:
+                continue
+            if swing.type != swing_type:
+                continue
+            swing_extremes.append(CascadeExtreme(index=index, price=float(swing.extremum_price)))
+        return swing_extremes
+
+    @staticmethod
+    def _merge_extremes(
+            bars: list[Bar],
+            *extremes: list[CascadeExtreme],
+    ) -> list[CascadeExtreme]:
+        unique: dict[tuple[int, float], CascadeExtreme] = {}
+        for extremes_list in extremes:
+            for extreme in extremes_list:
+                unique[(extreme.index, extreme.price)] = extreme
+        return sorted(unique.values(), key=lambda item: bars[item.index].time)
+
     def _get_cascade_extremes(
             self,
             bars: list[Bar],
@@ -510,15 +540,18 @@ class GuStrategy(Strategy):
             cascade_type: CascadeType,
             grouping_mode: CascadeGroupingMode,
     ) -> list[CascadeExtreme]:
+        swing_extremes = self._get_swing_extremes(bars, cascade_type=cascade_type)
         if grouping_mode is CascadeGroupingMode.ROLLING_WINDOW:
             time_groups = self._group_bars_by_time_window(
                 bars,
                 min_hours=self._config.CASCADE_ROLLING_WINDOW_MIN_HOURS,
                 max_hours=self._config.CASCADE_ROLLING_WINDOW_MAX_HOURS,
             )
-            return self._get_window_extremes(bars, time_groups, cascade_type=cascade_type)
+            window_extremes = self._get_window_extremes(bars, time_groups, cascade_type=cascade_type)
+            return self._merge_extremes(bars, window_extremes, swing_extremes)
         day_groups = self._group_bars_by_day(bars)
-        return self._get_daily_extremes(bars, day_groups, cascade_type=cascade_type)
+        daily_extremes = self._get_daily_extremes(bars, day_groups, cascade_type=cascade_type)
+        return self._merge_extremes(bars, daily_extremes, swing_extremes)
 
     @staticmethod
     def _calculate_pullbacks(


### PR DESCRIPTION
### Motivation
- Improve cascade detection by including intra-day swing extremes derived from `add_swings` so levels reflect human-like horizontals.
- Ensure cascade search can find levels not only on daily peaks but also on relevant intra-day swing points.
- Deduplicate and time-order extremes to avoid processing duplicates and preserve chronological cascade logic.

### Description
- Added ` _get_swing_extremes` to collect open swing points (`SwingType.HIGH/LOW`) as `CascadeExtreme` candidates.
- Added ` _merge_extremes` to deduplicate extremes and sort them by the corresponding bar `time`.
- Updated `_get_cascade_extremes` to merge swing extremes with rolling-window (`_get_window_extremes`) and daily (`_get_daily_extremes`) extremes before returning.
- No changes were made to the cascade validation logic; the existing `_get_cascade` reuses the expanded extremes list.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946ee4a4b288320837e252ecd9ba5e4)