### PR TITLE
Coerce numeric columns in data validator and add invalid-series issues

### DIFF
--- a/data/quality/data_validator.py
+++ b/data/quality/data_validator.py
@@ -22,6 +22,11 @@ class DataValidator:
         normalized = data.reset_index(drop=True)
         issues: list[DataQualityIssue] = []
         ts = pd.to_datetime(normalized["timestamp"], unit="ms", utc=True, errors="coerce")
+        numeric_columns = {
+            col: pd.to_numeric(normalized[col], errors="coerce")
+            for col in ("open", "high", "low", "close", "volume", "open_interest")
+            if col in normalized.columns
+        }
 
         def add_issue(pos: int, issue_type: str, severity: DataQualitySeverity, description: str) -> None:
             if pd.isna(ts.iloc[pos]):
@@ -39,8 +44,8 @@ class DataValidator:
             )
 
         for col in ("open", "high", "low", "close"):
-            if col in normalized.columns:
-                bad = normalized[col] < 0
+            if col in numeric_columns:
+                bad = numeric_columns[col] < 0
                 for pos in normalized.index[bad.fillna(False)]:
                     add_issue(int(pos), "negative_price", DataQualitySeverity.CRITICAL, f"Negative {col} value")
 
@@ -49,14 +54,14 @@ class DataValidator:
             "open_interest": "negative_open_interest",
         }
         for col, issue_type in issue_type_by_column.items():
-            if col in normalized.columns:
-                bad = normalized[col] < 0
+            if col in numeric_columns:
+                bad = numeric_columns[col] < 0
                 for pos in normalized.index[bad.fillna(False)]:
                     add_issue(int(pos), issue_type, DataQualitySeverity.ERROR, f"Negative {col} value")
 
-        if {"high", "low", "close"}.issubset(normalized.columns):
-            spread = (normalized["high"] - normalized["low"]).abs()
-            base = normalized["close"].abs().replace(0, pd.NA)
+        if {"high", "low", "close"}.issubset(numeric_columns):
+            spread = (numeric_columns["high"] - numeric_columns["low"]).abs()
+            base = numeric_columns["close"].abs().replace(0, pd.NA)
             ratio = spread / base
             suspicious = ratio > SPREAD_TO_CLOSE_WARNING_THRESHOLD
             for pos in normalized.index[suspicious.fillna(False)]:
@@ -68,9 +73,21 @@ class DataValidator:
                     f"Spread exceeds {threshold_pct}% of close",
                 )
 
-        if "volume" in normalized.columns:
-            zero_volume = normalized["volume"] == 0
+        if "volume" in numeric_columns:
+            zero_volume = numeric_columns["volume"] == 0
             for pos in normalized.index[zero_volume.fillna(False)]:
                 add_issue(int(pos), "zero_volume", DataQualitySeverity.INFO, "Zero candle volume")
+
+        for col, series in numeric_columns.items():
+            if series.notna().sum() == 0:
+                valid_ts_positions = normalized.index[ts.notna()]
+                if len(valid_ts_positions) == 0:
+                    continue
+                add_issue(
+                    int(valid_ts_positions[0]),
+                    f"invalid_{col}_series",
+                    DataQualitySeverity.ERROR,
+                    f"Column {col} could not be parsed as numeric values",
+                )
 
         return issues


### PR DESCRIPTION
### Motivation
- Ensure numeric checks operate on proper numeric types even when input columns contain mixed or invalid data. 
- Make `suspicious_spread` calculation resilient to non-numeric inputs so ratio math does not raise exceptions. 
- Surface cases where a present column cannot be parsed to numbers at all so they can be triaged.

### Description
- Convert `open`, `high`, `low`, `close`, `volume`, and `open_interest` to numeric once at the start of `DataValidator.validate` using `pd.to_numeric(..., errors='coerce')` and store them in `numeric_columns`. 
- Run negative-value, zero-volume, and spread checks against the coerced series and preserve the existing use of boolean masks with `.fillna(False)` for safe indexing. 
- Compute `suspicious_spread` using the coerced `high`, `low`, and `close` series so the ratio calculation is robust to invalid inputs. 
- Add generation of `invalid_<column>_series` issues when a column is present but all values become `NaN` after coercion, anchoring the issue to the first row with a valid timestamp.

### Testing
- Compiled the modified file with `python -m compileall data/quality/data_validator.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69879c417ff88320a685d1a81960a555)