### PR TITLE
Use column-specific watermarks for incremental OHLCV and OI fetchers

### DIFF
--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -47,10 +47,15 @@ class OhlcvFetcher:
 
     def fetch_symbol(self, symbol: str, timeframe: Timeframe, start_time: datetime, end_time: datetime) -> int:
         next_start = start_time
-        last_timestamp = self._storage.get_last_timestamp(symbol, timeframe)
+        watermark_column = "close"
+        last_timestamp = self._storage.get_last_timestamp_for_column(symbol, timeframe, watermark_column)
         if last_timestamp is not None:
             next_start = max(start_time, last_timestamp.to_pydatetime() + TIMEFRAME_TO_DELTA[timeframe])
 
+        watermark_display = last_timestamp.isoformat() if last_timestamp is not None else "None"
+        self._logger.info(
+            f"OHLCV watermark: {symbol} {timeframe.value} column={watermark_column} last={watermark_display} selected={next_start.isoformat()}"
+        )
         self._logger.info(f"OHLCV старт: {symbol} {timeframe.value} {next_start.isoformat()} -> {end_time.isoformat()}")
         if next_start > end_time:
             self._logger.info(f"OHLCV пропуск: {symbol} уже актуален")

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -47,10 +47,15 @@ class OiFetcher:
 
     def fetch_symbol(self, symbol: str, timeframe: Timeframe, start_time: datetime, end_time: datetime) -> int:
         next_start = start_time
-        last_timestamp = self._storage.get_last_timestamp(symbol, timeframe)
+        watermark_column = "open_interest"
+        last_timestamp = self._storage.get_last_timestamp_for_column(symbol, timeframe, watermark_column)
         if last_timestamp is not None:
             next_start = max(start_time, last_timestamp.to_pydatetime() + TIMEFRAME_TO_DELTA[timeframe])
 
+        watermark_display = last_timestamp.isoformat() if last_timestamp is not None else "None"
+        self._logger.info(
+            f"OI watermark: {symbol} {timeframe.value} column={watermark_column} last={watermark_display} selected={next_start.isoformat()}"
+        )
         self._logger.info(f"OI старт: {symbol} {timeframe.value} {next_start.isoformat()} -> {end_time.isoformat()}")
         if next_start > end_time:
             self._logger.info(f"OI пропуск: {symbol} уже актуален")

--- a/data/storage/parquet_storage.py
+++ b/data/storage/parquet_storage.py
@@ -51,6 +51,28 @@ class ParquetStorage:
             return None
         return pd.to_datetime(data["timestamp"], unit="ms", utc=True).max()
 
+    def get_last_timestamp_for_column(
+        self,
+        symbol: str,
+        timeframe: Timeframe,
+        column_name: str,
+    ) -> pd.Timestamp | None:
+        data = self.load(symbol, timeframe)
+        if data.empty or "timestamp" not in data.columns:
+            return None
+
+        if column_name == "timestamp":
+            return pd.to_datetime(data["timestamp"], unit="ms", utc=True).max()
+
+        if column_name not in data.columns:
+            return None
+
+        valid_rows = data[column_name].notna()
+        if not valid_rows.any():
+            return None
+
+        return pd.to_datetime(data.loc[valid_rows, "timestamp"], unit="ms", utc=True).max()
+
     def save_incremental(self, symbol: str, timeframe: Timeframe, new_data: pd.DataFrame) -> int:
         if new_data.empty:
             return 0
@@ -82,4 +104,3 @@ class ParquetStorage:
         merged.to_parquet(path, index=False)
 
         return max(len(merged) - previous_count, 0)
-


### PR DESCRIPTION
### Motivation
- Prevent fetcher desynchronization when parquet files contain partially empty columns by computing watermarks per relevant series instead of using a single global timestamp.
- Make the chosen watermark visible in logs to simplify diagnosis of resumption behavior and data alignment issues.

### Description
- Added `ParquetStorage.get_last_timestamp_for_column(symbol, timeframe, column_name)` which returns the latest `timestamp` for rows where the specified column is non-null and returns `None` for missing or fully-empty columns so fetchers can fallback to `start_time`.
- Updated `OhlcvFetcher` to use a market-series watermark (`close`) via the new storage method when computing `next_start` and added a diagnostic log line showing `column`, `last` watermark value, and the selected `next_start`.
- Updated `OiFetcher` to use an `open_interest`-specific watermark via the new storage method and added an analogous diagnostic log line.
- Preserved existing behavior of falling back to `start_time` when no valid watermark exists for the chosen column.

### Testing
- Compiled the modified modules with `python -m compileall data/storage/parquet_storage.py data/fetchers/ohlcv_fetcher.py data/fetchers/oi_fetcher.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69877204a0348320a95f3c933e41a1e3)