### PR TITLE
Refactor OHLCV fetch_many to sequential execution

### DIFF
--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -1,11 +1,9 @@
-"""OHLCV fetch coordinator with parallel processing and timeout controls."""
+"""OHLCV fetch coordinator with synchronous symbol processing."""
 
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
 from datetime import datetime
 from pathlib import Path
-from time import monotonic
 
 from constants import (
     DEFAULT_FETCHER_MAX_WORKERS,
@@ -86,84 +84,11 @@ class OhlcvFetcher:
         end_time: datetime,
     ) -> dict[str, int | str]:
         results: dict[str, int | str] = {}
-        poll_timeout_seconds = 0.5
-        executor = ThreadPoolExecutor(max_workers=self._max_workers)
-        try:
-            futures = {
-                executor.submit(self.fetch_symbol, s, timeframe, start_time, end_time): s for s in symbols
-            }
-            start_times = {future: monotonic() for future in futures}
-            soft_timeout_logged: set = set()
-            pending = set(futures)
-            deadline = monotonic() + self._request_timeout_seconds
-
-            while pending:
-                now = monotonic()
-                soft_expired = [future for future in pending if now - start_times[future] > self._request_timeout_seconds]
-                for future in soft_expired:
-                    if future in soft_timeout_logged:
-                        continue
-                    symbol = futures[future]
-                    msg = f"OHLCV soft-timeout задачи: {symbol}"
-                    self._logger.info(msg)
-
-                    soft_timeout_logged.add(future)
-
-                if now >= deadline:
-                    break
-
-                completed: list = []
-                try:
-                    for future in as_completed(pending, timeout=poll_timeout_seconds):
-                        completed.append(future)
-                except TimeoutError:
-                    continue
-
-                for future in completed:
-                    pending.remove(future)
-                    symbol = futures[future]
-                    try:
-                        results[symbol] = future.result()
-                    except Exception as exc:  # noqa: BLE001
-                        msg = f"OHLCV ошибка исполнения: {symbol}: {exc}"
-                        self._logger.info(msg)
-                        results[symbol] = msg
-
-            for future in list(pending):
-                symbol = futures[future]
-                if future.done():
-                    pending.remove(future)
-                    try:
-                        results[symbol] = future.result()
-                    except Exception as exc:  # noqa: BLE001
-                        msg = f"OHLCV ошибка исполнения: {symbol}: {exc}"
-                        self._logger.info(msg)
-                        results[symbol] = msg
-                    continue
-
-                try:
-                    cancelled = future.cancel()
-                except Exception:  # noqa: BLE001
-                    cancelled = False
-
-                if future in pending:
-                    pending.remove(future)
-
-                if cancelled:
-                    msg = f"OHLCV hard-timeout задачи: {symbol}"
-                    self._logger.info(msg)
-                    results[symbol] = msg
-                    continue
-
-                msg = f"OHLCV hard-timeout задачи: {symbol}"
-                self._logger.info(msg)
-                results[symbol] = msg
-        finally:
-            executor.shutdown(wait=False, cancel_futures=True)
-
         for symbol in symbols:
-            if symbol not in results:
-                msg = f"OHLCV hard-timeout задачи: {symbol}"
+            try:
+                results[symbol] = self.fetch_symbol(symbol, timeframe, start_time, end_time)
+            except Exception as exc:  # noqa: BLE001
+                msg = f"OHLCV ошибка исполнения: {symbol}: {exc}"
                 self._logger.info(msg)
                 results[symbol] = msg
 


### PR DESCRIPTION
### Motivation
- Упростить и стабилизировать логику получения OHLCV, убрав сложную параллельную обработку с soft/hard таймаутами и отменой задач.
- Избавиться от неиспользуемых импортов и временных механизмов, которые больше не нужны после рефакторинга.
- Сохранить контракт метода `fetch_many` чтобы он возвращал по одному результату на символ в виде `dict[str, int | str]`.

### Description
- Заменён параллельный workflow в `OhlcvFetcher.fetch_many(...)` на простой последовательный цикл `for symbol in symbols:` и синхронный вызов `self.fetch_symbol(symbol, timeframe, start_time, end_time)`.
- Локальная обработка исключений для каждого символа через `except Exception as exc` сохранена с логированием в формате `OHLCV ошибка исполнения: ...` и записью строки-результата в `results[symbol]`.
- Удалёна вся логика, связанная с `futures/pending`, soft-timeout, hard-timeout, `cancel`, и связанные временные/пулы потоков.
- Удалены неиспользуемые импорты `ThreadPoolExecutor`, `TimeoutError`, `as_completed`, `monotonic` и обновлён docstring модуля; изменён файл `data/fetchers/ohlcv_fetcher.py`.

### Testing
- Выполнены базовые проверочные команды: вывод файла `sed -n '1,260p' data/fetchers/ohlcv_fetcher.py` и просмотр `git diff` для проверки изменений, оба шага завершились успешно.
- Команда коммита `git commit` прошла успешно и включила изменения в репозиторий.
- Полноценный автоматизированный тестовый прогон не запускался для этого рефактора.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987a31790008320a72ab02daa2a9463)