### PR TITLE
Persist CoinGecko market cap cache to disk with TTL-aware reload

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -92,6 +92,7 @@ def _run_with_logging(command_name: str, config: AppConfig, body: Callable[[], i
 
 
 def _build_fetch_stack(config: AppConfig) -> tuple[MarketDataFetcher, CcxtFuturesClient, CoinGeckoClient]:
+    market_caps_cache_path = config.backtest.cache_dir / "market_caps.json"
     exchange_client = CcxtFuturesClient(
         exchange=Exchange.BINANCE,
         api_key=config.fetch.binance_api_key,
@@ -112,7 +113,10 @@ def _build_fetch_stack(config: AppConfig) -> tuple[MarketDataFetcher, CcxtFuture
         log_level=config.backtest.log_level,
         logs_dir=config.backtest.logs_dir,
     )
-    market_client = CoinGeckoClient(api_key=config.fetch.coingecko_api_key)
+    market_client = CoinGeckoClient(
+        api_key=config.fetch.coingecko_api_key,
+        cache_path=market_caps_cache_path,
+    )
     return (
         MarketDataFetcher(
             ohlcv_fetcher=ohlcv_fetcher,

--- a/data/clients/coingecko_client.py
+++ b/data/clients/coingecko_client.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import json
+import logging
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import requests
 
@@ -33,13 +36,56 @@ class CoinGeckoClient(MarketDataClient):
 
     BASE_URL = COINGECKO_BASE_URL
 
-    def __init__(self, api_key: str = "", cache_ttl_hours: int = 24) -> None:
+    def __init__(self, api_key: str = "", cache_ttl_hours: int = 24, cache_path: str | Path | None = None) -> None:
         self._api_key = api_key
         self._cache_ttl = timedelta(hours=cache_ttl_hours)
         self._market_cap_cache: dict[str, tuple[float, datetime]] = {}
         self._symbol_to_id: dict[str, str] = {}
+        self._cache_path = Path(cache_path) if cache_path else None
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self._load_market_cap_cache()
 
     # region Private
+
+    def _load_market_cap_cache(self) -> None:
+        if self._cache_path is None or not self._cache_path.exists():
+            return
+
+        try:
+            raw_payload = json.loads(self._cache_path.read_text(encoding="utf-8"))
+            if not isinstance(raw_payload, dict):
+                raise ValueError("cache payload must be an object")
+
+            loaded_cache: dict[str, tuple[float, datetime]] = {}
+            for symbol, payload in raw_payload.items():
+                if not isinstance(symbol, str) or not isinstance(payload, list) or len(payload) != 2:
+                    continue
+
+                market_cap, expires_at = payload
+                if not isinstance(expires_at, str):
+                    continue
+
+                expires_at_dt = datetime.fromisoformat(expires_at)
+                if expires_at_dt.tzinfo is None:
+                    expires_at_dt = expires_at_dt.replace(tzinfo=timezone.utc)
+
+                loaded_cache[symbol.upper()] = (float(market_cap), expires_at_dt)
+
+            self._market_cap_cache = loaded_cache
+        except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+            self._logger.warning("Failed to load CoinGecko cache from %s: %s", self._cache_path, exc)
+            self._market_cap_cache = {}
+
+    def _save_market_cap_cache(self) -> None:
+        if self._cache_path is None:
+            return
+
+        serialized_cache = {
+            symbol: [market_cap, expires_at.isoformat()]
+            for symbol, (market_cap, expires_at) in self._market_cap_cache.items()
+        }
+        self._cache_path.parent.mkdir(parents=True, exist_ok=True)
+        self._cache_path.write_text(json.dumps(serialized_cache, ensure_ascii=False, indent=2), encoding="utf-8")
 
     def _headers(self) -> dict[str, str]:
         headers = {COINGECKO_HEADER_ACCEPT_KEY: COINGECKO_HEADER_ACCEPT_JSON}
@@ -99,6 +145,7 @@ class CoinGeckoClient(MarketDataClient):
 
         market_cap = float(payload[0].get("market_cap") or 0.0)
         self._market_cap_cache[normalized] = (market_cap, now + self._cache_ttl)
+        self._save_market_cap_cache()
         return market_cap
 
     def get_top_coins_by_market_cap(self, limit: int) -> list[str]:


### PR DESCRIPTION
### Motivation
- Reduce repeated CoinGecko requests by persisting market-cap lookups to disk and reusing them while respecting TTL.
- Allow the fetch stack to share a single cache file located in the backtest cache directory.
- Fail gracefully when the cache file is missing or corrupted to avoid breaking startup.

### Description
- Added `cache_path` parameter to `CoinGeckoClient` and load/save logic to persist `symbol -> [market_cap, expires_at]` as JSON on disk.
- Implemented `_load_market_cap_cache` which deserializes the JSON, converts `expires_at` to a timezone-aware `datetime`, and falls back to an empty cache on error while logging a warning.
- Implemented `_save_market_cap_cache` and call it after updating a market cap entry so the cache is kept on disk.
- Wired the CLI fetch stack to pass `config.backtest.cache_dir / "market_caps.json"` into `CoinGeckoClient` when building the fetch stack.

### Testing
- Ran `python -m compileall data/clients/coingecko_client.py cli/commands.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698770236a108320acf10fc1f3c23ed8)