### PR TITLE
Add CCXT futures adapter, CoinGecko client, Parquet storage and parallel fetchers

### DIFF
--- a/data/clients/coingecko_client.py
+++ b/data/clients/coingecko_client.py
@@ -1,0 +1,91 @@
+"""CoinGecko market data adapter with in-memory market-cap cache."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import requests
+
+from constants import COINGECKO_TIMEOUT_SECONDS
+from domain.abstract.market_data_client import MarketDataClient
+
+
+class CoinGeckoClient(MarketDataClient):
+    """Market cap provider backed by CoinGecko REST API."""
+
+    BASE_URL = "https://api.coingecko.com/api/v3"
+
+    def __init__(self, api_key: str = "", cache_ttl_hours: int = 24) -> None:
+        self._api_key = api_key
+        self._cache_ttl = timedelta(hours=cache_ttl_hours)
+        self._market_cap_cache: dict[str, tuple[float, datetime]] = {}
+        self._symbol_to_id: dict[str, str] = {}
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"accept": "application/json"}
+        if self._api_key:
+            headers["x-cg-demo-api-key"] = self._api_key
+        return headers
+
+    def _resolve_coin_id(self, symbol: str) -> str:
+        normalized = symbol.lower().replace("/usdt", "").replace("usdt", "")
+        if normalized in self._symbol_to_id:
+            return self._symbol_to_id[normalized]
+
+        response = requests.get(
+            f"{self.BASE_URL}/coins/list",
+            headers=self._headers(),
+            timeout=COINGECKO_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        for item in response.json():
+            item_symbol = str(item.get("symbol") or "").lower()
+            if item_symbol == normalized and normalized not in self._symbol_to_id:
+                self._symbol_to_id[normalized] = str(item["id"])
+                break
+
+        if normalized not in self._symbol_to_id:
+            raise ValueError(f"Unable to resolve CoinGecko ID for symbol: {symbol}")
+
+        return self._symbol_to_id[normalized]
+
+    def get_market_cap(self, symbol: str) -> float:
+        normalized = symbol.upper()
+        now = datetime.now(tz=timezone.utc)
+
+        cached = self._market_cap_cache.get(normalized)
+        if cached and cached[1] > now:
+            return cached[0]
+
+        coin_id = self._resolve_coin_id(symbol)
+        response = requests.get(
+            f"{self.BASE_URL}/coins/markets",
+            headers=self._headers(),
+            params={"vs_currency": "usd", "ids": coin_id, "order": "market_cap_desc", "per_page": 1, "page": 1},
+            timeout=COINGECKO_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if not payload:
+            raise ValueError(f"CoinGecko returned empty market data for symbol: {symbol}")
+
+        market_cap = float(payload[0].get("market_cap") or 0.0)
+        self._market_cap_cache[normalized] = (market_cap, now + self._cache_ttl)
+        return market_cap
+
+    def get_top_coins_by_market_cap(self, limit: int) -> list[str]:
+        response = requests.get(
+            f"{self.BASE_URL}/coins/markets",
+            headers=self._headers(),
+            params={
+                "vs_currency": "usd",
+                "order": "market_cap_desc",
+                "per_page": limit,
+                "page": 1,
+                "sparkline": "false",
+            },
+            timeout=COINGECKO_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+
+        return [str(item.get("symbol") or "").upper() for item in response.json() if item.get("symbol")]

--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -1,0 +1,169 @@
+"""CCXT-based futures-only exchange adapter."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pandas as pd
+
+from constants import DEFAULT_FETCH_BATCH_SIZE, EXCHANGE_TIMEOUT_SECONDS
+from domain.abstract.exchange_client import ExchangeClient
+from domain.enums.exchange import Exchange
+from domain.enums.timeframe import Timeframe
+
+try:
+    import ccxt  # type: ignore
+except ImportError:  # pragma: no cover
+    ccxt = None
+
+
+_TIMEFRAME_TO_CCXT = {
+    Timeframe.M1: "1m",
+    Timeframe.M5: "5m",
+    Timeframe.M15: "15m",
+    Timeframe.M30: "30m",
+    Timeframe.H1: "1h",
+    Timeframe.H4: "4h",
+    Timeframe.D1: "1d",
+    Timeframe.W1: "1w",
+}
+
+
+def _to_utc_ms(value: datetime) -> int:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    return int(value.timestamp() * 1000)
+
+
+class CcxtFuturesClient(ExchangeClient):
+    """Futures-only implementation for Binance/Bybit/OKX via CCXT."""
+
+    def __init__(
+        self,
+        exchange: Exchange | str,
+        api_key: str = "",
+        secret: str = "",
+        password: str = "",
+        enable_rate_limit: bool = True,
+    ) -> None:
+        if ccxt is None:
+            raise RuntimeError("ccxt is required for CcxtFuturesClient")
+
+        self.exchange = Exchange(str(exchange).upper()) if isinstance(exchange, str) else exchange
+        self._client = self._build_client(exchange=self.exchange, api_key=api_key, secret=secret, password=password, enable_rate_limit=enable_rate_limit)
+        self._client.load_markets()
+
+    def _build_client(self, exchange: Exchange, api_key: str, secret: str, password: str, enable_rate_limit: bool) -> Any:
+        params: dict[str, Any] = {
+            "apiKey": api_key,
+            "secret": secret,
+            "password": password,
+            "enableRateLimit": enable_rate_limit,
+            "timeout": EXCHANGE_TIMEOUT_SECONDS * 1000,
+        }
+        if exchange == Exchange.BINANCE:
+            return ccxt.binanceusdm(params)
+        if exchange == Exchange.BYBIT:
+            params["options"] = {"defaultType": "swap"}
+            return ccxt.bybit(params)
+        if exchange == Exchange.OKX:
+            params["options"] = {"defaultType": "swap"}
+            return ccxt.okx(params)
+        raise ValueError(f"Unsupported exchange: {exchange}")
+
+    def get_futures_symbols(self) -> list[str]:
+        symbols: list[str] = []
+        for market in self._client.markets.values():
+            if not market.get("active", True):
+                continue
+            if not (market.get("swap") or market.get("future")):
+                continue
+
+            quote = str(market.get("quote") or "").upper()
+            settle = str(market.get("settle") or "").upper()
+            linear = bool(market.get("linear", False))
+
+            if quote != "USDT" and settle != "USDT":
+                continue
+            if not linear and settle != "USDT":
+                continue
+
+            symbol = str(market.get("symbol") or "")
+            if symbol:
+                symbols.append(symbol)
+
+        return sorted(set(symbols))
+
+    def fetch_ohlcv(self, symbol: str, timeframe: Timeframe, start_time: datetime, end_time: datetime) -> pd.DataFrame:
+        tf = _TIMEFRAME_TO_CCXT[timeframe]
+        start_ms = _to_utc_ms(start_time)
+        since = start_ms
+        end_ms = _to_utc_ms(end_time)
+
+        all_rows: list[list[float]] = []
+        while since <= end_ms:
+            batch = self._client.fetch_ohlcv(symbol, timeframe=tf, since=since, limit=DEFAULT_FETCH_BATCH_SIZE)
+            if not batch:
+                break
+            all_rows.extend(batch)
+            last_ts = int(batch[-1][0])
+            if last_ts >= end_ms:
+                break
+            since = last_ts + 1
+
+        frame = pd.DataFrame(all_rows, columns=["timestamp", "open", "high", "low", "close", "volume"])
+        if frame.empty:
+            return frame
+
+        frame = frame.loc[(frame["timestamp"] >= start_ms) & (frame["timestamp"] <= end_ms)]
+        frame["datetime"] = pd.to_datetime(frame["timestamp"], unit="ms", utc=True)
+        return frame.drop_duplicates(subset=["timestamp"]).sort_values("timestamp").reset_index(drop=True)
+
+    def fetch_open_interest(self, symbol: str, timeframe: Timeframe, start_time: datetime, end_time: datetime) -> pd.DataFrame:
+        if not hasattr(self._client, "fetch_open_interest_history"):
+            raise NotImplementedError(f"Exchange {self.exchange.value} does not support fetch_open_interest_history in CCXT")
+
+        tf = _TIMEFRAME_TO_CCXT[timeframe]
+        start_ms = _to_utc_ms(start_time)
+        since = start_ms
+        end_ms = _to_utc_ms(end_time)
+
+        rows: list[dict[str, Any]] = []
+        while since <= end_ms:
+            try:
+                batch = self._client.fetch_open_interest_history(
+                    symbol,
+                    timeframe=tf,
+                    since=since,
+                    limit=DEFAULT_FETCH_BATCH_SIZE,
+                    params={"intervalTime": tf, "period": tf},
+                )
+            except TypeError:
+                batch = self._client.fetch_open_interest_history(symbol, timeframe=tf, since=since, limit=DEFAULT_FETCH_BATCH_SIZE)
+            if not batch:
+                break
+
+            rows.extend(batch)
+            last_ts = int(batch[-1].get("timestamp") or 0)
+            if last_ts >= end_ms:
+                break
+            since = last_ts + 1
+
+        if not rows:
+            return pd.DataFrame(columns=["timestamp", "open_interest", "datetime"])
+
+        frame = pd.DataFrame(rows)
+        if "openInterestAmount" in frame.columns:
+            frame["open_interest"] = pd.to_numeric(frame["openInterestAmount"], errors="coerce")
+        elif "openInterestValue" in frame.columns:
+            frame["open_interest"] = pd.to_numeric(frame["openInterestValue"], errors="coerce")
+        else:
+            frame["open_interest"] = pd.to_numeric(frame.get("openInterest"), errors="coerce")
+
+        frame = frame.loc[(frame["timestamp"] >= start_ms) & (frame["timestamp"] <= end_ms)]
+        frame["datetime"] = pd.to_datetime(frame["timestamp"], unit="ms", utc=True)
+        frame = frame[["timestamp", "open_interest", "datetime"]]
+        return frame.drop_duplicates(subset=["timestamp"]).sort_values("timestamp").reset_index(drop=True)

--- a/data/fetchers/market_data_fetcher.py
+++ b/data/fetchers/market_data_fetcher.py
@@ -1,0 +1,92 @@
+"""High-level coordinator for OHLCV, OI and market-cap loading."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
+from datetime import datetime
+from typing import Any
+
+from domain.abstract.market_data_client import MarketDataClient
+from domain.enums.timeframe import Timeframe
+from data.fetchers.ohlcv_fetcher import OhlcvFetcher
+from data.fetchers.oi_fetcher import OiFetcher
+from utils.logger import get_logger
+
+
+class MarketDataFetcher:
+    """Coordinates parallel OHLCV/OI downloads and market-cap fetching."""
+
+    def __init__(
+        self,
+        ohlcv_fetcher: OhlcvFetcher,
+        oi_fetcher: OiFetcher,
+        market_data_client: MarketDataClient,
+        max_workers: int = 5,
+        request_timeout_seconds: int = 60,
+    ) -> None:
+        self._ohlcv_fetcher = ohlcv_fetcher
+        self._oi_fetcher = oi_fetcher
+        self._market_data_client = market_data_client
+        self._max_workers = max_workers
+        self._request_timeout_seconds = request_timeout_seconds
+        self._logger = get_logger(self.__class__.__name__)
+
+    def fetch_market_caps(self, symbols: list[str]) -> dict[str, Any]:
+        self._logger.info(f"MarketCap старт: {len(symbols)} инструментов")
+        results: dict[str, Any] = {}
+
+        with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
+            futures = {executor.submit(self._market_data_client.get_market_cap, symbol): symbol for symbol in symbols}
+            for future in as_completed(futures):
+                symbol = futures[future]
+                try:
+                    results[symbol] = future.result(timeout=self._request_timeout_seconds)
+                    self._logger.info(f"MarketCap готово: {symbol}")
+                except TimeoutError:
+                    msg = f"MarketCap таймаут: {symbol}"
+                    self._logger.info(msg)
+                    results[symbol] = msg
+                except Exception as exc:  # noqa: BLE001
+                    msg = f"MarketCap ошибка: {symbol}: {exc}"
+                    self._logger.info(msg)
+                    results[symbol] = msg
+
+        self._logger.info("MarketCap завершен")
+        return results
+
+    def fetch_all(
+        self,
+        symbols: list[str],
+        timeframe: Timeframe,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> dict[str, Any]:
+        self._logger.info(f"Загрузка старт: {len(symbols)} символов, TF={timeframe.value}")
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            ohlcv_future = executor.submit(
+                self._ohlcv_fetcher.fetch_many,
+                symbols,
+                timeframe,
+                start_time,
+                end_time,
+            )
+            oi_future = executor.submit(
+                self._oi_fetcher.fetch_many,
+                symbols,
+                timeframe,
+                start_time,
+                end_time,
+            )
+
+            ohlcv_result = ohlcv_future.result(timeout=self._request_timeout_seconds)
+            oi_result = oi_future.result(timeout=self._request_timeout_seconds)
+
+        market_caps = self.fetch_market_caps(symbols)
+        self._logger.info("Загрузка завершена")
+
+        return {
+            "ohlcv": ohlcv_result,
+            "open_interest": oi_result,
+            "market_caps": market_caps,
+        }

--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -1,0 +1,84 @@
+"""OHLCV fetch coordinator with parallel processing and timeout controls."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
+from datetime import datetime, timedelta
+from typing import Any
+
+from domain.abstract.exchange_client import ExchangeClient
+from domain.enums.timeframe import Timeframe
+from data.storage.parquet_storage import ParquetStorage
+from utils.logger import get_logger
+
+
+_TIMEFRAME_DELTA = {
+    Timeframe.M1: timedelta(minutes=1),
+    Timeframe.M5: timedelta(minutes=5),
+    Timeframe.M15: timedelta(minutes=15),
+    Timeframe.M30: timedelta(minutes=30),
+    Timeframe.H1: timedelta(hours=1),
+    Timeframe.H4: timedelta(hours=4),
+    Timeframe.D1: timedelta(days=1),
+    Timeframe.W1: timedelta(weeks=1),
+}
+
+
+class OhlcvFetcher:
+    """Fetches and stores OHLCV incrementally for one or many symbols."""
+
+    def __init__(
+        self,
+        exchange_client: ExchangeClient,
+        storage: ParquetStorage,
+        max_workers: int = 5,
+        request_timeout_seconds: int = 60,
+    ) -> None:
+        self._exchange_client = exchange_client
+        self._storage = storage
+        self._max_workers = max_workers
+        self._request_timeout_seconds = request_timeout_seconds
+        self._logger = get_logger(self.__class__.__name__)
+
+    def fetch_symbol(self, symbol: str, timeframe: Timeframe, start_time: datetime, end_time: datetime) -> int:
+        next_start = start_time
+        last_timestamp = self._storage.get_last_timestamp(symbol, timeframe)
+        if last_timestamp is not None:
+            next_start = max(start_time, last_timestamp.to_pydatetime() + _TIMEFRAME_DELTA[timeframe])
+
+        self._logger.info(f"OHLCV старт: {symbol} {timeframe.value} {next_start.isoformat()} -> {end_time.isoformat()}")
+        if next_start > end_time:
+            self._logger.info(f"OHLCV пропуск: {symbol} уже актуален")
+            return 0
+
+        data = self._exchange_client.fetch_ohlcv(symbol, timeframe, next_start, end_time)
+        added_rows = self._storage.save_incremental(symbol, timeframe, data)
+        self._logger.info(f"OHLCV завершен: {symbol}, добавлено {added_rows} строк")
+        return added_rows
+
+    def fetch_many(
+        self,
+        symbols: list[str],
+        timeframe: Timeframe,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> dict[str, Any]:
+        results: dict[str, Any] = {}
+        with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
+            futures = {
+                executor.submit(self.fetch_symbol, s, timeframe, start_time, end_time): s for s in symbols
+            }
+            for future in as_completed(futures):
+                symbol = futures[future]
+                try:
+                    results[symbol] = future.result(timeout=self._request_timeout_seconds)
+                except TimeoutError:
+                    msg = f"OHLCV таймаут: {symbol}"
+                    self._logger.info(msg)
+                    results[symbol] = msg
+                except Exception as exc:  # noqa: BLE001
+                    msg = f"OHLCV ошибка: {symbol}: {exc}"
+                    self._logger.info(msg)
+                    results[symbol] = msg
+
+        return results

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -1,0 +1,84 @@
+"""Open interest fetch coordinator with parallel processing and timeout controls."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
+from datetime import datetime, timedelta
+from typing import Any
+
+from domain.abstract.exchange_client import ExchangeClient
+from domain.enums.timeframe import Timeframe
+from data.storage.parquet_storage import ParquetStorage
+from utils.logger import get_logger
+
+
+_TIMEFRAME_DELTA = {
+    Timeframe.M1: timedelta(minutes=1),
+    Timeframe.M5: timedelta(minutes=5),
+    Timeframe.M15: timedelta(minutes=15),
+    Timeframe.M30: timedelta(minutes=30),
+    Timeframe.H1: timedelta(hours=1),
+    Timeframe.H4: timedelta(hours=4),
+    Timeframe.D1: timedelta(days=1),
+    Timeframe.W1: timedelta(weeks=1),
+}
+
+
+class OiFetcher:
+    """Fetches and stores open-interest data incrementally for one or many symbols."""
+
+    def __init__(
+        self,
+        exchange_client: ExchangeClient,
+        storage: ParquetStorage,
+        max_workers: int = 5,
+        request_timeout_seconds: int = 60,
+    ) -> None:
+        self._exchange_client = exchange_client
+        self._storage = storage
+        self._max_workers = max_workers
+        self._request_timeout_seconds = request_timeout_seconds
+        self._logger = get_logger(self.__class__.__name__)
+
+    def fetch_symbol(self, symbol: str, timeframe: Timeframe, start_time: datetime, end_time: datetime) -> int:
+        next_start = start_time
+        last_timestamp = self._storage.get_last_timestamp(symbol, timeframe)
+        if last_timestamp is not None:
+            next_start = max(start_time, last_timestamp.to_pydatetime() + _TIMEFRAME_DELTA[timeframe])
+
+        self._logger.info(f"OI старт: {symbol} {timeframe.value} {next_start.isoformat()} -> {end_time.isoformat()}")
+        if next_start > end_time:
+            self._logger.info(f"OI пропуск: {symbol} уже актуален")
+            return 0
+
+        data = self._exchange_client.fetch_open_interest(symbol, timeframe, next_start, end_time)
+        added_rows = self._storage.save_incremental(symbol, timeframe, data)
+        self._logger.info(f"OI завершен: {symbol}, добавлено {added_rows} строк")
+        return added_rows
+
+    def fetch_many(
+        self,
+        symbols: list[str],
+        timeframe: Timeframe,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> dict[str, Any]:
+        results: dict[str, Any] = {}
+        with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
+            futures = {
+                executor.submit(self.fetch_symbol, s, timeframe, start_time, end_time): s for s in symbols
+            }
+            for future in as_completed(futures):
+                symbol = futures[future]
+                try:
+                    results[symbol] = future.result(timeout=self._request_timeout_seconds)
+                except TimeoutError:
+                    msg = f"OI таймаут: {symbol}"
+                    self._logger.info(msg)
+                    results[symbol] = msg
+                except Exception as exc:  # noqa: BLE001
+                    msg = f"OI ошибка: {symbol}: {exc}"
+                    self._logger.info(msg)
+                    results[symbol] = msg
+
+        return results

--- a/data/storage/parquet_storage.py
+++ b/data/storage/parquet_storage.py
@@ -1,0 +1,55 @@
+"""Parquet storage with symbol/timeframe partition layout and incremental updates."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from domain.enums.timeframe import Timeframe
+
+
+class ParquetStorage:
+    """Store and incrementally update time-series in `{symbol}/{timeframe}/data.parquet`."""
+
+    def __init__(self, base_dir: str | Path = "cache") -> None:
+        self._base_dir = Path(base_dir)
+
+    def _data_path(self, symbol: str, timeframe: Timeframe) -> Path:
+        return self._base_dir / symbol / timeframe.value / "data.parquet"
+
+    def load(self, symbol: str, timeframe: Timeframe) -> pd.DataFrame:
+        path = self._data_path(symbol, timeframe)
+        if not path.exists():
+            return pd.DataFrame()
+        return pd.read_parquet(path)
+
+    def get_last_timestamp(self, symbol: str, timeframe: Timeframe) -> pd.Timestamp | None:
+        data = self.load(symbol, timeframe)
+        if data.empty or "timestamp" not in data.columns:
+            return None
+        return pd.to_datetime(data["timestamp"], unit="ms", utc=True).max()
+
+    def save_incremental(self, symbol: str, timeframe: Timeframe, new_data: pd.DataFrame) -> int:
+        if new_data.empty:
+            return 0
+
+        path = self._data_path(symbol, timeframe)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        incoming = new_data.copy()
+        if "timestamp" not in incoming.columns:
+            raise ValueError("new_data must contain 'timestamp' column")
+
+        existing = self.load(symbol, timeframe)
+        previous_count = len(existing)
+
+        if existing.empty:
+            merged = incoming
+        else:
+            merged = pd.concat([existing, incoming], ignore_index=True)
+
+        merged = merged.drop_duplicates(subset=["timestamp"], keep="last").sort_values("timestamp")
+        merged.to_parquet(path, index=False)
+
+        return max(len(merged) - previous_count, 0)

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,20 @@
+"""Logging utilities with concise timestamped output."""
+
+from __future__ import annotations
+
+import logging
+
+
+def get_logger(name: str, level: int = logging.INFO) -> logging.Logger:
+    """Create or return configured logger in `ЧЧ:ММ:СС Сообщение` format."""
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    logger.propagate = False
+
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setLevel(level)
+        handler.setFormatter(logging.Formatter("%(asctime)s %(message)s", datefmt="%H:%M:%S"))
+        logger.addHandler(handler)
+
+    return logger


### PR DESCRIPTION
### Motivation
- Добавить поддержу фьючерсных данных (Binance/Bybit/OKX) с фильтрацией USDT-M инструментов и нормализованной выгрузкой исторических данных.
- Обеспечить получение и кэширование рыночной капитализации через CoinGecko для отбора инструментов по капитализации.
- Организовать долговременное хранение тайм-серий в удобной структуре с возможностью инкрементальных обновлений.
- Координировать параллельную загрузку OHLCV, OI и market-cap с логированием прогресса и таймаутами.

### Description
- Реализован `CcxtFuturesClient` в `data/exchanges/ccxt_futures_client.py` как адаптер `ExchangeClient` для фьючерсов, поддерживающий `binanceusdm`, `bybit` и `okx`, с фильтрацией активных USDT-спот/settle линейных контрактов, отображением таймфреймов и пагинированной загрузкой `fetch_ohlcv` и `fetch_open_interest`.
- Добавлен `CoinGeckoClient` в `data/clients/coingecko_client.py` как адаптер `MarketDataClient` с разрешением `symbol -> CoinGecko ID`, методами `get_market_cap` и `get_top_coins_by_market_cap`, и in-memory кэшем капитализации с TTL по умолчанию 24 часа.
- Реализован `ParquetStorage` в `data/storage/parquet_storage.py` с layout путей `{symbol}/{timeframe}/data.parquet`, методами `load`, `get_last_timestamp` и `save_incremental` для дедупликации и инкрементальной дозагрузки данных.
- Добавлены координирующие загрузчики в `data/fetchers/`: `OhlcvFetcher` и `OiFetcher` (инкрементальный старт от последнего таймстемпа, `ThreadPoolExecutor`, обработка таймаутов/ошибок, логирование прогресса) и `MarketDataFetcher` для параллельного запуска OHLCV+OI и последующего параллельного получения market-cap.
- Добавлен простой логгер `get_logger` в `utils/logger.py` и использован во всех fetcher-компонентах для вывода прогресса в формате `ЧЧ:ММ:СС Сообщение`.

### Testing
- Выполнена статическая компиляция модулей командой `python -m compileall data utils`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69871a8d93188320ac96c8af9c6080b9)