### PR TITLE
Рефакторинг моделей отчёта: вложенные dataclass для BacktestReport

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -40,6 +40,9 @@ from data.quality.gap_detector import GapDetector
 from data.storage.parquet_storage import ParquetStorage
 from domain.enums.exchange import Exchange
 from domain.models.reporting.backtest_report import BacktestReport
+from domain.models.reporting.backtest_summary import BacktestSummary
+from domain.models.reporting.optimal_parameter_ranges import OptimalParameterRanges
+from domain.models.reporting.trade_results_distribution import TradeResultsDistribution
 from domain.models.reporting.quality_report import QualityReport
 from domain.models.reporting.quality_summary import QualitySummary
 from domain.models.reporting.quality_symbol_stats import QualitySymbolStats
@@ -209,25 +212,25 @@ def make_report(config: AppConfig, args: argparse.Namespace) -> int:
                 TARGET_PARAMETER_COMBINATIONS,
             )
 
-        summary = {
-            "total_combinations": int(len(frame)),
-            "profitable_combinations": int((frame["profit_factor"] > REPORT_PROFITABLE_PF_THRESHOLD).sum()),
-            "best_pf": round(float(frame["profit_factor"].max()), 4),
-        }
+        summary = BacktestSummary(
+            total_combinations=int(len(frame)),
+            profitable_combinations=int((frame["profit_factor"] > REPORT_PROFITABLE_PF_THRESHOLD).sum()),
+            best_pf=round(float(frame["profit_factor"].max()), 4),
+        )
 
         source = filtered if not filtered.empty else frame
 
-        optimal_ranges = {
-            "lookback": [int(source["lookback"].min()), int(source["lookback"].max())],
-            "volume_multiplier": [round(float(source["volume_mult"].min()), 4), round(float(source["volume_mult"].max()), 4)],
-        }
+        optimal_ranges = OptimalParameterRanges(
+            lookback=[int(source["lookback"].min()), int(source["lookback"].max())],
+            volume_multiplier=[round(float(source["volume_mult"].min()), 4), round(float(source["volume_mult"].max()), 4)],
+        )
 
-        distribution = {
-            "SL": int(source["sl_count"].sum()),
-            "BE": int(source["be_count"].sum()),
-            "TP1_BE": int(source["tp1_be_count"].sum()),
-            "TP2": int(source["tp2_count"].sum()),
-        }
+        distribution = TradeResultsDistribution(
+            SL=int(source["sl_count"].sum()),
+            BE=int(source["be_count"].sum()),
+            TP1_BE=int(source["tp1_be_count"].sum()),
+            TP2=int(source["tp2_count"].sum()),
+        )
 
         report = BacktestReport(
             summary=summary,

--- a/domain/models/reporting/__init__.py
+++ b/domain/models/reporting/__init__.py
@@ -1,6 +1,9 @@
 """Reporting DTO exports."""
 
 from domain.models.reporting.backtest_report import BacktestReport
+from domain.models.reporting.backtest_summary import BacktestSummary
+from domain.models.reporting.optimal_parameter_ranges import OptimalParameterRanges
+from domain.models.reporting.trade_results_distribution import TradeResultsDistribution
 from domain.models.reporting.fetch_all_result import FetchAllResult
 from domain.models.reporting.market_caps_result import MarketCapsResult
 from domain.models.reporting.quality_report import QualityReport
@@ -9,6 +12,9 @@ from domain.models.reporting.quality_symbol_stats import QualitySymbolStats
 
 __all__ = [
     "BacktestReport",
+    "BacktestSummary",
+    "OptimalParameterRanges",
+    "TradeResultsDistribution",
     "FetchAllResult",
     "MarketCapsResult",
     "QualityReport",

--- a/domain/models/reporting/backtest_report.py
+++ b/domain/models/reporting/backtest_report.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from domain.models.reporting.backtest_summary import BacktestSummary
+from domain.models.reporting.optimal_parameter_ranges import OptimalParameterRanges
+from domain.models.reporting.trade_results_distribution import TradeResultsDistribution
+
 
 @dataclass(frozen=True, slots=True)
 class BacktestReport:
-    summary: dict[str, int | float]
-    optimal_ranges: dict[str, list[int | float]]
-    trade_results_distribution: dict[str, int]
+    summary: BacktestSummary
+    optimal_ranges: OptimalParameterRanges
+    trade_results_distribution: TradeResultsDistribution

--- a/domain/models/reporting/backtest_summary.py
+++ b/domain/models/reporting/backtest_summary.py
@@ -1,0 +1,12 @@
+"""Backtest summary DTO."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestSummary:
+    total_combinations: int
+    profitable_combinations: int
+    best_pf: float

--- a/domain/models/reporting/optimal_parameter_ranges.py
+++ b/domain/models/reporting/optimal_parameter_ranges.py
@@ -1,0 +1,11 @@
+"""Optimal parameter ranges DTO."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class OptimalParameterRanges:
+    lookback: list[int]
+    volume_multiplier: list[float]

--- a/domain/models/reporting/trade_results_distribution.py
+++ b/domain/models/reporting/trade_results_distribution.py
@@ -1,0 +1,13 @@
+"""Trade results distribution DTO."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class TradeResultsDistribution:
+    SL: int
+    BE: int
+    TP1_BE: int
+    TP2: int


### PR DESCRIPTION
### Motivation
- Упростить и типизировать вложенные структуры бектест-отчёта, заменив свободные `dict` на специализированные dataclass-модели для более понятного кода и автодополнения.

### Description
- Добавлены dataclass-модели `BacktestSummary`, `OptimalParameterRanges`, `TradeResultsDistribution` в `domain/models/reporting/` для отдельных секций отчёта.
- Обновлён `BacktestReport` так, чтобы поля `summary`, `optimal_ranges`, `trade_results_distribution` были типизированы этими dataclass-классами вместо `dict`.
- Адаптована сборка отчёта в `cli/commands.py` (`make_report`) для создания объектов `BacktestSummary`, `OptimalParameterRanges`, `TradeResultsDistribution` и передачи их в `BacktestReport`.
- Экспорт новых моделей добавлен в `domain/models/reporting/__init__.py` и сериализация на диск по-прежнему выполняется через `dataclasses.asdict` для совместимости JSON-артефактов.

### Testing
- Запущена компиляция файлов командой `python -m compileall domain/models/reporting cli/commands.py`, которая завершилась успешно.
- Поведение сохранения отчётов проверено на уровне кода, так как вывод продолжает формироваться через `asdict` и формат JSON остаётся совместимым.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69876ad79c308320859b140a404a81e4)