### PR TITLE
Add exchange capability flag for trade count filter

### DIFF
--- a/crypto_screener/data/exchanges/binance.py
+++ b/crypto_screener/data/exchanges/binance.py
@@ -38,6 +38,10 @@ class Binance(Exchange):
     def get_name() -> str:
         return "Binance"
 
+    @property
+    def supports_trades_filter(self) -> bool:
+        return True
+
     def get_futures_symbols(self) -> list[FuturesSymbol]:
         try:
             markets = self._client.load_markets()

--- a/crypto_screener/data/exchanges/bybit.py
+++ b/crypto_screener/data/exchanges/bybit.py
@@ -39,6 +39,10 @@ class Bybit(Exchange):
     def get_name() -> str:
         return "Bybit"
 
+    @property
+    def supports_trades_filter(self) -> bool:
+        return False
+
     def get_futures_symbols(self) -> list[FuturesSymbol]:
         try:
             markets = self._client.load_markets()

--- a/crypto_screener/domain/exchange.py
+++ b/crypto_screener/domain/exchange.py
@@ -17,6 +17,11 @@ class Exchange(ABC):
     def get_name() -> str:
         pass
 
+    @property
+    @abstractmethod
+    def supports_trades_filter(self) -> bool:
+        ...
+
     @abstractmethod
     def get_futures_symbols(self) -> list[FuturesSymbol]:
         ...

--- a/crypto_screener/execution/run_test_market.py
+++ b/crypto_screener/execution/run_test_market.py
@@ -109,8 +109,8 @@ def run_test_market(
     symbols = set_contexts(symbols, listing_age_days_min, symbol_cfg.context)
     log.d(f"Получено {len(symbols)} символов до фильтрации.")
 
-    skip_trades_filter = exchange.get_name() == "Bybit"
-    trades_filter = None if skip_trades_filter else trades_24h_min
+    trades_filter_supported = exchange.supports_trades_filter
+    trades_filter = trades_24h_min if trades_filter_supported else None
 
     symbols = _filter_symbols(
         symbols,
@@ -118,14 +118,14 @@ def run_test_market(
         trades_filter,
         listing_age_days_min,
     )
-    if skip_trades_filter:
+    if trades_filter_supported:
         log.d(
-            f"Фильтры: объем ≥ {volume_24h_usdt_min}, возраст ≥ {listing_age_days_min} дней. "
-            "Фильтр по числу сделок отключен для Bybit."
+            f"Фильтры: объем ≥ {volume_24h_usdt_min}, сделки ≥ {trades_24h_min}, возраст ≥ {listing_age_days_min} дней"
         )
     else:
         log.d(
-            f"Фильтры: объем ≥ {volume_24h_usdt_min}, сделки ≥ {trades_24h_min}, возраст ≥ {listing_age_days_min} дней"
+            f"Фильтры: объем ≥ {volume_24h_usdt_min}, возраст ≥ {listing_age_days_min} дней. "
+            f"Фильтр по числу сделок отключен для {exchange.get_name()}."
         )
     log.d(f"После фильтрации осталось {len(symbols)} символов.")
 


### PR DESCRIPTION
## Summary
- add a capability flag to Exchange indicating support for trade count filtering
- implement the flag for Binance and Bybit and use it when applying trade filters during market testing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd0616fd883208d2fd4606bf3bd50)