### PR TITLE
Adjust level drawing bounds without cascade swings

### DIFF
--- a/crypto_screener/utils/plotter.py
+++ b/crypto_screener/utils/plotter.py
@@ -188,25 +188,12 @@ def _plot_ppo(
     level_price = getattr(data, "level_price", None)
     current_price = getattr(data, "current_price", None) or (data.bars[-1].close if data.bars else None)
     if level_price is not None and not cascade_swings:
-        price_ax.axhline(
-            y=level_price,
-            xmin=0,
-            xmax=1,
-            color=theme.cascade_level_color,
-            linestyle=theme.cascade_level_linestyle,
-            linewidth=theme.cascade_level_linewidth,
-            alpha=theme.cascade_level_alpha,
-            zorder=theme.cascade_level_zorder,
-        )
-        price_ax.text(
-            times[-1],
-            level_price,
-            f"{level_price:.4f}",
-            color=theme.cascade_level_color,
-            ha="right",
-            va="bottom",
-            fontsize=9,
-            alpha=0.9,
+        _draw_level_with_bounds(
+            ax=price_ax,
+            level_price=level_price,
+            bars=combined_bars,
+            theme=theme,
+            start_index=0,
         )
     if current_price is not None:
         price_ax.axhline(
@@ -398,27 +385,12 @@ def _plot_gu(
 
     level_price = data.level_price
     if level_price is not None and not cascade_swings:
-        price_ax.axhline(
-            y=level_price,
-            xmin=0,
-            xmax=1,
-            color=theme.cascade_level_color,
-            linestyle=theme.cascade_level_linestyle,
-            linewidth=theme.cascade_level_linewidth,
-            alpha=theme.cascade_level_alpha,
-            zorder=theme.cascade_level_zorder,
-        )
-        label_x = times[-1] + candle_width
-        price_ax.text(
-            label_x,
-            level_price,
-            f"{level_price:.4f}",
-            color=theme.cascade_level_color,
-            ha="left",
-            va="bottom",
-            fontsize=9,
-            alpha=0.9,
-            zorder=theme.cascade_level_zorder,
+        _draw_level_with_bounds(
+            ax=price_ax,
+            level_price=level_price,
+            bars=combined_bars,
+            theme=theme,
+            start_index=0,
         )
 
     volumes = _draw_volume(volume_ax, combined_bars, times, candle_width, theme)
@@ -631,20 +603,15 @@ def _draw_swing_group(
         )
 
 
-def _draw_cascade_level(
+def _draw_level_with_bounds(
         ax: Axes,
-        cascade_swings: list[Swing],
+        level_price: float,
         bars: list[Bar],
         theme: PlotTheme,
+        *,
+        start_index: int,
 ):
-    if not cascade_swings or not bars:
-        return
-
-    start_swing = cascade_swings[0]
-    level_price = start_swing.extremum_price
-    start_time = start_swing.time
-    start_index = next((index for index, bar in enumerate(bars) if bar.time == start_time), None)
-    if start_index is None:
+    if not bars or start_index >= len(bars):
         return
 
     end_index = len(bars) - 1
@@ -678,6 +645,31 @@ def _draw_cascade_level(
         fontsize=9,
         alpha=0.9,
         zorder=theme.cascade_level_zorder,
+    )
+
+
+def _draw_cascade_level(
+        ax: Axes,
+        cascade_swings: list[Swing],
+        bars: list[Bar],
+        theme: PlotTheme,
+):
+    if not cascade_swings or not bars:
+        return
+
+    start_swing = cascade_swings[0]
+    level_price = start_swing.extremum_price
+    start_time = start_swing.time
+    start_index = next((index for index, bar in enumerate(bars) if bar.time == start_time), None)
+    if start_index is None:
+        return
+
+    _draw_level_with_bounds(
+        ax=ax,
+        level_price=level_price,
+        bars=bars,
+        theme=theme,
+        start_index=start_index,
     )
 
 


### PR DESCRIPTION
## Summary
- draw level lines for missing cascade swings using candle time bounds
- reuse shared helper to mirror cascade level drawing logic for default cascades

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fda4f4bc88320b73cb8c70ce930c3)