### PR TITLE
Use ATR multiplier for take profit and diary formulas

### DIFF
--- a/bot/data/diary.py
+++ b/bot/data/diary.py
@@ -653,6 +653,12 @@ class WorkbookDiaryBackend(DiaryBackend):
         pinbar_filter_column = get_column_letter(
             self._ANOMALIES_HEADERS.index("long_filter_pinbar_shape_pass") + 1
         )
+        atr_mult_column = get_column_letter(
+            self._ANOMALIES_HEADERS.index("metrics_atr_mult") + 1
+        )
+        break_direction_column = get_column_letter(
+            self._ANOMALIES_HEADERS.index("metrics_break_direction") + 1
+        )
         pinbar_body_column = get_column_letter(
             self._ANOMALIES_HEADERS.index("pinbar_body_pct") + 1
         )
@@ -671,8 +677,15 @@ class WorkbookDiaryBackend(DiaryBackend):
         metrics_lower_wick_column = get_column_letter(
             self._ANOMALIES_HEADERS.index("metrics_lower_wick_pct") + 1
         )
+        take_profit_atr_mult_column = get_column_letter(
+            self._ANOMALIES_HEADERS.index("thresholds_take_profit_atr_mult") + 1
+        )
         long_rr_formula = (
-            f'=IFERROR((G{row_index}-I{row_index})/(I{row_index}-H{row_index}),"")'
+            f"=IFERROR("
+            f"IF(${atr_mult_column}{row_index}=0,\"\","
+            f"(({take_profit_atr_mult_column}{row_index}*(G{row_index}-H{row_index})/${atr_mult_column}{row_index})/"
+            f"(I{row_index}-H{row_index}))),\"\")"
+            f")"
         )
         long_filter_green_move_formula = (
             f"=IF($AC{row_index}>={threshold_cells['thresholds_min_green_move_pct']},TRUE,FALSE)"
@@ -765,11 +778,16 @@ class WorkbookDiaryBackend(DiaryBackend):
         thresholds_countertrend_formula = (
             f"={threshold_cells['thresholds_countertrend_only']}"
         )
+        take_profit_price_formula = (
+            f"I{row_index}+IF(${atr_mult_column}{row_index}=0,0,"
+            f"(G{row_index}-H{row_index})/${atr_mult_column}{row_index}*${take_profit_atr_mult_column}{row_index})"
+        )
+        break_direction_cell = f"${break_direction_column}{row_index}"
         long_pnl_formula = (
             f'=IF($L{row_index},'
             f'IF($I{row_index}=0,"",'
-            f'IF($AK{row_index}="HIGH_FIRST",(G{row_index}-I{row_index})/I{row_index}*100,'
-            f'IF(OR($AK{row_index}="LOW_FIRST",$AK{row_index}="BOTH"),(H{row_index}-I{row_index})/I{row_index}*100,0))),'
+            f'IF({break_direction_cell}="HIGH_FIRST",(MIN(G{row_index},{take_profit_price_formula})-I{row_index})/I{row_index}*100,'
+            f'IF(OR({break_direction_cell}="LOW_FIRST",{break_direction_cell}="BOTH"),(H{row_index}-I{row_index})/I{row_index}*100,0))),'
             f'"")'
         )
         long_equity_formula = (

--- a/bot/domain/analyzer.py
+++ b/bot/domain/analyzer.py
@@ -29,6 +29,24 @@ class AnalyzerSettings:
     max_upper_wick_pct: float = config.MAX_UPPER_WICK_PCT
     max_lower_wick_pct: float = config.MAX_LOWER_WICK_PCT
 
+    @classmethod
+    def from_snapshot(cls, snapshot: ThresholdSnapshot) -> "AnalyzerSettings":
+        return cls(
+            min_green_move_pct=snapshot.min_green_move_pct,
+            min_volume_spike=snapshot.min_volume_spike,
+            min_anomaly_relative_volume=config.ANOMALY_MIN_RELATIVE_VOLUME,
+            min_anomaly_atr_mult=config.ANOMALY_MIN_ATR_MULT,
+            min_anomaly_upper_wick_pct=config.ANOMALY_MIN_UPPER_WICK_PCT,
+            min_relative_volume=snapshot.min_relative_volume,
+            max_relative_volume=snapshot.max_relative_volume,
+            min_atr_mult=snapshot.min_atr_mult,
+            take_profit_atr_mult=snapshot.take_profit_atr_mult,
+            min_pct_move=snapshot.min_pct_move,
+            max_pct_move=snapshot.max_pct_move,
+            max_upper_wick_pct=snapshot.max_upper_wick_pct,
+            max_lower_wick_pct=snapshot.max_lower_wick_pct,
+        )
+
     def snapshot(self) -> ThresholdSnapshot:
         return ThresholdSnapshot(
             min_green_move_pct=self.min_green_move_pct,
@@ -99,15 +117,15 @@ class SignalAnalyzer:
             return None, anomaly
 
         direction = SignalDirection.LONG
+        entry_price = bar.close
+        stop_loss_price = bar.low
+        take_profit_offset = metrics.atr_mult * thresholds.take_profit_atr_mult
+        take_profit_price = entry_price + take_profit_offset
         levels = SignalLevels(
-            entry_price=bar.close,
-            take_profit_price=bar.high,
-            stop_loss_price=bar.low,
+            entry_price=entry_price,
+            take_profit_price=take_profit_price,
+            stop_loss_price=stop_loss_price,
         )
-
-        entry_price = levels.entry_price
-        take_profit_price = levels.take_profit_price
-        stop_loss_price = levels.stop_loss_price
 
         risk = entry_price - stop_loss_price
         if risk == 0:


### PR DESCRIPTION
## Summary
- compute take profit targets from ATR multiples instead of candle highs and provide conversion from threshold snapshots
- expose take-profit ATR multiplier through signals/anomalies and update diary RR/PnL formulas to use the configurable multiplier

## Testing
- python -m py_compile bot/domain/analyzer.py bot/data/diary.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953a7c2a9708320bf06ff705610149d)