### PR TITLE
Add typed BreakoutParams and tighten typing for strategy/backtest/fetch

### DIFF
--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any
 
 from domain.abstract.exchange_client import ExchangeClient
 from domain.enums.timeframe import Timeframe
@@ -84,8 +83,8 @@ class OhlcvFetcher:
         timeframe: Timeframe,
         start_time: datetime,
         end_time: datetime,
-    ) -> dict[str, Any]:
-        results: dict[str, Any] = {}
+    ) -> dict[str, int | str]:
+        results: dict[str, int | str] = {}
         with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
             futures = {
                 executor.submit(self.fetch_symbol, s, timeframe, start_time, end_time): s for s in symbols

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any
 
 from domain.abstract.exchange_client import ExchangeClient
 from domain.enums.timeframe import Timeframe
@@ -85,8 +84,8 @@ class OiFetcher:
         timeframe: Timeframe,
         start_time: datetime,
         end_time: datetime,
-    ) -> dict[str, Any]:
-        results: dict[str, Any] = {}
+    ) -> dict[str, int | str]:
+        results: dict[str, int | str] = {}
         with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
             futures = {
                 executor.submit(self.fetch_symbol, s, timeframe, start_time, end_time): s for s in symbols

--- a/strategy/base_strategy.py
+++ b/strategy/base_strategy.py
@@ -3,18 +3,21 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Generic, TypeVar
 
 import pandas as pd
 
 from domain.models.trade_result import TradeResult
 
 
-class BaseStrategy(ABC):
+StrategyParamsT = TypeVar("StrategyParamsT")
+
+
+class BaseStrategy(ABC, Generic[StrategyParamsT]):
     """Abstract strategy contract used by backtest runner."""
 
     @abstractmethod
-    def validate_config(self, params: dict[str, Any]) -> None:
+    def validate_config(self, params: StrategyParamsT) -> None:
         """Validate strategy parameters and raise ValueError for invalid configs."""
 
     @abstractmethod
@@ -22,5 +25,5 @@ class BaseStrategy(ABC):
         """Prepare and enrich source market data."""
 
     @abstractmethod
-    def generate_events(self, data: pd.DataFrame, params: dict[str, Any]) -> list[TradeResult]:
+    def generate_events(self, data: pd.DataFrame, params: StrategyParamsT) -> list[TradeResult]:
         """Run strategy simulation and return closed trades."""

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import pandas as pd
 
 from domain.enums.position_side import PositionSide
@@ -14,12 +12,13 @@ from domain.value_objects.price import Price
 from domain.value_objects.volume import Volume
 from simulation.order_processor import OrderProcessor
 from simulation.position_simulator import StatefulPositionSimulator
-from utils.formatters import datetime_to_timezone, utc_ms_to_local_datetime
 from simulation.trade_classifier import TradeClassifier
 from strategy.base_strategy import BaseStrategy
+from strategy.breakout.config import BreakoutParams
+from utils.formatters import datetime_to_timezone, utc_ms_to_local_datetime
 
 
-class BreakoutStrategy(BaseStrategy):
+class BreakoutStrategy(BaseStrategy[BreakoutParams]):
     """Breakout/retest-lite LONG strategy with TP1/TP2 and BE support."""
 
     REQUIRED_COLUMNS = ("timestamp", "open", "high", "low", "close", "volume")
@@ -30,19 +29,14 @@ class BreakoutStrategy(BaseStrategy):
         self._strategy_timezone = strategy_timezone
         self._simulation_timezone = simulation_timezone
 
-    def validate_config(self, params: dict[str, Any]) -> None:
-        lookback = int(params["lookback"])
-        volume_mult = float(params["volume_mult"])
-        min_rr = float(params["min_rr"])
-        tp2_mult = float(params["tp2_mult"])
-
-        if lookback < 5:
+    def validate_config(self, params: BreakoutParams) -> None:
+        if params.lookback < 5:
             raise ValueError("lookback must be >= 5")
-        if volume_mult <= 0:
+        if params.volume_mult <= 0:
             raise ValueError("volume_mult must be > 0")
-        if min_rr <= 0:
+        if params.min_rr <= 0:
             raise ValueError("min_rr must be > 0")
-        if tp2_mult <= 1:
+        if params.tp2_mult <= 1:
             raise ValueError("tp2_mult must be > 1")
 
     def prepare_data(self, data: pd.DataFrame) -> pd.DataFrame:
@@ -62,10 +56,10 @@ class BreakoutStrategy(BaseStrategy):
         prepared = prepared.dropna(subset=["open", "high", "low", "close", "volume"])
         return prepared
 
-    def generate_events(self, data: pd.DataFrame, params: dict[str, Any]) -> list[TradeResult]:
+    def generate_events(self, data: pd.DataFrame, params: BreakoutParams) -> list[TradeResult]:
         self.validate_config(params)
         prepared = self.prepare_data(data)
-        if len(prepared) < int(params["lookback"]) + 5:
+        if len(prepared) < params.lookback + 5:
             return []
 
         sim = StatefulPositionSimulator(
@@ -75,31 +69,26 @@ class BreakoutStrategy(BaseStrategy):
             simulation_timezone=self._simulation_timezone,
         )
 
-        lookback = int(params["lookback"])
-        vol_mult = float(params["volume_mult"])
-        min_rr = float(params["min_rr"])
-        tp2_mult = float(params["tp2_mult"])
-
         trades: list[TradeResult] = []
         pending_signal: TradeSignal | None = None
 
-        for idx in range(lookback, len(prepared)):
+        for idx in range(params.lookback, len(prepared)):
             row = prepared.iloc[idx]
             candle = self._to_candle(row)
 
             if sim.position is None and pending_signal is None:
-                rolling = prepared.iloc[idx - lookback : idx]
+                rolling = prepared.iloc[idx - params.lookback : idx]
                 level_high = float(rolling["high"].max())
                 level_low = float(rolling["low"].min())
                 avg_volume = float(rolling["volume"].mean())
 
                 breakout = row["close"] > level_high
-                volume_ok = row["volume"] >= avg_volume * vol_mult
+                volume_ok = row["volume"] >= avg_volume * params.volume_mult
                 if breakout and volume_ok:
                     risk = max(row["close"] - level_low, row["close"] * 0.002)
                     stop = row["close"] - risk
-                    tp1 = row["close"] + risk * min_rr
-                    tp2 = row["close"] + risk * min_rr * tp2_mult
+                    tp1 = row["close"] + risk * params.min_rr
+                    tp2 = row["close"] + risk * params.min_rr * params.tp2_mult
                     pending_signal = TradeSignal(
                         entry_price=Price(float(row["close"])),
                         entry_time=datetime_to_timezone(row["datetime"].to_pydatetime(), self._simulation_timezone),
@@ -107,7 +96,7 @@ class BreakoutStrategy(BaseStrategy):
                         take_profit_1=Price(float(tp1)),
                         take_profit_2=Price(float(tp2)),
                         position_side=PositionSide.LONG,
-                        symbol=str(params["symbol"]),
+                        symbol=params.symbol,
                     )
 
             if sim.position is None and pending_signal is not None:
@@ -134,7 +123,7 @@ class BreakoutStrategy(BaseStrategy):
             low=Price(float(row["low"])),
             close=Price(float(row["close"])),
             volume=Volume(float(row["volume"])),
-            open_interest=Volume(float(row.get("open_interest", 0.0) or 0.0)),
+            open_interest=Volume(float(row.get("open_interest", 0.0))),
         )
 
     # endregion Private

--- a/strategy/breakout/config.py
+++ b/strategy/breakout/config.py
@@ -2,17 +2,33 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from math import prod
+
+from domain.enums.sl_mode import SLMode
 
 TARGET_PARAMETER_COMBINATIONS = 5832
 
-BREAKOUT_PARAMETER_GRID: dict[str, list[float | int | str]] = {
+
+@dataclass(frozen=True, slots=True)
+class BreakoutParams:
+    lookback: int
+    volume_mult: float
+    retest_window: int
+    retest_zone: float
+    min_rr: float
+    sl_mode: SLMode
+    tp2_mult: float
+    symbol: str
+
+
+BREAKOUT_PARAMETER_GRID: dict[str, list[float | int | SLMode]] = {
     "lookback": [8, 13, 21, 34, 55, 89],
     "volume_mult": [1.1, 1.3, 1.5],
     "retest_window": [2, 4, 6],
     "retest_zone": [0.0015, 0.0020, 0.0030],
     "min_rr": [1.0, 1.5, 2.0],
-    "sl_mode": ["LEVEL", "BREAKOUT_EXTREME"],
+    "sl_mode": [SLMode.LEVEL, SLMode.BREAKOUT_EXTREME],
     "tp2_mult": [1.1, 1.25, 1.4, 1.5, 1.75, 2.0],
 }
 

--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 from itertools import product
 from pathlib import Path
-from typing import Any
 import logging
 
 import pandas as pd
 
 from domain.enums.trade_result_type import TradeResultType
 from domain.models.trade_result import TradeResult
-from strategy.breakout.config import BREAKOUT_PARAMETER_GRID, PARAMETER_GRID_SIZE, TARGET_PARAMETER_COMBINATIONS
+from strategy.base_strategy import BaseStrategy
+from strategy.breakout.config import BREAKOUT_PARAMETER_GRID, PARAMETER_GRID_SIZE, TARGET_PARAMETER_COMBINATIONS, BreakoutParams
 from vectorbt_runner.backtest_summary import BacktestSummary
 from vectorbt_runner.data_preparer import DataPreparer
 
@@ -31,7 +31,7 @@ class BacktestRunner:
         self._results_dir = Path(results_dir)
         self._results_file_name = results_file_name
 
-    def build_parameter_grid(self) -> list[dict[str, Any]]:
+    def build_parameter_grid(self) -> list[BreakoutParams]:
         lookback = BREAKOUT_PARAMETER_GRID["lookback"]
         volume_mult = BREAKOUT_PARAMETER_GRID["volume_mult"]
         retest_window = BREAKOUT_PARAMETER_GRID["retest_window"]
@@ -42,15 +42,16 @@ class BacktestRunner:
 
         # combos = |lookback| × |volume_mult| × |retest_window| × |retest_zone| × |min_rr| × |sl_mode| × |tp2_mult| = 6×3×3×3×3×2×6 = 5832
         return [
-            {
-                "lookback": lb,
-                "volume_mult": vm,
-                "retest_window": rw,
-                "retest_zone": rz,
-                "min_rr": rr,
-                "sl_mode": sl,
-                "tp2_mult": tp2,
-            }
+            BreakoutParams(
+                lookback=int(lb),
+                volume_mult=float(vm),
+                retest_window=int(rw),
+                retest_zone=float(rz),
+                min_rr=float(rr),
+                sl_mode=sl,
+                tp2_mult=float(tp2),
+                symbol="",
+            )
             for lb, vm, rw, rz, rr, sl, tp2 in product(
                 lookback,
                 volume_mult,
@@ -62,16 +63,25 @@ class BacktestRunner:
             )
         ]
 
-    def run(self, strategy: Any, symbol_frames: dict[str, pd.DataFrame]) -> pd.DataFrame:
+    def run(self, strategy: BaseStrategy[BreakoutParams], symbol_frames: dict[str, pd.DataFrame]) -> pd.DataFrame:
         self._ensure_vectorbt_available()
 
-        rows: list[dict[str, Any]] = []
+        rows: list[dict[str, int | float | str]] = []
         grid = self.build_parameter_grid()
 
         for params in grid:
             all_trades: list[TradeResult] = []
             for symbol, frame in symbol_frames.items():
-                cfg = {**params, "symbol": symbol}
+                cfg = BreakoutParams(
+                    lookback=params.lookback,
+                    volume_mult=params.volume_mult,
+                    retest_window=params.retest_window,
+                    retest_zone=params.retest_zone,
+                    min_rr=params.min_rr,
+                    sl_mode=params.sl_mode,
+                    tp2_mult=params.tp2_mult,
+                    symbol=symbol,
+                )
                 trades = strategy.generate_events(frame, cfg)
                 all_trades.extend(trades)
 
@@ -114,10 +124,20 @@ class BacktestRunner:
             )
             raise RuntimeError(msg)
 
-    def _build_metrics_row(self, params: dict[str, Any], trades: list[TradeResult]) -> dict[str, Any]:
+    def _build_metrics_row(self, params: BreakoutParams, trades: list[TradeResult]) -> dict[str, int | float | str]:
+        base_row: dict[str, int | float | str] = {
+            "lookback": params.lookback,
+            "volume_mult": params.volume_mult,
+            "retest_window": params.retest_window,
+            "retest_zone": params.retest_zone,
+            "min_rr": params.min_rr,
+            "sl_mode": params.sl_mode.value,
+            "tp2_mult": params.tp2_mult,
+        }
+
         if not trades:
             return {
-                **params,
+                **base_row,
                 "profit_factor": 0.0,
                 "pnl_percent": 0.0,
                 "win_rate": 0.0,
@@ -167,7 +187,7 @@ class BacktestRunner:
 
         result_types = [trade.result_type for trade in trades]
         return {
-            **params,
+            **base_row,
             "profit_factor": round(float(pf), 4),
             "pnl_percent": round(float(pnl_percent), 4),
             "win_rate": round(float(win_rate), 4),


### PR DESCRIPTION
### Motivation
- Reduce reliance on untyped `dict[str, Any]` for strategy parameters and fetch results to improve type-safety and clarity. 
- Make the backtest runner and strategies explicitly consume concrete parameter types for safer refactors and IDE support. 
- Replace stringly-typed `sl_mode` values with the `SLMode` enum to avoid accidental misspecification.

### Description
- Introduced `BreakoutParams` dataclass in `strategy/breakout/config.py` and switched the grid to use `SLMode` enum values instead of raw strings. 
- Made `BaseStrategy` generic (`BaseStrategy[StrategyParamsT]`) and updated signatures to accept `StrategyParamsT` for `validate_config` and `generate_events`. 
- Refactored `BreakoutStrategy` to implement `BaseStrategy[BreakoutParams]` and to use `BreakoutParams` fields directly for validation and event generation. 
- Updated `vectorbt_runner.BacktestRunner` to build a typed `list[BreakoutParams]`, accept `BaseStrategy[BreakoutParams]`, construct per-symbol `BreakoutParams` with `symbol`, and return typed metric rows `dict[str, int | float | str]`. 
- Tightened fetcher return typing in `OhlcvFetcher.fetch_many` and `OiFetcher.fetch_many` from `dict[str, Any]` to `dict[str, int | str]` to represent either added row counts or error messages.

### Testing
- Ran `python -m compileall strategy vectorbt_runner data/fetchers domain/models/reporting` which completed successfully (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698765ee22cc83209d6269076f5d1d24)