### PR TITLE
Draw cascade level from first candle only

### DIFF
--- a/crypto_screener/utils/plotter.py
+++ b/crypto_screener/utils/plotter.py
@@ -640,8 +640,7 @@ def _draw_cascade_level(
         return
 
     start_swing = cascade_swings[0]
-    level_swings = cascade_swings[1:] if len(cascade_swings) > 1 else cascade_swings
-    level_price = np.mean([swing.extremum_price for swing in level_swings])
+    level_price = start_swing.extremum_price
     start_time = start_swing.time
     start_index = next((index for index, bar in enumerate(bars) if bar.time == start_time), None)
     if start_index is None:


### PR DESCRIPTION
## Summary
- draw the cascade level using the first candle of the selected cascade as the anchor price
- keep cascade level rendering aligned with the chosen cascade instead of later swings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd160d5b88320bd6f4f41b7762dab)