### PR TITLE
Improve logging: rotating file handler, colored console, and config-driven levels

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -26,8 +26,12 @@ from vectorbt_runner.backtest_runner import BacktestRunner
 from vectorbt_runner.data_preparer import DataPreparer
 
 
-def _run_with_logging(command_name: str, body: Callable[[], int]) -> int:
-    logger = get_logger(command_name)
+def _run_with_logging(command_name: str, config: AppConfig, body: Callable[[], int]) -> int:
+    logger = get_logger(
+        command_name,
+        level=config.backtest.log_level,
+        logs_dir=config.backtest.logs_dir,
+    )
     logger.info(f"{command_name}: старт")
     try:
         code = body()
@@ -49,11 +53,15 @@ def _build_fetch_stack(config: AppConfig) -> tuple[MarketDataFetcher, CcxtFuture
         exchange_client=exchange_client,
         storage=storage,
         max_workers=config.fetch.max_concurrent_requests,
+        log_level=config.backtest.log_level,
+        logs_dir=config.backtest.logs_dir,
     )
     oi_fetcher = OiFetcher(
         exchange_client=exchange_client,
         storage=storage,
         max_workers=config.fetch.max_concurrent_requests,
+        log_level=config.backtest.log_level,
+        logs_dir=config.backtest.logs_dir,
     )
     market_client = CoinGeckoClient(api_key=config.fetch.coingecko_api_key)
     return (
@@ -62,6 +70,8 @@ def _build_fetch_stack(config: AppConfig) -> tuple[MarketDataFetcher, CcxtFuture
             oi_fetcher=oi_fetcher,
             market_data_client=market_client,
             max_workers=config.fetch.max_concurrent_requests,
+            log_level=config.backtest.log_level,
+            logs_dir=config.backtest.logs_dir,
         ),
         exchange_client,
         market_client,
@@ -76,7 +86,7 @@ def _resolve_symbols(exchange_client: CcxtFuturesClient, market_client: CoinGeck
 
 def fetch_data(config: AppConfig, args: argparse.Namespace) -> int:
     def _inner() -> int:
-        logger = get_logger("fetch-data")
+        logger = get_logger("fetch-data", level=config.backtest.log_level, logs_dir=config.backtest.logs_dir)
         fetcher, exchange_client, market_client = _build_fetch_stack(config)
         symbols = _resolve_symbols(exchange_client, market_client, top_n=args.top_n)
         if not symbols:
@@ -89,12 +99,12 @@ def fetch_data(config: AppConfig, args: argparse.Namespace) -> int:
         logger.info(f"fetch-data: загружено symbols={len(symbols)}")
         return 0
 
-    return _run_with_logging("fetch-data", _inner)
+    return _run_with_logging("fetch-data", config, _inner)
 
 
 def update_cache(config: AppConfig, args: argparse.Namespace) -> int:
     def _inner() -> int:
-        logger = get_logger("update-cache")
+        logger = get_logger("update-cache", level=config.backtest.log_level, logs_dir=config.backtest.logs_dir)
         fetcher, exchange_client, market_client = _build_fetch_stack(config)
         symbols = _resolve_symbols(exchange_client, market_client, top_n=args.top_n)
         if not symbols:
@@ -107,12 +117,12 @@ def update_cache(config: AppConfig, args: argparse.Namespace) -> int:
         logger.info(f"update-cache: обновлено symbols={len(symbols)}")
         return 0
 
-    return _run_with_logging("update-cache", _inner)
+    return _run_with_logging("update-cache", config, _inner)
 
 
 def run_backtest(config: AppConfig, args: argparse.Namespace) -> int:
     def _inner() -> int:
-        logger = get_logger("run-backtest")
+        logger = get_logger("run-backtest", level=config.backtest.log_level, logs_dir=config.backtest.logs_dir)
         preparer = DataPreparer(config.backtest.cache_dir)
         symbols = args.symbols or preparer.list_symbols(config.fetch.timeframe)
         if not symbols:
@@ -143,12 +153,12 @@ def run_backtest(config: AppConfig, args: argparse.Namespace) -> int:
         )
         return 0
 
-    return _run_with_logging("run-backtest", _inner)
+    return _run_with_logging("run-backtest", config, _inner)
 
 
 def make_report(config: AppConfig, args: argparse.Namespace) -> int:
     def _inner() -> int:
-        logger = get_logger("make-report")
+        logger = get_logger("make-report", level=config.backtest.log_level, logs_dir=config.backtest.logs_dir)
         csv_path = Path(args.input) if args.input else config.backtest.results_dir / config.backtest.results_file_name
         if not csv_path.exists():
             logger.info(f"make-report: файл не найден: {csv_path}")
@@ -194,12 +204,12 @@ def make_report(config: AppConfig, args: argparse.Namespace) -> int:
         logger.info(f"make-report: сохранено {output_path}")
         return 0
 
-    return _run_with_logging("make-report", _inner)
+    return _run_with_logging("make-report", config, _inner)
 
 
 def check_quality(config: AppConfig, args: argparse.Namespace) -> int:
     def _inner() -> int:
-        logger = get_logger("check-quality")
+        logger = get_logger("check-quality", level=config.backtest.log_level, logs_dir=config.backtest.logs_dir)
         preparer = DataPreparer(config.backtest.cache_dir)
         symbols = args.symbols or preparer.list_symbols(config.fetch.timeframe)
         if not symbols:
@@ -224,4 +234,4 @@ def check_quality(config: AppConfig, args: argparse.Namespace) -> int:
         logger.info(f"check-quality: итог issues={total_issues} gaps={total_gaps}")
         return 0
 
-    return _run_with_logging("check-quality", _inner)
+    return _run_with_logging("check-quality", config, _inner)

--- a/data/fetchers/market_data_fetcher.py
+++ b/data/fetchers/market_data_fetcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 from domain.abstract.market_data_client import MarketDataClient
@@ -23,13 +24,15 @@ class MarketDataFetcher:
         market_data_client: MarketDataClient,
         max_workers: int = 5,
         request_timeout_seconds: int = 60,
+        log_level: int | str = "INFO",
+        logs_dir: str | Path = "./logs",
     ) -> None:
         self._ohlcv_fetcher = ohlcv_fetcher
         self._oi_fetcher = oi_fetcher
         self._market_data_client = market_data_client
         self._max_workers = max_workers
         self._request_timeout_seconds = request_timeout_seconds
-        self._logger = get_logger(self.__class__.__name__)
+        self._logger = get_logger(self.__class__.__name__, level=log_level, logs_dir=logs_dir)
 
     def fetch_market_caps(self, symbols: list[str]) -> dict[str, Any]:
         self._logger.info(f"MarketCap старт: {len(symbols)} инструментов")

--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any
 
 from domain.abstract.exchange_client import ExchangeClient
@@ -37,12 +38,14 @@ class OhlcvFetcher:
         storage: ParquetStorage,
         max_workers: int = 5,
         request_timeout_seconds: int = 60,
+        log_level: int | str = "INFO",
+        logs_dir: str | Path = "./logs",
     ) -> None:
         self._exchange_client = exchange_client
         self._storage = storage
         self._max_workers = max_workers
         self._request_timeout_seconds = request_timeout_seconds
-        self._logger = get_logger(self.__class__.__name__)
+        self._logger = get_logger(self.__class__.__name__, level=log_level, logs_dir=logs_dir)
         self._aligner = TimeAlignment()
         self._deduplicator = Deduplicator()
         self._gap_detector = GapDetector()

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any
 
 from domain.abstract.exchange_client import ExchangeClient
@@ -37,12 +38,14 @@ class OiFetcher:
         storage: ParquetStorage,
         max_workers: int = 5,
         request_timeout_seconds: int = 60,
+        log_level: int | str = "INFO",
+        logs_dir: str | Path = "./logs",
     ) -> None:
         self._exchange_client = exchange_client
         self._storage = storage
         self._max_workers = max_workers
         self._request_timeout_seconds = request_timeout_seconds
-        self._logger = get_logger(self.__class__.__name__)
+        self._logger = get_logger(self.__class__.__name__, level=log_level, logs_dir=logs_dir)
         self._aligner = TimeAlignment()
         self._deduplicator = Deduplicator()
         self._oi_aligner = OiAligner()

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -3,18 +3,59 @@
 from __future__ import annotations
 
 import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
 
 
-def get_logger(name: str, level: int = logging.INFO) -> logging.Logger:
+class _ColorFormatter(logging.Formatter):
+    """Adds ANSI colors for INFO/WARNING/ERROR levels in console output."""
+
+    RESET = "\033[0m"
+    COLORS = {
+        logging.INFO: "\033[32m",
+        logging.WARNING: "\033[33m",
+        logging.ERROR: "\033[31m",
+        logging.CRITICAL: "\033[31m",
+    }
+
+    def format(self, record: logging.LogRecord) -> str:
+        message = super().format(record)
+        color = self.COLORS.get(record.levelno)
+        if color is None:
+            return message
+        return f"{color}{message}{self.RESET}"
+
+
+def get_logger(
+    name: str,
+    level: int | str = logging.INFO,
+    logs_dir: str | Path = "./logs",
+) -> logging.Logger:
     """Create or return configured logger in `ЧЧ:ММ:СС Сообщение` format."""
+    if isinstance(level, str):
+        resolved_level = getattr(logging, level.upper(), logging.INFO)
+    else:
+        resolved_level = level
     logger = logging.getLogger(name)
-    logger.setLevel(level)
+    logger.setLevel(resolved_level)
     logger.propagate = False
 
+    resolved_logs_dir = Path(logs_dir)
+    resolved_logs_dir.mkdir(parents=True, exist_ok=True)
+    file_path = resolved_logs_dir / f"{name}.log"
+
     if not logger.handlers:
-        handler = logging.StreamHandler()
-        handler.setLevel(level)
-        handler.setFormatter(logging.Formatter("%(asctime)s %(message)s", datefmt="%H:%M:%S"))
-        logger.addHandler(handler)
+        stream_handler = logging.StreamHandler()
+        stream_handler.setLevel(resolved_level)
+        stream_handler.setFormatter(_ColorFormatter("%(asctime)s %(message)s", datefmt="%H:%M:%S"))
+        logger.addHandler(stream_handler)
+
+        file_handler = RotatingFileHandler(file_path, maxBytes=5 * 1024 * 1024, backupCount=5, encoding="utf-8")
+        file_handler.setLevel(resolved_level)
+        file_handler.setFormatter(logging.Formatter("%(asctime)s %(message)s", datefmt="%H:%M:%S"))
+        logger.addHandler(file_handler)
+    else:
+        for handler in logger.handlers:
+            handler.setLevel(resolved_level)
 
     return logger


### PR DESCRIPTION
### Motivation
- Add file logging to central logger using `BacktestConfig.logs_dir` and keep messages simple (`%H:%M:%S %(message)s`).
- Provide colored console output for `INFO/WARNING/ERROR` while leaving `DEBUG` uncolored for readability.
- Make logging level configurable from `config.backtest.log_level` and ensure all CLI commands and fetchers use the same logger mechanism.

### Description
- Updated `utils/logger.py` to introduce `_ColorFormatter`, a `RotatingFileHandler` writing to `<logs_dir>/<logger_name>.log`, and a `get_logger(name, level, logs_dir)` signature that resolves string/int levels and preserves the `"%H:%M:%S %(message)s"` format.
- Console handler uses `_ColorFormatter` to color `INFO`/`WARNING`/`ERROR` while file handler uses plain formatter and rotation (`maxBytes=5MB`, `backupCount=5`).
- Propagated `config.backtest.log_level` and `config.backtest.logs_dir` into the CLI entry `_run_with_logging(...)` and into individual `get_logger(...)` calls for all commands so they use the config-driven level and logs directory.
- Extended `OhlcvFetcher`, `OiFetcher`, and `MarketDataFetcher` constructors to accept `log_level` and `logs_dir` and create their internal loggers via the updated `get_logger(...)`.

### Testing
- Ran `python -m compileall cli data utils config.py main.py` and byte-compilation completed successfully.
- Ran `python main.py make-report --input ./cache/results/nonexistent.csv` which failed due to a missing dependency (`pandas`) in the environment so the full CLI flow could not be exercised.
- Performed a smoke test by running a small Python snippet that called `get_logger("cli-test", level="INFO", logs_dir="logs")`; the snippet produced colored console output and created `logs/cli-test.log` containing the expected log line, which confirmed file writing and formatting behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987248308f08320987ebfd08e433d2d)