### PR TITLE
Disable multithreading in CLI runtime

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,27 @@
 
 from __future__ import annotations
 
+import os
+
 from cli.parser import build_parser, resolve_handler
 from config import load_config
 
 
+def _force_single_thread_mode() -> None:
+    """Disable library-level multithreading to avoid lockups/timeouts in long runs."""
+    single_thread_env = {
+        "OMP_NUM_THREADS": "1",
+        "OPENBLAS_NUM_THREADS": "1",
+        "MKL_NUM_THREADS": "1",
+        "VECLIB_MAXIMUM_THREADS": "1",
+        "NUMEXPR_NUM_THREADS": "1",
+    }
+    for key, value in single_thread_env.items():
+        os.environ[key] = value
+
+
 def main() -> int:
+    _force_single_thread_mode()
     config = load_config()
     parser = build_parser()
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- added `_force_single_thread_mode()` in `main.py`
- force-set thread-related environment variables (`OMP_NUM_THREADS`, `OPENBLAS_NUM_THREADS`, `MKL_NUM_THREADS`, `VECLIB_MAXIMUM_THREADS`, `NUMEXPR_NUM_THREADS`) to `1`
- invoke this setup at the start of `main()` before config/parser initialization

## Why
This removes implicit library-level multithreading to reduce risks of lock contention, hangs, and timeout-related instability during long data/backtest runs.

## Notes
- No tests were added (per request).
- Change is centralized in the CLI entrypoint so it applies consistently to all commands.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69882841034c8320a163bb611dfaa54c)