### PR TITLE
Уточнить детекцию stale-series для OI после выравнивания

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -262,6 +262,8 @@ def _make_report_inner(config: AppConfig, args: argparse.Namespace) -> int:
 
 
 def _collect_oi_alignment_issues(frame: pd.DataFrame) -> list[dict[str, str]]:
+    min_stale_observations = 3
+
     if "open_interest" not in frame.columns:
         return [
             {
@@ -296,7 +298,16 @@ def _collect_oi_alignment_issues(frame: pd.DataFrame) -> list[dict[str, str]]:
                     }
                 )
 
-        stale_ratio = (oi.ffill().diff().fillna(0) == 0).mean()
+        aligned_oi = oi.ffill()
+        aligned_valid_mask = aligned_oi.notna()
+        comparison_mask = aligned_valid_mask & aligned_valid_mask.shift(1, fill_value=False)
+        compared_observations = int(comparison_mask.sum())
+
+        if compared_observations >= min_stale_observations:
+            stale_ratio = (aligned_oi.diff().eq(0) & comparison_mask).sum() / compared_observations
+        else:
+            stale_ratio = 0.0
+
         if stale_ratio > OI_STALE_RATIO_THRESHOLD:
             issues.append(
                 {


### PR DESCRIPTION
### Motivation
- Устранить ложные срабатывания при детекции почти неизменного `open_interest` за счёт учёта только сопоставимых точек после выравнивания и исключения участков, где OI остаётся неопределённым даже после `ffill`.

### Description
- В функцию `_collect_oi_alignment_issues` добавлен порог `min_stale_observations = 3` и переработано вычисление: используется `aligned_oi = oi.ffill()`, строится `comparison_mask` только для точек, где текущая и предыдущая значения определены, `stale_ratio` считается как доля нулевых дельт среди этих сравнений, при недостаточном числе сравнений `stale_ratio` равен 0, при этом тип и severity остаются `QUALITY_OI_ALIGNMENT_STALE_SERIES_ISSUE`.

### Testing
- Выполнен `python -m compileall cli/commands.py`, компиляция прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698795164b8c832091b623b17fa201a1)