### PR TITLE
Обработка таймаутов OHLCV/OI по-отдельности в fetch_all

### DIFF
--- a/data/fetchers/market_data_fetcher.py
+++ b/data/fetchers/market_data_fetcher.py
@@ -102,6 +102,9 @@ class MarketDataFetcher:
     ) -> FetchAllResult:
         self._logger.info(f"Загрузка старт: {len(symbols)} символов, TF={timeframe.value}")
 
+        ohlcv_result: dict[str, int | str]
+        oi_result: dict[str, int | str]
+
         with ThreadPoolExecutor(max_workers=FETCH_ALL_MAX_WORKERS) as executor:
             ohlcv_future = executor.submit(
                 self._ohlcv_fetcher.fetch_many,
@@ -118,8 +121,21 @@ class MarketDataFetcher:
                 end_time,
             )
 
-            ohlcv_result = ohlcv_future.result(timeout=self._request_timeout_seconds)
-            oi_result = oi_future.result(timeout=self._request_timeout_seconds)
+            try:
+                ohlcv_result = ohlcv_future.result(timeout=self._request_timeout_seconds)
+            except TimeoutError:
+                ohlcv_future.cancel()
+                msg = "OHLCV канал: таймаут при ожидании результата fetch_many"
+                self._logger.info(msg)
+                ohlcv_result = {symbol: msg for symbol in symbols}
+
+            try:
+                oi_result = oi_future.result(timeout=self._request_timeout_seconds)
+            except TimeoutError:
+                oi_future.cancel()
+                msg = "OI канал: таймаут при ожидании результата fetch_many"
+                self._logger.info(msg)
+                oi_result = {symbol: msg for symbol in symbols}
 
         market_caps = self.fetch_market_caps(symbols)
         self._logger.info("Загрузка завершена")


### PR DESCRIPTION
### Motivation
- Избежать падения всего процесса при таймауте одного из параллельных каналов (OHLCV или OI). 
- Обеспечить продолжение обработки второго канала и вызова `fetch_market_caps` даже при частичном провале одного канала. 
- Сохранить согласованную структуру возвращаемого `FetchAllResult` и типовую целостность полей при частичных сбоях.

### Description
- В `MarketDataFetcher.fetch_all` добавлены явные аннотации типов `ohlcv_result` и `oi_result` как `dict[str, int | str]` для гарантии совместимости типов. 
- Обёрнуты вызовы `ohlcv_future.result(...)` и `oi_future.result(...)` отдельно в `try/except TimeoutError` блоки. 
- При таймауте соответствующий `future` отменяется, логируется канал с явной причиной (`OHLCV` или `OI`), и формируется fallback-словарь по всем символам с сообщением об ошибке. 
- Поток выполнения продолжается к вызову `fetch_market_caps`, и в итоге всегда возвращается `FetchAllResult` с консистентными полями `ohlcv`, `open_interest` и `market_caps`.

### Testing
- Запущена проверка компиляции файла командой `python -m compileall data/fetchers/market_data_fetcher.py`, которая прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987930088a4832097ef76dca2349069)