### PR TITLE
Align GU cascade touch epsilon with PPO (set to 1.0)

### DIFF
--- a/crypto_screener/config/gu_config.py
+++ b/crypto_screener/config/gu_config.py
@@ -22,7 +22,7 @@ class GuConfig:
     # Размер окна ATR для анализа лонгового каскада.
     CASCADE_ATR_WINDOW: int = 50
     # Допуск по касаниям в долях ATR.
-    CASCADE_TOUCH_EPS_NATR: float = 6.0
+    CASCADE_TOUCH_EPS_NATR: float = 1.0
     # Максимальное перебитие уровня в долях ATR.
     CASCADE_OVERTOUCH_NATR: float = 0.5
     # Минимальное число свингов для образования каскада.


### PR DESCRIPTION
### Motivation
- The GU strategy configured `CASCADE_TOUCH_EPS_NATR` at `6.0`, which produced a different touch tolerance than the PPO strategy's `1.0` value.
- Cascade detection pulls `touch_eps_natr` from the strategy config, so unifying the constant ensures consistent cascade detection behavior across strategies.

### Description
- Update `crypto_screener/config/gu_config.py` to set `CASCADE_TOUCH_EPS_NATR` from `6.0` to `1.0`.
- No other code changes are required because `CascadeDetectorConfig.from_strategy_config` reads `CASCADE_TOUCH_EPS_NATR` and `GuStrategy` constructs the detector with that config.
- `CascadeDetector` uses the configured `touch_eps_natr` directly to compute `touch_tolerance`, so the new value is applied at runtime.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694707bf99108320abede7a97dc24bb8)