### PR TITLE
Add cascade overtouch tolerance and validation

### DIFF
--- a/crypto_screener/config/gu_config.py
+++ b/crypto_screener/config/gu_config.py
@@ -29,6 +29,8 @@ class GuConfig:
     CASCADE_ATR_WINDOW: int = 50
     # Допуск по касаниям в долях ATR.
     CASCADE_TOUCH_EPS_NATR: float = 6.0
+    # Максимальное перебитие уровня в долях ATR.
+    CASCADE_OVERTOUCH_NATR: float = 0.5
     # Минимальное число свингов для образования каскада.
     CASCADE_LENGTH_MIN: int = 3
     # Минимальная доля отката после второго касания относительно первого.

--- a/crypto_screener/domain/strategies/gu.py
+++ b/crypto_screener/domain/strategies/gu.py
@@ -662,6 +662,7 @@ class GuStrategy(Strategy):
                     continue
 
                 touch_indices = []
+                overtouch_tolerance = self._config.CASCADE_OVERTOUCH_NATR * avg_range
                 for day_idx in range(start_day, len(cascade_extremes)):
                     day_price = cascade_extremes[day_idx].price
                     if is_long and day_price > level_price + touch_tolerance:
@@ -681,6 +682,13 @@ class GuStrategy(Strategy):
 
                 if len(touch_indices) < min_touches:
                     continue
+
+                if is_long:
+                    if any(bars[index].high - level_price > overtouch_tolerance for index in touch_indices):
+                        continue
+                else:
+                    if any(level_price - bars[index].low > overtouch_tolerance for index in touch_indices):
+                        continue
 
                 if is_long:
                     touch_prices = [bars[index].high for index in touch_indices]


### PR DESCRIPTION
### Motivation
- Introduce a stricter check to reject cascade candidates where touches significantly pierce the level beyond acceptable ATR-based tolerance.
- Keep existing `CASCADE_TOUCH_EPS_NATR` as the closeness criterion while adding an explicit overtouch limit to filter false candidates.

### Description
- Added `CASCADE_OVERTOUCH_NATR: float = 0.5` to `crypto_screener/config/gu_config.py` with the comment "максимальное перебитие уровня в долях ATR".
- In `crypto_screener/domain/strategies/gu.py` inside `_get_cascade` compute `overtouch_tolerance = self._config.CASCADE_OVERTOUCH_NATR * avg_range` and apply it to each candidate touch.
- For long cascades reject candidates where `bars[index].high - level_price > overtouch_tolerance` for any touch, and for short cascades reject where `level_price - bars[index].low > overtouch_tolerance` for any touch.
- Left `CASCADE_TOUCH_EPS_NATR` unchanged as the closeness/touch epsilon criterion.

### Testing
- No automated tests were executed for this change.
- No test failures reported because no tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946ef63e8b8832095b6c73a76f399a5)