### PR TITLE
Fix global timeout handling for parallel market data fetchers

### DIFF
--- a/data/fetchers/market_data_fetcher.py
+++ b/data/fetchers/market_data_fetcher.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
 from datetime import datetime
 from pathlib import Path
+from time import monotonic
 
 from constants import (
     DEFAULT_FETCHER_MAX_WORKERS,
@@ -48,19 +49,46 @@ class MarketDataFetcher:
 
         with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
             futures = {executor.submit(self._market_data_client.get_market_cap, symbol): symbol for symbol in symbols}
-            for future in as_completed(futures):
-                symbol = futures[future]
+            pending = set(futures)
+            deadline = monotonic() + self._request_timeout_seconds
+
+            while pending:
+                remaining = deadline - monotonic()
+                if remaining <= 0:
+                    for future in pending:
+                        symbol = futures[future]
+                        msg = f"MarketCap таймаут: {symbol}"
+                        self._logger.info(msg)
+                        results[symbol] = msg
+                        future.cancel()
+                    pending.clear()
+                    break
+
                 try:
-                    results[symbol] = future.result(timeout=self._request_timeout_seconds)
-                    self._logger.info(f"MarketCap готово: {symbol}")
+                    for future in as_completed(pending, timeout=remaining):
+                        pending.remove(future)
+                        symbol = futures[future]
+                        try:
+                            results[symbol] = future.result()
+                            self._logger.info(f"MarketCap готово: {symbol}")
+                        except Exception as exc:  # noqa: BLE001
+                            msg = f"MarketCap ошибка: {symbol}: {exc}"
+                            self._logger.info(msg)
+                            results[symbol] = msg
                 except TimeoutError:
-                    msg = f"MarketCap таймаут: {symbol}"
-                    self._logger.info(msg)
-                    results[symbol] = msg
-                except Exception as exc:  # noqa: BLE001
-                    msg = f"MarketCap ошибка: {symbol}: {exc}"
-                    self._logger.info(msg)
-                    results[symbol] = msg
+                    for future in pending:
+                        symbol = futures[future]
+                        msg = f"MarketCap таймаут: {symbol}"
+                        self._logger.info(msg)
+                        results[symbol] = msg
+                        future.cancel()
+                    pending.clear()
+
+        for symbol in symbols:
+            if symbol not in results:
+                msg = f"MarketCap таймаут: {symbol}"
+                self._logger.info(msg)
+                results[symbol] = msg
 
         self._logger.info("MarketCap завершен")
         return MarketCapsResult(market_caps=results)

--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
 from datetime import datetime
 from pathlib import Path
+from time import monotonic
 
 from constants import (
     DEFAULT_FETCHER_MAX_WORKERS,
@@ -89,17 +90,44 @@ class OhlcvFetcher:
             futures = {
                 executor.submit(self.fetch_symbol, s, timeframe, start_time, end_time): s for s in symbols
             }
-            for future in as_completed(futures):
-                symbol = futures[future]
+            pending = set(futures)
+            deadline = monotonic() + self._request_timeout_seconds
+
+            while pending:
+                remaining = deadline - monotonic()
+                if remaining <= 0:
+                    for future in pending:
+                        symbol = futures[future]
+                        msg = f"OHLCV таймаут: {symbol}"
+                        self._logger.info(msg)
+                        results[symbol] = msg
+                        future.cancel()
+                    pending.clear()
+                    break
+
                 try:
-                    results[symbol] = future.result(timeout=self._request_timeout_seconds)
+                    for future in as_completed(pending, timeout=remaining):
+                        pending.remove(future)
+                        symbol = futures[future]
+                        try:
+                            results[symbol] = future.result()
+                        except Exception as exc:  # noqa: BLE001
+                            msg = f"OHLCV ошибка: {symbol}: {exc}"
+                            self._logger.info(msg)
+                            results[symbol] = msg
                 except TimeoutError:
-                    msg = f"OHLCV таймаут: {symbol}"
-                    self._logger.info(msg)
-                    results[symbol] = msg
-                except Exception as exc:  # noqa: BLE001
-                    msg = f"OHLCV ошибка: {symbol}: {exc}"
-                    self._logger.info(msg)
-                    results[symbol] = msg
+                    for future in pending:
+                        symbol = futures[future]
+                        msg = f"OHLCV таймаут: {symbol}"
+                        self._logger.info(msg)
+                        results[symbol] = msg
+                        future.cancel()
+                    pending.clear()
+
+        for symbol in symbols:
+            if symbol not in results:
+                msg = f"OHLCV таймаут: {symbol}"
+                self._logger.info(msg)
+                results[symbol] = msg
 
         return results

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
 from datetime import datetime
 from pathlib import Path
+from time import monotonic
 
 from constants import (
     DEFAULT_FETCHER_MAX_WORKERS,
@@ -90,17 +91,44 @@ class OiFetcher:
             futures = {
                 executor.submit(self.fetch_symbol, s, timeframe, start_time, end_time): s for s in symbols
             }
-            for future in as_completed(futures):
-                symbol = futures[future]
+            pending = set(futures)
+            deadline = monotonic() + self._request_timeout_seconds
+
+            while pending:
+                remaining = deadline - monotonic()
+                if remaining <= 0:
+                    for future in pending:
+                        symbol = futures[future]
+                        msg = f"OI таймаут: {symbol}"
+                        self._logger.info(msg)
+                        results[symbol] = msg
+                        future.cancel()
+                    pending.clear()
+                    break
+
                 try:
-                    results[symbol] = future.result(timeout=self._request_timeout_seconds)
+                    for future in as_completed(pending, timeout=remaining):
+                        pending.remove(future)
+                        symbol = futures[future]
+                        try:
+                            results[symbol] = future.result()
+                        except Exception as exc:  # noqa: BLE001
+                            msg = f"OI ошибка: {symbol}: {exc}"
+                            self._logger.info(msg)
+                            results[symbol] = msg
                 except TimeoutError:
-                    msg = f"OI таймаут: {symbol}"
-                    self._logger.info(msg)
-                    results[symbol] = msg
-                except Exception as exc:  # noqa: BLE001
-                    msg = f"OI ошибка: {symbol}: {exc}"
-                    self._logger.info(msg)
-                    results[symbol] = msg
+                    for future in pending:
+                        symbol = futures[future]
+                        msg = f"OI таймаут: {symbol}"
+                        self._logger.info(msg)
+                        results[symbol] = msg
+                        future.cancel()
+                    pending.clear()
+
+        for symbol in symbols:
+            if symbol not in results:
+                msg = f"OI таймаут: {symbol}"
+                self._logger.info(msg)
+                results[symbol] = msg
 
         return results


### PR DESCRIPTION
### Motivation

- Ensure a single global deadline is applied to batches of concurrent fetches to avoid per-future blocking and partial hangs.
- Explicitly mark and cancel unfinished work on timeout so logs and downstream logic can treat those symbols as timed out.
- Guarantee that every requested symbol gets a result entry even when some workers hang or time out.

### Description

- Reworked futures processing to use a global deadline based on `monotonic()` and `as_completed(..., timeout=remaining)` in `OhlcvFetcher.fetch_many`, `OiFetcher.fetch_many`, and `MarketDataFetcher.fetch_market_caps`.
- On reaching the deadline or on `TimeoutError`, all remaining `future`s are marked with the original timeout message format (e.g. `"OHLCV таймаут: {symbol}"`, `"OI таймаут: {symbol}"`, `"MarketCap таймаут: {symbol}"`) and `future.cancel()` is called for each pending future.
- Wrapped per-future completion handling to catch and log individual exceptions preserving existing message format like `"... ошибка: {symbol}: {exc}"`.
- Added a final completeness pass after pool shutdown to ensure every input `symbol` has a corresponding entry in the returned results dictionary.

### Testing

- Compiled modified modules with `python -m compileall data/fetchers/ohlcv_fetcher.py data/fetchers/oi_fetcher.py data/fetchers/market_data_fetchers.py` and compilation completed successfully.
- Compiled each updated file individually (`data/fetchers/ohlcv_fetcher.py`, `data/fetchers/oi_fetcher.py`, `data/fetchers/market_data_fetcher.py`) and there were no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987851a783c8320aecb2e122b1a8eb5)