### PR TITLE
Add allowed timeframe configuration for strategies

### DIFF
--- a/crypto_screener/config/app_config.py
+++ b/crypto_screener/config/app_config.py
@@ -12,7 +12,7 @@ from crypto_screener.domain.strategies.strategy import Strategy
 _timezone: ZoneInfo = ZoneInfo("Europe/Belgrade")
 
 # Таймфреймы.
-_timeframes: list[Timeframe] = [Timeframe.H1, Timeframe.M30, Timeframe.M15, Timeframe.M5]
+_timeframes: list[Timeframe] = [Timeframe.D1, Timeframe.H1, Timeframe.M30, Timeframe.M15, Timeframe.M5]
 _timeframe_intervals: dict[Timeframe, timedelta] = {
     timeframe: timedelta(minutes=timeframe.minutes)
     for timeframe in Timeframe
@@ -26,6 +26,7 @@ _poll_intervals: dict[Timeframe, timedelta] = {
     Timeframe.M30: timedelta(minutes=10),
     Timeframe.H1: timedelta(minutes=15),
     Timeframe.H4: timedelta(hours=1),
+    Timeframe.D1: timedelta(hours=6),
 }
 
 # Интервалы опроса Capture для анализа таймфреймов.
@@ -36,6 +37,7 @@ _capture_poll_intervals: dict[Timeframe, timedelta] = {
     Timeframe.M30: timedelta(seconds=20),
     Timeframe.H1: timedelta(minutes=1),
     Timeframe.H4: timedelta(minutes=5),
+    Timeframe.D1: timedelta(minutes=30),
 }
 
 # Данные для тестирования конкретных символов.

--- a/crypto_screener/config/gu_config.py
+++ b/crypto_screener/config/gu_config.py
@@ -1,8 +1,13 @@
 from dataclasses import dataclass
 
+from crypto_screener.domain.models.timeframe import Timeframe
+
 
 @dataclass(frozen=True)
 class GuConfig:
+    # Допустимые таймфреймы.
+    ALLOWED_TIMEFRAMES: tuple[Timeframe, ...] = (Timeframe.D1,)
+
     # region Сетапы.
     CAPTURE_TIMEOUT_MULTIPLIER: int = 12
     # Количество баров для анализа уровня.

--- a/crypto_screener/config/ppo_config.py
+++ b/crypto_screener/config/ppo_config.py
@@ -1,8 +1,18 @@
 from dataclasses import dataclass
 
+from crypto_screener.domain.models.timeframe import Timeframe
+
 
 @dataclass(frozen=True)
 class PpoConfig:
+    # Допустимые таймфреймы.
+    ALLOWED_TIMEFRAMES: tuple[Timeframe, ...] = (
+        Timeframe.H1,
+        Timeframe.M30,
+        Timeframe.M15,
+        Timeframe.M5,
+    )
+
     # region Сетапы.
     CAPTURE_TIMEOUT_MULTIPLIER: int = 12
     # endregion

--- a/crypto_screener/domain/models/timeframe.py
+++ b/crypto_screener/domain/models/timeframe.py
@@ -10,6 +10,7 @@ class Timeframe(Enum):
     M30 = ("30m", 30)
     H1 = ("1h", 60)
     H4 = ("4h", 240)
+    D1 = ("1d", 1440)
 
     @property
     def tf(self) -> str:

--- a/crypto_screener/domain/strategies/gu.py
+++ b/crypto_screener/domain/strategies/gu.py
@@ -32,6 +32,10 @@ class GuStrategy(Strategy):
         self._config = config
         self._direction = direction
 
+    @property
+    def allowed_timeframes(self) -> tuple[Timeframe, ...]:
+        return self._config.ALLOWED_TIMEFRAMES
+
     def detect_setup(
             self,
             symbol: str,

--- a/crypto_screener/domain/strategies/ppo.py
+++ b/crypto_screener/domain/strategies/ppo.py
@@ -31,6 +31,10 @@ class PpoStrategy(Strategy):
             CascadeDetectorConfig.from_strategy_config(config)
         )
 
+    @property
+    def allowed_timeframes(self) -> tuple[Timeframe, ...]:
+        return self._config.ALLOWED_TIMEFRAMES
+
     def detect_setup(
             self,
             symbol: str,

--- a/crypto_screener/domain/strategies/strategy.py
+++ b/crypto_screener/domain/strategies/strategy.py
@@ -27,6 +27,14 @@ class StrategyVolumeConfig:
 class Strategy(ABC):
     name: str
 
+    @property
+    @abstractmethod
+    def allowed_timeframes(self) -> tuple[Timeframe, ...]:
+        """Возвращает поддерживаемые таймфреймы."""
+
+    def is_timeframe_allowed(self, timeframe: Timeframe) -> bool:
+        return timeframe in self.allowed_timeframes
+
     def trim_by_volume(self, bars: list[Bar]) -> list[Bar]:
         volume_config = self.get_volume_config()
         length = len(bars)

--- a/crypto_screener/execution/run_live.py
+++ b/crypto_screener/execution/run_live.py
@@ -1140,6 +1140,12 @@ def _run_analysis_task(
     bars_cache: dict[int, list[Bar]] = {}
     try:
         for strategy in strategies:
+            if not strategy.is_timeframe_allowed(timeframe):
+                log.d(
+                    f"Пропуск анализа {symbol.symbol} на {timeframe.tf}: таймфрейм не поддерживается "
+                    f"стратегией {strategy.name}."
+                )
+                continue
             bars: list[Bar] = []
             setup: Optional[Setup] = None
             outcome = None

--- a/crypto_screener/execution/run_test_symbol.py
+++ b/crypto_screener/execution/run_test_symbol.py
@@ -98,7 +98,13 @@ def _detect_setup(
         bars: list[Bar],
         timeframe: Timeframe,
         context: Context,
-) -> Setup:
+) -> Optional[Setup]:
+    if not strategy.is_timeframe_allowed(timeframe):
+        log.d(
+            f"Пропуск анализа {symbol} на {timeframe.tf}: таймфрейм не поддерживается "
+            f"стратегией {strategy.name}."
+        )
+        return None
     setup = strategy.detect_setup(symbol, bars, timeframe, context)
     if setup.is_filled:
         log.d(f"На {symbol} ({timeframe.tf}) обнаружен {setup.name.capitalize()}-сетап.")
@@ -148,6 +154,8 @@ def run_test_bars(
         return None
     detection_time = detection_time or bars[-1].time
     setup = _detect_setup(strategy, symbol, bars, timeframe, context)
+    if not setup:
+        return None
     match plot_policy:
         case PlotPolicy.ON_ANY:
             _plot(setup, subdir, postmortem_bars, detection_time, context=context)


### PR DESCRIPTION
## Summary
- add allowed timeframe lists for PPO and GU strategies and include the D1 timeframe option
- skip setup analysis on unsupported timeframes while updating default timeframe lists and polling intervals

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fc26a9e00832097fef38832fe86f8)