### PR TITLE
Validate required columns for make-report CSV input

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -214,6 +214,21 @@ def _make_report_inner(config: AppConfig, args: argparse.Namespace) -> int:
         return 1
 
     frame = pd.read_csv(csv_path)
+    required_columns = [
+        "trades_count",
+        "profit_factor",
+        "lookback",
+        "volume_mult",
+        "sl_count",
+        "be_count",
+        "tp1_be_count",
+        "tp2_count",
+    ]
+    missing_columns = [column for column in required_columns if column not in frame.columns]
+    if missing_columns:
+        logger.error("make-report: отсутствуют обязательные колонки: %s", ", ".join(missing_columns))
+        return 1
+
     if frame.empty:
         logger.info("make-report: пустой файл результатов")
         return 1


### PR DESCRIPTION
### Motivation
- Ensure `make-report` handles invalid CSV inputs gracefully by detecting missing mandatory columns, logging which fields are absent, and returning exit code `1` instead of raising an exception.

### Description
- In `_make_report_inner`, immediately after `pd.read_csv` add a check for required columns `trades_count`, `profit_factor`, `lookback`, `volume_mult`, `sl_count`, `be_count`, `tp1_be_count`, and `tp2_count`, and if any are missing log them via `logger.error(...)` and return `1`, preserving the existing report-generation pipeline for valid CSV files.

### Testing
- Ran `python -m py_compile cli/commands.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698795b136c48320a4bda5bf1aa15490)