### PR TITLE
Разделение soft/hard таймаутов в fetch-координаторах

### DIFF
--- a/data/fetchers/market_data_fetcher.py
+++ b/data/fetchers/market_data_fetcher.py
@@ -127,24 +127,25 @@ class MarketDataFetcher:
                 ),
             }
             start_times = {name: monotonic() for name in channels}
+            soft_timeout_logged: set[str] = set()
             pending = set(channels)
             channel_results: dict[str, dict[str, int | str]] = {}
+            deadline = monotonic() + channel_timeout_seconds
 
             while pending:
                 now = monotonic()
-                expired = [
-                    name
-                    for name in pending
-                    if now - start_times[name] > channel_timeout_seconds
-                ]
-                for name in expired:
-                    pending.remove(name)
-                    channels[name].cancel()
+                soft_expired = [name for name in pending if now - start_times[name] > channel_timeout_seconds]
+                for name in soft_expired:
+                    if name in soft_timeout_logged:
+                        continue
                     channel_label = "OHLCV" if name == "ohlcv" else "OI"
-                    msg = f"{channel_label} канал: пер-канальный таймаут fetch_many"
+                    msg = f"{channel_label} канал: soft-timeout fetch_many"
                     self._logger.info(msg)
-                    if graceful_fallback:
-                        channel_results[name] = {symbol: msg for symbol in symbols}
+
+                    soft_timeout_logged.add(name)
+
+                if now >= deadline:
+                    break
 
                 completed = []
                 for name in list(pending):
@@ -171,6 +172,45 @@ class MarketDataFetcher:
                             break
                     except TimeoutError:
                         continue
+
+            hard_timed_out: list[str] = []
+            for name in list(pending):
+                future = channels[name]
+                channel_label = "OHLCV" if name == "ohlcv" else "OI"
+                try:
+                    cancelled = future.cancel()
+                except Exception:  # noqa: BLE001
+                    cancelled = False
+
+                if cancelled:
+                    pending.remove(name)
+                    msg = f"{channel_label} канал: hard-timeout fetch_many"
+                    self._logger.info(msg)
+                    if graceful_fallback:
+                        channel_results[name] = {symbol: msg for symbol in symbols}
+                    continue
+
+                hard_timed_out.append(name)
+
+            for future in as_completed([channels[name] for name in hard_timed_out]):
+                name = "ohlcv" if future is channels["ohlcv"] else "oi"
+                if name in pending:
+                    pending.remove(name)
+                channel_label = "OHLCV" if name == "ohlcv" else "OI"
+                try:
+                    channel_results[name] = future.result()
+                except Exception as exc:  # noqa: BLE001
+                    msg = f"{channel_label} канал: ошибка исполнения fetch_many: {exc}"
+                    self._logger.info(msg)
+                    if graceful_fallback:
+                        channel_results[name] = {symbol: msg for symbol in symbols}
+
+            for name in pending:
+                channel_label = "OHLCV" if name == "ohlcv" else "OI"
+                msg = f"{channel_label} канал: hard-timeout fetch_many"
+                self._logger.info(msg)
+                if graceful_fallback:
+                    channel_results[name] = {symbol: msg for symbol in symbols}
 
             ohlcv_result = channel_results.get("ohlcv", {}) if graceful_fallback else channel_results["ohlcv"]
             oi_result = channel_results.get("oi", {}) if graceful_fallback else channel_results["oi"]

--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -92,42 +92,79 @@ class OhlcvFetcher:
                 executor.submit(self.fetch_symbol, s, timeframe, start_time, end_time): s for s in symbols
             }
             start_times = {future: monotonic() for future in futures}
+            soft_timeout_logged: set = set()
             pending = set(futures)
+            deadline = monotonic() + self._request_timeout_seconds
 
             while pending:
                 now = monotonic()
-                expired = [
-                    future
-                    for future in pending
-                    if now - start_times[future] > self._request_timeout_seconds
-                ]
-                for future in expired:
-                    pending.remove(future)
+                soft_expired = [future for future in pending if now - start_times[future] > self._request_timeout_seconds]
+                for future in soft_expired:
+                    if future in soft_timeout_logged:
+                        continue
                     symbol = futures[future]
-                    msg = f"OHLCV таймаут задачи: {symbol}"
+                    msg = f"OHLCV soft-timeout задачи: {symbol}"
                     self._logger.info(msg)
-                    results[symbol] = msg
-                    future.cancel()
 
-                if not pending:
+                    soft_timeout_logged.add(future)
+
+                if now >= deadline:
                     break
 
+                completed: list = []
                 try:
                     for future in as_completed(pending, timeout=poll_timeout_seconds):
-                        pending.remove(future)
-                        symbol = futures[future]
-                        try:
-                            results[symbol] = future.result()
-                        except Exception as exc:  # noqa: BLE001
-                            msg = f"OHLCV ошибка исполнения: {symbol}: {exc}"
-                            self._logger.info(msg)
-                            results[symbol] = msg
+                        completed.append(future)
                 except TimeoutError:
                     continue
 
+                for future in completed:
+                    pending.remove(future)
+                    symbol = futures[future]
+                    try:
+                        results[symbol] = future.result()
+                    except Exception as exc:  # noqa: BLE001
+                        msg = f"OHLCV ошибка исполнения: {symbol}: {exc}"
+                        self._logger.info(msg)
+                        results[symbol] = msg
+
+            hard_timed_out: list = []
+            for future in list(pending):
+                symbol = futures[future]
+                try:
+                    cancelled = future.cancel()
+                except Exception:  # noqa: BLE001
+                    cancelled = False
+
+                if cancelled:
+                    pending.remove(future)
+                    msg = f"OHLCV hard-timeout задачи: {symbol}"
+                    self._logger.info(msg)
+                    results[symbol] = msg
+                    continue
+
+                hard_timed_out.append(future)
+
+            for future in as_completed(hard_timed_out):
+                if future in pending:
+                    pending.remove(future)
+                symbol = futures[future]
+                try:
+                    results[symbol] = future.result()
+                except Exception as exc:  # noqa: BLE001
+                    msg = f"OHLCV ошибка исполнения: {symbol}: {exc}"
+                    self._logger.info(msg)
+                    results[symbol] = msg
+
+            for future in pending:
+                symbol = futures[future]
+                msg = f"OHLCV hard-timeout задачи: {symbol}"
+                self._logger.info(msg)
+                results[symbol] = msg
+
         for symbol in symbols:
             if symbol not in results:
-                msg = f"OHLCV таймаут задачи: {symbol}"
+                msg = f"OHLCV hard-timeout задачи: {symbol}"
                 self._logger.info(msg)
                 results[symbol] = msg
 

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -120,42 +120,79 @@ class OiFetcher:
                 executor.submit(self.fetch_symbol, s, timeframe, start_time, end_time): s for s in symbols
             }
             start_times = {future: monotonic() for future in futures}
+            soft_timeout_logged: set = set()
             pending = set(futures)
+            deadline = monotonic() + self._request_timeout_seconds
 
             while pending:
                 now = monotonic()
-                expired = [
-                    future
-                    for future in pending
-                    if now - start_times[future] > self._request_timeout_seconds
-                ]
-                for future in expired:
-                    pending.remove(future)
+                soft_expired = [future for future in pending if now - start_times[future] > self._request_timeout_seconds]
+                for future in soft_expired:
+                    if future in soft_timeout_logged:
+                        continue
                     symbol = futures[future]
-                    msg = f"OI таймаут задачи: {symbol}"
+                    msg = f"OI soft-timeout задачи: {symbol}"
                     self._logger.info(msg)
-                    results[symbol] = msg
-                    future.cancel()
 
-                if not pending:
+                    soft_timeout_logged.add(future)
+
+                if now >= deadline:
                     break
 
+                completed: list = []
                 try:
                     for future in as_completed(pending, timeout=poll_timeout_seconds):
-                        pending.remove(future)
-                        symbol = futures[future]
-                        try:
-                            results[symbol] = future.result()
-                        except Exception as exc:  # noqa: BLE001
-                            msg = f"OI ошибка исполнения: {symbol}: {exc}"
-                            self._logger.info(msg)
-                            results[symbol] = msg
+                        completed.append(future)
                 except TimeoutError:
                     continue
 
+                for future in completed:
+                    pending.remove(future)
+                    symbol = futures[future]
+                    try:
+                        results[symbol] = future.result()
+                    except Exception as exc:  # noqa: BLE001
+                        msg = f"OI ошибка исполнения: {symbol}: {exc}"
+                        self._logger.info(msg)
+                        results[symbol] = msg
+
+            hard_timed_out: list = []
+            for future in list(pending):
+                symbol = futures[future]
+                try:
+                    cancelled = future.cancel()
+                except Exception:  # noqa: BLE001
+                    cancelled = False
+
+                if cancelled:
+                    pending.remove(future)
+                    msg = f"OI hard-timeout задачи: {symbol}"
+                    self._logger.info(msg)
+                    results[symbol] = msg
+                    continue
+
+                hard_timed_out.append(future)
+
+            for future in as_completed(hard_timed_out):
+                if future in pending:
+                    pending.remove(future)
+                symbol = futures[future]
+                try:
+                    results[symbol] = future.result()
+                except Exception as exc:  # noqa: BLE001
+                    msg = f"OI ошибка исполнения: {symbol}: {exc}"
+                    self._logger.info(msg)
+                    results[symbol] = msg
+
+            for future in pending:
+                symbol = futures[future]
+                msg = f"OI hard-timeout задачи: {symbol}"
+                self._logger.info(msg)
+                results[symbol] = msg
+
         for symbol in symbols:
             if symbol not in results:
-                msg = f"OI таймаут задачи: {symbol}"
+                msg = f"OI hard-timeout задачи: {symbol}"
                 self._logger.info(msg)
                 results[symbol] = msg
 


### PR DESCRIPTION
### Motivation
- Устранить преждевременное снятие задач с учёта при наступлении soft-timeout и избежать ложных сообщений «таймаут задачи». 
- Чётко разграничить поведение soft-timeout (логировать и продолжать отслеживать) и hard-timeout (после общего дедлайна считать задачу проваленной и собрать финальный результат). 
- Не полагаться на `future.cancel()` как на гарантию остановки; для уже выполняющихся задач дождаться их `done()`/`result()` и корректно обработать ошибки. 

### Description
- В `OhlcvFetcher.fetch_many` и `OiFetcher.fetch_many` добавлена логика soft-timeout: при превышении локального порога теперь логируется soft-timeout, future остаётся в `pending` и продолжает отслеживаться. 
- В тех же методах введён единственный общий дедлайн (hard-timeout), после которого выполняется попытка `future.cancel()` и для незаканчивающихся задач ожидается их реальный исход через `future.result()`; `results[symbol]` формируется один раз по финальному исходу (успех/ошибка/реальный timeout). 
- Сообщения логирования разделены на `soft-timeout` и `hard-timeout`, и добавлена вспомогательная структура `soft_timeout_logged` чтобы не дублировать предупреждения. 
- Аналогичное разделение soft/hard таймаутов применено в `MarketDataFetcher.fetch_all` для пер-канального контроля, чтобы не возвращать fallback на этапе soft-timeout пока канал ещё может завершиться успешно. 

### Testing
- Скомпилированы изменённые модули командой `python -m compileall data/fetchers/ohlcv_fetcher.py data/fetchers/oi_fetcher.py data/fetchers/market_data_fetcher.py` и компиляция прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69879f21e04c8320afc9321ccd71fb97)