### PR TITLE
Split config dataclasses into modules and move Fill model to simulation/models

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -2,83 +2,39 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import tzinfo
-from pathlib import Path
 import os
+from pathlib import Path
 
+from config.app_config import AppConfig
+from config.backtest_config import BacktestConfig
+from config.fetch_config import FetchConfig
+from config.simulation_config import SimulationConfig
+from config.strategy_config import StrategyConfig
 from constants import (
     DEFAULT_BACKTEST_OUTPUT_FILE,
     DEFAULT_CACHE_DIR,
     DEFAULT_COMMISSION_RATE,
     DEFAULT_LOG_LEVEL,
-    DEFAULT_LOGS_DIR,
     DEFAULT_MAX_CONCURRENT_REQUESTS,
-    DEFAULT_RESULTS_DIR,
     DEFAULT_RETRY_ATTEMPTS,
     DEFAULT_RETRY_BACKOFF_SECONDS,
+    DEFAULT_RESULTS_DIR,
     DEFAULT_SLIPPAGE,
-    DEFAULT_SPREAD,
     DEFAULT_TIMEFRAME,
     DEFAULT_TIMEZONE,
+    DEFAULT_SPREAD,
+    DEFAULT_LOGS_DIR,
 )
 from domain.enums.timeframe import Timeframe
-from utils.formatters import resolve_timezone
 
-
-@dataclass(slots=True)
-class FetchConfig:
-    binance_api_key: str
-    binance_secret_key: str
-    coingecko_api_key: str
-    max_concurrent_requests: int = DEFAULT_MAX_CONCURRENT_REQUESTS
-    timeframe: Timeframe = DEFAULT_TIMEFRAME
-    timezone: str = DEFAULT_TIMEZONE
-
-    @property
-    def tzinfo(self) -> tzinfo:
-        return resolve_timezone(self.timezone)
-
-
-@dataclass(slots=True)
-class StrategyConfig:
-    timezone: str = DEFAULT_TIMEZONE
-    default_timeframe: Timeframe = DEFAULT_TIMEFRAME
-
-    @property
-    def tzinfo(self) -> tzinfo:
-        return resolve_timezone(self.timezone)
-
-
-@dataclass(slots=True)
-class SimulationConfig:
-    commission_rate: float = DEFAULT_COMMISSION_RATE
-    slippage: float = DEFAULT_SLIPPAGE
-    spread: float = DEFAULT_SPREAD
-    timezone: str = DEFAULT_TIMEZONE
-
-    @property
-    def tzinfo(self) -> tzinfo:
-        return resolve_timezone(self.timezone)
-
-
-@dataclass(slots=True)
-class BacktestConfig:
-    log_level: str = DEFAULT_LOG_LEVEL
-    cache_dir: Path = Path(DEFAULT_CACHE_DIR)
-    logs_dir: Path = Path(DEFAULT_LOGS_DIR)
-    results_dir: Path = Path(DEFAULT_RESULTS_DIR)
-    results_file_name: str = DEFAULT_BACKTEST_OUTPUT_FILE
-    retry_attempts: int = DEFAULT_RETRY_ATTEMPTS
-    retry_backoff_seconds: float = DEFAULT_RETRY_BACKOFF_SECONDS
-
-
-@dataclass(slots=True)
-class AppConfig:
-    fetch: FetchConfig
-    strategy: StrategyConfig
-    simulation: SimulationConfig
-    backtest: BacktestConfig
+__all__ = [
+    "AppConfig",
+    "BacktestConfig",
+    "FetchConfig",
+    "SimulationConfig",
+    "StrategyConfig",
+    "load_config",
+]
 
 
 def _load_env_file(env_path: Path) -> None:
@@ -149,7 +105,11 @@ def load_config(env_path: str | Path = ".env") -> AppConfig:
         ),
     )
 
-    for path in (backtest_config.cache_dir, backtest_config.logs_dir, backtest_config.results_dir):
+    for path in (
+        backtest_config.cache_dir,
+        backtest_config.logs_dir,
+        backtest_config.results_dir,
+    ):
         path.mkdir(parents=True, exist_ok=True)
 
     return AppConfig(

--- a/config/app_config.py
+++ b/config/app_config.py
@@ -1,0 +1,18 @@
+"""Aggregate application configuration dataclass."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from config.backtest_config import BacktestConfig
+from config.fetch_config import FetchConfig
+from config.simulation_config import SimulationConfig
+from config.strategy_config import StrategyConfig
+
+
+@dataclass(slots=True)
+class AppConfig:
+    fetch: FetchConfig
+    strategy: StrategyConfig
+    simulation: SimulationConfig
+    backtest: BacktestConfig

--- a/config/backtest_config.py
+++ b/config/backtest_config.py
@@ -1,0 +1,27 @@
+"""Backtest runner configuration dataclass."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from constants import (
+    DEFAULT_BACKTEST_OUTPUT_FILE,
+    DEFAULT_CACHE_DIR,
+    DEFAULT_LOG_LEVEL,
+    DEFAULT_LOGS_DIR,
+    DEFAULT_RESULTS_DIR,
+    DEFAULT_RETRY_ATTEMPTS,
+    DEFAULT_RETRY_BACKOFF_SECONDS,
+)
+
+
+@dataclass(slots=True)
+class BacktestConfig:
+    log_level: str = DEFAULT_LOG_LEVEL
+    cache_dir: Path = Path(DEFAULT_CACHE_DIR)
+    logs_dir: Path = Path(DEFAULT_LOGS_DIR)
+    results_dir: Path = Path(DEFAULT_RESULTS_DIR)
+    results_file_name: str = DEFAULT_BACKTEST_OUTPUT_FILE
+    retry_attempts: int = DEFAULT_RETRY_ATTEMPTS
+    retry_backoff_seconds: float = DEFAULT_RETRY_BACKOFF_SECONDS

--- a/config/fetch_config.py
+++ b/config/fetch_config.py
@@ -1,0 +1,24 @@
+"""Fetch layer configuration dataclass."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import tzinfo
+
+from constants import DEFAULT_MAX_CONCURRENT_REQUESTS, DEFAULT_TIMEFRAME, DEFAULT_TIMEZONE
+from domain.enums.timeframe import Timeframe
+from utils.formatters import resolve_timezone
+
+
+@dataclass(slots=True)
+class FetchConfig:
+    binance_api_key: str
+    binance_secret_key: str
+    coingecko_api_key: str
+    max_concurrent_requests: int = DEFAULT_MAX_CONCURRENT_REQUESTS
+    timeframe: Timeframe = DEFAULT_TIMEFRAME
+    timezone: str = DEFAULT_TIMEZONE
+
+    @property
+    def tzinfo(self) -> tzinfo:
+        return resolve_timezone(self.timezone)

--- a/config/simulation_config.py
+++ b/config/simulation_config.py
@@ -1,0 +1,21 @@
+"""Simulation layer configuration dataclass."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import tzinfo
+
+from constants import DEFAULT_COMMISSION_RATE, DEFAULT_SLIPPAGE, DEFAULT_SPREAD, DEFAULT_TIMEZONE
+from utils.formatters import resolve_timezone
+
+
+@dataclass(slots=True)
+class SimulationConfig:
+    commission_rate: float = DEFAULT_COMMISSION_RATE
+    slippage: float = DEFAULT_SLIPPAGE
+    spread: float = DEFAULT_SPREAD
+    timezone: str = DEFAULT_TIMEZONE
+
+    @property
+    def tzinfo(self) -> tzinfo:
+        return resolve_timezone(self.timezone)

--- a/config/strategy_config.py
+++ b/config/strategy_config.py
@@ -1,0 +1,20 @@
+"""Strategy layer configuration dataclass."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import tzinfo
+
+from constants import DEFAULT_TIMEFRAME, DEFAULT_TIMEZONE
+from domain.enums.timeframe import Timeframe
+from utils.formatters import resolve_timezone
+
+
+@dataclass(slots=True)
+class StrategyConfig:
+    timezone: str = DEFAULT_TIMEZONE
+    default_timeframe: Timeframe = DEFAULT_TIMEFRAME
+
+    @property
+    def tzinfo(self) -> tzinfo:
+        return resolve_timezone(self.timezone)

--- a/simulation/__init__.py
+++ b/simulation/__init__.py
@@ -1,6 +1,7 @@
 """Simulation package exports."""
 
-from simulation.order_processor import Fill, OrderProcessor
+from simulation.models.fill import Fill
+from simulation.order_processor import OrderProcessor
 from simulation.position_simulator import StatefulPositionSimulator
 from simulation.trade_classifier import TradeClassifier
 

--- a/simulation/models/__init__.py
+++ b/simulation/models/__init__.py
@@ -1,0 +1,5 @@
+"""Simulation models exports."""
+
+from simulation.models.fill import Fill
+
+__all__ = ["Fill"]

--- a/simulation/models/fill.py
+++ b/simulation/models/fill.py
@@ -1,0 +1,13 @@
+"""Order fill model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class Fill:
+    """Single order fill snapshot."""
+
+    price: float
+    commission: float

--- a/simulation/order_processor.py
+++ b/simulation/order_processor.py
@@ -5,14 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from domain.enums.position_side import PositionSide
-
-
-@dataclass(frozen=True, slots=True)
-class Fill:
-    """Single order fill snapshot."""
-
-    price: float
-    commission: float
+from simulation.models.fill import Fill
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
### Motivation
- Separate configuration dataclasses into focused modules to improve organization and maintainability.
- Decouple the `Fill` model from `OrderProcessor` so simulation models are reusable and easier to import.

### Description
- Added `config/fetch_config.py`, `config/strategy_config.py`, `config/simulation_config.py`, `config/backtest_config.py`, and `config/app_config.py` and refactored `config/__init__.py` to preserve `load_config` and the public `config` API while composing `AppConfig` from the new dataclasses.
- Moved the `Fill` dataclass to `simulation/models/fill.py` and added `simulation/models/__init__.py` to export the model.
- Updated `simulation/order_processor.py` to import `Fill` from `simulation.models.fill` and adjusted `simulation/__init__.py` exports accordingly.
- Ensured external call sites continue to use the same `config` package interface so no callers needed API changes.

### Testing
- Ran `python -m py_compile main.py cli/parser.py cli/commands.py config/__init__.py config/app_config.py config/fetch_config.py config/strategy_config.py config/simulation_config.py config/backtest_config.py simulation/order_processor.py simulation/models/fill.py simulation/__init__.py simulation/models/__init__.py` and the command completed without errors.
- No new tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987380972148320ad4045fa0fe6b2b9)