### PR TITLE
Add plotting defaults to setup data classes

### DIFF
--- a/crypto_screener/domain/models/setup_data.py
+++ b/crypto_screener/domain/models/setup_data.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 from crypto_screener.domain.models.bar import Bar
@@ -17,18 +17,22 @@ class SetupData(ABC):
 
 @dataclass
 class Ppo(SetupData):
-    main_low_swing: Optional[Swing]
-    main_high_swing: Optional[Swing]
-    cascade_swings: Optional[list[Swing]]
-    resistance_swings: Optional[list[Swing]]
-    support_swings: Optional[list[Swing]]
+    main_low_swing: Optional[Swing] = None
+    main_high_swing: Optional[Swing] = None
+    cascade_swings: list[Swing] = field(default_factory=list)
+    resistance_swings: list[Swing] = field(default_factory=list)
+    support_swings: list[Swing] = field(default_factory=list)
+    level_price: Optional[float] = None
+    current_price: Optional[float] = None
 
 
 @dataclass
 class Gu(SetupData):
     direction: CascadeType
-    level_price: Optional[float]
-    open_extremums: Optional[list[float]]
+    level_price: Optional[float] = None
+    open_extremums: Optional[list[float]] = None
+    cascade_swings: list[Swing] = field(default_factory=list)
+    support_swings: list[Swing] = field(default_factory=list)
     atr: Optional[float] = None
     current_price: Optional[float] = None
     distance_to_level: Optional[float] = None

--- a/crypto_screener/domain/strategies/ppo.py
+++ b/crypto_screener/domain/strategies/ppo.py
@@ -47,11 +47,6 @@ class PpoStrategy(Strategy):
                 symbol=symbol,
                 timeframe=timeframe,
                 bars=bars,
-                main_low_swing=None,
-                main_high_swing=None,
-                cascade_swings=None,
-                resistance_swings=None,
-                support_swings=None
             )
         )
 

--- a/crypto_screener/utils/plotter.py
+++ b/crypto_screener/utils/plotter.py
@@ -131,11 +131,11 @@ def _plot_ppo(
 
     y_offset = max((max_price - min_price) * theme.y_offset_ratio, theme.y_offset_min)
 
-    cascade_swings = getattr(data, "cascade_swings", None)
-    resistance_swings = getattr(data, "resistance_swings", None)
-    support_swings = getattr(data, "support_swings", None)
-    main_low_swing = getattr(data, "main_low_swing", None)
-    main_high_swing = getattr(data, "main_high_swing", None)
+    cascade_swings = data.cascade_swings
+    resistance_swings = data.resistance_swings
+    support_swings = data.support_swings
+    main_low_swing = data.main_low_swing
+    main_high_swing = data.main_high_swing
 
     if main_low_swing and main_high_swing:
         start_time = _datetime_to_mpl(main_low_swing.time)
@@ -185,8 +185,8 @@ def _plot_ppo(
         )
     _format_ax(price_ax, times, min_price, max_price, theme)
 
-    level_price = getattr(data, "level_price", None)
-    current_price = getattr(data, "current_price", None) or (data.bars[-1].close if data.bars else None)
+    level_price = data.level_price
+    current_price = data.current_price or (data.bars[-1].close if data.bars else None)
     if level_price is not None:
         price_ax.axhline(
             y=level_price,
@@ -423,8 +423,8 @@ def _plot_gu(
     _format_volume_ax(volume_ax, volumes, theme)
     _format_time_axis(volume_ax, theme)
 
-    cascade_swings = getattr(data, "cascade_swings", None)
-    support_swings = getattr(data, "support_swings", None)
+    cascade_swings = data.cascade_swings
+    support_swings = data.support_swings
 
     if cascade_swings:
         _draw_cascade_level(price_ax, cascade_swings, combined_bars, theme)


### PR DESCRIPTION
## Summary
- add explicit optional plotting fields with defaults to Ppo and Gu setup data classes
- adjust Ppo strategy initialization to rely on dataclass defaults
- read plotting attributes directly from setup data instead of using getattr

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fe39a42f083209ac592df25d4d2bb)