### PR TITLE
Remove unused Gu cascade rolling window config

### DIFF
--- a/crypto_screener/config/gu_config.py
+++ b/crypto_screener/config/gu_config.py
@@ -41,10 +41,6 @@ class GuConfig:
     CASCADE_MIN_GAP_BARS: int = 5
     # Минимальное соотношение отступа поддержки от низа проторговки к размеру проторговки.
     SUPPORT_CONSOLIDATION_RATIO_MIN: float = 0.3
-    # Минимальная длительность окна группировки каскадов.
-    CASCADE_ROLLING_WINDOW_MIN_HOURS: int = 12
-    # Максимальная длительность окна группировки каскадов.
-    CASCADE_ROLLING_WINDOW_MAX_HOURS: int = 36
     # endregion
 
     # region Позиции.


### PR DESCRIPTION
### Motivation
- Remove obsolete cascade rolling window settings that are not used during Gu cascade detection to ensure squeeze-related config does not affect cascade selection.
- Reduce configuration surface and avoid confusion from unused parameters.

### Description
- Deleted `CASCADE_ROLLING_WINDOW_MIN_HOURS` and `CASCADE_ROLLING_WINDOW_MAX_HOURS` from `crypto_screener/config/gu_config.py`.
- Kept all other `GuConfig` fields intact and unchanged.
- No other references to the removed settings were found in the codebase, so no additional code changes were required.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694708fc22108320bbe443a12587f5d0)