### PR TITLE
Differentiate negative open interest issue type in data validator

### DIFF
--- a/data/quality/data_validator.py
+++ b/data/quality/data_validator.py
@@ -44,11 +44,15 @@ class DataValidator:
                 for pos in normalized.index[bad.fillna(False)]:
                     add_issue(int(pos), "negative_price", DataQualitySeverity.CRITICAL, f"Negative {col} value")
 
-        for col in ("volume", "open_interest"):
+        issue_type_by_column = {
+            "volume": "negative_volume",
+            "open_interest": "negative_open_interest",
+        }
+        for col, issue_type in issue_type_by_column.items():
             if col in normalized.columns:
                 bad = normalized[col] < 0
                 for pos in normalized.index[bad.fillna(False)]:
-                    add_issue(int(pos), "negative_volume", DataQualitySeverity.ERROR, f"Negative {col} value")
+                    add_issue(int(pos), issue_type, DataQualitySeverity.ERROR, f"Negative {col} value")
 
         if {"high", "low", "close"}.issubset(normalized.columns):
             spread = (normalized["high"] - normalized["low"]).abs()


### PR DESCRIPTION
### Motivation
- Ensure negative-value anomalies are reported with distinct issue types for `volume` and `open_interest` so they can be distinguished in quality reports.

### Description
- In `data/quality/data_validator.py` updated `DataValidator.validate` to map columns to issue types (`"volume" -> "negative_volume"`, `"open_interest" -> "negative_open_interest"`) and emit corresponding `DataQualityIssue` entries while preserving existing severity and descriptions.

### Testing
- Ran `python -m compileall data/quality/data_validator.py cli/commands.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987922a56548320bdc4c2810c441082)