### PR TITLE
Parse numeric timestamps as milliseconds in TimeAlignment.align_to_utc

### DIFF
--- a/data/quality/time_alignment.py
+++ b/data/quality/time_alignment.py
@@ -15,7 +15,7 @@ class TimeAlignment:
         aligned = data.copy()
 
         if "timestamp" in aligned.columns:
-            ts = pd.to_datetime(aligned["timestamp"], utc=True, errors="coerce")
+            ts = pd.to_datetime(aligned["timestamp"], unit="ms", utc=True, errors="coerce")
         elif "datetime" in aligned.columns:
             ts = pd.to_datetime(aligned["datetime"], utc=True, errors="coerce")
         else:


### PR DESCRIPTION
### Motivation
- Ensure integer `timestamp` columns are interpreted as milliseconds so epoch values are parsed correctly and millisecond precision is preserved when normalizing to the project's UTC timestamp-ms / UTC datetime parquet contract.

### Description
- Updated `TimeAlignment.align_to_utc` to parse `timestamp` using `pd.to_datetime(aligned["timestamp"], unit="ms", utc=True, errors="coerce")`, kept the `datetime` branch unchanged, and preserved the existing normalization `(ts.astype("int64") // 1_000_000)`.

### Testing
- Ran `python -m py_compile data/quality/time_alignment.py` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698783ead7d883209531692041782232)