### PR TITLE
Remove unused `CASCADE_OVERTOUCH_NATR` from GU config

### DIFF
--- a/crypto_screener/config/gu_config.py
+++ b/crypto_screener/config/gu_config.py
@@ -23,8 +23,6 @@ class GuConfig:
     CASCADE_ATR_WINDOW: int = 50
     # Допуск по касаниям в долях ATR.
     CASCADE_TOUCH_EPS_NATR: float = 1.0
-    # Максимальное перебитие уровня в долях ATR.
-    CASCADE_OVERTOUCH_NATR: float = 0.5
     # Минимальное число свингов для образования каскада.
     CASCADE_LENGTH_MIN: int = 3
     # Минимальная доля отката после второго касания относительно первого.


### PR DESCRIPTION
### Motivation
- The cascade detection logic uses ATR-based `avg_range` to determine over-crosses, so the separate `CASCADE_OVERTOUCH_NATR` setting is redundant.
- The existing `CascadeDetector` already checks `look_bar.high > level_price + avg_range` (and the mirrored `low` check for SHORT), making the config unused.
- Removing unused configuration reduces confusion and prevents maintaining an obsolete parameter.

### Description
- Deleted the `CASCADE_OVERTOUCH_NATR` field from the `GuConfig` dataclass in `crypto_screener/config/gu_config.py`.
- No changes were made to `cascade_detector.py` because its ATR-based crossing logic already implements the desired behavior using `avg_range` and mirrored SHORT conditions.
- Updated repository with a commit titled `Remove unused cascade overtouch config`.

### Testing
- No automated tests were run for this change.
- The change is a config cleanup and does not modify runtime logic in code paths that were inspected.
- Existing behavior for cascade detection remains unchanged according to the reviewed code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947084871348320845295c66324c789)