### PR TITLE
Limit cascade level rendering to cascade span

### DIFF
--- a/crypto_screener/domain/models/setup_data.py
+++ b/crypto_screener/domain/models/setup_data.py
@@ -33,3 +33,5 @@ class Gu(SetupData):
     current_price: Optional[float] = None
     distance_to_level: Optional[float] = None
     distance_atr_ratio: Optional[float] = None
+    cascade_swings: Optional[list[Swing]] = None
+    support_swings: Optional[list[Swing]] = None

--- a/crypto_screener/utils/plotter.py
+++ b/crypto_screener/utils/plotter.py
@@ -131,11 +131,11 @@ def _plot_ppo(
 
     y_offset = max((max_price - min_price) * theme.y_offset_ratio, theme.y_offset_min)
 
-    cascade_swings = getattr(data, "cascade_swings", None)
-    resistance_swings = getattr(data, "resistance_swings", None)
-    support_swings = getattr(data, "support_swings", None)
-    main_low_swing = getattr(data, "main_low_swing", None)
-    main_high_swing = getattr(data, "main_high_swing", None)
+    cascade_swings = data.cascade_swings
+    resistance_swings = data.resistance_swings
+    support_swings = data.support_swings
+    main_low_swing = data.main_low_swing
+    main_high_swing = data.main_high_swing
 
     if main_low_swing and main_high_swing:
         start_time = _datetime_to_mpl(main_low_swing.time)
@@ -394,9 +394,9 @@ def _plot_gu(
         )
     _format_ax(price_ax, times, min_price, max_price, theme)
 
-    cascade_swings = getattr(data, "cascade_swings", None)
+    cascade_swings = data.cascade_swings
 
-    level_price = getattr(data, "level_price", None)
+    level_price = data.level_price
     if level_price is not None and not cascade_swings:
         price_ax.axhline(
             y=level_price,
@@ -425,7 +425,7 @@ def _plot_gu(
     _format_volume_ax(volume_ax, volumes, theme)
     _format_time_axis(volume_ax, theme)
 
-    support_swings = getattr(data, "support_swings", None)
+    support_swings = data.support_swings
 
     if cascade_swings:
         _draw_cascade_level(price_ax, cascade_swings, combined_bars, theme)

--- a/crypto_screener/utils/plotter.py
+++ b/crypto_screener/utils/plotter.py
@@ -187,7 +187,7 @@ def _plot_ppo(
 
     level_price = getattr(data, "level_price", None)
     current_price = getattr(data, "current_price", None) or (data.bars[-1].close if data.bars else None)
-    if level_price is not None:
+    if level_price is not None and not cascade_swings:
         price_ax.axhline(
             y=level_price,
             xmin=0,
@@ -394,8 +394,10 @@ def _plot_gu(
         )
     _format_ax(price_ax, times, min_price, max_price, theme)
 
+    cascade_swings = getattr(data, "cascade_swings", None)
+
     level_price = getattr(data, "level_price", None)
-    if level_price is not None:
+    if level_price is not None and not cascade_swings:
         price_ax.axhline(
             y=level_price,
             xmin=0,
@@ -423,7 +425,6 @@ def _plot_gu(
     _format_volume_ax(volume_ax, volumes, theme)
     _format_time_axis(volume_ax, theme)
 
-    cascade_swings = getattr(data, "cascade_swings", None)
     support_swings = getattr(data, "support_swings", None)
 
     if cascade_swings:
@@ -640,8 +641,7 @@ def _draw_cascade_level(
         return
 
     start_swing = cascade_swings[0]
-    level_swings = cascade_swings[1:] if len(cascade_swings) > 1 else cascade_swings
-    level_price = np.mean([swing.extremum_price for swing in level_swings])
+    level_price = start_swing.extremum_price
     start_time = start_swing.time
     start_index = next((index for index, bar in enumerate(bars) if bar.time == start_time), None)
     if start_index is None:
@@ -665,6 +665,18 @@ def _draw_cascade_level(
         linewidth=theme.cascade_level_linewidth,
         linestyles=theme.cascade_level_linestyle,
         alpha=theme.cascade_level_alpha,
+        zorder=theme.cascade_level_zorder,
+    )
+
+    ax.text(
+        end_time_mpl,
+        level_price,
+        f"{level_price:.4f}",
+        color=theme.cascade_level_color,
+        ha="left",
+        va="bottom",
+        fontsize=9,
+        alpha=0.9,
         zorder=theme.cascade_level_zorder,
     )
 


### PR DESCRIPTION
## Summary
- avoid drawing the cascade level across the entire chart when cascade swings are available
- render the cascade level and label only from the first cascade bar through the cutoff point

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd160d5b88320bd6f4f41b7762dab)