### PR TITLE
Fix DataValidator positional indexing and NaT handling

### DIFF
--- a/data/quality/data_validator.py
+++ b/data/quality/data_validator.py
@@ -19,11 +19,14 @@ class DataValidator:
         if data.empty or "timestamp" not in data.columns:
             return []
 
+        normalized = data.reset_index(drop=True)
         issues: list[DataQualityIssue] = []
-        ts = pd.to_datetime(data["timestamp"], unit="ms", utc=True, errors="coerce")
+        ts = pd.to_datetime(normalized["timestamp"], unit="ms", utc=True, errors="coerce")
 
-        def add_issue(index: int, issue_type: str, severity: DataQualitySeverity, description: str) -> None:
-            tstamp = ts.iloc[index].to_pydatetime().astimezone(timezone.utc)
+        def add_issue(pos: int, issue_type: str, severity: DataQualitySeverity, description: str) -> None:
+            if pd.isna(ts.iloc[pos]):
+                return
+            tstamp = ts.iloc[pos].to_pydatetime().astimezone(timezone.utc)
             issues.append(
                 DataQualityIssue(
                     symbol=symbol,
@@ -36,34 +39,34 @@ class DataValidator:
             )
 
         for col in ("open", "high", "low", "close"):
-            if col in data.columns:
-                bad = data[col] < 0
-                for idx in data.index[bad.fillna(False)]:
-                    add_issue(int(idx), "negative_price", DataQualitySeverity.CRITICAL, f"Negative {col} value")
+            if col in normalized.columns:
+                bad = normalized[col] < 0
+                for pos in normalized.index[bad.fillna(False)]:
+                    add_issue(int(pos), "negative_price", DataQualitySeverity.CRITICAL, f"Negative {col} value")
 
         for col in ("volume", "open_interest"):
-            if col in data.columns:
-                bad = data[col] < 0
-                for idx in data.index[bad.fillna(False)]:
-                    add_issue(int(idx), "negative_volume", DataQualitySeverity.ERROR, f"Negative {col} value")
+            if col in normalized.columns:
+                bad = normalized[col] < 0
+                for pos in normalized.index[bad.fillna(False)]:
+                    add_issue(int(pos), "negative_volume", DataQualitySeverity.ERROR, f"Negative {col} value")
 
-        if {"high", "low", "close"}.issubset(data.columns):
-            spread = (data["high"] - data["low"]).abs()
-            base = data["close"].abs().replace(0, pd.NA)
+        if {"high", "low", "close"}.issubset(normalized.columns):
+            spread = (normalized["high"] - normalized["low"]).abs()
+            base = normalized["close"].abs().replace(0, pd.NA)
             ratio = spread / base
             suspicious = ratio > SPREAD_TO_CLOSE_WARNING_THRESHOLD
-            for idx in data.index[suspicious.fillna(False)]:
+            for pos in normalized.index[suspicious.fillna(False)]:
                 threshold_pct = int(SPREAD_TO_CLOSE_WARNING_THRESHOLD * 100)
                 add_issue(
-                    int(idx),
+                    int(pos),
                     "suspicious_spread",
                     DataQualitySeverity.WARNING,
                     f"Spread exceeds {threshold_pct}% of close",
                 )
 
-        if "volume" in data.columns:
-            zero_volume = data["volume"] == 0
-            for idx in data.index[zero_volume.fillna(False)]:
-                add_issue(int(idx), "zero_volume", DataQualitySeverity.INFO, "Zero candle volume")
+        if "volume" in normalized.columns:
+            zero_volume = normalized["volume"] == 0
+            for pos in normalized.index[zero_volume.fillna(False)]:
+                add_issue(int(pos), "zero_volume", DataQualitySeverity.INFO, "Zero candle volume")
 
         return issues


### PR DESCRIPTION
### Motivation

- Ensure all anomaly checks operate on a consistent positional index to avoid mismatches when input frames have non-sequential indices.
- Avoid raising exceptions when encountering invalid timestamps by preventing `to_pydatetime()` calls on `NaT` values.
- Standardize indexing behavior across all validation branches so reported issue positions map correctly to the normalized frame.

### Description

- Normalize the incoming frame with `normalized = data.reset_index(drop=True)` and build `ts` from `normalized["timestamp"]` so all checks use the same positional reference.
- Replace usages of `data` with `normalized` in the `negative_price`, `negative_volume`, `suspicious_spread`, and `zero_volume` branches and iterate using positional indices via `for pos in normalized.index[mask.fillna(False)]`.
- Rename the `add_issue` index parameter to `pos` and add a guard `if pd.isna(ts.iloc[pos]): return` to skip invalid timestamps before calling `to_pydatetime()`.
- Keep the reported issue creation intact while ensuring timestamps and positions are derived from the normalized, positionally-aligned frame.

### Testing

- Compiled the module with `python -m compileall data/quality/data_validator.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69878497040483208d4b9f0e231d3064)