### PR TITLE
Centralize magic literals across data, logging, and breakout modules

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 from domain.enums.timeframe import Timeframe
+from domain.enums.sl_mode import SLMode
 
 SUPPORTED_TIMEFRAMES: tuple[Timeframe, ...] = tuple(Timeframe)
 DEFAULT_TIMEFRAME = Timeframe.H1
@@ -12,11 +15,81 @@ DEFAULT_MAX_CONCURRENT_REQUESTS = 10
 DEFAULT_FETCH_BATCH_SIZE = 1000
 DEFAULT_RETRY_ATTEMPTS = 3
 DEFAULT_RETRY_BACKOFF_SECONDS = 1.0
+MILLISECONDS_IN_SECOND = 1000
 
 # Timeouts (seconds)
 HTTP_TIMEOUT_SECONDS = 30
 EXCHANGE_TIMEOUT_SECONDS = 20
 COINGECKO_TIMEOUT_SECONDS = 20
+
+# Fetcher defaults
+DEFAULT_FETCHER_MAX_WORKERS = 5
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 60
+
+# Fetching domain constants
+TIMEFRAME_TO_DELTA = {
+    Timeframe.M1: timedelta(minutes=1),
+    Timeframe.M5: timedelta(minutes=5),
+    Timeframe.M15: timedelta(minutes=15),
+    Timeframe.M30: timedelta(minutes=30),
+    Timeframe.H1: timedelta(hours=1),
+    Timeframe.H4: timedelta(hours=4),
+    Timeframe.D1: timedelta(days=1),
+    Timeframe.W1: timedelta(weeks=1),
+}
+
+OHLCV_FRAME_COLUMNS = ("timestamp", "open", "high", "low", "close", "volume")
+OPEN_INTEREST_FRAME_COLUMNS = ("timestamp", "open_interest", "datetime")
+CCXT_OPTION_DEFAULT_TYPE_KEY = "defaultType"
+CCXT_MARKET_TYPE_SWAP = "swap"
+FUTURES_SETTLEMENT_QUOTE_ASSET = "USDT"
+SIMULATION_COIN_SUFFIX_SLASH_USDT = "/usdt"
+SIMULATION_COIN_SUFFIX_USDT = "usdt"
+
+# CoinGecko constants
+COINGECKO_BASE_URL = "https://api.coingecko.com/api/v3"
+COINGECKO_HEADER_ACCEPT_KEY = "accept"
+COINGECKO_HEADER_ACCEPT_JSON = "application/json"
+COINGECKO_HEADER_API_KEY = "x-cg-demo-api-key"
+COINGECKO_VS_CURRENCY_KEY = "vs_currency"
+COINGECKO_VS_CURRENCY_USD = "usd"
+COINGECKO_ORDER_KEY = "order"
+COINGECKO_ORDER_MARKET_CAP_DESC = "market_cap_desc"
+COINGECKO_PARAM_IDS = "ids"
+COINGECKO_PARAM_PER_PAGE = "per_page"
+COINGECKO_PARAM_PAGE = "page"
+COINGECKO_PARAM_SPARKLINE = "sparkline"
+COINGECKO_SPARKLINE_FALSE = "false"
+COINGECKO_DEFAULT_PAGE = 1
+
+# Logger constants
+LOGGER_DATE_FORMAT = "%H:%M:%S"
+LOGGER_MESSAGE_FORMAT = "%(asctime)s %(message)s"
+LOGGER_COLOR_RESET = "\033[0m"
+LOGGER_COLOR_INFO = "\033[32m"
+LOGGER_COLOR_WARNING = "\033[33m"
+LOGGER_COLOR_ERROR = "\033[31m"
+LOGGER_FILE_MAX_BYTES = 5 * 1024 * 1024
+LOGGER_FILE_BACKUP_COUNT = 5
+LOGGER_FILE_ENCODING = "utf-8"
+
+# Data preparer constants
+DATA_PREPARER_NUMERIC_COLUMNS = ("open", "high", "low", "close", "volume", "open_interest")
+DATA_PREPARER_EMPTY_FLOAT_DTYPE = "float64"
+DATA_PREPARER_EMPTY_BOOL_DTYPE = "bool"
+DATA_PREPARER_TRADE_COLUMNS = ("entry_time", "exit_time", "pnl", "pnl_percent", "result_type")
+SIMULATION_ZERO_VALUE = 0.0
+SIMULATION_UNIT_INCREMENT = 1.0
+
+# Breakout grid constants
+BREAKOUT_LOOKBACK_VALUES = (8, 13, 21, 34, 55, 89)
+BREAKOUT_VOLUME_MULT_VALUES = (1.1, 1.3, 1.5)
+BREAKOUT_RETEST_WINDOW_VALUES = (2, 4, 6)
+BREAKOUT_RETEST_ZONE_VALUES = (0.0015, 0.0020, 0.0030)
+BREAKOUT_MIN_RR_VALUES = (1.0, 1.5, 2.0)
+BREAKOUT_SL_MODE_VALUES = (SLMode.LEVEL, SLMode.BREAKOUT_EXTREME)
+BREAKOUT_TP2_MULT_VALUES = (1.1, 1.25, 1.4, 1.5, 1.75, 2.0)
+BREAKOUT_TARGET_PARAMETER_COMBINATIONS = 5832
 
 # Trading defaults
 DEFAULT_COMMISSION_RATE = 0.0004

--- a/data/clients/coingecko_client.py
+++ b/data/clients/coingecko_client.py
@@ -6,14 +6,32 @@ from datetime import datetime, timedelta, timezone
 
 import requests
 
-from constants import COINGECKO_TIMEOUT_SECONDS
+from constants import (
+    COINGECKO_BASE_URL,
+    COINGECKO_DEFAULT_PAGE,
+    COINGECKO_HEADER_ACCEPT_JSON,
+    COINGECKO_HEADER_ACCEPT_KEY,
+    COINGECKO_HEADER_API_KEY,
+    COINGECKO_ORDER_KEY,
+    COINGECKO_ORDER_MARKET_CAP_DESC,
+    COINGECKO_PARAM_IDS,
+    COINGECKO_PARAM_PAGE,
+    COINGECKO_PARAM_PER_PAGE,
+    COINGECKO_PARAM_SPARKLINE,
+    COINGECKO_SPARKLINE_FALSE,
+    COINGECKO_TIMEOUT_SECONDS,
+    COINGECKO_VS_CURRENCY_KEY,
+    COINGECKO_VS_CURRENCY_USD,
+    SIMULATION_COIN_SUFFIX_SLASH_USDT,
+    SIMULATION_COIN_SUFFIX_USDT,
+)
 from domain.abstract.market_data_client import MarketDataClient
 
 
 class CoinGeckoClient(MarketDataClient):
     """Market cap provider backed by CoinGecko REST API."""
 
-    BASE_URL = "https://api.coingecko.com/api/v3"
+    BASE_URL = COINGECKO_BASE_URL
 
     def __init__(self, api_key: str = "", cache_ttl_hours: int = 24) -> None:
         self._api_key = api_key
@@ -24,13 +42,13 @@ class CoinGeckoClient(MarketDataClient):
     # region Private
 
     def _headers(self) -> dict[str, str]:
-        headers = {"accept": "application/json"}
+        headers = {COINGECKO_HEADER_ACCEPT_KEY: COINGECKO_HEADER_ACCEPT_JSON}
         if self._api_key:
-            headers["x-cg-demo-api-key"] = self._api_key
+            headers[COINGECKO_HEADER_API_KEY] = self._api_key
         return headers
 
     def _resolve_coin_id(self, symbol: str) -> str:
-        normalized = symbol.lower().replace("/usdt", "").replace("usdt", "")
+        normalized = symbol.lower().replace(SIMULATION_COIN_SUFFIX_SLASH_USDT, "").replace(SIMULATION_COIN_SUFFIX_USDT, "")
         if normalized in self._symbol_to_id:
             return self._symbol_to_id[normalized]
 
@@ -65,7 +83,13 @@ class CoinGeckoClient(MarketDataClient):
         response = requests.get(
             f"{self.BASE_URL}/coins/markets",
             headers=self._headers(),
-            params={"vs_currency": "usd", "ids": coin_id, "order": "market_cap_desc", "per_page": 1, "page": 1},
+            params={
+                COINGECKO_VS_CURRENCY_KEY: COINGECKO_VS_CURRENCY_USD,
+                COINGECKO_PARAM_IDS: coin_id,
+                COINGECKO_ORDER_KEY: COINGECKO_ORDER_MARKET_CAP_DESC,
+                COINGECKO_PARAM_PER_PAGE: COINGECKO_DEFAULT_PAGE,
+                COINGECKO_PARAM_PAGE: COINGECKO_DEFAULT_PAGE,
+            },
             timeout=COINGECKO_TIMEOUT_SECONDS,
         )
         response.raise_for_status()
@@ -82,11 +106,11 @@ class CoinGeckoClient(MarketDataClient):
             f"{self.BASE_URL}/coins/markets",
             headers=self._headers(),
             params={
-                "vs_currency": "usd",
-                "order": "market_cap_desc",
-                "per_page": limit,
-                "page": 1,
-                "sparkline": "false",
+                COINGECKO_VS_CURRENCY_KEY: COINGECKO_VS_CURRENCY_USD,
+                COINGECKO_ORDER_KEY: COINGECKO_ORDER_MARKET_CAP_DESC,
+                COINGECKO_PARAM_PER_PAGE: limit,
+                COINGECKO_PARAM_PAGE: COINGECKO_DEFAULT_PAGE,
+                COINGECKO_PARAM_SPARKLINE: COINGECKO_SPARKLINE_FALSE,
             },
             timeout=COINGECKO_TIMEOUT_SECONDS,
         )

--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -7,7 +7,16 @@ from typing import Any
 
 import pandas as pd
 
-from constants import DEFAULT_FETCH_BATCH_SIZE, EXCHANGE_TIMEOUT_SECONDS
+from constants import (
+    CCXT_MARKET_TYPE_SWAP,
+    CCXT_OPTION_DEFAULT_TYPE_KEY,
+    DEFAULT_FETCH_BATCH_SIZE,
+    EXCHANGE_TIMEOUT_SECONDS,
+    FUTURES_SETTLEMENT_QUOTE_ASSET,
+    MILLISECONDS_IN_SECOND,
+    OHLCV_FRAME_COLUMNS,
+    OPEN_INTEREST_FRAME_COLUMNS,
+)
 from domain.abstract.exchange_client import ExchangeClient
 from domain.enums.exchange import Exchange
 from domain.enums.timeframe import Timeframe
@@ -35,7 +44,7 @@ def _to_utc_ms(value: datetime) -> int:
         value = value.replace(tzinfo=timezone.utc)
     else:
         value = value.astimezone(timezone.utc)
-    return int(value.timestamp() * 1000)
+    return int(value.timestamp() * MILLISECONDS_IN_SECOND)
 
 
 class CcxtFuturesClient(ExchangeClient):
@@ -64,15 +73,15 @@ class CcxtFuturesClient(ExchangeClient):
             "secret": secret,
             "password": password,
             "enableRateLimit": enable_rate_limit,
-            "timeout": EXCHANGE_TIMEOUT_SECONDS * 1000,
+            "timeout": EXCHANGE_TIMEOUT_SECONDS * MILLISECONDS_IN_SECOND,
         }
         if exchange == Exchange.BINANCE:
             return ccxt.binanceusdm(params)
         if exchange == Exchange.BYBIT:
-            params["options"] = {"defaultType": "swap"}
+            params["options"] = {CCXT_OPTION_DEFAULT_TYPE_KEY: CCXT_MARKET_TYPE_SWAP}
             return ccxt.bybit(params)
         if exchange == Exchange.OKX:
-            params["options"] = {"defaultType": "swap"}
+            params["options"] = {CCXT_OPTION_DEFAULT_TYPE_KEY: CCXT_MARKET_TYPE_SWAP}
             return ccxt.okx(params)
         raise ValueError(f"Unsupported exchange: {exchange}")
 
@@ -90,9 +99,9 @@ class CcxtFuturesClient(ExchangeClient):
             settle = str(market.get("settle") or "").upper()
             linear = bool(market.get("linear", False))
 
-            if quote != "USDT" and settle != "USDT":
+            if quote != FUTURES_SETTLEMENT_QUOTE_ASSET and settle != FUTURES_SETTLEMENT_QUOTE_ASSET:
                 continue
-            if not linear and settle != "USDT":
+            if not linear and settle != FUTURES_SETTLEMENT_QUOTE_ASSET:
                 continue
 
             symbol = str(market.get("symbol") or "")
@@ -118,7 +127,7 @@ class CcxtFuturesClient(ExchangeClient):
                 break
             since = last_ts + 1
 
-        frame = pd.DataFrame(all_rows, columns=["timestamp", "open", "high", "low", "close", "volume"])
+        frame = pd.DataFrame(all_rows, columns=OHLCV_FRAME_COLUMNS)
         if frame.empty:
             return frame
 
@@ -157,7 +166,7 @@ class CcxtFuturesClient(ExchangeClient):
             since = last_ts + 1
 
         if not rows:
-            return pd.DataFrame(columns=["timestamp", "open_interest", "datetime"])
+            return pd.DataFrame(columns=OPEN_INTEREST_FRAME_COLUMNS)
 
         frame = pd.DataFrame(rows)
         if "openInterestAmount" in frame.columns:
@@ -169,5 +178,5 @@ class CcxtFuturesClient(ExchangeClient):
 
         frame = frame.loc[(frame["timestamp"] >= start_ms) & (frame["timestamp"] <= end_ms)]
         frame["datetime"] = pd.to_datetime(frame["timestamp"], unit="ms", utc=True)
-        frame = frame[["timestamp", "open_interest", "datetime"]]
+        frame = frame[list(OPEN_INTEREST_FRAME_COLUMNS)]
         return frame.drop_duplicates(subset=["timestamp"]).sort_values("timestamp").reset_index(drop=True)

--- a/data/fetchers/market_data_fetcher.py
+++ b/data/fetchers/market_data_fetcher.py
@@ -5,13 +5,20 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
 from datetime import datetime
 from pathlib import Path
-from constants import FETCH_ALL_MAX_WORKERS
+
+from constants import (
+    DEFAULT_FETCHER_MAX_WORKERS,
+    DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    DEFAULT_LOG_LEVEL,
+    DEFAULT_LOGS_DIR,
+    FETCH_ALL_MAX_WORKERS,
+)
+from data.fetchers.ohlcv_fetcher import OhlcvFetcher
+from data.fetchers.oi_fetcher import OiFetcher
 from domain.abstract.market_data_client import MarketDataClient
 from domain.enums.timeframe import Timeframe
 from domain.models.reporting.fetch_all_result import FetchAllResult
 from domain.models.reporting.market_caps_result import MarketCapsResult
-from data.fetchers.ohlcv_fetcher import OhlcvFetcher
-from data.fetchers.oi_fetcher import OiFetcher
 from utils.logger import get_logger
 
 
@@ -23,10 +30,10 @@ class MarketDataFetcher:
         ohlcv_fetcher: OhlcvFetcher,
         oi_fetcher: OiFetcher,
         market_data_client: MarketDataClient,
-        max_workers: int = 5,
-        request_timeout_seconds: int = 60,
-        log_level: int | str = "INFO",
-        logs_dir: str | Path = "./logs",
+        max_workers: int = DEFAULT_FETCHER_MAX_WORKERS,
+        request_timeout_seconds: int = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+        log_level: int | str = DEFAULT_LOG_LEVEL,
+        logs_dir: str | Path = DEFAULT_LOGS_DIR,
     ) -> None:
         self._ohlcv_fetcher = ohlcv_fetcher
         self._oi_fetcher = oi_fetcher

--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -3,29 +3,24 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 
-from domain.abstract.exchange_client import ExchangeClient
-from domain.enums.timeframe import Timeframe
+from constants import (
+    DEFAULT_FETCHER_MAX_WORKERS,
+    DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    DEFAULT_LOG_LEVEL,
+    DEFAULT_LOGS_DIR,
+    TIMEFRAME_TO_DELTA,
+)
 from data.quality.data_validator import DataValidator
 from data.quality.deduplicator import Deduplicator
 from data.quality.gap_detector import GapDetector
 from data.quality.time_alignment import TimeAlignment
 from data.storage.parquet_storage import ParquetStorage
+from domain.abstract.exchange_client import ExchangeClient
+from domain.enums.timeframe import Timeframe
 from utils.logger import get_logger
-
-
-_TIMEFRAME_DELTA = {
-    Timeframe.M1: timedelta(minutes=1),
-    Timeframe.M5: timedelta(minutes=5),
-    Timeframe.M15: timedelta(minutes=15),
-    Timeframe.M30: timedelta(minutes=30),
-    Timeframe.H1: timedelta(hours=1),
-    Timeframe.H4: timedelta(hours=4),
-    Timeframe.D1: timedelta(days=1),
-    Timeframe.W1: timedelta(weeks=1),
-}
 
 
 class OhlcvFetcher:
@@ -35,10 +30,10 @@ class OhlcvFetcher:
         self,
         exchange_client: ExchangeClient,
         storage: ParquetStorage,
-        max_workers: int = 5,
-        request_timeout_seconds: int = 60,
-        log_level: int | str = "INFO",
-        logs_dir: str | Path = "./logs",
+        max_workers: int = DEFAULT_FETCHER_MAX_WORKERS,
+        request_timeout_seconds: int = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+        log_level: int | str = DEFAULT_LOG_LEVEL,
+        logs_dir: str | Path = DEFAULT_LOGS_DIR,
     ) -> None:
         self._exchange_client = exchange_client
         self._storage = storage
@@ -54,7 +49,7 @@ class OhlcvFetcher:
         next_start = start_time
         last_timestamp = self._storage.get_last_timestamp(symbol, timeframe)
         if last_timestamp is not None:
-            next_start = max(start_time, last_timestamp.to_pydatetime() + _TIMEFRAME_DELTA[timeframe])
+            next_start = max(start_time, last_timestamp.to_pydatetime() + TIMEFRAME_TO_DELTA[timeframe])
 
         self._logger.info(f"OHLCV старт: {symbol} {timeframe.value} {next_start.isoformat()} -> {end_time.isoformat()}")
         if next_start > end_time:

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -3,29 +3,24 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 
-from domain.abstract.exchange_client import ExchangeClient
-from domain.enums.timeframe import Timeframe
+from constants import (
+    DEFAULT_FETCHER_MAX_WORKERS,
+    DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    DEFAULT_LOG_LEVEL,
+    DEFAULT_LOGS_DIR,
+    TIMEFRAME_TO_DELTA,
+)
 from data.quality.data_validator import DataValidator
 from data.quality.deduplicator import Deduplicator
 from data.quality.oi_aligner import OiAligner
 from data.quality.time_alignment import TimeAlignment
 from data.storage.parquet_storage import ParquetStorage
+from domain.abstract.exchange_client import ExchangeClient
+from domain.enums.timeframe import Timeframe
 from utils.logger import get_logger
-
-
-_TIMEFRAME_DELTA = {
-    Timeframe.M1: timedelta(minutes=1),
-    Timeframe.M5: timedelta(minutes=5),
-    Timeframe.M15: timedelta(minutes=15),
-    Timeframe.M30: timedelta(minutes=30),
-    Timeframe.H1: timedelta(hours=1),
-    Timeframe.H4: timedelta(hours=4),
-    Timeframe.D1: timedelta(days=1),
-    Timeframe.W1: timedelta(weeks=1),
-}
 
 
 class OiFetcher:
@@ -35,10 +30,10 @@ class OiFetcher:
         self,
         exchange_client: ExchangeClient,
         storage: ParquetStorage,
-        max_workers: int = 5,
-        request_timeout_seconds: int = 60,
-        log_level: int | str = "INFO",
-        logs_dir: str | Path = "./logs",
+        max_workers: int = DEFAULT_FETCHER_MAX_WORKERS,
+        request_timeout_seconds: int = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+        log_level: int | str = DEFAULT_LOG_LEVEL,
+        logs_dir: str | Path = DEFAULT_LOGS_DIR,
     ) -> None:
         self._exchange_client = exchange_client
         self._storage = storage
@@ -54,7 +49,7 @@ class OiFetcher:
         next_start = start_time
         last_timestamp = self._storage.get_last_timestamp(symbol, timeframe)
         if last_timestamp is not None:
-            next_start = max(start_time, last_timestamp.to_pydatetime() + _TIMEFRAME_DELTA[timeframe])
+            next_start = max(start_time, last_timestamp.to_pydatetime() + TIMEFRAME_TO_DELTA[timeframe])
 
         self._logger.info(f"OI старт: {symbol} {timeframe.value} {next_start.isoformat()} -> {end_time.isoformat()}")
         if next_start > end_time:

--- a/strategy/breakout/config.py
+++ b/strategy/breakout/config.py
@@ -5,9 +5,19 @@ from __future__ import annotations
 from dataclasses import dataclass
 from math import prod
 
+from constants import (
+    BREAKOUT_LOOKBACK_VALUES,
+    BREAKOUT_MIN_RR_VALUES,
+    BREAKOUT_RETEST_WINDOW_VALUES,
+    BREAKOUT_RETEST_ZONE_VALUES,
+    BREAKOUT_SL_MODE_VALUES,
+    BREAKOUT_TARGET_PARAMETER_COMBINATIONS,
+    BREAKOUT_TP2_MULT_VALUES,
+    BREAKOUT_VOLUME_MULT_VALUES,
+)
 from domain.enums.sl_mode import SLMode
 
-TARGET_PARAMETER_COMBINATIONS = 5832
+TARGET_PARAMETER_COMBINATIONS = BREAKOUT_TARGET_PARAMETER_COMBINATIONS
 
 
 @dataclass(frozen=True, slots=True)
@@ -23,13 +33,13 @@ class BreakoutParams:
 
 
 BREAKOUT_PARAMETER_GRID: dict[str, list[float | int | SLMode]] = {
-    "lookback": [8, 13, 21, 34, 55, 89],
-    "volume_mult": [1.1, 1.3, 1.5],
-    "retest_window": [2, 4, 6],
-    "retest_zone": [0.0015, 0.0020, 0.0030],
-    "min_rr": [1.0, 1.5, 2.0],
-    "sl_mode": [SLMode.LEVEL, SLMode.BREAKOUT_EXTREME],
-    "tp2_mult": [1.1, 1.25, 1.4, 1.5, 1.75, 2.0],
+    "lookback": list(BREAKOUT_LOOKBACK_VALUES),
+    "volume_mult": list(BREAKOUT_VOLUME_MULT_VALUES),
+    "retest_window": list(BREAKOUT_RETEST_WINDOW_VALUES),
+    "retest_zone": list(BREAKOUT_RETEST_ZONE_VALUES),
+    "min_rr": list(BREAKOUT_MIN_RR_VALUES),
+    "sl_mode": list(BREAKOUT_SL_MODE_VALUES),
+    "tp2_mult": list(BREAKOUT_TP2_MULT_VALUES),
 }
 
 PARAMETER_GRID_SIZE = prod(len(values) for values in BREAKOUT_PARAMETER_GRID.values())

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -6,16 +6,29 @@ import logging
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
+from constants import (
+    LOGGER_COLOR_ERROR,
+    LOGGER_COLOR_INFO,
+    LOGGER_COLOR_RESET,
+    LOGGER_COLOR_WARNING,
+    LOGGER_DATE_FORMAT,
+    LOGGER_FILE_BACKUP_COUNT,
+    LOGGER_FILE_ENCODING,
+    LOGGER_FILE_MAX_BYTES,
+    LOGGER_MESSAGE_FORMAT,
+    DEFAULT_LOGS_DIR,
+)
+
 
 class _ColorFormatter(logging.Formatter):
     """Adds ANSI colors for INFO/WARNING/ERROR levels in console output."""
 
-    RESET = "\033[0m"
+    RESET = LOGGER_COLOR_RESET
     COLORS = {
-        logging.INFO: "\033[32m",
-        logging.WARNING: "\033[33m",
-        logging.ERROR: "\033[31m",
-        logging.CRITICAL: "\033[31m",
+        logging.INFO: LOGGER_COLOR_INFO,
+        logging.WARNING: LOGGER_COLOR_WARNING,
+        logging.ERROR: LOGGER_COLOR_ERROR,
+        logging.CRITICAL: LOGGER_COLOR_ERROR,
     }
 
     def format(self, record: logging.LogRecord) -> str:
@@ -29,7 +42,7 @@ class _ColorFormatter(logging.Formatter):
 def get_logger(
     name: str,
     level: int | str = logging.INFO,
-    logs_dir: str | Path = "./logs",
+    logs_dir: str | Path = DEFAULT_LOGS_DIR,
 ) -> logging.Logger:
     """Create or return configured logger in `ЧЧ:ММ:СС Сообщение` format."""
     if isinstance(level, str):
@@ -47,12 +60,17 @@ def get_logger(
     if not logger.handlers:
         stream_handler = logging.StreamHandler()
         stream_handler.setLevel(resolved_level)
-        stream_handler.setFormatter(_ColorFormatter("%(asctime)s %(message)s", datefmt="%H:%M:%S"))
+        stream_handler.setFormatter(_ColorFormatter(LOGGER_MESSAGE_FORMAT, datefmt=LOGGER_DATE_FORMAT))
         logger.addHandler(stream_handler)
 
-        file_handler = RotatingFileHandler(file_path, maxBytes=5 * 1024 * 1024, backupCount=5, encoding="utf-8")
+        file_handler = RotatingFileHandler(
+            file_path,
+            maxBytes=LOGGER_FILE_MAX_BYTES,
+            backupCount=LOGGER_FILE_BACKUP_COUNT,
+            encoding=LOGGER_FILE_ENCODING,
+        )
         file_handler.setLevel(resolved_level)
-        file_handler.setFormatter(logging.Formatter("%(asctime)s %(message)s", datefmt="%H:%M:%S"))
+        file_handler.setFormatter(logging.Formatter(LOGGER_MESSAGE_FORMAT, datefmt=LOGGER_DATE_FORMAT))
         logger.addHandler(file_handler)
     else:
         for handler in logger.handlers:

--- a/vectorbt_runner/data_preparer.py
+++ b/vectorbt_runner/data_preparer.py
@@ -7,17 +7,21 @@ from pathlib import Path
 import pandas as pd
 
 from constants import (
+    DATA_PREPARER_EMPTY_BOOL_DTYPE,
+    DATA_PREPARER_EMPTY_FLOAT_DTYPE,
+    DATA_PREPARER_NUMERIC_COLUMNS,
+    DATA_PREPARER_TRADE_COLUMNS,
     SIMULATION_DATETIME_UNIT_MS,
     SIMULATION_PARQUET_FILE_NAME,
     SIMULATION_PNL_PERCENT_DIVISOR,
     SIMULATION_PRICE_INIT,
     SIMULATION_TIMEZONE_UTC,
+    SIMULATION_UNIT_INCREMENT,
+    SIMULATION_ZERO_VALUE,
     STRATEGY_REQUIRED_COLUMNS,
 )
 from domain.enums.timeframe import Timeframe
 from domain.models.trade_result import TradeResult
-
-
 from vectorbt_runner.vectorbt_inputs import VectorbtInputs
 
 
@@ -55,7 +59,7 @@ class DataPreparer:
         normalized["datetime"] = pd.to_datetime(normalized["timestamp"], unit=SIMULATION_DATETIME_UNIT_MS, utc=True, errors="coerce")
         normalized = normalized.dropna(subset=["datetime"])
 
-        numeric_cols = [col for col in ("open", "high", "low", "close", "volume", "open_interest") if col in normalized.columns]
+        numeric_cols = [col for col in DATA_PREPARER_NUMERIC_COLUMNS if col in normalized.columns]
         for col in numeric_cols:
             normalized[col] = pd.to_numeric(normalized[col], errors="coerce")
 
@@ -68,9 +72,9 @@ class DataPreparer:
         """Build synthetic price/signals/equity series from closed trades."""
         if not trades:
             index = pd.DatetimeIndex([], tz=SIMULATION_TIMEZONE_UTC)
-            empty_float = pd.Series([], index=index, dtype="float64")
-            empty_bool = pd.Series([], index=index, dtype="bool")
-            trades_frame = pd.DataFrame(columns=["entry_time", "exit_time", "pnl", "pnl_percent", "result_type"])
+            empty_float = pd.Series([], index=index, dtype=DATA_PREPARER_EMPTY_FLOAT_DTYPE)
+            empty_bool = pd.Series([], index=index, dtype=DATA_PREPARER_EMPTY_BOOL_DTYPE)
+            trades_frame = pd.DataFrame(columns=DATA_PREPARER_TRADE_COLUMNS)
             return VectorbtInputs(
                 close=empty_float,
                 entries=empty_bool,
@@ -96,13 +100,13 @@ class DataPreparer:
             sorted(set(trades_frame["entry_time"].tolist() + trades_frame["exit_time"].tolist())),
             tz=SIMULATION_TIMEZONE_UTC,
         )
-        close = pd.Series(initial_price, index=timeline, dtype="float64")
-        entries = pd.Series(False, index=timeline, dtype="bool")
-        exits = pd.Series(False, index=timeline, dtype="bool")
-        equity_curve = pd.Series(0.0, index=timeline, dtype="float64")
+        close = pd.Series(initial_price, index=timeline, dtype=DATA_PREPARER_EMPTY_FLOAT_DTYPE)
+        entries = pd.Series(False, index=timeline, dtype=DATA_PREPARER_EMPTY_BOOL_DTYPE)
+        exits = pd.Series(False, index=timeline, dtype=DATA_PREPARER_EMPTY_BOOL_DTYPE)
+        equity_curve = pd.Series(SIMULATION_ZERO_VALUE, index=timeline, dtype=DATA_PREPARER_EMPTY_FLOAT_DTYPE)
 
         running_price = float(initial_price)
-        cumulative_pnl = 0.0
+        cumulative_pnl = SIMULATION_ZERO_VALUE
         for trade in trade_rows:
             entry_time = trade["entry_time"]
             exit_time = trade["exit_time"]
@@ -113,14 +117,14 @@ class DataPreparer:
             exits.loc[exit_time] = True
             close.loc[entry_time] = running_price
 
-            running_price *= 1.0 + (pnl_percent / SIMULATION_PNL_PERCENT_DIVISOR)
+            running_price *= SIMULATION_UNIT_INCREMENT + (pnl_percent / SIMULATION_PNL_PERCENT_DIVISOR)
             close.loc[exit_time] = running_price
 
             cumulative_pnl += pnl
             equity_curve.loc[exit_time] = cumulative_pnl
 
         close = close.ffill()
-        equity_curve = equity_curve.replace(0.0, pd.NA).ffill().fillna(0.0)
+        equity_curve = equity_curve.replace(SIMULATION_ZERO_VALUE, pd.NA).ffill().fillna(SIMULATION_ZERO_VALUE)
 
         return VectorbtInputs(
             close=close,


### PR DESCRIPTION
### Motivation
- Reduce scattered "magic" literals across core modules and make defaults/configurable from a single place. 
- Improve readability and make future tuning of timeouts, fetcher defaults, logger settings and grid parameters easier.

### Description
- Added many named constants to `constants.py` (fetcher defaults, time delta mapping per `Timeframe`, OHLCV/OI frame column names, CCXT keys/strings, CoinGecko URL/params/headers, logger formats/rotation settings, data-preparer dtypes/values, breakout grid value sets). 
- Replaced inline literals with imports from `constants.py` in the following modules: `data/exchanges/ccxt_futures_client.py`, `data/clients/coingecko_client.py`, `data/fetchers/market_data_fetcher.py`, `data/fetchers/ohlcv_fetcher.py`, `data/fetchers/oi_fetcher.py`, `utils/logger.py`, `vectorbt_runner/data_preparer.py`, and `strategy/breakout/config.py`. 
- Kept original behavior unchanged while updating code to use the centralized names; grid parameter constants in `strategy/breakout/config.py` are now sourced from `constants.py`.
- Adjusted small helpers to use constants (e.g. millisecond multiplier, TIMEFRAME -> timedelta mapping, OHLCV/OI column names, CoinGecko query keys) and updated logger formatting to use centralized formats/limits.

### Testing
- Compiled the modified modules to validate syntax: `python -m compileall constants.py data/exchanges/ccxt_futures_client.py data/clients/coingecko_client.py data/fetchers/market_data_fetcher.py data/fetchers/ohlcv_fetcher.py data/fetchers/oi_fetcher.py utils/logger.py vectorbt_runner/data_preparer.py strategy/breakout/config.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69876c5b3bf8832092d4e015d7eec0fb)