### PR TITLE
Unify CoinGecko canonical symbol keys across cache and id lookup

### DIFF
--- a/data/clients/coingecko_client.py
+++ b/data/clients/coingecko_client.py
@@ -57,6 +57,10 @@ class CoinGeckoClient(MarketDataClient):
             .replace(SIMULATION_COIN_SUFFIX_USDT, "")
         )
 
+    @classmethod
+    def _canonical_symbol_key(cls, symbol: str) -> str:
+        return cls._normalize_symbol(symbol).upper()
+
     def _load_market_cap_cache(self) -> None:
         if self._cache_path is None or not self._cache_path.exists():
             return
@@ -75,6 +79,9 @@ class CoinGeckoClient(MarketDataClient):
                 symbol = row.symbol
                 if not isinstance(symbol, str) or not symbol:
                     continue
+                canonical_symbol = self._canonical_symbol_key(symbol)
+                if not canonical_symbol:
+                    continue
 
                 expires_at_dt = pd.Timestamp(row.expires_at)
                 if pd.isna(expires_at_dt):
@@ -89,11 +96,11 @@ class CoinGeckoClient(MarketDataClient):
                 if expires_at <= now:
                     continue
 
-                loaded_cache[symbol.upper()] = (float(row.market_cap), expires_at)
+                loaded_cache[canonical_symbol] = (float(row.market_cap), expires_at)
                 if has_coin_id:
                     coin_id = str(row.coin_id or "")
                     if coin_id:
-                        self._symbol_to_id[self._normalize_symbol(symbol)] = coin_id
+                        self._symbol_to_id[canonical_symbol] = coin_id
 
             self._market_cap_cache = loaded_cache
         except (OSError, ValueError, TypeError) as exc:
@@ -109,7 +116,7 @@ class CoinGeckoClient(MarketDataClient):
                 "symbol": symbol,
                 "market_cap": market_cap,
                 "expires_at": pd.Timestamp(expires_at).tz_convert(timezone.utc),
-                "coin_id": self._symbol_to_id.get(self._normalize_symbol(symbol), ""),
+                "coin_id": self._symbol_to_id.get(symbol, ""),
             }
             for symbol, (market_cap, expires_at) in self._market_cap_cache.items()
         ]
@@ -190,8 +197,9 @@ class CoinGeckoClient(MarketDataClient):
 
     def _resolve_coin_id(self, symbol: str) -> str:
         normalized = self._normalize_symbol(symbol)
-        if normalized in self._symbol_to_id:
-            return self._symbol_to_id[normalized]
+        canonical_symbol = self._canonical_symbol_key(symbol)
+        if canonical_symbol in self._symbol_to_id:
+            return self._symbol_to_id[canonical_symbol]
 
         response = requests.get(
             f"{self.BASE_URL}/coins/list",
@@ -273,17 +281,17 @@ class CoinGeckoClient(MarketDataClient):
                 f"Unable to resolve CoinGecko ID for symbol '{symbol}' (normalized='{normalized}') from candidates: {candidates}"
             )
 
-        self._symbol_to_id[normalized] = selected["id"]
+        self._symbol_to_id[canonical_symbol] = selected["id"]
 
-        return self._symbol_to_id[normalized]
+        return self._symbol_to_id[canonical_symbol]
 
     # endregion Private
 
     def get_market_cap(self, symbol: str) -> float:
-        normalized = symbol.upper()
+        canonical_symbol = self._canonical_symbol_key(symbol)
         now = datetime.now(tz=timezone.utc)
 
-        cached = self._market_cap_cache.get(normalized)
+        cached = self._market_cap_cache.get(canonical_symbol)
         if cached and cached[1] > now:
             return cached[0]
 
@@ -306,7 +314,7 @@ class CoinGeckoClient(MarketDataClient):
             raise ValueError(f"CoinGecko returned empty market data for symbol: {symbol}")
 
         market_cap = float(payload[0].get("market_cap") or 0.0)
-        self._market_cap_cache[normalized] = (market_cap, now + self._cache_ttl)
+        self._market_cap_cache[canonical_symbol] = (market_cap, now + self._cache_ttl)
         self._save_market_cap_cache()
         return market_cap
 


### PR DESCRIPTION
### Motivation
- Сейчас ключи для символов кэша и сопоставления `coin_id` приходят в разных форматах, что ведёт к дублированию записей для одного актива и проблемам при чтении/записи parquet-кэша.
- Цель изменений — ввести единый canonical-формат ключа символа, чтобы lookup, запись в `_market_cap_cache` и сериализация использовали один и тот же ключ.

### Description
- Добавлен метод `@classmethod _canonical_symbol_key` который строится на ` _normalize_symbol` и приводит результат к верхнему регистру, и он теперь используется как единый canonical key для всех операций. 
- В `get_market_cap` чтение и запись в `_market_cap_cache` унифицировано на использование `canonical_symbol` вместо ряда альтернатив (раньше использовалось `symbol.upper()`).
- В `_load_market_cap_cache` реализована «мягкая миграция`: при загрузке parquet-строк `symbol` приводится к `canonical_symbol` и затем применяется к `_market_cap_cache` и `_symbol_to_id`, чтобы корректно преобразовать старые/legacy-ключи.
- В `_save_market_cap_cache` сериализация теперь записывает записи по ключам из `_market_cap_cache` (т.е. по canonical key) и берёт `coin_id` по тому же canonical-формату, а в `_resolve_coin_id` кеш `_symbol_to_id` чтение/запись приведено к тому же canonical-формату.

### Testing
- Выполнена компиляция файла с помощью `python -m py_compile data/clients/coingecko_client.py`, которая прошла успешно.
- Никаких новых автоматизированных тестов не было добавлено или изменено.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987a0e4463c83209793ca797493f866)