### PR TITLE
Avoid blocking waits for hard-timeout fetch tasks

### DIFF
--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -87,7 +87,8 @@ class OhlcvFetcher:
     ) -> dict[str, int | str]:
         results: dict[str, int | str] = {}
         poll_timeout_seconds = 0.5
-        with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
+        executor = ThreadPoolExecutor(max_workers=self._max_workers)
+        try:
             futures = {
                 executor.submit(self.fetch_symbol, s, timeframe, start_time, end_time): s for s in symbols
             }
@@ -128,39 +129,37 @@ class OhlcvFetcher:
                         self._logger.info(msg)
                         results[symbol] = msg
 
-            hard_timed_out: list = []
             for future in list(pending):
                 symbol = futures[future]
+                if future.done():
+                    pending.remove(future)
+                    try:
+                        results[symbol] = future.result()
+                    except Exception as exc:  # noqa: BLE001
+                        msg = f"OHLCV ошибка исполнения: {symbol}: {exc}"
+                        self._logger.info(msg)
+                        results[symbol] = msg
+                    continue
+
                 try:
                     cancelled = future.cancel()
                 except Exception:  # noqa: BLE001
                     cancelled = False
 
-                if cancelled:
+                if future in pending:
                     pending.remove(future)
+
+                if cancelled:
                     msg = f"OHLCV hard-timeout задачи: {symbol}"
                     self._logger.info(msg)
                     results[symbol] = msg
                     continue
 
-                hard_timed_out.append(future)
-
-            for future in as_completed(hard_timed_out):
-                if future in pending:
-                    pending.remove(future)
-                symbol = futures[future]
-                try:
-                    results[symbol] = future.result()
-                except Exception as exc:  # noqa: BLE001
-                    msg = f"OHLCV ошибка исполнения: {symbol}: {exc}"
-                    self._logger.info(msg)
-                    results[symbol] = msg
-
-            for future in pending:
-                symbol = futures[future]
                 msg = f"OHLCV hard-timeout задачи: {symbol}"
                 self._logger.info(msg)
                 results[symbol] = msg
+        finally:
+            executor.shutdown(wait=False, cancel_futures=True)
 
         for symbol in symbols:
             if symbol not in results:

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -115,7 +115,8 @@ class OiFetcher:
     ) -> dict[str, int | str]:
         results: dict[str, int | str] = {}
         poll_timeout_seconds = 0.5
-        with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
+        executor = ThreadPoolExecutor(max_workers=self._max_workers)
+        try:
             futures = {
                 executor.submit(self.fetch_symbol, s, timeframe, start_time, end_time): s for s in symbols
             }
@@ -156,39 +157,37 @@ class OiFetcher:
                         self._logger.info(msg)
                         results[symbol] = msg
 
-            hard_timed_out: list = []
             for future in list(pending):
                 symbol = futures[future]
+                if future.done():
+                    pending.remove(future)
+                    try:
+                        results[symbol] = future.result()
+                    except Exception as exc:  # noqa: BLE001
+                        msg = f"OI ошибка исполнения: {symbol}: {exc}"
+                        self._logger.info(msg)
+                        results[symbol] = msg
+                    continue
+
                 try:
                     cancelled = future.cancel()
                 except Exception:  # noqa: BLE001
                     cancelled = False
 
-                if cancelled:
+                if future in pending:
                     pending.remove(future)
+
+                if cancelled:
                     msg = f"OI hard-timeout задачи: {symbol}"
                     self._logger.info(msg)
                     results[symbol] = msg
                     continue
 
-                hard_timed_out.append(future)
-
-            for future in as_completed(hard_timed_out):
-                if future in pending:
-                    pending.remove(future)
-                symbol = futures[future]
-                try:
-                    results[symbol] = future.result()
-                except Exception as exc:  # noqa: BLE001
-                    msg = f"OI ошибка исполнения: {symbol}: {exc}"
-                    self._logger.info(msg)
-                    results[symbol] = msg
-
-            for future in pending:
-                symbol = futures[future]
                 msg = f"OI hard-timeout задачи: {symbol}"
                 self._logger.info(msg)
                 results[symbol] = msg
+        finally:
+            executor.shutdown(wait=False, cancel_futures=True)
 
         for symbol in symbols:
             if symbol not in results:


### PR DESCRIPTION
### Motivation
- Long-running or hung worker calls caused `fetch_many` to block while waiting on `as_completed(hard_timed_out)`, delaying return when APIs hang. 
- The intent is to ensure `fetch_many` returns quickly after a request-level timeout and to mark straggling tasks as hard-timeout without waiting for them. 

### Description
- Replaced the blocking `as_completed(hard_timed_out)` phase with a non-blocking pass that first collects results from futures where `future.done()` is true and otherwise immediately treats remaining tasks as hard-timeout by logging `"... hard-timeout задачи: {symbol}"` and recording that value in `results` for both `OhlcvFetcher.fetch_many` and `OiFetcher.fetch_many`.
- Switched from `with ThreadPoolExecutor(...)` context manager to explicit `ThreadPoolExecutor(...)` with a `try/finally` and `executor.shutdown(wait=False, cancel_futures=True)` to avoid waiting on worker threads and to return control quickly if calls hang.
- Preserved existing soft-timeout logging and per-future exception handling, and ensured any completed futures are still collected before marking remaining tasks as hard-timeout.

### Testing
- Ran `python -m py_compile data/fetchers/ohlcv_fetcher.py data/fetchers/oi_fetcher.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987a208f2088320b65426eb505b1a91)