### PR TITLE
Reorder class private sections for consistent method layout

### DIFF
--- a/data/clients/coingecko_client.py
+++ b/data/clients/coingecko_client.py
@@ -21,6 +21,8 @@ class CoinGeckoClient(MarketDataClient):
         self._market_cap_cache: dict[str, tuple[float, datetime]] = {}
         self._symbol_to_id: dict[str, str] = {}
 
+    # region Private
+
     def _headers(self) -> dict[str, str]:
         headers = {"accept": "application/json"}
         if self._api_key:
@@ -48,6 +50,8 @@ class CoinGeckoClient(MarketDataClient):
             raise ValueError(f"Unable to resolve CoinGecko ID for symbol: {symbol}")
 
         return self._symbol_to_id[normalized]
+
+    # endregion Private
 
     def get_market_cap(self, symbol: str) -> float:
         normalized = symbol.upper()

--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -56,6 +56,8 @@ class CcxtFuturesClient(ExchangeClient):
         self._client = self._build_client(exchange=self.exchange, api_key=api_key, secret=secret, password=password, enable_rate_limit=enable_rate_limit)
         self._client.load_markets()
 
+    # region Private
+
     def _build_client(self, exchange: Exchange, api_key: str, secret: str, password: str, enable_rate_limit: bool) -> Any:
         params: dict[str, Any] = {
             "apiKey": api_key,
@@ -73,6 +75,8 @@ class CcxtFuturesClient(ExchangeClient):
             params["options"] = {"defaultType": "swap"}
             return ccxt.okx(params)
         raise ValueError(f"Unsupported exchange: {exchange}")
+
+    # endregion Private
 
     def get_futures_symbols(self) -> list[str]:
         symbols: list[str] = []

--- a/simulation/order_processor.py
+++ b/simulation/order_processor.py
@@ -15,6 +15,17 @@ class OrderProcessor:
     commission_rate: float
     slippage: float
 
+    # region Private
+
+    def _apply_slippage(self, price: float, *, is_buy: bool) -> float:
+        multiplier = 1 + self.slippage if is_buy else 1 - self.slippage
+        return price * multiplier
+
+    def _commission(self, notional: float) -> float:
+        return notional * self.commission_rate
+
+    # endregion Private
+
     def execute_entry(self, candle_open: float, side: PositionSide, size: float) -> Fill:
         """Execute market entry at candle open with adverse slippage and commission."""
         is_buy = side == PositionSide.LONG
@@ -33,10 +44,3 @@ class OrderProcessor:
         if side == PositionSide.LONG:
             return entry_price * (1 + reserve)
         return entry_price * (1 - reserve)
-
-    def _apply_slippage(self, price: float, *, is_buy: bool) -> float:
-        multiplier = 1 + self.slippage if is_buy else 1 - self.slippage
-        return price * multiplier
-
-    def _commission(self, notional: float) -> float:
-        return notional * self.commission_rate

--- a/simulation/position_simulator.py
+++ b/simulation/position_simulator.py
@@ -33,61 +33,7 @@ class StatefulPositionSimulator(PositionSimulator):
     _closed_size: float = 0.0
     _last_exit_price: float = 0.0
 
-    def register_signal(self, signal: TradeSignal, size: float) -> None:
-        """Store signal; position will be opened by market order on next processed candle open."""
-        self._pending_signal = signal
-        self._pending_size = size
-
-    def process_candle(self, candle: Candle) -> TradeResult | None:
-        """Open pending signal and process active position against current candle."""
-        if self.position is None and self._pending_signal is not None:
-            self._open_from_pending_signal(candle)
-
-        if self.position is None:
-            return None
-
-        if self.side == PositionSide.LONG:
-            return self._process_long(candle)
-        return self._process_short(candle)
-
-    def open_position(self, position: Position) -> None:
-        """Set active position. Intended for already-executed fills."""
-        self.position = position
-        self._realized_pnl = 0.0
-        self._closed_size = 0.0
-        self._last_exit_price = position.entry_price.value
-
-    def close_position(self, price: float) -> TradeResult:
-        """Close remaining position at given price and return classified trade result."""
-        if self.position is None:
-            msg = "No active position to close."
-            raise RuntimeError(msg)
-
-        remaining_size = self.position.size.value - self._closed_size
-        if remaining_size > 0:
-            self._close_leg(size=remaining_size, target_price=price)
-
-        result_type = self.trade_classifier.classify_result_type(
-            tp1_done=self.position.tp1_done,
-            exit_at_breakeven=self.position.sl_moved_to_be and price == self.position.stop_loss.value,
-            exit_at_tp2=price == self.position.take_profit_2.value,
-        )
-        trade_result = self.trade_classifier.build_result(
-            position=self.position,
-            exit_price=self._last_exit_price,
-            exit_time=datetime_to_timezone(self.position.entry_time, self.simulation_timezone),
-            result_type=result_type,
-            pnl=self._realized_pnl,
-        )
-        self.position = None
-        return trade_result
-
-    def update_stop(self, new_stop: float) -> None:
-        """Update stop-loss level for active position."""
-        if self.position is None:
-            msg = "No active position to update stop for."
-            raise RuntimeError(msg)
-        self.position.stop_loss = Price(new_stop)
+    # region Private
 
     def _open_from_pending_signal(self, candle: Candle) -> None:
         signal = self._pending_signal
@@ -189,3 +135,61 @@ class StatefulPositionSimulator(PositionSimulator):
         )
         self.position = None
         return trade_result
+
+    # endregion Private
+
+    def register_signal(self, signal: TradeSignal, size: float) -> None:
+        """Store signal; position will be opened by market order on next processed candle open."""
+        self._pending_signal = signal
+        self._pending_size = size
+
+    def process_candle(self, candle: Candle) -> TradeResult | None:
+        """Open pending signal and process active position against current candle."""
+        if self.position is None and self._pending_signal is not None:
+            self._open_from_pending_signal(candle)
+
+        if self.position is None:
+            return None
+
+        if self.side == PositionSide.LONG:
+            return self._process_long(candle)
+        return self._process_short(candle)
+
+    def open_position(self, position: Position) -> None:
+        """Set active position. Intended for already-executed fills."""
+        self.position = position
+        self._realized_pnl = 0.0
+        self._closed_size = 0.0
+        self._last_exit_price = position.entry_price.value
+
+    def close_position(self, price: float) -> TradeResult:
+        """Close remaining position at given price and return classified trade result."""
+        if self.position is None:
+            msg = "No active position to close."
+            raise RuntimeError(msg)
+
+        remaining_size = self.position.size.value - self._closed_size
+        if remaining_size > 0:
+            self._close_leg(size=remaining_size, target_price=price)
+
+        result_type = self.trade_classifier.classify_result_type(
+            tp1_done=self.position.tp1_done,
+            exit_at_breakeven=self.position.sl_moved_to_be and price == self.position.stop_loss.value,
+            exit_at_tp2=price == self.position.take_profit_2.value,
+        )
+        trade_result = self.trade_classifier.build_result(
+            position=self.position,
+            exit_price=self._last_exit_price,
+            exit_time=datetime_to_timezone(self.position.entry_time, self.simulation_timezone),
+            result_type=result_type,
+            pnl=self._realized_pnl,
+        )
+        self.position = None
+        return trade_result
+
+    def update_stop(self, new_stop: float) -> None:
+        """Update stop-loss level for active position."""
+        if self.position is None:
+            msg = "No active position to update stop for."
+            raise RuntimeError(msg)
+        self.position.stop_loss = Price(new_stop)


### PR DESCRIPTION
### Motivation
- Improve code consistency and readability by grouping class-private helpers immediately after fields/constructor.
- Make it easier to distinguish implementation details from public API by moving `_...` methods into a dedicated section.
- Add paired region markers for uniform structure across similar classes.

### Description
- Grouped private helper methods under a `# region Private` block placed directly after the dataclass fields/constructor in `StatefulPositionSimulator` and added a matching `# endregion Private`, moving public API methods after that block.
- Moved `_apply_slippage` and `_commission` into a `# region Private` block at the top of `OrderProcessor` and added `# endregion Private` to enclose them.
- Wrapped `CoinGeckoClient` internal helpers (`_headers`, `_resolve_coin_id`) in `# region Private` / `# endregion Private` placed immediately after `__init__` in `data/clients/coingecko_client.py`.
- Wrapped `_build_client` in `# region Private` / `# endregion Private` placed right after `CcxtFuturesClient` constructor in `data/exchanges/ccxt_futures_client.py`.
- Files updated: `simulation/position_simulator.py`, `simulation/order_processor.py`, `data/clients/coingecko_client.py`, and `data/exchanges/ccxt_futures_client.py`.

### Testing
- Ran `python -m compileall simulation/position_simulator.py simulation/order_processor.py data/clients/coingecko_client.py data/exchanges/ccxt_futures_client.py` and compilation completed successfully.
- Verified repository changes were staged and committed locally without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698738b4622483209b51a33828013dad)