### PR TITLE
Draw cascade levels from cascade start to chart end

### DIFF
--- a/crypto_screener/utils/plotter.py
+++ b/crypto_screener/utils/plotter.py
@@ -610,16 +610,18 @@ def _draw_level_with_bounds(
         theme: PlotTheme,
         *,
         start_index: int,
+        stop_on_breakout: bool = True,
 ):
     if not bars or start_index >= len(bars):
         return
 
     end_index = len(bars) - 1
-    for index in range(start_index + 1, len(bars)):
-        bar = bars[index]
-        if bar.open > level_price or bar.close > level_price:
-            end_index = index
-            break
+    if stop_on_breakout:
+        for index in range(start_index + 1, len(bars)):
+            bar = bars[index]
+            if bar.open > level_price or bar.close > level_price:
+                end_index = index
+                break
 
     start_time_mpl = _datetime_to_mpl(bars[start_index].time)
     end_time_mpl = _datetime_to_mpl(bars[end_index].time)
@@ -670,6 +672,7 @@ def _draw_cascade_level(
         bars=bars,
         theme=theme,
         start_index=start_index,
+        stop_on_breakout=False,
     )
 
 


### PR DESCRIPTION
## Summary
- add control to level drawing to stop honoring breakout points when desired
- render cascade levels from the first cascade swing through the end of the chart

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd841610083208c5c3877496dc4e1)