### PR TITLE
Add retracement validation for GU cascades

### DIFF
--- a/crypto_screener/domain/strategies/gu.py
+++ b/crypto_screener/domain/strategies/gu.py
@@ -425,6 +425,101 @@ class GuStrategy(Strategy):
             prices = [swing.extremum_price for _, swing in window]
             level = float(np.median(prices)) if prices else 0.0
             if all(abs(price - level) <= touch_tolerance for price in prices):
+                first_retracement = 0.0
+                after_last_retracement = 0.0
+                bars_after_first = bars[first_index + 1:]
+                bars_after_last = bars[last_index + 1:]
+                if cascade_type is CascadeType.LONG:
+                    first_retracement_swing = next(
+                        (
+                            bar.swing
+                            for bar in bars_after_first
+                            if bar.swing
+                            and bar.swing.is_open
+                            and bar.swing.type is SwingType.LOW
+                        ),
+                        None,
+                    )
+                    if first_retracement_swing:
+                        first_retracement_price = first_retracement_swing.extremum_price
+                    else:
+                        first_retracement_price = min(
+                            (bar.low for bar in bars_after_first),
+                            default=first_swing.extremum_price,
+                        )
+                    first_retracement = max(
+                        0.0,
+                        first_swing.extremum_price - first_retracement_price,
+                    )
+
+                    after_last_swing = next(
+                        (
+                            bar.swing
+                            for bar in bars_after_last
+                            if bar.swing
+                            and bar.swing.is_open
+                            and bar.swing.type is SwingType.LOW
+                        ),
+                        None,
+                    )
+                    if after_last_swing:
+                        after_last_price = after_last_swing.extremum_price
+                    else:
+                        after_last_price = min(
+                            (bar.low for bar in bars_after_last),
+                            default=last_swing.extremum_price,
+                        )
+                    after_last_retracement = max(
+                        0.0,
+                        last_swing.extremum_price - after_last_price,
+                    )
+                else:
+                    first_retracement_swing = next(
+                        (
+                            bar.swing
+                            for bar in bars_after_first
+                            if bar.swing
+                            and bar.swing.is_open
+                            and bar.swing.type is SwingType.HIGH
+                        ),
+                        None,
+                    )
+                    if first_retracement_swing:
+                        first_retracement_price = first_retracement_swing.extremum_price
+                    else:
+                        first_retracement_price = max(
+                            (bar.high for bar in bars_after_first),
+                            default=first_swing.extremum_price,
+                        )
+                    first_retracement = max(
+                        0.0,
+                        first_retracement_price - first_swing.extremum_price,
+                    )
+
+                    after_last_swing = next(
+                        (
+                            bar.swing
+                            for bar in bars_after_last
+                            if bar.swing
+                            and bar.swing.is_open
+                            and bar.swing.type is SwingType.HIGH
+                        ),
+                        None,
+                    )
+                    if after_last_swing:
+                        after_last_price = after_last_swing.extremum_price
+                    else:
+                        after_last_price = max(
+                            (bar.high for bar in bars_after_last),
+                            default=last_swing.extremum_price,
+                        )
+                    after_last_retracement = max(
+                        0.0,
+                        after_last_price - last_swing.extremum_price,
+                    )
+
+                if after_last_retracement > 0.5 * first_retracement:
+                    continue
                 return Cascade(swings=[swing for _, swing in window], direction=cascade_type)
         return None
 


### PR DESCRIPTION
### Motivation
- Prevent false-positive cascades by validating that the initial pullback is not substantially deeper than the pullback after the last touch. 
- Measure retracements using available open `Swing`s and fall back to bar extremes when swings are absent. 
- Apply different retracement directions for `LONG` (downward retracements to LOW swings/bars) and `SHORT` (upward retracements to HIGH swings/bars). 

### Description
- Inserted retracement calculations into `GuStrategy._find_cascade_by_open_swings` in `crypto_screener/domain/strategies/gu.py` immediately after the cascade level touch check. 
- Compute `first_retracement` from `first_swing` using the first open opposite-type `Swing` after `first_index` or `bar.low`/`bar.high` fallback, and compute `after_last_retracement` from `last_swing` using the first open opposite-type `Swing` after `last_index` or bar extremes fallback. 
- Use `SwingType`, `bar.swing`, and extremum prices for calculations and ensure non-negative retracement values with defaults. 
- Invalidate (skip) a candidate cascade when `after_last_retracement > 0.5 * first_retracement` and otherwise return the `Cascade` as before. 

### Testing
- No automated tests were run. 
- Code changes were limited to `crypto_screener/domain/strategies/gu.py` and follow existing project patterns for swings and bars.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947b9ba89388320a4aee48eade2ce92)