### PR TITLE
Add `CASCADE_SWING_GAP_DIVISOR` and enforce minimum gaps when selecting swing triples

### DIFF
--- a/crypto_screener/config/gu_config.py
+++ b/crypto_screener/config/gu_config.py
@@ -27,6 +27,8 @@ class GuConfig:
     CASCADE_TOUCH_EPS_NATR: float = 1.0
     # Минимальное число свингов для образования каскада.
     CASCADE_LENGTH_MIN: int = 3
+    # Делитель для минимального разрыва между свингами в каскаде.
+    CASCADE_SWING_GAP_DIVISOR: int = 6
     # Минимальная доля отката после второго касания относительно первого.
     CASCADE_PULLBACK_SECOND_RATIO_MIN: float = 0.5
     # Максимальная доля отката после второго касания относительно первого.

--- a/crypto_screener/domain/strategies/gu.py
+++ b/crypto_screener/domain/strategies/gu.py
@@ -412,8 +412,18 @@ class GuStrategy(Strategy):
         min_width_hours = self._config.CASCADE_MIN_WIDTH_HOURS
 
         for start in range(len(open_swings) - min_cascade_length + 1):
-            window = open_swings[start:start + min_cascade_length]
-            first_index, first_swing = window[0]
+            first_index, first_swing = open_swings[start]
+            second_index, second_swing = open_swings[start + 1]
+            third_index, third_swing = open_swings[start + 2]
+            distance_from_first = third_index - first_index
+            min_gap = max(distance_from_first // self._config.CASCADE_SWING_GAP_DIVISOR, 1)
+            if second_index - first_index < min_gap or third_index - second_index < min_gap:
+                continue
+            window = [
+                (first_index, first_swing),
+                (second_index, second_swing),
+                (third_index, third_swing),
+            ]
             last_index, last_swing = window[-1]
             bars_index_delta = last_index - first_index
             time_delta_hours = (last_swing.time - first_swing.time).total_seconds() / 3600


### PR DESCRIPTION
### Motivation
- Prevent cascade detection from selecting three open swings that are too close in bars and produce spurious cascades.
- Make the minimum spacing between selected swings configurable via strategy config.
- Keep existing cascade validation (width, touches, retracements) unchanged and only apply them to filtered swing triplets.

### Description
- Add `CASCADE_SWING_GAP_DIVISOR` to `GuConfig` as an integer configuration parameter. 
- Update `GuStrategy._find_cascade_by_open_swings` to select triples using `first_index`, `second_index`, `third_index` from `open_swings` and compute `distance_from_first` and `min_gap` as `max(distance_from_first // self._config.CASCADE_SWING_GAP_DIVISOR, 1)`.
- Require `second_index - first_index >= min_gap` and `third_index - second_index >= min_gap` before forming the `window`, and then run the existing cascade checks on the filtered triples.
- Use `self._config.CASCADE_SWING_GAP_DIVISOR` for the new behavior and leave other cascade validations intact.

### Testing
- No automated tests were run for this change per repository instructions.
- Manual static checks only; no test failures reported.
- No additional test files were added.
- Linting/formatting adjustments not required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69481bd006388320809a37e7909c516c)