### PR TITLE
Guard support price bounds in GU strategy

### DIFF
--- a/crypto_screener/domain/strategies/gu.py
+++ b/crypto_screener/domain/strategies/gu.py
@@ -148,7 +148,10 @@ class GuStrategy(Strategy):
 
             support_price_min = cascade_low_swing.extremum_price + consolidation_range * self._config.SUPPORT_CONSOLIDATION_RATIO_MIN
             support_price_max = target_swing.extremum_price
-            open_low_swings = self._filter_by_price(open_low_swings, support_price_min, support_price_max)
+            if support_price_min < support_price_max:
+                open_low_swings = self._filter_by_price(open_low_swings, support_price_min, support_price_max)
+            else:
+                open_low_swings = []
             support_swing = open_low_swings[-1] if open_low_swings else None
             if not support_swing:
                 last_red_bar = next((bar for bar in reversed(cascade_bars) if bar.close < bar.open), None)


### PR DESCRIPTION
### Motivation
- Prevent `ValueError` from `_filter_by_price` when computed `support_price_min` is not less than `support_price_max`.
- Align long-side cascade handling with the short-side branch which already checks bounds before filtering.
- Ensure `detect_setup` exits cleanly or falls back to empty supports when price bounds are invalid to avoid crashes.

### Description
- Add a conditional check `if support_price_min < support_price_max` before calling `_filter_by_price` in the long branch of `detect_setup`.
- When bounds are invalid, set `open_low_swings` to an empty list so `support_swing` and downstream logic handle the absence of supports.
- This avoids invoking `_filter_by_price` with invalid bounds and prevents the `ValueError` without changing the filter implementation.

### Testing
- No automated tests were run for this change.
- CI or unit test suites were not executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69470ada8c3483208c35b8b1c8b91f97)