### PR TITLE
Add vectorbt integration for portfolio metrics in backtest runner

### DIFF
--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -13,6 +13,12 @@ import pandas as pd
 from domain.enums.trade_result_type import TradeResultType
 from domain.models.trade_result import TradeResult
 from strategy.breakout.config import BREAKOUT_PARAMETER_GRID, PARAMETER_GRID_SIZE, TARGET_PARAMETER_COMBINATIONS
+from vectorbt_runner.data_preparer import DataPreparer
+
+try:
+    import vectorbt as vbt
+except ImportError:  # pragma: no cover - environment dependent
+    vbt = None
 
 
 @dataclass(slots=True)
@@ -64,6 +70,8 @@ class BacktestRunner:
         ]
 
     def run(self, strategy: Any, symbol_frames: dict[str, pd.DataFrame]) -> pd.DataFrame:
+        self._ensure_vectorbt_available()
+
         rows: list[dict[str, Any]] = []
         grid = self.build_parameter_grid()
 
@@ -103,6 +111,14 @@ class BacktestRunner:
             best_pf=best_pf,
         )
 
+    def _ensure_vectorbt_available(self) -> None:
+        if vbt is None:
+            msg = (
+                "vectorbt is not installed in the current environment. "
+                "Install it (for example: pip install vectorbt) and retry run-backtest."
+            )
+            raise RuntimeError(msg)
+
     def _build_metrics_row(self, params: dict[str, Any], trades: list[TradeResult]) -> dict[str, Any]:
         if not trades:
             return {
@@ -118,24 +134,50 @@ class BacktestRunner:
                 "tp2_count": 0,
             }
 
-        pnl_values = [trade.pnl for trade in trades]
-        profits = sum(value for value in pnl_values if value > 0)
-        losses = abs(sum(value for value in pnl_values if value < 0))
-        pf = profits / losses if losses > 0 else (99.0 if profits > 0 else 0.0)
+        prepared = DataPreparer.prepare_vectorbt_inputs(trades)
+        portfolio = vbt.Portfolio.from_signals(
+            close=prepared.close,
+            entries=prepared.entries,
+            exits=prepared.exits,
+            direction="longonly",
+            init_cash=100.0,
+            size=1.0,
+            size_type="amount",
+            fees=0.0,
+            slippage=0.0,
+            freq="1min",
+        )
 
-        wins = sum(1 for value in pnl_values if value > 0)
+        pnl_values = [trade.pnl for trade in trades]
         pnl_percent = sum(trade.pnl_percent.value for trade in trades)
-        equity = pd.Series(pnl_values).cumsum()
-        drawdown = float((equity.cummax() - equity).max()) if not equity.empty else 0.0
+
+        pf = portfolio.trades.profit_factor()
+        win_rate = portfolio.trades.win_rate()
+        trades_count = int(portfolio.trades.count())
+
+        max_dd = portfolio.drawdowns.max_drawdown()
+        if pd.isna(max_dd):
+            max_dd = 0.0
+        else:
+            max_dd = abs(float(max_dd))
+
+        if pd.isna(pf):
+            profits = sum(value for value in pnl_values if value > 0)
+            losses = abs(sum(value for value in pnl_values if value < 0))
+            pf = profits / losses if losses > 0 else (99.0 if profits > 0 else 0.0)
+
+        if pd.isna(win_rate):
+            wins = sum(1 for value in pnl_values if value > 0)
+            win_rate = wins / len(trades)
 
         result_types = [trade.result_type for trade in trades]
         return {
             **params,
             "profit_factor": round(float(pf), 4),
             "pnl_percent": round(float(pnl_percent), 4),
-            "win_rate": round(wins / len(trades), 4),
-            "trades_count": len(trades),
-            "max_dd": round(drawdown, 6),
+            "win_rate": round(float(win_rate), 4),
+            "trades_count": trades_count,
+            "max_dd": round(float(max_dd), 6),
             "sl_count": result_types.count(TradeResultType.SL),
             "be_count": result_types.count(TradeResultType.BE),
             "tp1_be_count": result_types.count(TradeResultType.TP1_BE),

--- a/vectorbt_runner/data_preparer.py
+++ b/vectorbt_runner/data_preparer.py
@@ -2,11 +2,24 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 import pandas as pd
 
 from domain.enums.timeframe import Timeframe
+from domain.models.trade_result import TradeResult
+
+
+@dataclass(frozen=True, slots=True)
+class VectorbtInputs:
+    """Prepared inputs that can be directly consumed by vectorbt."""
+
+    close: pd.Series
+    entries: pd.Series
+    exits: pd.Series
+    equity_curve: pd.Series
+    trades: pd.DataFrame
 
 
 class DataPreparer:
@@ -50,3 +63,70 @@ class DataPreparer:
         normalized = normalized.dropna(subset=["open", "high", "low", "close", "volume"])
         normalized = normalized.sort_values("datetime").drop_duplicates(subset=["timestamp"], keep="last")
         return normalized.reset_index(drop=True)
+
+    @staticmethod
+    def prepare_vectorbt_inputs(trades: list[TradeResult], initial_price: float = 100.0) -> VectorbtInputs:
+        """Build synthetic price/signals/equity series from closed trades."""
+        if not trades:
+            index = pd.DatetimeIndex([], tz="UTC")
+            empty_float = pd.Series([], index=index, dtype="float64")
+            empty_bool = pd.Series([], index=index, dtype="bool")
+            trades_frame = pd.DataFrame(columns=["entry_time", "exit_time", "pnl", "pnl_percent", "result_type"])
+            return VectorbtInputs(
+                close=empty_float,
+                entries=empty_bool,
+                exits=empty_bool,
+                equity_curve=empty_float,
+                trades=trades_frame,
+            )
+
+        trades_sorted = sorted(trades, key=lambda trade: (trade.entry_time, trade.exit_time))
+        trade_rows = [
+            {
+                "entry_time": pd.Timestamp(trade.entry_time, tz="UTC"),
+                "exit_time": pd.Timestamp(trade.exit_time, tz="UTC"),
+                "pnl": float(trade.pnl),
+                "pnl_percent": float(trade.pnl_percent.value),
+                "result_type": trade.result_type.value,
+            }
+            for trade in trades_sorted
+        ]
+        trades_frame = pd.DataFrame(trade_rows)
+
+        timeline = pd.DatetimeIndex(
+            sorted(set(trades_frame["entry_time"].tolist() + trades_frame["exit_time"].tolist())),
+            tz="UTC",
+        )
+        close = pd.Series(initial_price, index=timeline, dtype="float64")
+        entries = pd.Series(False, index=timeline, dtype="bool")
+        exits = pd.Series(False, index=timeline, dtype="bool")
+        equity_curve = pd.Series(0.0, index=timeline, dtype="float64")
+
+        running_price = float(initial_price)
+        cumulative_pnl = 0.0
+        for trade in trade_rows:
+            entry_time = trade["entry_time"]
+            exit_time = trade["exit_time"]
+            pnl_percent = trade["pnl_percent"]
+            pnl = trade["pnl"]
+
+            entries.loc[entry_time] = True
+            exits.loc[exit_time] = True
+            close.loc[entry_time] = running_price
+
+            running_price *= 1.0 + (pnl_percent / 100.0)
+            close.loc[exit_time] = running_price
+
+            cumulative_pnl += pnl
+            equity_curve.loc[exit_time] = cumulative_pnl
+
+        close = close.ffill()
+        equity_curve = equity_curve.replace(0.0, pd.NA).ffill().fillna(0.0)
+
+        return VectorbtInputs(
+            close=close,
+            entries=entries,
+            exits=exits,
+            equity_curve=equity_curve,
+            trades=trades_frame,
+        )


### PR DESCRIPTION
### Motivation
- Provide more robust portfolio-level metrics by running trades through `vectorbt` to compute `profit_factor`, drawdown, `win_rate`, and `trades_count` instead of purely manual calculations.
- Transform closed-trade results into a `vectorbt`-friendly format (price series, entry/exit signals and equity curve) so `Portfolio.from_signals` can be used.
- Keep the existing CSV output format and per-result counters intact for backward compatibility with downstream tools.
- Fail fast with a clear message when `vectorbt` is not available in the runtime environment.

### Description
- Added `VectorbtInputs` dataclass and `DataPreparer.prepare_vectorbt_inputs(...)` to build synthetic `close`, `entries`, `exits`, `equity_curve` and a normalized trades `DataFrame` from `list[TradeResult]` in `vectorbt_runner/data_preparer.py`.
- Updated `vectorbt_runner/backtest_runner.py` to import `DataPreparer`, attempt `import vectorbt as vbt` with a `try/except` guard, and call `_ensure_vectorbt_available()` at run-time to surface a helpful `RuntimeError` if missing.
- Replaced the hand-rolled PF/winrate/dd computation with `vbt.Portfolio.from_signals(...)` and extracted `profit_factor`, `win_rate`, `trades_count`, and `max_dd` from the produced portfolio while retaining fallback logic for `NaN` results.
- Preserved the CSV output schema and existing counters (`sl_count`, `be_count`, `tp1_be_count`, `tp2_count`, `pnl_percent`, etc.) and left `_save_results` behavior unchanged.

### Testing
- Ran `python -m compileall vectorbt_runner` successfully to ensure syntax correctness of the modified modules.
- Attempted a runtime import check for `vectorbt_runner.backtest_runner`, but the environment lacked `pandas` (and therefore prevented full execution and `vectorbt` validation), so end-to-end vectorbt metric execution could not be verified automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987363f0f24832082fe9c3dcf81796e)