### PR TITLE
Restrict OI alignment and updates to the fetch interval

### DIFF
--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -66,10 +66,22 @@ class OiFetcher:
         data = self._aligner.align_to_utc(data)
         data = self._deduplicator.deduplicate(data)
 
+        next_start_ms = int(next_start.timestamp() * 1000)
+        end_time_ms = int(end_time.timestamp() * 1000)
+        interval_mask = (data["timestamp"] >= next_start_ms) & (data["timestamp"] <= end_time_ms)
+        data = data.loc[interval_mask].copy()
+
         ohlcv = self._storage.load(symbol, timeframe)
         if not ohlcv.empty and "timestamp" in ohlcv.columns:
-            aligned = self._oi_aligner.align(ohlcv[["timestamp"]], data)
-            data = aligned[["timestamp", "open_interest"]]
+            ohlcv_interval = ohlcv.loc[
+                (ohlcv["timestamp"] >= next_start_ms) & (ohlcv["timestamp"] <= end_time_ms), ["timestamp"]
+            ].copy()
+            if not ohlcv_interval.empty:
+                aligned = self._oi_aligner.align(ohlcv_interval, data)
+                data = aligned[["timestamp", "open_interest"]]
+
+        if not data.empty and "timestamp" in data.columns:
+            data = data.loc[(data["timestamp"] >= next_start_ms) & (data["timestamp"] <= end_time_ms)].copy()
 
         issues = self._validator.validate(symbol, timeframe, data)
         if issues:


### PR DESCRIPTION
### Motivation
- Избежать перезаписи старых значений OI за пределами окна инкрементальной загрузки и сделать выравнивание OI детерминированным по загруженному интервалу.
- Ускорить и упростить выравнивание путём привязки только к OHLCV-таймстампам внутри окна загрузки.
- Предотвратить ошибочные действия, если в OHLCV-кэше нет рядов внутри окна обновления.

### Description
- В `OiFetcher.fetch_symbol` добавлена конвертация `next_start`/`end_time` в миллисекунды и фильтрация загруженных OI сразу после `align_to_utc` и `deduplicate` по интервалу `next_start..end_time` (файл `data/fetchers/oi_fetcher.py`).
- Выравнивание через `self._oi_aligner.align(...)` теперь выполняется только на срезе OHLCV, ограниченном тем же интервалом, вместо всего кэша OHLCV.
- Добавлена защита: если OHLCV-срез пустой, выравнивание не выполняется и используется исходный путь данных после `align_to_utc`/`deduplicate`.
- Перед вызовом `save_incremental` данные дополнительно фильтруются по интервалу, чтобы сохранялись только реально обновляемые строки.

### Testing
- Выполнена компиляция модуля с помощью `python -m compileall data/fetchers/oi_fetcher.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69879483e7248320bea4478627eb0ec9)