### PR TITLE
Handle missing and invalid timestamp series in DataValidator

### DIFF
--- a/data/quality/data_validator.py
+++ b/data/quality/data_validator.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import timezone
+from datetime import datetime, timezone
 
 import pandas as pd
 
@@ -16,12 +16,41 @@ class DataValidator:
     """Validate common anomalies in OHLCV/OI data."""
 
     def validate(self, symbol: str, timeframe: Timeframe, data: pd.DataFrame) -> list[DataQualityIssue]:
-        if data.empty or "timestamp" not in data.columns:
+        if data.empty:
             return []
 
         normalized = data.reset_index(drop=True)
         issues: list[DataQualityIssue] = []
+
+        def add_dataset_issue(issue_type: str, severity: DataQualitySeverity, description: str) -> None:
+            issues.append(
+                DataQualityIssue(
+                    symbol=symbol,
+                    timeframe=timeframe,
+                    issue_type=issue_type,
+                    severity=severity,
+                    timestamp=datetime.fromtimestamp(0, tz=timezone.utc),
+                    description=description,
+                )
+            )
+
+        if "timestamp" not in normalized.columns:
+            add_dataset_issue(
+                "missing_timestamp_column",
+                DataQualitySeverity.ERROR,
+                "Отсутствует колонка timestamp: данные нельзя валидировать по времени, дальнейшие проверки остановлены.",
+            )
+            return issues
+
         ts = pd.to_datetime(normalized["timestamp"], unit="ms", utc=True, errors="coerce")
+        if ts.notna().sum() == 0:
+            add_dataset_issue(
+                "invalid_timestamp_series",
+                DataQualitySeverity.ERROR,
+                "Колонка timestamp не распознана (все значения NaT): данные нельзя валидировать по времени, дальнейшие проверки остановлены.",
+            )
+            return issues
+
         numeric_columns = {
             col: pd.to_numeric(normalized[col], errors="coerce")
             for col in ("open", "high", "low", "close", "volume", "open_interest")


### PR DESCRIPTION
### Motivation
- Ensure dataset-level timestamp problems are reported as explicit `DataQualityIssue` records instead of silently returning no issues, so they appear in quality reports and trigger follow-up actions.
- Provide clear descriptions that make it obvious why further validation cannot proceed when timestamps are absent or entirely unparseable.

### Description
- Added a dataset-level helper `add_dataset_issue` and emit `missing_timestamp_column` (severity `ERROR`) when the `timestamp` column is absent. 
- Emit `invalid_timestamp_series` (severity `ERROR`) when `pd.to_datetime(..., errors='coerce')` yields only `NaT`, and stop further row-level checks in that case. 
- Use a deterministic UTC timestamp for dataset-level issues so `DataQualityIssue` instances are valid and included in reports. 
- Verified that `check-quality` aggregation already collects arbitrary `issue_type` and `severity` values via `Counter`, so new issue types flow into `summary.by_issue_type` and `summary.by_severity` without further code changes.

### Testing
- Compiled changed modules with `python -m compileall data/quality/data_validator.py cli/commands.py` and compilation succeeded. 
- Inspected `cli/commands.py` `_check_quality_inner` to confirm new issues are counted into `issues_by_type` and `issues_by_severity` (aggregation via `Counter`), and no additional code changes were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69879de9146483208e0dc25212e1f7a0)