### PR TITLE
Split vectorbt_runner into BacktestSummary and VectorbtInputs modules

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -32,8 +32,7 @@ from strategy.breakout.breakout_strategy import BreakoutStrategy
 from utils.formatters import datetime_to_utc
 from utils.logger import get_logger
 from strategy.breakout.config import TARGET_PARAMETER_COMBINATIONS
-from vectorbt_runner.backtest_runner import BacktestRunner
-from vectorbt_runner.data_preparer import DataPreparer
+from vectorbt_runner import BacktestRunner, DataPreparer
 
 
 def _run_with_logging(command_name: str, config: AppConfig, body: Callable[[], int]) -> int:

--- a/vectorbt_runner/__init__.py
+++ b/vectorbt_runner/__init__.py
@@ -1,0 +1,13 @@
+"""Vectorbt runner package exports."""
+
+from vectorbt_runner.backtest_runner import BacktestRunner
+from vectorbt_runner.backtest_summary import BacktestSummary
+from vectorbt_runner.data_preparer import DataPreparer
+from vectorbt_runner.vectorbt_inputs import VectorbtInputs
+
+__all__ = [
+    "BacktestRunner",
+    "BacktestSummary",
+    "DataPreparer",
+    "VectorbtInputs",
+]

--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from itertools import product
 from pathlib import Path
 from typing import Any
@@ -13,19 +12,13 @@ import pandas as pd
 from domain.enums.trade_result_type import TradeResultType
 from domain.models.trade_result import TradeResult
 from strategy.breakout.config import BREAKOUT_PARAMETER_GRID, PARAMETER_GRID_SIZE, TARGET_PARAMETER_COMBINATIONS
+from vectorbt_runner.backtest_summary import BacktestSummary
 from vectorbt_runner.data_preparer import DataPreparer
 
 try:
     import vectorbt as vbt
 except ImportError:  # pragma: no cover - environment dependent
     vbt = None
-
-
-@dataclass(slots=True)
-class BacktestSummary:
-    total_combinations: int
-    profitable_combinations: int
-    best_pf: float
 
 
 logger = logging.getLogger(__name__)

--- a/vectorbt_runner/backtest_summary.py
+++ b/vectorbt_runner/backtest_summary.py
@@ -1,0 +1,10 @@
+"""Backtest summary value object."""
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class BacktestSummary:
+    total_combinations: int
+    profitable_combinations: int
+    best_pf: float

--- a/vectorbt_runner/data_preparer.py
+++ b/vectorbt_runner/data_preparer.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 
 import pandas as pd
@@ -11,15 +10,7 @@ from domain.enums.timeframe import Timeframe
 from domain.models.trade_result import TradeResult
 
 
-@dataclass(frozen=True, slots=True)
-class VectorbtInputs:
-    """Prepared inputs that can be directly consumed by vectorbt."""
-
-    close: pd.Series
-    entries: pd.Series
-    exits: pd.Series
-    equity_curve: pd.Series
-    trades: pd.DataFrame
+from vectorbt_runner.vectorbt_inputs import VectorbtInputs
 
 
 class DataPreparer:

--- a/vectorbt_runner/vectorbt_inputs.py
+++ b/vectorbt_runner/vectorbt_inputs.py
@@ -1,0 +1,16 @@
+"""Prepared inputs that can be directly consumed by vectorbt."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+
+@dataclass(frozen=True, slots=True)
+class VectorbtInputs:
+    close: pd.Series
+    entries: pd.Series
+    exits: pd.Series
+    equity_curve: pd.Series
+    trades: pd.DataFrame


### PR DESCRIPTION
### Motivation
- Reduce file size and separate responsibilities by extracting small value objects from larger modules to improve readability and import clarity.
- Make `BacktestRunner` and `DataPreparer` single-responsibility modules while exposing the smaller data classes as dedicated modules for reuse.

### Description
- Added `vectorbt_runner/backtest_summary.py` containing the `BacktestSummary` dataclass and removed that class from `vectorbt_runner/backtest_runner.py`.
- Added `vectorbt_runner/vectorbt_inputs.py` containing the `VectorbtInputs` dataclass and updated `vectorbt_runner/data_preparer.py` to import it from the new module.
- Created package exports in `vectorbt_runner/__init__.py` exposing `BacktestRunner`, `BacktestSummary`, `DataPreparer`, and `VectorbtInputs`.
- Updated `cli/commands.py` to import `BacktestRunner` and `DataPreparer` from the package (`from vectorbt_runner import BacktestRunner, DataPreparer`) and adjusted internal imports in affected modules.

### Testing
- Compiled the updated modules with `python -m compileall vectorbt_runner cli/commands.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698744fd60848320a8dd04394b634bc1)