### PR TITLE
Stateful candle-by-candle position simulator with TP1/BE/TP2, order processing and result classification

### DIFF
--- a/simulation/__init__.py
+++ b/simulation/__init__.py
@@ -1,0 +1,7 @@
+"""Simulation package exports."""
+
+from simulation.order_processor import Fill, OrderProcessor
+from simulation.position_simulator import StatefulPositionSimulator
+from simulation.trade_classifier import TradeClassifier
+
+__all__ = ["Fill", "OrderProcessor", "StatefulPositionSimulator", "TradeClassifier"]

--- a/simulation/order_processor.py
+++ b/simulation/order_processor.py
@@ -1,0 +1,49 @@
+"""Order execution and transaction cost calculations for simulation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from domain.enums.position_side import PositionSide
+
+
+@dataclass(frozen=True, slots=True)
+class Fill:
+    """Single order fill snapshot."""
+
+    price: float
+    commission: float
+
+
+@dataclass(frozen=True, slots=True)
+class OrderProcessor:
+    """Calculates execution prices and trading costs."""
+
+    commission_rate: float
+    slippage: float
+
+    def execute_entry(self, candle_open: float, side: PositionSide, size: float) -> Fill:
+        """Execute market entry at candle open with adverse slippage and commission."""
+        is_buy = side == PositionSide.LONG
+        fill_price = self._apply_slippage(candle_open, is_buy=is_buy)
+        return Fill(price=fill_price, commission=self._commission(fill_price * size))
+
+    def execute_exit(self, target_price: float, side: PositionSide, size: float) -> Fill:
+        """Execute market exit at target level with adverse slippage and commission."""
+        is_buy = side == PositionSide.SHORT
+        fill_price = self._apply_slippage(target_price, is_buy=is_buy)
+        return Fill(price=fill_price, commission=self._commission(fill_price * size))
+
+    def breakeven_price(self, entry_price: float, side: PositionSide) -> float:
+        """Calculate breakeven level including commissions and slippage reserve."""
+        reserve = 2 * self.commission_rate + self.slippage
+        if side == PositionSide.LONG:
+            return entry_price * (1 + reserve)
+        return entry_price * (1 - reserve)
+
+    def _apply_slippage(self, price: float, *, is_buy: bool) -> float:
+        multiplier = 1 + self.slippage if is_buy else 1 - self.slippage
+        return price * multiplier
+
+    def _commission(self, notional: float) -> float:
+        return notional * self.commission_rate

--- a/simulation/position_simulator.py
+++ b/simulation/position_simulator.py
@@ -1,0 +1,189 @@
+"""Stateful position simulator with SL/TP/BE lifecycle management."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from domain.abstract.position_simulator import PositionSimulator
+from domain.enums.position_side import PositionSide
+from domain.models.candle import Candle
+from domain.models.position import Position
+from domain.models.trade_result import TradeResult
+from domain.models.trade_signal import TradeSignal
+from domain.value_objects.price import Price
+from domain.value_objects.volume import Volume
+from simulation.order_processor import OrderProcessor
+from simulation.trade_classifier import TradeClassifier
+
+
+@dataclass(slots=True)
+class StatefulPositionSimulator(PositionSimulator):
+    """Processes candles one-by-one and closes position based on conservative priority rules."""
+
+    side: PositionSide
+    order_processor: OrderProcessor
+    trade_classifier: TradeClassifier
+
+    position: Position | None = None
+    _pending_signal: TradeSignal | None = None
+    _pending_size: float = 0.0
+    _realized_pnl: float = 0.0
+    _closed_size: float = 0.0
+    _last_exit_price: float = 0.0
+
+    def register_signal(self, signal: TradeSignal, size: float) -> None:
+        """Store signal; position will be opened by market order on next processed candle open."""
+        self._pending_signal = signal
+        self._pending_size = size
+
+    def process_candle(self, candle: Candle) -> TradeResult | None:
+        """Open pending signal and process active position against current candle."""
+        if self.position is None and self._pending_signal is not None:
+            self._open_from_pending_signal(candle)
+
+        if self.position is None:
+            return None
+
+        if self.side == PositionSide.LONG:
+            return self._process_long(candle)
+        return self._process_short(candle)
+
+    def open_position(self, position: Position) -> None:
+        """Set active position. Intended for already-executed fills."""
+        self.position = position
+        self._realized_pnl = 0.0
+        self._closed_size = 0.0
+        self._last_exit_price = position.entry_price.value
+
+    def close_position(self, price: float) -> TradeResult:
+        """Close remaining position at given price and return classified trade result."""
+        if self.position is None:
+            msg = "No active position to close."
+            raise RuntimeError(msg)
+
+        remaining_size = self.position.size.value - self._closed_size
+        if remaining_size > 0:
+            self._close_leg(size=remaining_size, target_price=price)
+
+        result_type = self.trade_classifier.classify_result_type(
+            tp1_done=self.position.tp1_done,
+            exit_at_breakeven=self.position.sl_moved_to_be and price == self.position.stop_loss.value,
+            exit_at_tp2=price == self.position.take_profit_2.value,
+        )
+        trade_result = self.trade_classifier.build_result(
+            position=self.position,
+            exit_price=self._last_exit_price,
+            exit_time=self.position.entry_time,
+            result_type=result_type,
+            pnl=self._realized_pnl,
+        )
+        self.position = None
+        return trade_result
+
+    def update_stop(self, new_stop: float) -> None:
+        """Update stop-loss level for active position."""
+        if self.position is None:
+            msg = "No active position to update stop for."
+            raise RuntimeError(msg)
+        self.position.stop_loss = Price(new_stop)
+
+    def _open_from_pending_signal(self, candle: Candle) -> None:
+        signal = self._pending_signal
+        if signal is None:
+            return
+
+        fill = self.order_processor.execute_entry(candle.open.value, self.side, self._pending_size)
+        self.position = Position(
+            entry_price=Price(fill.price),
+            entry_time=candle.timestamp,
+            size=Volume(self._pending_size),
+            stop_loss=signal.stop_loss,
+            take_profit_1=signal.take_profit_1,
+            take_profit_2=signal.take_profit_2,
+        )
+        self._realized_pnl = -fill.commission
+        self._closed_size = 0.0
+        self._last_exit_price = fill.price
+        self._pending_signal = None
+        self._pending_size = 0.0
+
+    def _process_long(self, candle: Candle) -> TradeResult | None:
+        assert self.position is not None
+
+        if candle.low.value <= self.position.stop_loss.value:
+            return self._finalize(candle, self.position.stop_loss.value, exit_at_be=self.position.sl_moved_to_be)
+
+        if not self.position.tp1_done and candle.high.value >= self.position.take_profit_1.value:
+            self._take_tp1()
+            if candle.low.value <= self.position.stop_loss.value:
+                return self._finalize(candle, self.position.stop_loss.value, exit_at_be=True)
+
+        if self.position.tp1_done and candle.low.value <= self.position.stop_loss.value:
+            return self._finalize(candle, self.position.stop_loss.value, exit_at_be=True)
+
+        if candle.high.value >= self.position.take_profit_2.value:
+            return self._finalize(candle, self.position.take_profit_2.value, exit_at_tp2=True)
+
+        return None
+
+    def _process_short(self, candle: Candle) -> TradeResult | None:
+        assert self.position is not None
+
+        if candle.high.value >= self.position.stop_loss.value:
+            return self._finalize(candle, self.position.stop_loss.value, exit_at_be=self.position.sl_moved_to_be)
+
+        if not self.position.tp1_done and candle.low.value <= self.position.take_profit_1.value:
+            self._take_tp1()
+            if candle.high.value >= self.position.stop_loss.value:
+                return self._finalize(candle, self.position.stop_loss.value, exit_at_be=True)
+
+        if self.position.tp1_done and candle.high.value >= self.position.stop_loss.value:
+            return self._finalize(candle, self.position.stop_loss.value, exit_at_be=True)
+
+        if candle.low.value <= self.position.take_profit_2.value:
+            return self._finalize(candle, self.position.take_profit_2.value, exit_at_tp2=True)
+
+        return None
+
+    def _take_tp1(self) -> None:
+        assert self.position is not None
+        tp1_size = self.position.size.value * 0.5
+        self._close_leg(size=tp1_size, target_price=self.position.take_profit_1.value)
+        self.position.tp1_done = True
+        self.position.sl_moved_to_be = True
+        self.position.stop_loss = Price(self.order_processor.breakeven_price(self.position.entry_price.value, self.side))
+
+    def _close_leg(self, *, size: float, target_price: float) -> None:
+        assert self.position is not None
+
+        fill = self.order_processor.execute_exit(target_price, self.side, size)
+        if self.side == PositionSide.LONG:
+            gross = (fill.price - self.position.entry_price.value) * size
+        else:
+            gross = (self.position.entry_price.value - fill.price) * size
+
+        self._realized_pnl += gross - fill.commission
+        self._closed_size += size
+        self._last_exit_price = fill.price
+
+    def _finalize(self, candle: Candle, target_price: float, *, exit_at_be: bool = False, exit_at_tp2: bool = False) -> TradeResult:
+        assert self.position is not None
+
+        remaining_size = self.position.size.value - self._closed_size
+        if remaining_size > 0:
+            self._close_leg(size=remaining_size, target_price=target_price)
+
+        result_type = self.trade_classifier.classify_result_type(
+            tp1_done=self.position.tp1_done,
+            exit_at_breakeven=exit_at_be,
+            exit_at_tp2=exit_at_tp2,
+        )
+        trade_result = self.trade_classifier.build_result(
+            position=self.position,
+            exit_price=self._last_exit_price,
+            exit_time=candle.timestamp,
+            result_type=result_type,
+            pnl=self._realized_pnl,
+        )
+        self.position = None
+        return trade_result

--- a/simulation/trade_classifier.py
+++ b/simulation/trade_classifier.py
@@ -1,0 +1,45 @@
+"""Trade result classification and PnL calculations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from domain.enums.trade_result_type import TradeResultType
+from domain.models.position import Position
+from domain.models.trade_result import TradeResult
+from domain.value_objects.percentage import Percentage
+from domain.value_objects.price import Price
+
+
+@dataclass(frozen=True, slots=True)
+class TradeClassifier:
+    """Builds final trade results from simulator state."""
+
+    def classify_result_type(self, *, tp1_done: bool, exit_at_breakeven: bool, exit_at_tp2: bool) -> TradeResultType:
+        if exit_at_tp2:
+            return TradeResultType.TP2
+        if exit_at_breakeven:
+            return TradeResultType.TP1_BE if tp1_done else TradeResultType.BE
+        return TradeResultType.SL
+
+    def build_result(
+        self,
+        *,
+        position: Position,
+        exit_price: float,
+        exit_time: datetime,
+        result_type: TradeResultType,
+        pnl: float,
+    ) -> TradeResult:
+        entry_notional = position.entry_price.value * position.size.value
+        pnl_percent_value = 0.0 if entry_notional == 0 else (pnl / entry_notional) * 100
+        return TradeResult(
+            entry_price=position.entry_price,
+            exit_price=Price(exit_price),
+            entry_time=position.entry_time,
+            exit_time=exit_time,
+            result_type=result_type,
+            pnl=pnl,
+            pnl_percent=Percentage(pnl_percent_value),
+        )


### PR DESCRIPTION
### Motivation
- Реализовать stateful симулятор позиций по требованиям: обработка OHLC-свечей шаг за шагом с учётом SL, TP1 (частичное закрытие), BE и TP2.  
- Вынести логику расчёта цены исполнения и издержек в отдельный модуль для корректного учёта проскальзывания и комиссий.  
- Обеспечить корректную классификацию итогов сделки и вычисление PnL/PnL% для последующей агрегации результатов.

### Description
- Добавлен `StatefulPositionSimulator` в `simulation/position_simulator.py` с отложенным входом по сигналу (market на `open` следующей свечи), состоянием позиции (`tp1_done`, `sl_moved_to_be`), пошаговой обработкой свечей и консервативным приоритетом уровней (SL-first, включая спорные случаи SL vs TP и BE vs TP2).  
- Реализовано частичное закрытие 50% на TP1 с переносом стопа оставшейся части в BE и дальнейшей обработкой остатка до BE/TP2; учтены расчёты PnL и аккумулирование реализованной прибыли при закрытиях по частям.  
- Вынесены расчёты исполнения и издержек в `simulation/order_processor.py` (`OrderProcessor`, `Fill`) с методами `execute_entry`, `execute_exit`, `breakeven_price`, учётом неблагоприятного проскальзывания и комиссий.  
- Добавлен `simulation/trade_classifier.py` (`TradeClassifier`) для определения результата сделки (`SL`, `BE`, `TP1_BE`, `TP2`) и сборки `TradeResult` с расчетом `pnl` и `pnl_percent`.  
- Обновлён `simulation/__init__.py` для экспорта новых компонент.

### Testing
- Запущена компиляция модулей командой `python -m compileall simulation domain` и завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698720e7b0148320b776ae01f638c754)