### PR TITLE
Replace GU cascade detection with cascade-level algorithm and add symmetric SHORT handling

### DIFF
--- a/crypto_screener/domain/strategies/gu.py
+++ b/crypto_screener/domain/strategies/gu.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from crypto_screener.config.gu_config import GuConfig, gu_cfg
 from crypto_screener.domain.models.bar import Bar
+from crypto_screener.domain.models.cascade_level import CascadeLevel
 from crypto_screener.domain.models.cascade_type import CascadeType
 from crypto_screener.domain.models.context import Context
 from crypto_screener.domain.models.setup import Capture, Setup, Trade, Unfilled
@@ -19,10 +20,6 @@ from crypto_screener.domain.strategies.strategy import (
     StrategyVolumeConfig,
 )
 from crypto_screener.domain.swing_detector import add_swings
-from crypto_screener.domain.strategies.cascade_detector import (
-    CascadeDetector,
-    CascadeDetectorConfig,
-)
 
 
 @dataclass(frozen=True)
@@ -44,9 +41,6 @@ class GuStrategy(Strategy):
 
     def __init__(self, config: GuConfig = gu_cfg) -> None:
         self._config = config
-        self._cascade_detector = CascadeDetector(
-            CascadeDetectorConfig.from_strategy_config(config)
-        )
 
     def detect_setup(
             self,
@@ -384,10 +378,7 @@ class GuStrategy(Strategy):
             self,
             bars: list[Bar]
     ) -> Cascade | None:
-        swings = self._cascade_detector.detect(
-            bars,
-            cascade_type=CascadeType.LONG,
-        )
+        swings = self._detect_cascade_swings(bars, cascade_type=CascadeType.LONG)
         if not swings:
             return None
         return Cascade(swings=swings, direction=CascadeType.LONG)
@@ -396,13 +387,268 @@ class GuStrategy(Strategy):
             self,
             bars: list[Bar]
     ) -> Cascade | None:
-        swings = self._cascade_detector.detect(
-            bars,
-            cascade_type=CascadeType.SHORT,
-        )
+        swings = self._detect_cascade_swings(bars, cascade_type=CascadeType.SHORT)
         if not swings:
             return None
         return Cascade(swings=swings, direction=CascadeType.SHORT)
+
+    def _detect_cascade_swings(
+            self,
+            bars: list[Bar],
+            *,
+            cascade_type: CascadeType,
+    ) -> list[Swing]:
+        if not bars or len(bars) < 2:
+            return []
+
+        bars = bars[:-1]
+        if not bars:
+            return []
+
+        bars_count = len(bars)
+        avg_range = self._calculate_average_range(bars, self._config.CASCADE_ATR_WINDOW)
+        touch_tolerance = max(self._config.CASCADE_TOUCH_EPS_NATR * avg_range, 0.0)
+        min_pullback = max(self._config.CASCADE_MIN_PULLBACK_NATR * avg_range, 0.0)
+        min_pullback_bars = self._config.CASCADE_MIN_PULLBACK_BARS
+        min_gap_bars = self._config.CASCADE_MIN_GAP_BARS
+        min_touches = max(self._config.CASCADE_LENGTH_MIN, 3)
+        is_long = cascade_type is CascadeType.LONG
+
+        bar_data = []
+        for index, bar in enumerate(bars):
+            price = bar.high if is_long else bar.low
+            bar_data.append((index, price))
+
+        levels: list[CascadeLevel] = []
+        for index, level_price in bar_data:
+            cross_index = None
+            atr_crossed = False
+            for look_ahead in range(index + 1, bars_count):
+                look_bar = bars[look_ahead]
+                if is_long:
+                    if look_bar.high > level_price + avg_range:
+                        atr_crossed = True
+                        break
+                    if look_bar.high > level_price:
+                        cross_index = look_ahead
+                        break
+                else:
+                    if look_bar.low < level_price - avg_range:
+                        atr_crossed = True
+                        break
+                    if look_bar.low < level_price:
+                        cross_index = look_ahead
+                        break
+            if atr_crossed:
+                continue
+            end_idx = cross_index if cross_index is not None else bars_count
+            if is_long:
+                touches_raw = [
+                    i for i in range(index, end_idx)
+                    if level_price - bars[i].close <= touch_tolerance
+                    and bars[i].close <= level_price
+                ]
+            else:
+                touches_raw = [
+                    i for i in range(index, end_idx)
+                    if bars[i].close - level_price <= touch_tolerance
+                    and bars[i].close >= level_price
+                ]
+            if touches_raw:
+                levels.append(CascadeLevel(
+                    price=level_price,
+                    is_crossed=cross_index is not None,
+                    distance=(cross_index - index) if cross_index is not None else (bars_count - 1 - index),
+                    touches_raw=touches_raw,
+                ))
+
+        best_level_touches = []
+        best_level_touches_count = 0
+        best_level_price = None
+
+        for level in levels:
+            if level.is_crossed:
+                continue
+            touches = self._refine_touches(
+                bars,
+                level.price,
+                level.touches_raw,
+                min_gap_bars=min_gap_bars,
+                min_pullback=min_pullback,
+                min_pullback_bars=min_pullback_bars,
+                cascade_type=cascade_type,
+            )
+            touches_count = len(touches)
+
+            if touches_count > best_level_touches_count or (
+                    touches_count == best_level_touches_count and
+                    (not best_level_touches or touches[-1] > best_level_touches[-1])
+            ):
+                best_level_touches = touches
+                best_level_touches_count = touches_count
+                best_level_price = level.price
+
+        if not best_level_touches or best_level_touches_count < min_touches or best_level_price is None:
+            return []
+
+        if not self._passes_pullback_ratios(
+                bars,
+                best_level_touches,
+                best_level_price,
+                avg_range,
+                cascade_type=cascade_type,
+        ):
+            return []
+
+        first_touch_index = min(best_level_touches)
+        last_touch_index = max(best_level_touches)
+        if is_long:
+            last_touch_segment_extreme = min(bar.low for bar in bars[last_touch_index:])
+            first_touch_segment_extreme = min(bar.low for bar in bars[first_touch_index:last_touch_index - 1])
+            if last_touch_segment_extreme <= first_touch_segment_extreme:
+                return []
+        else:
+            last_touch_segment_extreme = max(bar.high for bar in bars[last_touch_index:])
+            first_touch_segment_extreme = max(bar.high for bar in bars[first_touch_index:last_touch_index - 1])
+            if last_touch_segment_extreme >= first_touch_segment_extreme:
+                return []
+
+        swing_type = SwingType.HIGH if is_long else SwingType.LOW
+        cascade_swings = []
+        for touch_index in best_level_touches:
+            bar = bars[touch_index]
+            swing = Swing(
+                time=bar.time,
+                extremum_price=best_level_price,
+                close_price=bar.close,
+                type=swing_type,
+                is_open=True,
+            )
+            cascade_swings.append(swing)
+
+        return cascade_swings
+
+    @staticmethod
+    def _refine_touches(
+            bars: list[Bar],
+            price: float,
+            touches_count: list[int],
+            *,
+            min_gap_bars: int,
+            min_pullback: float,
+            min_pullback_bars: int,
+            cascade_type: CascadeType,
+    ) -> list[int]:
+        if not touches_count:
+            return []
+        is_long = cascade_type is CascadeType.LONG
+        refined = touches_count[:]
+        while True:
+            changed = False
+            new_touches = []
+            last_touch = None
+            for touch_idx in refined:
+                if last_touch is None:
+                    new_touches.append(touch_idx)
+                    last_touch = touch_idx
+                    continue
+                if touch_idx - last_touch < min_gap_bars:
+                    changed = True
+                    continue
+                pullback_bars = bars[last_touch + 1:touch_idx]
+                if not pullback_bars:
+                    changed = True
+                    continue
+                if is_long:
+                    pullback_depth = max((price - pullback_bar.low) for pullback_bar in pullback_bars)
+                else:
+                    pullback_depth = max((pullback_bar.high - price) for pullback_bar in pullback_bars)
+                consecutive = 0
+                max_consecutive = 0
+                for pullback_bar in pullback_bars:
+                    if is_long:
+                        is_pullback = pullback_bar.close <= price - min_pullback
+                    else:
+                        is_pullback = pullback_bar.close >= price + min_pullback
+                    if is_pullback:
+                        consecutive += 1
+                        max_consecutive = max(max_consecutive, consecutive)
+                    else:
+                        consecutive = 0
+                has_pullback = pullback_depth >= min_pullback and max_consecutive >= min_pullback_bars
+                if not has_pullback:
+                    changed = True
+                    continue
+                new_touches.append(touch_idx)
+                last_touch = touch_idx
+            if not changed:
+                return new_touches
+            refined = new_touches
+
+    def _calculate_pullbacks(
+            self,
+            bars: list[Bar],
+            touch_indices: list[int],
+            level_price: float,
+            *,
+            cascade_type: CascadeType,
+    ) -> list[float]:
+        pullbacks: list[float] = []
+        for left_idx, right_idx in zip(touch_indices, touch_indices[1:]):
+            segment = bars[left_idx + 1:right_idx]
+            if not segment:
+                return []
+            if cascade_type is CascadeType.LONG:
+                segment_extreme = min(bar.low for bar in segment)
+                depth = level_price - segment_extreme
+            else:
+                segment_extreme = max(bar.high for bar in segment)
+                depth = segment_extreme - level_price
+            if depth <= 0:
+                return []
+            pullbacks.append(depth)
+        return pullbacks
+
+    def _passes_pullback_ratios(
+            self,
+            bars: list[Bar],
+            touch_indices: list[int],
+            level_price: float,
+            avg_range: float,
+            *,
+            cascade_type: CascadeType,
+    ) -> bool:
+        pullbacks = self._calculate_pullbacks(
+            bars,
+            touch_indices,
+            level_price,
+            cascade_type=cascade_type,
+        )
+        if len(pullbacks) < 2:
+            return False
+        first_depth = pullbacks[0]
+        second_depth = pullbacks[1]
+        if first_depth <= 0 or second_depth <= 0:
+            return False
+        min_pullback = self._config.CASCADE_MIN_PULLBACK_NATR * avg_range
+        if first_depth < min_pullback or second_depth < min_pullback:
+            return False
+        ratio = second_depth / first_depth
+        if not (
+                self._config.CASCADE_PULLBACK_SECOND_RATIO_MIN
+                <= ratio
+                <= self._config.CASCADE_PULLBACK_SECOND_RATIO_MAX
+        ):
+            return False
+        for depth in pullbacks[2:]:
+            ratio = depth / second_depth
+            if not (
+                    self._config.CASCADE_PULLBACK_NEXT_RATIO_MIN
+                    <= ratio
+                    <= self._config.CASCADE_PULLBACK_NEXT_RATIO_MAX
+            ):
+                return False
+        return True
 
     @staticmethod
     def _longest(*cascades: Cascade | None) -> Cascade | None:


### PR DESCRIPTION
### Motivation
- Align GU cascade detection with the cascade-level algorithm used by PPO to unify touch/pullback logic and parameters.
- Provide symmetric handling for SHORT cascades by inverting high/low checks, touch directions and pullback logic.
- Remove squeeze-related checks so that price `squeeze` no longer participates in GU cascade detection.
- Localize the cascade-level algorithm into the GU module to allow independent tuning and avoid relying on the shared `CascadeDetector`.

### Description
- Removed the `CascadeDetector` dependency/initialization from `GuStrategy` and switched `_get_cascade_long`/`_get_cascade_short` to use a new in-module detector `
_detect_cascade_swings`.
- Added a local cascade-level implementation using `CascadeLevel` semantics and helper functions `
_refine_touches`, `
_calculate_pullbacks`, and `
_passes_pullback_ratios` that use config parameters like `CASCADE_ATR_WINDOW`, `CASCADE_TOUCH_EPS_NATR`, `CASCADE_MIN_PULLBACK_NATR`, `CASCADE_MIN_PULLBACK_BARS`, and `CASCADE_MIN_GAP_BARS`.
- Implemented symmetric SHORT path by inverting price selections, touch tolerance and pullback checks when `cascade_type is CascadeType.SHORT`.
- Removed calls/logic that relied on a price `squeeze` check so the GU flow no longer depends on `_is_price_squeezed` or related squeeze gating.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694705e55c7083208b8ecc14fa6014d8)