### PR TITLE
Add `# region Private` sections for private methods

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -37,6 +37,8 @@ __all__ = [
 ]
 
 
+# region Private
+
 def _load_env_file(env_path: Path) -> None:
     if not env_path.exists():
         return
@@ -57,6 +59,8 @@ def _parse_timeframe(raw: str | None, *, default: Timeframe) -> Timeframe:
     normalized = raw.strip().upper()
     return Timeframe(normalized)
 
+
+# endregion Private
 
 def load_config(env_path: str | Path = ".env") -> AppConfig:
     env_file = Path(env_path)

--- a/data/storage/parquet_storage.py
+++ b/data/storage/parquet_storage.py
@@ -15,10 +15,10 @@ class ParquetStorage:
     def __init__(self, base_dir: str | Path = "cache") -> None:
         self._base_dir = Path(base_dir)
 
+    # region Private
+
     def _data_path(self, symbol: str, timeframe: Timeframe) -> Path:
         return self._base_dir / symbol / timeframe.value / "data.parquet"
-
-
 
     @staticmethod
     def _ensure_utc_columns(data: pd.DataFrame) -> pd.DataFrame:
@@ -33,6 +33,8 @@ class ParquetStorage:
         normalized["timestamp"] = (ts.astype("int64") // 1_000_000).astype("int64")
         normalized["datetime"] = ts
         return normalized
+
+    # endregion Private
 
     def load(self, symbol: str, timeframe: Timeframe) -> pd.DataFrame:
         path = self._data_path(symbol, timeframe)
@@ -80,3 +82,4 @@ class ParquetStorage:
         merged.to_parquet(path, index=False)
 
         return max(len(merged) - previous_count, 0)
+

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -124,6 +124,8 @@ class BreakoutStrategy(BaseStrategy):
 
         return trades
 
+    # region Private
+
     def _to_candle(self, row: pd.Series) -> Candle:
         return Candle(
             timestamp=datetime_to_timezone(row["datetime"].to_pydatetime(), self._simulation_timezone),
@@ -134,3 +136,5 @@ class BreakoutStrategy(BaseStrategy):
             volume=Volume(float(row["volume"])),
             open_interest=Volume(float(row.get("open_interest", 0.0) or 0.0)),
         )
+
+    # endregion Private

--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -104,6 +104,8 @@ class BacktestRunner:
             best_pf=best_pf,
         )
 
+    # region Private
+
     def _ensure_vectorbt_available(self) -> None:
         if vbt is None:
             msg = (
@@ -180,3 +182,5 @@ class BacktestRunner:
     def _save_results(self, results: pd.DataFrame) -> None:
         self._results_dir.mkdir(parents=True, exist_ok=True)
         results.to_csv(self._results_dir / self._results_file_name, index=False)
+
+    # endregion Private


### PR DESCRIPTION
### Motivation

- Group private (`_...`) methods with explicit region markers to improve code readability and enable IDE folding. 
- Keep public API and runtime behavior unchanged while making intent of private helpers clearer.

### Description

- Added `# region Private` / `# endregion Private` markers around private methods in `vectorbt_runner/backtest_runner.py` (around `_ensure_vectorbt_available`, `_build_metrics_row`, `_save_results`).
- Added `# region Private` / `# endregion Private` markers around private methods in `data/storage/parquet_storage.py` (around `_data_path`, `_ensure_utc_columns`).
- Added `# region Private` / `# endregion Private` markers around the private helper in `strategy/breakout/breakout_strategy.py` (around `_to_candle`).
- Added `# region Private` / `# endregion Private` markers around private functions in `config/__init__.py` (around `_load_env_file`, `_parse_timeframe`).
- No changes to public APIs or logic were made.

### Testing

- Ran syntax/compile check with `python -m compileall vectorbt_runner/backtest_runner.py data/storage/parquet_storage.py strategy/breakout/breakout_strategy.py config/__init__.py` which completed successfully.
- Verified repository status after changes to ensure the intended files were updated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69876552f2788320b963fa97b85c8f88)