### PR TITLE
Adjust breakout parameter grid to 5832 and add combo-count warnings

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -23,6 +23,7 @@ from domain.enums.exchange import Exchange
 from strategy.breakout.breakout_strategy import BreakoutStrategy
 from utils.formatters import datetime_to_utc
 from utils.logger import get_logger
+from strategy.breakout.config import TARGET_PARAMETER_COMBINATIONS
 from vectorbt_runner.backtest_runner import BacktestRunner
 from vectorbt_runner.data_preparer import DataPreparer
 
@@ -178,6 +179,13 @@ def make_report(config: AppConfig, args: argparse.Namespace) -> int:
 
         filtered = frame[(frame["trades_count"] >= 30) & (frame["profit_factor"] > 1.0)].copy()
         filtered = filtered.sort_values("profit_factor", ascending=False)
+
+        if len(frame) != TARGET_PARAMETER_COMBINATIONS:
+            logger.warning(
+                "make-report: фактическое число комбинаций=%s отличается от целевого=%s",
+                len(frame),
+                TARGET_PARAMETER_COMBINATIONS,
+            )
 
         summary = {
             "total_combinations": int(len(frame)),

--- a/strategy/breakout/config.py
+++ b/strategy/breakout/config.py
@@ -1,0 +1,19 @@
+"""Source-of-truth breakout parameter ranges for grid backtests."""
+
+from __future__ import annotations
+
+from math import prod
+
+TARGET_PARAMETER_COMBINATIONS = 5832
+
+BREAKOUT_PARAMETER_GRID: dict[str, list[float | int | str]] = {
+    "lookback": [8, 13, 21, 34, 55, 89],
+    "volume_mult": [1.1, 1.3, 1.5],
+    "retest_window": [2, 4, 6],
+    "retest_zone": [0.0015, 0.0020, 0.0030],
+    "min_rr": [1.0, 1.5, 2.0],
+    "sl_mode": ["LEVEL", "BREAKOUT_EXTREME"],
+    "tp2_mult": [1.1, 1.25, 1.4, 1.5, 1.75, 2.0],
+}
+
+PARAMETER_GRID_SIZE = prod(len(values) for values in BREAKOUT_PARAMETER_GRID.values())

--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -6,11 +6,13 @@ from dataclasses import dataclass
 from itertools import product
 from pathlib import Path
 from typing import Any
+import logging
 
 import pandas as pd
 
 from domain.enums.trade_result_type import TradeResultType
 from domain.models.trade_result import TradeResult
+from strategy.breakout.config import BREAKOUT_PARAMETER_GRID, PARAMETER_GRID_SIZE, TARGET_PARAMETER_COMBINATIONS
 
 
 @dataclass(slots=True)
@@ -18,6 +20,9 @@ class BacktestSummary:
     total_combinations: int
     profitable_combinations: int
     best_pf: float
+
+
+logger = logging.getLogger(__name__)
 
 
 class BacktestRunner:
@@ -28,14 +33,15 @@ class BacktestRunner:
         self._results_file_name = results_file_name
 
     def build_parameter_grid(self) -> list[dict[str, Any]]:
-        lookback = [13, 21, 34]
-        volume_mult = [1.2, 1.5, 2.0]
-        retest_window = [2, 4, 6]
-        retest_zone = [0.002, 0.003]
-        min_rr = [1.0, 1.5, 2.0]
-        sl_mode = ["LEVEL", "BREAKOUT_EXTREME"]
-        tp2_mult = [1.25, 1.5, 2.0]
+        lookback = BREAKOUT_PARAMETER_GRID["lookback"]
+        volume_mult = BREAKOUT_PARAMETER_GRID["volume_mult"]
+        retest_window = BREAKOUT_PARAMETER_GRID["retest_window"]
+        retest_zone = BREAKOUT_PARAMETER_GRID["retest_zone"]
+        min_rr = BREAKOUT_PARAMETER_GRID["min_rr"]
+        sl_mode = BREAKOUT_PARAMETER_GRID["sl_mode"]
+        tp2_mult = BREAKOUT_PARAMETER_GRID["tp2_mult"]
 
+        # combos = |lookback| × |volume_mult| × |retest_window| × |retest_zone| × |min_rr| × |sl_mode| × |tp2_mult| = 6×3×3×3×3×2×6 = 5832
         return [
             {
                 "lookback": lb,
@@ -76,6 +82,19 @@ class BacktestRunner:
         return results
 
     def build_summary(self, results: pd.DataFrame) -> BacktestSummary:
+        if PARAMETER_GRID_SIZE != TARGET_PARAMETER_COMBINATIONS:
+            logger.warning(
+                "run-backtest: расчетная мощность сетки=%s отличается от целевой=%s",
+                PARAMETER_GRID_SIZE,
+                TARGET_PARAMETER_COMBINATIONS,
+            )
+        if len(results) != TARGET_PARAMETER_COMBINATIONS:
+            logger.warning(
+                "run-backtest: фактическое число комбинаций=%s отличается от целевого=%s",
+                len(results),
+                TARGET_PARAMETER_COMBINATIONS,
+            )
+
         profitable = int((results["profit_factor"] > 1.0).sum()) if not results.empty else 0
         best_pf = float(results["profit_factor"].max()) if not results.empty else 0.0
         return BacktestSummary(


### PR DESCRIPTION
### Motivation
- Централизовать и пересчитать диапазоны параметров сетки так, чтобы их произведение давало ровно 5832 комбинации и чтобы значения были source of truth для бектестера.
- Сохранить поведение сборки отчёта/сводки на основе фактического количества результатов, но логировать расхождения с целевым числом комбинаций.

### Description
- Добавлен `strategy/breakout/config.py` с `BREAKOUT_PARAMETER_GRID`, `TARGET_PARAMETER_COMBINATIONS = 5832` и `PARAMETER_GRID_SIZE` (произведение размеров наборов).
- Обновлён `BacktestRunner.build_parameter_grid()` в `vectorbt_runner/backtest_runner.py` для чтения диапазонов из `BREAKOUT_PARAMETER_GRID` и добавлен явный комментарий с формулой количества комбинаций (`6×3×3×3×3×2×6 = 5832`).
- В `BacktestRunner.build_summary()` добавлены предупреждающие логи, если вычисленная `PARAMETER_GRID_SIZE` или фактическое `len(results)` отличаются от `TARGET_PARAMETER_COMBINATIONS`, при этом итог по `total_combinations` по-прежнему берётся как `int(len(results))`.
- В `make-report` (`cli/commands.py`) добавлен импорт `TARGET_PARAMETER_COMBINATIONS` и предупреждение в логи, если `len(frame)` отличается от целевого, при этом отчёт продолжает использовать `len(frame)` в поле `summary`.

### Testing
- Проверена синтаксическая корректность изменённых модулей командой `python -m compileall strategy/breakout/config.py vectorbt_runner/backtest_runner.py cli/commands.py`, компиляция прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698726817df08320a8bc78b755a1375a)