### PR TITLE
Unify cascade detection for Gu and Ppo strategies

### DIFF
--- a/crypto_screener/config/gu_config.py
+++ b/crypto_screener/config/gu_config.py
@@ -43,6 +43,10 @@ class GuConfig:
     CASCADE_PULLBACK_NEXT_RATIO_MAX: float = 0.9
     # Минимальная глубина первых откатов в долях ATR.
     CASCADE_MIN_PULLBACK_NATR: float = 2.5
+    # Минимальная длительность отката в барах.
+    CASCADE_MIN_PULLBACK_BARS: int = 3
+    # Минимальный разрыв между касаниями в барах.
+    CASCADE_MIN_GAP_BARS: int = 5
     # Минимальное соотношение отступа поддержки от низа проторговки к размеру проторговки.
     SUPPORT_CONSOLIDATION_RATIO_MIN: float = 0.3
     # Минимальная длительность окна группировки каскадов.

--- a/crypto_screener/config/ppo_config.py
+++ b/crypto_screener/config/ppo_config.py
@@ -45,6 +45,14 @@ class PpoConfig:
     CASCADE_MIN_GAP_BARS: int = 5
     # Минимальное число свингов для образования каскада.
     CASCADE_LENGTH_MIN: int = 3
+    # Минимальная доля отката после второго касания относительно первого.
+    CASCADE_PULLBACK_SECOND_RATIO_MIN: float = 0.5
+    # Максимальная доля отката после второго касания относительно первого.
+    CASCADE_PULLBACK_SECOND_RATIO_MAX: float = 1.0
+    # Минимальная доля отката после третьего и далее относительно второго.
+    CASCADE_PULLBACK_NEXT_RATIO_MIN: float = 0.1
+    # Максимальная доля отката после третьего и далее относительно второго.
+    CASCADE_PULLBACK_NEXT_RATIO_MAX: float = 0.9
     # Минимальный разрыв от верха каскада до начала сопротивления (в долях отката).
     RESISTANCE_GAP_RATIO_MIN: float = 0.1
     # Максимальное количество свингов после каскада.

--- a/crypto_screener/domain/strategies/cascade_detector.py
+++ b/crypto_screener/domain/strategies/cascade_detector.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import inf
+
+import numpy as np
+
+from crypto_screener.domain.models.bar import Bar
+from crypto_screener.domain.models.cascade_level import CascadeLevel
+from crypto_screener.domain.models.cascade_type import CascadeType
+from crypto_screener.domain.models.swing import Swing, SwingType
+
+
+@dataclass(frozen=True)
+class CascadeDetectorConfig:
+    atr_window: int
+    touch_eps_natr: float
+    min_pullback_natr: float
+    min_pullback_bars: int
+    min_gap_bars: int
+    length_min: int
+    pullback_second_ratio_min: float
+    pullback_second_ratio_max: float
+    pullback_next_ratio_min: float
+    pullback_next_ratio_max: float
+
+    @classmethod
+    def from_strategy_config(cls, config: object) -> "CascadeDetectorConfig":
+        return cls(
+            atr_window=config.CASCADE_ATR_WINDOW,
+            touch_eps_natr=config.CASCADE_TOUCH_EPS_NATR,
+            min_pullback_natr=config.CASCADE_MIN_PULLBACK_NATR,
+            min_pullback_bars=config.CASCADE_MIN_PULLBACK_BARS,
+            min_gap_bars=config.CASCADE_MIN_GAP_BARS,
+            length_min=config.CASCADE_LENGTH_MIN,
+            pullback_second_ratio_min=config.CASCADE_PULLBACK_SECOND_RATIO_MIN,
+            pullback_second_ratio_max=config.CASCADE_PULLBACK_SECOND_RATIO_MAX,
+            pullback_next_ratio_min=config.CASCADE_PULLBACK_NEXT_RATIO_MIN,
+            pullback_next_ratio_max=config.CASCADE_PULLBACK_NEXT_RATIO_MAX,
+        )
+
+
+class CascadeDetector:
+    def __init__(self, config: CascadeDetectorConfig) -> None:
+        self._config = config
+
+    def detect(
+            self,
+            bars: list[Bar],
+            *,
+            cascade_type: CascadeType,
+            price_min: float | None = None,
+            price_max: float | None = None,
+    ) -> list[Swing]:
+        if not bars or len(bars) < 2:
+            return []
+
+        bars = bars[:-1]
+        if not bars:
+            return []
+
+        if price_min is not None and price_max is not None and price_min >= price_max:
+            return []
+
+        bounds_min = price_min if price_min is not None else -inf
+        bounds_max = price_max if price_max is not None else inf
+
+        bars_count = len(bars)
+        avg_range = self._calculate_average_range(bars, self._config.atr_window)
+        touch_tolerance = max(self._config.touch_eps_natr * avg_range, 0.0)
+        min_pullback = max(self._config.min_pullback_natr * avg_range, 0.0)
+        min_pullback_bars = self._config.min_pullback_bars
+        min_gap_bars = self._config.min_gap_bars
+        min_touches = max(self._config.length_min, 3)
+        is_long = cascade_type is CascadeType.LONG
+
+        bar_data = []
+        for index, bar in enumerate(bars):
+            price = bar.high if is_long else bar.low
+            if bounds_min <= price <= bounds_max:
+                bar_data.append((index, price, bar.open, bar.close))
+
+        levels: list[CascadeLevel] = []
+        for index, level_price, _open, _close in bar_data:
+            cross_index = None
+            atr_crossed = False
+            for look_ahead in range(index + 1, bars_count):
+                look_bar = bars[look_ahead]
+                if is_long:
+                    if look_bar.high > level_price + avg_range:
+                        atr_crossed = True
+                        break
+                    if look_bar.high > level_price:
+                        cross_index = look_ahead
+                        break
+                else:
+                    if look_bar.low < level_price - avg_range:
+                        atr_crossed = True
+                        break
+                    if look_bar.low < level_price:
+                        cross_index = look_ahead
+                        break
+            if atr_crossed:
+                continue
+            end_idx = cross_index if cross_index is not None else bars_count
+            if is_long:
+                touches_raw = [
+                    i for i in range(index, end_idx)
+                    if level_price - bars[i].close <= touch_tolerance
+                    and bars[i].close <= level_price
+                ]
+            else:
+                touches_raw = [
+                    i for i in range(index, end_idx)
+                    if bars[i].close - level_price <= touch_tolerance
+                    and bars[i].close >= level_price
+                ]
+            if touches_raw:
+                levels.append(CascadeLevel(
+                    price=level_price,
+                    is_crossed=cross_index is not None,
+                    distance=(cross_index - index) if cross_index is not None else (bars_count - 1 - index),
+                    touches_raw=touches_raw,
+                ))
+
+        def refine_touches(
+                price: float,
+                touches_count: list[int],
+        ) -> list[int]:
+            if not touches_count:
+                return []
+            refined = touches_count[:]
+            while True:
+                changed = False
+                new_touches = []
+                last_touch = None
+                for touch_idx in refined:
+                    if last_touch is None:
+                        new_touches.append(touch_idx)
+                        last_touch = touch_idx
+                        continue
+                    if touch_idx - last_touch < min_gap_bars:
+                        changed = True
+                        continue
+                    pullback_bars = bars[last_touch + 1:touch_idx]
+                    if not pullback_bars:
+                        changed = True
+                        continue
+                    if is_long:
+                        pullback_depth = max((price - pullback_bar.low) for pullback_bar in pullback_bars)
+                    else:
+                        pullback_depth = max((pullback_bar.high - price) for pullback_bar in pullback_bars)
+                    consecutive = 0
+                    max_consecutive = 0
+                    for pullback_bar in pullback_bars:
+                        if is_long:
+                            is_pullback = pullback_bar.close <= price - min_pullback
+                        else:
+                            is_pullback = pullback_bar.close >= price + min_pullback
+                        if is_pullback:
+                            consecutive += 1
+                            max_consecutive = max(max_consecutive, consecutive)
+                        else:
+                            consecutive = 0
+                    has_pullback = pullback_depth >= min_pullback and max_consecutive >= min_pullback_bars
+                    if not has_pullback:
+                        changed = True
+                        continue
+                    new_touches.append(touch_idx)
+                    last_touch = touch_idx
+                if not changed:
+                    return new_touches
+                refined = new_touches
+
+        best_level_touches = []
+        best_level_touches_count = 0
+        best_level_price = None
+
+        for level in levels:
+            if level.is_crossed:
+                continue
+            touches = refine_touches(level.price, level.touches_raw)
+            touches_count = len(touches)
+
+            if touches_count > best_level_touches_count or (
+                    touches_count == best_level_touches_count and
+                    (not best_level_touches or touches[-1] > best_level_touches[-1])
+            ):
+                best_level_touches = touches
+                best_level_touches_count = touches_count
+                best_level_price = level.price
+
+        if not best_level_touches or best_level_touches_count < min_touches or best_level_price is None:
+            return []
+
+        if not self._passes_pullback_ratios(
+                bars,
+                best_level_touches,
+                best_level_price,
+                avg_range,
+                cascade_type=cascade_type,
+        ):
+            return []
+
+        first_touch_index = min(best_level_touches)
+        last_touch_index = max(best_level_touches)
+        if is_long:
+            last_touch_segment_extreme = min(bar.low for bar in bars[last_touch_index:])
+            first_touch_segment_extreme = min(bar.low for bar in bars[first_touch_index:last_touch_index - 1])
+            if last_touch_segment_extreme <= first_touch_segment_extreme:
+                return []
+        else:
+            last_touch_segment_extreme = max(bar.high for bar in bars[last_touch_index:])
+            first_touch_segment_extreme = max(bar.high for bar in bars[first_touch_index:last_touch_index - 1])
+            if last_touch_segment_extreme >= first_touch_segment_extreme:
+                return []
+
+        swing_type = SwingType.HIGH if is_long else SwingType.LOW
+        cascade_swings = []
+        for touch_index in best_level_touches:
+            bar = bars[touch_index]
+            swing = Swing(
+                time=bar.time,
+                extremum_price=best_level_price,
+                close_price=bar.close,
+                type=swing_type,
+                is_open=True,
+            )
+            cascade_swings.append(swing)
+
+        return cascade_swings
+
+    @staticmethod
+    def _calculate_average_range(bars: list[Bar], window: int) -> float:
+        if not bars or window <= 0:
+            return 0.0
+        window = min(window, len(bars))
+        ranges = [bar.high - bar.low for bar in bars[-window:]]
+        return float(np.mean(ranges)) if ranges else 0.0
+
+    def _calculate_pullbacks(
+            self,
+            bars: list[Bar],
+            touch_indices: list[int],
+            level_price: float,
+            *,
+            cascade_type: CascadeType,
+    ) -> list[float]:
+        pullbacks: list[float] = []
+        for left_idx, right_idx in zip(touch_indices, touch_indices[1:]):
+            segment = bars[left_idx + 1:right_idx]
+            if not segment:
+                return []
+            if cascade_type is CascadeType.LONG:
+                segment_extreme = min(bar.low for bar in segment)
+                depth = level_price - segment_extreme
+            else:
+                segment_extreme = max(bar.high for bar in segment)
+                depth = segment_extreme - level_price
+            if depth <= 0:
+                return []
+            pullbacks.append(depth)
+        return pullbacks
+
+    def _passes_pullback_ratios(
+            self,
+            bars: list[Bar],
+            touch_indices: list[int],
+            level_price: float,
+            avg_range: float,
+            *,
+            cascade_type: CascadeType,
+    ) -> bool:
+        pullbacks = self._calculate_pullbacks(
+            bars,
+            touch_indices,
+            level_price,
+            cascade_type=cascade_type,
+        )
+        if len(pullbacks) < 2:
+            return False
+        first_depth = pullbacks[0]
+        second_depth = pullbacks[1]
+        if first_depth <= 0 or second_depth <= 0:
+            return False
+        min_pullback = self._config.min_pullback_natr * avg_range
+        if first_depth < min_pullback or second_depth < min_pullback:
+            return False
+        ratio = second_depth / first_depth
+        if not (
+                self._config.pullback_second_ratio_min
+                <= ratio
+                <= self._config.pullback_second_ratio_max
+        ):
+            return False
+        for depth in pullbacks[2:]:
+            ratio = depth / second_depth
+            if not (
+                    self._config.pullback_next_ratio_min
+                    <= ratio
+                    <= self._config.pullback_next_ratio_max
+            ):
+                return False
+        return True

--- a/crypto_screener/domain/strategies/gu.py
+++ b/crypto_screener/domain/strategies/gu.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
 
 import numpy as np
 
-from crypto_screener.config.gu_config import CascadeGroupingMode, GuConfig, gu_cfg
+from crypto_screener.config.gu_config import GuConfig, gu_cfg
 from crypto_screener.domain.models.bar import Bar
 from crypto_screener.domain.models.cascade_type import CascadeType
 from crypto_screener.domain.models.context import Context
@@ -20,6 +19,10 @@ from crypto_screener.domain.strategies.strategy import (
     StrategyVolumeConfig,
 )
 from crypto_screener.domain.swing_detector import add_swings
+from crypto_screener.domain.strategies.cascade_detector import (
+    CascadeDetector,
+    CascadeDetectorConfig,
+)
 
 
 @dataclass(frozen=True)
@@ -36,17 +39,14 @@ class Cascade:
         return self.direction is CascadeType.SHORT
 
 
-@dataclass(frozen=True)
-class CascadeExtreme:
-    index: int
-    price: float
-
-
 class GuStrategy(Strategy):
     name = "ГУ"
 
     def __init__(self, config: GuConfig = gu_cfg) -> None:
         self._config = config
+        self._cascade_detector = CascadeDetector(
+            CascadeDetectorConfig.from_strategy_config(config)
+        )
 
     def detect_setup(
             self,
@@ -384,7 +384,10 @@ class GuStrategy(Strategy):
             self,
             bars: list[Bar]
     ) -> Cascade | None:
-        swings = self._get_cascade(bars, cascade_type=CascadeType.LONG)
+        swings = self._cascade_detector.detect(
+            bars,
+            cascade_type=CascadeType.LONG,
+        )
         if not swings:
             return None
         return Cascade(swings=swings, direction=CascadeType.LONG)
@@ -393,7 +396,10 @@ class GuStrategy(Strategy):
             self,
             bars: list[Bar]
     ) -> Cascade | None:
-        swings = self._get_cascade(bars, cascade_type=CascadeType.SHORT)
+        swings = self._cascade_detector.detect(
+            bars,
+            cascade_type=CascadeType.SHORT,
+        )
         if not swings:
             return None
         return Cascade(swings=swings, direction=CascadeType.SHORT)
@@ -410,386 +416,6 @@ class GuStrategy(Strategy):
             return duration, last_time
 
         return max(candidates, key=key)
-
-    @staticmethod
-    def _group_bars_by_day(bars: list[Bar]) -> list[tuple[int, int]]:
-        if not bars:
-            return []
-        groups: list[tuple[int, int]] = []
-        start_index = 0
-        current_date = bars[0].time.date()
-        for index, bar in enumerate(bars):
-            bar_date = bar.time.date()
-            if bar_date != current_date:
-                groups.append((start_index, index - 1))
-                current_date = bar_date
-                start_index = index
-        groups.append((start_index, len(bars) - 1))
-        return groups
-
-    @staticmethod
-    def _group_bars_by_time_window(
-            bars: list[Bar],
-            *,
-            window_hours: int,
-    ) -> list[tuple[int, int, datetime, datetime]]:
-        if not bars or window_hours <= 0:
-            return []
-        groups: list[tuple[int, int, datetime, datetime]] = []
-        start_index = 0
-        while start_index < len(bars):
-            start_time = bars[start_index].time
-            window_start = start_time
-            window_end = start_time + timedelta(hours=window_hours)
-            end_index = start_index
-            for index in range(start_index + 1, len(bars)):
-                if bars[index].time <= window_end:
-                    end_index = index
-                else:
-                    break
-            groups.append((start_index, end_index, window_start, window_end))
-            start_index = end_index + 1
-        return groups
-
-    @staticmethod
-    def _get_window_extremes(
-            bars: list[Bar],
-            time_groups: list[tuple[int, int, datetime, datetime]],
-            *,
-            cascade_type: CascadeType,
-    ) -> list[CascadeExtreme]:
-        window_extremes: list[CascadeExtreme] = []
-        for start_index, end_index, _window_start, _window_end in time_groups:
-            # Экстремумы окна: лонг — максимум окна, шорт — минимум окна (аналогично дневным экстремумам).
-            window_indices = list(range(start_index, end_index + 1))
-            if not window_indices:
-                continue
-            if cascade_type is CascadeType.LONG:
-                window_price = max(bars[index].high for index in window_indices)
-                for index in window_indices:
-                    if bars[index].high == window_price:
-                        window_extremes.append(CascadeExtreme(index=index, price=float(window_price)))
-                        break
-            else:
-                window_price = min(bars[index].low for index in window_indices)
-                for index in window_indices:
-                    if bars[index].low == window_price:
-                        window_extremes.append(CascadeExtreme(index=index, price=float(window_price)))
-                        break
-        return window_extremes
-
-    @staticmethod
-    def _get_daily_extremes(
-            bars: list[Bar],
-            day_groups: list[tuple[int, int]],
-            *,
-            cascade_type: CascadeType,
-    ) -> list[CascadeExtreme]:
-        daily_extremes: list[CascadeExtreme] = []
-        for start_index, end_index in day_groups:
-            day_bars = bars[start_index:end_index + 1]
-            if cascade_type is CascadeType.LONG:
-                day_price = max(bar.high for bar in day_bars)
-                for index in range(start_index, end_index + 1):
-                    if bars[index].high == day_price:
-                        daily_extremes.append(CascadeExtreme(index=index, price=float(day_price)))
-                        break
-            else:
-                day_price = min(bar.low for bar in day_bars)
-                for index in range(start_index, end_index + 1):
-                    if bars[index].low == day_price:
-                        daily_extremes.append(CascadeExtreme(index=index, price=float(day_price)))
-                        break
-        return daily_extremes
-
-    @staticmethod
-    def _get_swing_extremes(
-            bars: list[Bar],
-            *,
-            cascade_type: CascadeType,
-    ) -> list[CascadeExtreme]:
-        swing_type = SwingType.HIGH if cascade_type is CascadeType.LONG else SwingType.LOW
-        swing_extremes: list[CascadeExtreme] = []
-        for index, bar in enumerate(bars):
-            swing = bar.swing
-            if swing is None:
-                continue
-            if not swing.is_open:
-                continue
-            if swing.type != swing_type:
-                continue
-            swing_extremes.append(CascadeExtreme(index=index, price=float(swing.extremum_price)))
-        return swing_extremes
-
-    @staticmethod
-    def _merge_extremes(
-            bars: list[Bar],
-            *extremes: list[CascadeExtreme],
-    ) -> list[CascadeExtreme]:
-        unique: dict[tuple[int, float], CascadeExtreme] = {}
-        for extremes_list in extremes:
-            for extreme in extremes_list:
-                unique[(extreme.index, extreme.price)] = extreme
-        return sorted(unique.values(), key=lambda item: bars[item.index].time)
-
-    def _get_cascade_extremes(
-            self,
-            bars: list[Bar],
-            *,
-            cascade_type: CascadeType,
-            grouping_mode: CascadeGroupingMode,
-            window_hours: int | None = None,
-    ) -> list[CascadeExtreme]:
-        swing_extremes = self._get_swing_extremes(bars, cascade_type=cascade_type)
-        if grouping_mode is CascadeGroupingMode.ROLLING_WINDOW:
-            if window_hours is None:
-                window_hours = self._config.CASCADE_ROLLING_WINDOW_MAX_HOURS
-            time_groups = self._group_bars_by_time_window(
-                bars,
-                window_hours=window_hours,
-            )
-            window_extremes = self._get_window_extremes(bars, time_groups, cascade_type=cascade_type)
-            return self._merge_extremes(bars, window_extremes, swing_extremes)
-        day_groups = self._group_bars_by_day(bars)
-        daily_extremes = self._get_daily_extremes(bars, day_groups, cascade_type=cascade_type)
-        return self._merge_extremes(bars, daily_extremes, swing_extremes)
-
-    @staticmethod
-    def _calculate_pullbacks(
-            bars: list[Bar],
-            touch_indices: list[int],
-            level_price: float,
-            *,
-            cascade_type: CascadeType,
-    ) -> list[tuple[float, float]]:
-        pullbacks: list[tuple[float, float]] = []
-        for left_idx, right_idx in zip(touch_indices, touch_indices[1:]):
-            segment = bars[left_idx + 1:right_idx]
-            if not segment:
-                return []
-            if cascade_type is CascadeType.LONG:
-                segment_extreme = min(bar.low for bar in segment)
-                depth = level_price - segment_extreme
-            else:
-                segment_extreme = max(bar.high for bar in segment)
-                depth = segment_extreme - level_price
-            if depth <= 0:
-                return []
-            pullbacks.append((depth, segment_extreme))
-        return pullbacks
-
-    @staticmethod
-    def _is_price_squeezed(
-            pullbacks: list[tuple[float, float]],
-            *,
-            cascade_type: CascadeType,
-    ) -> bool:
-        extremes = [extreme for _, extreme in pullbacks]
-        if len(extremes) < 2:
-            return False
-        if cascade_type is CascadeType.LONG:
-            return all(curr >= prev for prev, curr in zip(extremes, extremes[1:]))
-        return all(curr <= prev for prev, curr in zip(extremes, extremes[1:]))
-
-    def _passes_pullback_rules(
-            self,
-            pullbacks: list[tuple[float, float]],
-            avg_range: float,
-    ) -> bool:
-        if len(pullbacks) < 2:
-            return False
-        first_depth = pullbacks[0][0]
-        second_depth = pullbacks[1][0]
-        if first_depth <= 0 or second_depth <= 0:
-            return False
-        min_pullback = self._config.CASCADE_MIN_PULLBACK_NATR * avg_range
-        if first_depth < min_pullback or second_depth < min_pullback:
-            return False
-        ratio = second_depth / first_depth
-        if not (
-                self._config.CASCADE_PULLBACK_SECOND_RATIO_MIN
-                <= ratio
-                <= self._config.CASCADE_PULLBACK_SECOND_RATIO_MAX
-        ):
-            return False
-        for depth, _ in pullbacks[2:]:
-            ratio = depth / second_depth
-            if not (
-                    self._config.CASCADE_PULLBACK_NEXT_RATIO_MIN
-                    <= ratio
-                    <= self._config.CASCADE_PULLBACK_NEXT_RATIO_MAX
-            ):
-                return False
-        return True
-
-    def _get_cascade(
-            self,
-            bars: list[Bar],
-            *,
-            cascade_type: CascadeType,
-    ) -> list[Swing]:
-        if not bars or len(bars) < 2:
-            return []
-
-        bars = bars[:-1]
-        if not bars:
-            return []
-
-        avg_range = self._calculate_average_range(bars, self._config.CASCADE_ATR_WINDOW)
-        touch_tolerance = max(self._config.CASCADE_TOUCH_EPS_NATR * avg_range, 0.0)
-        min_touches = max(self._config.CASCADE_LENGTH_MIN, 3)
-        is_long = cascade_type is CascadeType.LONG
-        swing_type = SwingType.HIGH if is_long else SwingType.LOW
-
-        def rolling_window_sizes() -> list[int]:
-            min_hours = self._config.CASCADE_ROLLING_WINDOW_MIN_HOURS
-            max_hours = self._config.CASCADE_ROLLING_WINDOW_MAX_HOURS
-            if min_hours <= 0 or max_hours <= 0:
-                return []
-            if max_hours <= min_hours:
-                return [max_hours]
-            sizes: list[int] = []
-            size = max_hours
-            while size > min_hours:
-                sizes.append(size)
-                size -= min_hours
-            sizes.append(min_hours)
-            return sizes
-
-        def find_cascade(cascade_extremes: list[CascadeExtreme]) -> list[Swing]:
-            if len(cascade_extremes) < min_touches:
-                return []
-
-            best_candidate = None
-            best_duration = None
-            best_last_time = None
-
-            for start_day in range(len(cascade_extremes) - 1):
-                level_price = cascade_extremes[start_day].price
-                next_day_price = cascade_extremes[start_day + 1].price
-                if abs(next_day_price - level_price) > touch_tolerance:
-                    continue
-
-                touch_indices = []
-                overtouch_tolerance = self._config.CASCADE_OVERTOUCH_NATR * avg_range
-                for day_idx in range(start_day, len(cascade_extremes)):
-                    day_price = cascade_extremes[day_idx].price
-                    if is_long and day_price > level_price + touch_tolerance:
-                        break
-                    if not is_long and day_price < level_price - touch_tolerance:
-                        break
-                    if abs(day_price - level_price) > touch_tolerance:
-                        continue
-                    bar = bars[cascade_extremes[day_idx].index]
-                    close_price = bar.close
-                    if is_long:
-                        if close_price <= level_price and (level_price - close_price) <= touch_tolerance:
-                            touch_indices.append(cascade_extremes[day_idx].index)
-                    else:
-                        if close_price >= level_price and (close_price - level_price) <= touch_tolerance:
-                            touch_indices.append(cascade_extremes[day_idx].index)
-
-                if len(touch_indices) < min_touches:
-                    continue
-
-                if is_long:
-                    if any(bars[index].high - level_price > overtouch_tolerance for index in touch_indices):
-                        continue
-                else:
-                    if any(level_price - bars[index].low > overtouch_tolerance for index in touch_indices):
-                        continue
-
-                if is_long:
-                    touch_prices = [bars[index].high for index in touch_indices]
-                else:
-                    touch_prices = [bars[index].low for index in touch_indices]
-                if not touch_prices:
-                    continue
-                level_price = float(np.median(touch_prices))
-                if any(abs(price - level_price) > touch_tolerance for price in touch_prices):
-                    continue
-
-                first_index = touch_indices[0]
-                first_swing = bars[first_index].swing
-                if (
-                        first_swing is None
-                        or not first_swing.is_open
-                        or first_swing.type != swing_type
-                        or abs(first_swing.extremum_price - level_price) > touch_tolerance
-                ):
-                    continue
-
-                pullbacks = self._calculate_pullbacks(
-                    bars,
-                    touch_indices,
-                    level_price,
-                    cascade_type=cascade_type,
-                )
-                if not pullbacks:
-                    continue
-                if not self._passes_pullback_rules(pullbacks, avg_range):
-                    continue
-                if not self._is_price_squeezed(pullbacks, cascade_type=cascade_type):
-                    continue
-
-                last_index = touch_indices[-1]
-                duration = bars[last_index].time - bars[first_index].time
-                last_time = bars[last_index].time
-                if best_duration is None or duration > best_duration:
-                    best_candidate = (touch_indices, level_price, first_swing)
-                    best_duration = duration
-                    best_last_time = last_time
-                elif duration == best_duration and best_last_time is not None and last_time > best_last_time:
-                    best_candidate = (touch_indices, level_price, first_swing)
-                    best_duration = duration
-                    best_last_time = last_time
-
-            if not best_candidate:
-                return []
-
-            touch_indices, level_price, first_swing = best_candidate
-            cascade_swings = [first_swing]
-            first_index = touch_indices[0]
-            for touch_index in touch_indices:
-                if touch_index == first_index:
-                    continue
-                bar = bars[touch_index]
-                cascade_swings.append(Swing(
-                    time=bar.time,
-                    extremum_price=level_price,
-                    close_price=bar.close,
-                    type=swing_type,
-                    is_open=True
-                ))
-
-            return cascade_swings
-        for grouping_mode in (
-                CascadeGroupingMode.ROLLING_WINDOW,
-                CascadeGroupingMode.CALENDAR,
-        ):
-            if grouping_mode is CascadeGroupingMode.ROLLING_WINDOW:
-                for window_hours in rolling_window_sizes():
-                    cascade_extremes = self._get_cascade_extremes(
-                        bars,
-                        cascade_type=cascade_type,
-                        grouping_mode=grouping_mode,
-                        window_hours=window_hours,
-                    )
-                    cascade_swings = find_cascade(cascade_extremes)
-                    if cascade_swings:
-                        return cascade_swings
-                continue
-
-            cascade_extremes = self._get_cascade_extremes(
-                bars,
-                cascade_type=cascade_type,
-                grouping_mode=grouping_mode,
-            )
-            cascade_swings = find_cascade(cascade_extremes)
-            if cascade_swings:
-                return cascade_swings
-
-        return []
 
     def get_runtime_config(self) -> StrategyRuntimeConfig:
         return StrategyRuntimeConfig(

--- a/crypto_screener/domain/strategies/ppo.py
+++ b/crypto_screener/domain/strategies/ppo.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 
 from crypto_screener.domain.models.bar import Bar
-from crypto_screener.domain.models.cascade_level import CascadeLevel
+from crypto_screener.domain.models.cascade_type import CascadeType
 from crypto_screener.domain.models.context import Context
 from crypto_screener.domain.models.setup import Capture, Setup, Trade, Unfilled
 from crypto_screener.domain.models.setup_data import Ppo
@@ -17,6 +17,10 @@ from crypto_screener.domain.strategies.strategy import (
     StrategyVolumeConfig,
 )
 from crypto_screener.domain.swing_detector import add_swings
+from crypto_screener.domain.strategies.cascade_detector import (
+    CascadeDetector,
+    CascadeDetectorConfig,
+)
 
 
 class PpoStrategy(Strategy):
@@ -24,6 +28,9 @@ class PpoStrategy(Strategy):
 
     def __init__(self, config: PpoConfig = ppo_cfg) -> None:
         self._config = config
+        self._cascade_detector = CascadeDetector(
+            CascadeDetectorConfig.from_strategy_config(config)
+        )
 
     def detect_setup(
             self,
@@ -140,10 +147,11 @@ class PpoStrategy(Strategy):
         # Анализ лонгового каскада.
         cascade_price_min = correction_low_swing.close_price + retrace_range * self._config.CASCADE_RETRACE_RATIO_MIN
         cascade_price_max = main_high_swing.close_price
-        cascade_long = self._get_cascade_long(
+        cascade_long = self._cascade_detector.detect(
             correction_bars,
-            cascade_price_min,
-            cascade_price_max,
+            cascade_type=CascadeType.LONG,
+            price_min=cascade_price_min,
+            price_max=cascade_price_max,
         )
         if not cascade_long:
             return setup
@@ -422,144 +430,6 @@ class PpoStrategy(Strategy):
         )
 
         return [(main_low_index, main_low_swing), (max_high_index, main_high_swing)]
-
-    def _get_cascade_long(
-            self,
-            bars: list[Bar],
-            price_min: float,
-            price_max: float,
-    ) -> list[Swing]:
-        if not bars or price_min >= price_max or len(bars) < 2:
-            return []
-
-        bars = bars[:-1]
-        bars_count = len(bars)
-
-        def calculate_average_range(window: int) -> float:
-            if not bars or window <= 0:
-                return 0.0
-            window = min(window, bars_count)
-            ranges = [bar.high - bar.low for bar in bars[-window:]]
-            return float(np.mean(ranges)) if ranges else 0.0
-
-        avg_range = calculate_average_range(self._config.CASCADE_ATR_WINDOW)
-        touch_tolerance = max(self._config.CASCADE_TOUCH_EPS_NATR * avg_range, 0.0)
-        min_pullback = max(self._config.CASCADE_MIN_PULLBACK_NATR * avg_range, 0.0)
-        min_pullback_bars = self._config.CASCADE_MIN_PULLBACK_BARS
-        min_gap_bars = self._config.CASCADE_MIN_GAP_BARS
-        levels: list[CascadeLevel] = []
-        bar_data = [(i, bar.high, bar.open, bar.close)
-                    for i, bar in enumerate(bars)
-                    if price_min <= bar.high <= price_max]
-        for index, high_price, open_price, close_price in bar_data:
-            level_price = high_price
-            cross_index = None
-            atr_crossed = False
-            for look_ahead in range(index + 1, bars_count):
-                look_bar = bars[look_ahead]
-                if look_bar.high > level_price + avg_range or look_bar.high > level_price + avg_range:
-                    atr_crossed = True
-                    break
-                if look_bar.high > level_price or look_bar.high > level_price:
-                    cross_index = look_ahead
-                    break
-            if atr_crossed:
-                continue
-            end_idx = cross_index if cross_index is not None else bars_count
-            touches_raw = [
-                i for i in range(index, end_idx)
-                if level_price - bars[i].close <= touch_tolerance
-                   and bars[i].close <= level_price
-            ]
-            if touches_raw:
-                levels.append(CascadeLevel(
-                    price=level_price,
-                    is_crossed=cross_index is not None,
-                    distance=(cross_index - index) if cross_index is not None else (bars_count - 1 - index),
-                    touches_raw=touches_raw,
-                ))
-
-        def _refine_touches(
-                price: float,
-                touches_count: list[int]
-        ) -> list[int]:
-            if not touches_count:
-                return []
-            refined = touches_count[:]
-            while True:
-                changed = False
-                new_touches = []
-                last_touch = None
-                for touch_idx in refined:
-                    if last_touch is None:
-                        new_touches.append(touch_idx)
-                        last_touch = touch_idx
-                        continue
-                    if touch_idx - last_touch < min_gap_bars:
-                        changed = True
-                        continue
-                    pullback_bars = bars[last_touch + 1:touch_idx]
-                    if not pullback_bars:
-                        changed = True
-                        continue
-                    pullback_depth = max((price - pullback_bar.low) for pullback_bar in pullback_bars)
-                    consecutive = 0
-                    max_consecutive = 0
-                    for pullback_bar in pullback_bars:
-                        if pullback_bar.close <= price - min_pullback:
-                            consecutive += 1
-                            max_consecutive = max(max_consecutive, consecutive)
-                        else:
-                            consecutive = 0
-                    has_pullback = pullback_depth >= min_pullback and max_consecutive >= min_pullback_bars
-                    if not has_pullback:
-                        changed = True
-                        continue
-                    new_touches.append(touch_idx)
-                    last_touch = touch_idx
-                if not changed:
-                    return new_touches
-                refined = new_touches
-
-        best_level_touches = []
-        best_level_touches_count = 0
-        best_level_price = None
-
-        for level in levels:
-            if level.is_crossed:
-                continue
-            touches = _refine_touches(level.price, level.touches_raw)
-            touches_count = len(touches)
-
-            if touches_count > best_level_touches_count or \
-                    (touches_count == best_level_touches_count and
-                     (not best_level_touches or touches[-1] > best_level_touches[-1])):
-                best_level_touches = touches
-                best_level_touches_count = touches_count
-                best_level_price = level.price
-
-        if not best_level_touches or best_level_touches_count < self._config.CASCADE_LENGTH_MIN:
-            return []
-        first_touch_index = min(best_level_touches)
-        last_touch_index = max(best_level_touches)
-        last_touch_segment_low = min(bar.low for bar in bars[last_touch_index:])
-        first_touch_segment_low = min(bar.low for bar in bars[first_touch_index:last_touch_index - 1])
-        if last_touch_segment_low <= first_touch_segment_low:
-            return []
-
-        cascade_swings = []
-        for touch_index in best_level_touches:
-            bar = bars[touch_index]
-            swing = Swing(
-                time=bar.time,
-                extremum_price=best_level_price,
-                close_price=bar.close,
-                type=SwingType.HIGH,
-                is_open=True
-            )
-            cascade_swings.append(swing)
-
-        return cascade_swings
 
     def get_runtime_config(self) -> StrategyRuntimeConfig:
         return StrategyRuntimeConfig(


### PR DESCRIPTION
### Motivation
- Provide a single, shared cascade detection implementation so `Gu` and `Ppo` use identical touch/pullback mechanics.
- Preserve both long and short cascade support while keeping `Gu` and `Ppo` behavioral differences (e.g. `Gu` may search without retrace bounds).
- Make cascade-related configuration parameters compatible between strategies to allow fair comparisons.
- Ensure existing pullback ratio and depth rules from the original `Gu` logic are preserved in the generalized detector.

### Description
- Added `crypto_screener/domain/strategies/cascade_detector.py` which implements `CascadeDetector` and `CascadeDetectorConfig` and the unified detection logic with support for `CascadeType.LONG` and `CascadeType.SHORT`.
- Refactored `crypto_screener/domain/strategies/gu.py` and `crypto_screener/domain/strategies/ppo.py` to instantiate and use `CascadeDetector` via `CascadeDetectorConfig.from_strategy_config(config)` and removed duplicated cascade search code.
- Aligned cascade configuration parameters in `crypto_screener/config/gu_config.py` and `crypto_screener/config/ppo_config.py` by adding `CASCADE_MIN_PULLBACK_BARS`, `CASCADE_MIN_GAP_BARS` and the `CASCADE_PULLBACK_*` ratio settings.
- Kept `Ppo` usage with contextual bounds by passing `price_min`/`price_max` to the detector, while `Gu` calls the detector without price bounds to preserve the retrace‑free search mode.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694702c5cf4c832087ee2d9694264242)