### PR TITLE
Remove private simulator hack in breakout strategy final close

### DIFF
--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -172,7 +172,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
 
         if sim.position is not None:
             final_row = prepared.iloc[-1]
-            trades.append(sim._finalize(self._to_candle(final_row), float(final_row["close"])))  # noqa: SLF001
+            final_time = datetime_to_timezone(final_row["datetime"].to_pydatetime(), self._simulation_timezone)
+            trades.append(sim.close_position(price=float(final_row["close"]), exit_time=final_time))
 
         return trades
 


### PR DESCRIPTION
## Summary
- replaced direct call to `StatefulPositionSimulator._finalize` in `BreakoutStrategy.generate_events`
- switched to public `close_position(price, exit_time)` API for end-of-data position closure
- removed the `# noqa: SLF001` workaround in strategy code

## Why
The strategy used a private simulator method (`_finalize`) to force-close an open position on the last candle. This is a fragile coupling and effectively a hack around class encapsulation.

Using the simulator's public `close_position` keeps behavior explicit and stable while preserving existing logic for trade-result classification.

## Changed file
- `strategy/breakout/breakout_strategy.py`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69882b1386c48320aa50387596d56467)