### PR TITLE
Add configurable timezone handling and enforce UTC parquet storage

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Callable
 
@@ -21,6 +21,7 @@ from data.quality.gap_detector import GapDetector
 from data.storage.parquet_storage import ParquetStorage
 from domain.enums.exchange import Exchange
 from strategy.breakout.breakout_strategy import BreakoutStrategy
+from utils.formatters import datetime_to_utc
 from utils.logger import get_logger
 from vectorbt_runner.backtest_runner import BacktestRunner
 from vectorbt_runner.data_preparer import DataPreparer
@@ -84,6 +85,12 @@ def _resolve_symbols(exchange_client: CcxtFuturesClient, market_client: CoinGeck
     return sorted(top_symbols.intersection(futures_symbols))
 
 
+
+def _fetch_period(config: AppConfig, days: int) -> tuple[datetime, datetime]:
+    local_end = datetime.now(tz=config.fetch.tzinfo)
+    local_start = local_end - timedelta(days=days)
+    return datetime_to_utc(local_start), datetime_to_utc(local_end)
+
 def fetch_data(config: AppConfig, args: argparse.Namespace) -> int:
     def _inner() -> int:
         logger = get_logger("fetch-data", level=config.backtest.log_level, logs_dir=config.backtest.logs_dir)
@@ -93,8 +100,7 @@ def fetch_data(config: AppConfig, args: argparse.Namespace) -> int:
             logger.info("fetch-data: не найдено символов для загрузки")
             return 0
 
-        end_time = datetime.now(tz=timezone.utc)
-        start_time = end_time - timedelta(days=args.days)
+        start_time, end_time = _fetch_period(config, args.days)
         fetcher.fetch_all(symbols=symbols, timeframe=config.fetch.timeframe, start_time=start_time, end_time=end_time)
         logger.info(f"fetch-data: загружено symbols={len(symbols)}")
         return 0
@@ -111,8 +117,7 @@ def update_cache(config: AppConfig, args: argparse.Namespace) -> int:
             logger.info("update-cache: не найдено символов для обновления")
             return 0
 
-        end_time = datetime.now(tz=timezone.utc)
-        start_time = end_time - timedelta(days=args.days)
+        start_time, end_time = _fetch_period(config, args.days)
         fetcher.fetch_all(symbols=symbols, timeframe=config.fetch.timeframe, start_time=start_time, end_time=end_time)
         logger.info(f"update-cache: обновлено symbols={len(symbols)}")
         return 0
@@ -141,6 +146,8 @@ def run_backtest(config: AppConfig, args: argparse.Namespace) -> int:
         strategy = BreakoutStrategy(
             commission_rate=config.simulation.commission_rate,
             slippage=config.simulation.slippage,
+            strategy_timezone=config.strategy.timezone,
+            simulation_timezone=config.simulation.timezone,
         )
         runner = BacktestRunner(config.backtest.results_dir, config.backtest.results_file_name)
         results = runner.run(strategy, symbol_frames)

--- a/config.py
+++ b/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import tzinfo
 from pathlib import Path
 import os
 
@@ -22,6 +23,7 @@ from constants import (
     DEFAULT_TIMEZONE,
 )
 from domain.enums.timeframe import Timeframe
+from utils.formatters import resolve_timezone
 
 
 @dataclass(slots=True)
@@ -33,11 +35,19 @@ class FetchConfig:
     timeframe: Timeframe = DEFAULT_TIMEFRAME
     timezone: str = DEFAULT_TIMEZONE
 
+    @property
+    def tzinfo(self) -> tzinfo:
+        return resolve_timezone(self.timezone)
+
 
 @dataclass(slots=True)
 class StrategyConfig:
     timezone: str = DEFAULT_TIMEZONE
     default_timeframe: Timeframe = DEFAULT_TIMEFRAME
+
+    @property
+    def tzinfo(self) -> tzinfo:
+        return resolve_timezone(self.timezone)
 
 
 @dataclass(slots=True)
@@ -46,6 +56,10 @@ class SimulationConfig:
     slippage: float = DEFAULT_SLIPPAGE
     spread: float = DEFAULT_SPREAD
     timezone: str = DEFAULT_TIMEZONE
+
+    @property
+    def tzinfo(self) -> tzinfo:
+        return resolve_timezone(self.timezone)
 
 
 @dataclass(slots=True)
@@ -92,7 +106,11 @@ def load_config(env_path: str | Path = ".env") -> AppConfig:
     env_file = Path(env_path)
     _load_env_file(env_file)
 
-    timezone = os.getenv("TIMEZONE", DEFAULT_TIMEZONE)
+    default_timezone = os.getenv("TIMEZONE", DEFAULT_TIMEZONE)
+
+    fetch_timezone = os.getenv("FETCH_TIMEZONE", default_timezone)
+    strategy_timezone = os.getenv("STRATEGY_TIMEZONE", default_timezone)
+    simulation_timezone = os.getenv("SIMULATION_TIMEZONE", default_timezone)
 
     timeframe = _parse_timeframe(os.getenv("TIMEFRAME"), default=DEFAULT_TIMEFRAME)
 
@@ -104,11 +122,11 @@ def load_config(env_path: str | Path = ".env") -> AppConfig:
             os.getenv("MAX_CONCURRENT_REQUESTS", str(DEFAULT_MAX_CONCURRENT_REQUESTS))
         ),
         timeframe=timeframe,
-        timezone=timezone,
+        timezone=fetch_timezone,
     )
 
     strategy_config = StrategyConfig(
-        timezone=timezone,
+        timezone=strategy_timezone,
         default_timeframe=_parse_timeframe(os.getenv("STRATEGY_TIMEFRAME"), default=timeframe),
     )
 
@@ -116,7 +134,7 @@ def load_config(env_path: str | Path = ".env") -> AppConfig:
         commission_rate=float(os.getenv("COMMISSION_RATE", str(DEFAULT_COMMISSION_RATE))),
         slippage=float(os.getenv("SLIPPAGE", str(DEFAULT_SLIPPAGE))),
         spread=float(os.getenv("SPREAD", str(DEFAULT_SPREAD))),
-        timezone=timezone,
+        timezone=simulation_timezone,
     )
 
     backtest_config = BacktestConfig(

--- a/data/quality/time_alignment.py
+++ b/data/quality/time_alignment.py
@@ -1,4 +1,4 @@
-"""Timestamp normalization helpers for UTC storage."""
+"""Timestamp normalization helpers enforcing UTC parquet contract."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import pandas as pd
 
 
 class TimeAlignment:
-    """Normalize all time columns to UTC and millisecond timestamps."""
+    """Normalize all time columns to UTC timestamp-ms + UTC datetime for parquet storage."""
 
     def align_to_utc(self, data: pd.DataFrame) -> pd.DataFrame:
         if data.empty:

--- a/data/storage/parquet_storage.py
+++ b/data/storage/parquet_storage.py
@@ -1,4 +1,4 @@
-"""Parquet storage with symbol/timeframe partition layout and incremental updates."""
+"""Parquet storage with UTC timestamp persistence for symbol/timeframe partitions."""
 
 from __future__ import annotations
 
@@ -18,11 +18,30 @@ class ParquetStorage:
     def _data_path(self, symbol: str, timeframe: Timeframe) -> Path:
         return self._base_dir / symbol / timeframe.value / "data.parquet"
 
+
+
+    @staticmethod
+    def _ensure_utc_columns(data: pd.DataFrame) -> pd.DataFrame:
+        normalized = data.copy()
+        if "timestamp" not in normalized.columns:
+            raise ValueError("data must contain 'timestamp' column")
+
+        ts = pd.to_datetime(normalized["timestamp"], unit="ms", utc=True, errors="coerce")
+        normalized = normalized.loc[ts.notna()].copy()
+        ts = ts.loc[ts.notna()]
+
+        normalized["timestamp"] = (ts.astype("int64") // 1_000_000).astype("int64")
+        normalized["datetime"] = ts
+        return normalized
+
     def load(self, symbol: str, timeframe: Timeframe) -> pd.DataFrame:
         path = self._data_path(symbol, timeframe)
         if not path.exists():
             return pd.DataFrame()
-        return pd.read_parquet(path)
+        frame = pd.read_parquet(path)
+        if frame.empty:
+            return frame
+        return self._ensure_utc_columns(frame)
 
     def get_last_timestamp(self, symbol: str, timeframe: Timeframe) -> pd.Timestamp | None:
         data = self.load(symbol, timeframe)
@@ -37,9 +56,7 @@ class ParquetStorage:
         path = self._data_path(symbol, timeframe)
         path.parent.mkdir(parents=True, exist_ok=True)
 
-        incoming = new_data.copy()
-        if "timestamp" not in incoming.columns:
-            raise ValueError("new_data must contain 'timestamp' column")
+        incoming = self._ensure_utc_columns(new_data)
 
         existing = self.load(symbol, timeframe)
         previous_count = len(existing)
@@ -58,6 +75,7 @@ class ParquetStorage:
                 else:
                     merged = merged.rename(columns={col: base_col})
 
+        merged = self._ensure_utc_columns(merged)
         merged = merged.drop_duplicates(subset=["timestamp"], keep="last").sort_values("timestamp")
         merged.to_parquet(path, index=False)
 

--- a/simulation/position_simulator.py
+++ b/simulation/position_simulator.py
@@ -14,6 +14,7 @@ from domain.value_objects.price import Price
 from domain.value_objects.volume import Volume
 from simulation.order_processor import OrderProcessor
 from simulation.trade_classifier import TradeClassifier
+from utils.formatters import datetime_to_timezone
 
 
 @dataclass(slots=True)
@@ -23,6 +24,7 @@ class StatefulPositionSimulator(PositionSimulator):
     side: PositionSide
     order_processor: OrderProcessor
     trade_classifier: TradeClassifier
+    simulation_timezone: str
 
     position: Position | None = None
     _pending_signal: TradeSignal | None = None
@@ -73,7 +75,7 @@ class StatefulPositionSimulator(PositionSimulator):
         trade_result = self.trade_classifier.build_result(
             position=self.position,
             exit_price=self._last_exit_price,
-            exit_time=self.position.entry_time,
+            exit_time=datetime_to_timezone(self.position.entry_time, self.simulation_timezone),
             result_type=result_type,
             pnl=self._realized_pnl,
         )
@@ -95,7 +97,7 @@ class StatefulPositionSimulator(PositionSimulator):
         fill = self.order_processor.execute_entry(candle.open.value, self.side, self._pending_size)
         self.position = Position(
             entry_price=Price(fill.price),
-            entry_time=candle.timestamp,
+            entry_time=datetime_to_timezone(candle.timestamp, self.simulation_timezone),
             size=Volume(self._pending_size),
             stop_loss=signal.stop_loss,
             take_profit_1=signal.take_profit_1,
@@ -181,7 +183,7 @@ class StatefulPositionSimulator(PositionSimulator):
         trade_result = self.trade_classifier.build_result(
             position=self.position,
             exit_price=self._last_exit_price,
-            exit_time=candle.timestamp,
+            exit_time=datetime_to_timezone(candle.timestamp, self.simulation_timezone),
             result_type=result_type,
             pnl=self._realized_pnl,
         )

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import timezone
 from typing import Any
 
 import pandas as pd
@@ -15,6 +14,7 @@ from domain.value_objects.price import Price
 from domain.value_objects.volume import Volume
 from simulation.order_processor import OrderProcessor
 from simulation.position_simulator import StatefulPositionSimulator
+from utils.formatters import datetime_to_timezone, utc_ms_to_local_datetime
 from simulation.trade_classifier import TradeClassifier
 from strategy.base_strategy import BaseStrategy
 
@@ -24,9 +24,11 @@ class BreakoutStrategy(BaseStrategy):
 
     REQUIRED_COLUMNS = ("timestamp", "open", "high", "low", "close", "volume")
 
-    def __init__(self, *, commission_rate: float, slippage: float) -> None:
+    def __init__(self, *, commission_rate: float, slippage: float, strategy_timezone: str, simulation_timezone: str) -> None:
         self._commission_rate = commission_rate
         self._slippage = slippage
+        self._strategy_timezone = strategy_timezone
+        self._simulation_timezone = simulation_timezone
 
     def validate_config(self, params: dict[str, Any]) -> None:
         lookback = int(params["lookback"])
@@ -49,7 +51,9 @@ class BreakoutStrategy(BaseStrategy):
             raise ValueError(f"Missing required columns: {missing}")
 
         prepared = data.copy()
-        prepared["datetime"] = pd.to_datetime(prepared["timestamp"], unit="ms", utc=True, errors="coerce")
+        prepared["datetime"] = pd.to_numeric(prepared["timestamp"], errors="coerce").map(
+            lambda value: utc_ms_to_local_datetime(value, self._strategy_timezone) if pd.notna(value) else pd.NaT
+        )
         prepared = prepared.dropna(subset=["datetime"])
         prepared = prepared.sort_values("datetime").reset_index(drop=True)
 
@@ -68,6 +72,7 @@ class BreakoutStrategy(BaseStrategy):
             side=PositionSide.LONG,
             order_processor=OrderProcessor(commission_rate=self._commission_rate, slippage=self._slippage),
             trade_classifier=TradeClassifier(),
+            simulation_timezone=self._simulation_timezone,
         )
 
         lookback = int(params["lookback"])
@@ -97,7 +102,7 @@ class BreakoutStrategy(BaseStrategy):
                     tp2 = row["close"] + risk * min_rr * tp2_mult
                     pending_signal = TradeSignal(
                         entry_price=Price(float(row["close"])),
-                        entry_time=row["datetime"].to_pydatetime().astimezone(timezone.utc),
+                        entry_time=datetime_to_timezone(row["datetime"].to_pydatetime(), self._simulation_timezone),
                         stop_loss=Price(float(stop)),
                         take_profit_1=Price(float(tp1)),
                         take_profit_2=Price(float(tp2)),
@@ -119,10 +124,9 @@ class BreakoutStrategy(BaseStrategy):
 
         return trades
 
-    @staticmethod
-    def _to_candle(row: pd.Series) -> Candle:
+    def _to_candle(self, row: pd.Series) -> Candle:
         return Candle(
-            timestamp=row["datetime"].to_pydatetime().astimezone(timezone.utc),
+            timestamp=datetime_to_timezone(row["datetime"].to_pydatetime(), self._simulation_timezone),
             open=Price(float(row["open"])),
             high=Price(float(row["high"])),
             low=Price(float(row["low"])),

--- a/utils/formatters.py
+++ b/utils/formatters.py
@@ -1,0 +1,46 @@
+"""Timezone and datetime formatting helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+DEFAULT_STORAGE_TIMEZONE = timezone.utc
+
+
+def resolve_timezone(timezone_name: str) -> ZoneInfo:
+    """Resolve IANA timezone name into ZoneInfo instance."""
+    return ZoneInfo(timezone_name)
+
+
+def utc_ms_to_local_datetime(timestamp_ms: int | float, timezone_name: str) -> datetime:
+    """Convert UTC timestamp in milliseconds to timezone-aware datetime in provided TZ."""
+    tz = resolve_timezone(timezone_name)
+    utc_dt = datetime.fromtimestamp(float(timestamp_ms) / 1000.0, tz=timezone.utc)
+    return utc_dt.astimezone(tz)
+
+
+def datetime_to_timezone(value: datetime, timezone_name: str) -> datetime:
+    """Convert aware/naive datetime to provided TZ. Naive datetimes are treated as target TZ."""
+    tz = resolve_timezone(timezone_name)
+    if value.tzinfo is None:
+        return value.replace(tzinfo=tz)
+    return value.astimezone(tz)
+
+
+def datetime_to_utc(value: datetime, source_timezone_name: str | None = None) -> datetime:
+    """Convert aware/naive datetime to UTC; naive is interpreted in source_timezone_name or UTC."""
+    if value.tzinfo is None:
+        if source_timezone_name is None:
+            aware = value.replace(tzinfo=timezone.utc)
+        else:
+            aware = value.replace(tzinfo=resolve_timezone(source_timezone_name))
+    else:
+        aware = value
+    return aware.astimezone(timezone.utc)
+
+
+def datetime_to_utc_ms(value: datetime, source_timezone_name: str | None = None) -> int:
+    """Convert aware/naive datetime to UTC timestamp in milliseconds."""
+    utc_dt = datetime_to_utc(value, source_timezone_name=source_timezone_name)
+    return int(utc_dt.timestamp() * 1000)


### PR DESCRIPTION
### Motivation
- Centralize timezone conversions so input timestamps can be interpreted in a configurable local TZ and persisted in UTC consistently.  
- Allow separate timezones for fetching, strategy preprocessing and simulation to avoid hardcoded `UTC` assumptions.  
- Ensure parquet cache always stores UTC millisecond `timestamp` (and UTC-aware `datetime`) to avoid ambiguity when merging/aligning data.

### Description
- Added centralized helpers in `utils/formatters.py` (`resolve_timezone`, `utc_ms_to_local_datetime`, `datetime_to_timezone`, `datetime_to_utc`, `datetime_to_utc_ms`) for TZ resolution and conversions.  
- Extended `config.py` to support `FETCH_TIMEZONE`, `STRATEGY_TIMEZONE`, `SIMULATION_TIMEZONE` (fallback to `TIMEZONE`) and added `tzinfo` accessors on `fetch`, `strategy` and `simulation` configs.  
- Updated CLI handlers in `cli/commands.py` so `fetch-data`/`update-cache` compute period boundaries in configured fetch TZ and convert them to UTC before calling fetch/storage, and passed strategy/simulation timezones into the backtest `BreakoutStrategy`.  
- Modified `strategy/breakout/breakout_strategy.py` to prepare working `datetime` values in `strategy_timezone` (using `utc_ms_to_local_datetime`) and to create `TradeSignal`/`Candle` timestamps in `simulation_timezone`.  
- Modified `simulation/position_simulator.py` to accept `simulation_timezone` and normalize `entry_time`/`exit_time` via timezone helpers instead of assuming UTC.  
- Enforced parquet UTC contract in `data/storage/parquet_storage.py` by normalizing loaded/incoming/merged frames to a UTC millisecond `timestamp` and keeping a UTC-aware `datetime` column, and clarified the contract in `data/quality/time_alignment.py` docstring.

### Testing
- Run static compilation check with `python -m compileall config.py cli/commands.py strategy/breakout/breakout_strategy.py simulation/position_simulator.py data/storage/parquet_storage.py data/quality/time_alignment.py utils/formatters.py`, which completed successfully.  
- No unit tests were added (per project constraints).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987255880ac8320be4e4dbd0b144a4a)