### PR TITLE
Add unified retry helper and wire retry config through fetch stack

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -99,29 +99,39 @@ def _build_fetch_stack(config: AppConfig) -> tuple[MarketDataFetcher, CcxtFuture
         exchange=Exchange.BINANCE,
         api_key=config.fetch.binance_api_key,
         secret=config.fetch.binance_secret_key,
+        retry_attempts=config.backtest.retry_attempts,
+        retry_backoff_seconds=config.backtest.retry_backoff_seconds,
     )
     storage = ParquetStorage(base_dir=config.backtest.cache_dir)
     ohlcv_fetcher = OhlcvFetcher(
         exchange_client=exchange_client,
         storage=storage,
+        retry_attempts=config.backtest.retry_attempts,
+        retry_backoff_seconds=config.backtest.retry_backoff_seconds,
         log_level=config.backtest.log_level,
         logs_dir=config.backtest.logs_dir,
     )
     oi_fetcher = OiFetcher(
         exchange_client=exchange_client,
         storage=storage,
+        retry_attempts=config.backtest.retry_attempts,
+        retry_backoff_seconds=config.backtest.retry_backoff_seconds,
         log_level=config.backtest.log_level,
         logs_dir=config.backtest.logs_dir,
     )
     market_client = CoinGeckoClient(
         api_key=config.fetch.coingecko_api_key,
         cache_path=market_caps_cache_path,
+        retry_attempts=config.backtest.retry_attempts,
+        retry_backoff_seconds=config.backtest.retry_backoff_seconds,
     )
     return (
         MarketDataFetcher(
             ohlcv_fetcher=ohlcv_fetcher,
             oi_fetcher=oi_fetcher,
             market_data_client=market_client,
+            retry_attempts=config.backtest.retry_attempts,
+            retry_backoff_seconds=config.backtest.retry_backoff_seconds,
             log_level=config.backtest.log_level,
             logs_dir=config.backtest.logs_dir,
         ),

--- a/data/clients/coingecko_client.py
+++ b/data/clients/coingecko_client.py
@@ -31,6 +31,7 @@ from constants import (
     SIMULATION_COIN_SUFFIX_USDT,
 )
 from domain.abstract.market_data_client import MarketDataClient
+from utils.retry import RetryExhaustedError, run_with_retry
 
 
 class CoinGeckoClient(MarketDataClient):
@@ -38,13 +39,22 @@ class CoinGeckoClient(MarketDataClient):
 
     BASE_URL = COINGECKO_BASE_URL
 
-    def __init__(self, api_key: str = "", cache_ttl_hours: int = 24, cache_path: str | Path | None = None) -> None:
+    def __init__(
+        self,
+        api_key: str = "",
+        cache_ttl_hours: int = 24,
+        cache_path: str | Path | None = None,
+        retry_attempts: int = 3,
+        retry_backoff_seconds: float = 1.0,
+    ) -> None:
         self._api_key = api_key
         self._cache_ttl = timedelta(hours=cache_ttl_hours)
         self._market_cap_cache: dict[str, tuple[float, datetime]] = {}
         self._symbol_to_id: dict[str, str] = {}
         self._cache_path = Path(cache_path) if cache_path else None
         self._logger = logging.getLogger(self.__class__.__name__)
+        self._retry_attempts = retry_attempts
+        self._retry_backoff_seconds = retry_backoff_seconds
         self._load_market_cap_cache()
 
     # region Private
@@ -144,13 +154,36 @@ class CoinGeckoClient(MarketDataClient):
             headers[COINGECKO_HEADER_API_KEY] = self._api_key
         return headers
 
+    def _request(self, endpoint: str, symbol: str, params: dict[str, str | int] | None = None) -> requests.Response:
+        def _perform_get() -> requests.Response:
+            response = requests.get(
+                url=f"{self.BASE_URL}{endpoint}",
+                headers=self._headers(),
+                params=params,
+                timeout=COINGECKO_TIMEOUT_SECONDS,
+            )
+            response.raise_for_status()
+            return response
+
+        try:
+            return run_with_retry(
+                operation="coingecko_get",
+                call=_perform_get,
+                attempts=self._retry_attempts,
+                backoff_seconds=self._retry_backoff_seconds,
+                retriable_exceptions=(requests.RequestException,),
+                logger=self._logger,
+                endpoint=endpoint,
+                symbol=symbol,
+                jitter_seconds=0.25,
+            )
+        except RetryExhaustedError as exc:
+            raise RuntimeError(
+                f"CoinGecko retry exhausted: endpoint={endpoint} symbol={symbol} attempts={self._retry_attempts}"
+            ) from exc
+
     def _candidate_has_usdt_market(self, coin_id: str, base_symbol: str) -> bool:
-        response = requests.get(
-            f"{self.BASE_URL}/coins/{coin_id}/tickers",
-            headers=self._headers(),
-            timeout=COINGECKO_TIMEOUT_SECONDS,
-        )
-        response.raise_for_status()
+        response = self._request(endpoint=f"/coins/{coin_id}/tickers", symbol=base_symbol)
         for ticker in response.json().get("tickers", []):
             base = str(ticker.get("base") or "").lower()
             target = str(ticker.get("target") or "").lower()
@@ -163,9 +196,9 @@ class CoinGeckoClient(MarketDataClient):
         if not candidate_ids:
             return None
 
-        response = requests.get(
-            f"{self.BASE_URL}/coins/markets",
-            headers=self._headers(),
+        response = self._request(
+            endpoint="/coins/markets",
+            symbol="multiple",
             params={
                 COINGECKO_VS_CURRENCY_KEY: COINGECKO_VS_CURRENCY_USD,
                 COINGECKO_PARAM_IDS: ",".join(candidate_ids),
@@ -173,9 +206,7 @@ class CoinGeckoClient(MarketDataClient):
                 COINGECKO_PARAM_PER_PAGE: len(candidate_ids),
                 COINGECKO_PARAM_PAGE: COINGECKO_DEFAULT_PAGE,
             },
-            timeout=COINGECKO_TIMEOUT_SECONDS,
         )
-        response.raise_for_status()
 
         metrics_by_id = {
             str(item.get("id") or ""): item
@@ -201,12 +232,7 @@ class CoinGeckoClient(MarketDataClient):
         if canonical_symbol in self._symbol_to_id:
             return self._symbol_to_id[canonical_symbol]
 
-        response = requests.get(
-            f"{self.BASE_URL}/coins/list",
-            headers=self._headers(),
-            timeout=COINGECKO_TIMEOUT_SECONDS,
-        )
-        response.raise_for_status()
+        response = self._request(endpoint="/coins/list", symbol=symbol)
         candidates = []
         for item in response.json():
             item_symbol = str(item.get("symbol") or "").lower()
@@ -296,9 +322,9 @@ class CoinGeckoClient(MarketDataClient):
             return cached[0]
 
         coin_id = self._resolve_coin_id(symbol)
-        response = requests.get(
-            f"{self.BASE_URL}/coins/markets",
-            headers=self._headers(),
+        response = self._request(
+            endpoint="/coins/markets",
+            symbol=symbol,
             params={
                 COINGECKO_VS_CURRENCY_KEY: COINGECKO_VS_CURRENCY_USD,
                 COINGECKO_PARAM_IDS: coin_id,
@@ -306,9 +332,7 @@ class CoinGeckoClient(MarketDataClient):
                 COINGECKO_PARAM_PER_PAGE: COINGECKO_DEFAULT_PAGE,
                 COINGECKO_PARAM_PAGE: COINGECKO_DEFAULT_PAGE,
             },
-            timeout=COINGECKO_TIMEOUT_SECONDS,
         )
-        response.raise_for_status()
         payload = response.json()
         if not payload:
             raise ValueError(f"CoinGecko returned empty market data for symbol: {symbol}")
@@ -319,9 +343,9 @@ class CoinGeckoClient(MarketDataClient):
         return market_cap
 
     def get_top_coins_by_market_cap(self, limit: int) -> list[str]:
-        response = requests.get(
-            f"{self.BASE_URL}/coins/markets",
-            headers=self._headers(),
+        response = self._request(
+            endpoint="/coins/markets",
+            symbol=f"top_{limit}",
             params={
                 COINGECKO_VS_CURRENCY_KEY: COINGECKO_VS_CURRENCY_USD,
                 COINGECKO_ORDER_KEY: COINGECKO_ORDER_MARKET_CAP_DESC,
@@ -329,8 +353,6 @@ class CoinGeckoClient(MarketDataClient):
                 COINGECKO_PARAM_PAGE: COINGECKO_DEFAULT_PAGE,
                 COINGECKO_PARAM_SPARKLINE: COINGECKO_SPARKLINE_FALSE,
             },
-            timeout=COINGECKO_TIMEOUT_SECONDS,
         )
-        response.raise_for_status()
 
         return [str(item.get("symbol") or "").upper() for item in response.json() if item.get("symbol")]

--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from typing import Any
 
@@ -20,6 +21,7 @@ from constants import (
 from domain.abstract.exchange_client import ExchangeClient
 from domain.enums.exchange import Exchange
 from domain.enums.timeframe import Timeframe
+from utils.retry import RetryExhaustedError, run_with_retry
 
 try:
     import ccxt  # type: ignore
@@ -60,11 +62,16 @@ class CcxtFuturesClient(ExchangeClient):
         secret: str = "",
         password: str = "",
         enable_rate_limit: bool = True,
+        retry_attempts: int = 3,
+        retry_backoff_seconds: float = 1.0,
     ) -> None:
         if ccxt is None:
             raise RuntimeError("ccxt is required for CcxtFuturesClient")
 
         self.exchange = Exchange(str(exchange).upper()) if isinstance(exchange, str) else exchange
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self._retry_attempts = retry_attempts
+        self._retry_backoff_seconds = retry_backoff_seconds
         self._client = self._build_client(exchange=self.exchange, api_key=api_key, secret=secret, password=password, enable_rate_limit=enable_rate_limit)
         self._client.load_markets()
 
@@ -89,6 +96,25 @@ class CcxtFuturesClient(ExchangeClient):
         raise ValueError(f"Unsupported exchange: {exchange}")
 
     # endregion Private
+
+    def _retry_exchange_call(self, operation: str, symbol: str, endpoint: str, call: Any, **kwargs: Any) -> Any:
+        try:
+            return run_with_retry(
+                operation=operation,
+                call=call,
+                attempts=self._retry_attempts,
+                backoff_seconds=self._retry_backoff_seconds,
+                retriable_exceptions=(Exception,),
+                logger=self._logger,
+                endpoint=endpoint,
+                symbol=symbol,
+                jitter_seconds=0.25,
+                **kwargs,
+            )
+        except RetryExhaustedError as exc:
+            raise RuntimeError(
+                f"Exchange retry exhausted: operation={operation} symbol={symbol} endpoint={endpoint} attempts={self._retry_attempts}"
+            ) from exc
 
     def get_futures_symbols(self) -> list[str]:
         symbols: list[str] = []
@@ -121,7 +147,15 @@ class CcxtFuturesClient(ExchangeClient):
 
         all_rows: list[list[float]] = []
         while since <= end_ms:
-            batch = self._client.fetch_ohlcv(symbol, timeframe=tf, since=since, limit=DEFAULT_FETCH_BATCH_SIZE)
+            batch = self._retry_exchange_call(
+                operation="ccxt_fetch_ohlcv",
+                symbol=symbol,
+                endpoint="fetch_ohlcv",
+                call=self._client.fetch_ohlcv,
+                timeframe=tf,
+                since=since,
+                limit=DEFAULT_FETCH_BATCH_SIZE,
+            )
             if not batch:
                 break
             all_rows.extend(batch)
@@ -150,15 +184,26 @@ class CcxtFuturesClient(ExchangeClient):
         rows: list[dict[str, Any]] = []
         while since <= end_ms:
             try:
-                batch = self._client.fetch_open_interest_history(
-                    symbol,
+                batch = self._retry_exchange_call(
+                    operation="ccxt_fetch_open_interest_history",
+                    symbol=symbol,
+                    endpoint="fetch_open_interest_history",
+                    call=self._client.fetch_open_interest_history,
                     timeframe=tf,
                     since=since,
                     limit=DEFAULT_FETCH_BATCH_SIZE,
                     params={"intervalTime": tf, "period": tf},
                 )
             except TypeError:
-                batch = self._client.fetch_open_interest_history(symbol, timeframe=tf, since=since, limit=DEFAULT_FETCH_BATCH_SIZE)
+                batch = self._retry_exchange_call(
+                    operation="ccxt_fetch_open_interest_history",
+                    symbol=symbol,
+                    endpoint="fetch_open_interest_history",
+                    call=self._client.fetch_open_interest_history,
+                    timeframe=tf,
+                    since=since,
+                    limit=DEFAULT_FETCH_BATCH_SIZE,
+                )
             if not batch:
                 break
 

--- a/data/fetchers/market_data_fetcher.py
+++ b/data/fetchers/market_data_fetcher.py
@@ -28,6 +28,8 @@ class MarketDataFetcher:
         oi_fetcher: OiFetcher,
         market_data_client: MarketDataClient,
         request_timeout_seconds: int = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+        retry_attempts: int = 3,
+        retry_backoff_seconds: float = 1.0,
         log_level: int | str = DEFAULT_LOG_LEVEL,
         logs_dir: str | Path = DEFAULT_LOGS_DIR,
     ) -> None:
@@ -35,6 +37,8 @@ class MarketDataFetcher:
         self._oi_fetcher = oi_fetcher
         self._market_data_client = market_data_client
         self._request_timeout_seconds = request_timeout_seconds
+        self._retry_attempts = retry_attempts
+        self._retry_backoff_seconds = retry_backoff_seconds
         self._logger = get_logger(self.__class__.__name__, level=log_level, logs_dir=logs_dir)
 
     def fetch_market_caps(self, symbols: list[str]) -> MarketCapsResult:

--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -29,12 +29,16 @@ class OhlcvFetcher:
         exchange_client: ExchangeClient,
         storage: ParquetStorage,
         request_timeout_seconds: int = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+        retry_attempts: int = 3,
+        retry_backoff_seconds: float = 1.0,
         log_level: int | str = DEFAULT_LOG_LEVEL,
         logs_dir: str | Path = DEFAULT_LOGS_DIR,
     ) -> None:
         self._exchange_client = exchange_client
         self._storage = storage
         self._request_timeout_seconds = request_timeout_seconds
+        self._retry_attempts = retry_attempts
+        self._retry_backoff_seconds = retry_backoff_seconds
         self._logger = get_logger(self.__class__.__name__, level=log_level, logs_dir=logs_dir)
         self._aligner = TimeAlignment()
         self._deduplicator = Deduplicator()

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -29,12 +29,16 @@ class OiFetcher:
         exchange_client: ExchangeClient,
         storage: ParquetStorage,
         request_timeout_seconds: int = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+        retry_attempts: int = 3,
+        retry_backoff_seconds: float = 1.0,
         log_level: int | str = DEFAULT_LOG_LEVEL,
         logs_dir: str | Path = DEFAULT_LOGS_DIR,
     ) -> None:
         self._exchange_client = exchange_client
         self._storage = storage
         self._request_timeout_seconds = request_timeout_seconds
+        self._retry_attempts = retry_attempts
+        self._retry_backoff_seconds = retry_backoff_seconds
         self._logger = get_logger(self.__class__.__name__, level=log_level, logs_dir=logs_dir)
         self._aligner = TimeAlignment()
         self._deduplicator = Deduplicator()

--- a/utils/retry.py
+++ b/utils/retry.py
@@ -1,0 +1,82 @@
+"""Retry helper with structured attempt logging."""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import ParamSpec, TypeVar
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+@dataclass(slots=True)
+class RetryExhaustedError(Exception):
+    """Controlled error raised when all retry attempts are exhausted."""
+
+    operation: str
+    attempts: int
+    reason: str
+
+    def __str__(self) -> str:
+        return (
+            f"Retry exhausted for operation='{self.operation}' after {self.attempts} attempts: "
+            f"{self.reason}"
+        )
+
+
+def run_with_retry(
+    operation: str,
+    call: Callable[P, R],
+    *args: P.args,
+    attempts: int,
+    backoff_seconds: float,
+    retriable_exceptions: tuple[type[Exception], ...],
+    logger: logging.Logger | None = None,
+    endpoint: str | None = None,
+    symbol: str | None = None,
+    jitter_seconds: float | None = None,
+    **kwargs: P.kwargs,
+) -> R:
+    """Execute callable with retries and structured logs for each attempt."""
+    if attempts < 1:
+        raise ValueError("attempts must be >= 1")
+
+    target_logger = logger or logging.getLogger(__name__)
+    endpoint_value = endpoint or "n/a"
+    symbol_value = symbol or "n/a"
+
+    for attempt_number in range(1, attempts + 1):
+        try:
+            result = call(*args, **kwargs)
+            target_logger.info(
+                "retry operation=%s attempt=%s/%s endpoint=%s symbol=%s result=success",
+                operation,
+                attempt_number,
+                attempts,
+                endpoint_value,
+                symbol_value,
+            )
+            return result
+        except retriable_exceptions as exc:
+            is_last = attempt_number >= attempts
+            target_logger.warning(
+                "retry operation=%s attempt=%s/%s endpoint=%s symbol=%s result=failure reason=%s",
+                operation,
+                attempt_number,
+                attempts,
+                endpoint_value,
+                symbol_value,
+                exc,
+            )
+            if is_last:
+                raise RetryExhaustedError(operation=operation, attempts=attempts, reason=str(exc)) from exc
+
+            sleep_seconds = backoff_seconds
+            if jitter_seconds and jitter_seconds > 0:
+                sleep_seconds += random.uniform(0.0, jitter_seconds)
+            if sleep_seconds > 0:
+                time.sleep(sleep_seconds)


### PR DESCRIPTION
### Motivation
- Improve reliability of network and batch exchange calls by adding a unified retry strategy with configurable attempts/backoff and optional jitter. 
- Prevent silent degradation on transient failures in CoinGecko HTTP calls and CCXT batch fetches by surfacing controlled errors with context. 
- Make retry behavior configurable from the backtest configuration so fetch layers and clients share the same settings.

### Description
- Added a shared retry helper `utils/retry.py` implementing `run_with_retry` and `RetryExhaustedError` with structured logs for each attempt (`operation`, `attempt`, `endpoint`, `symbol`, `reason`, `result`).
- Reworked `CoinGeckoClient` to route all `requests.get(...)` calls (`/coins/list`, `/coins/markets`, `/coins/{id}/tickers`) through a `_request(...)` wrapper that uses `run_with_retry` and raises a contextual `RuntimeError` when retries are exhausted.
- Wrapped CCXT batch operations in `CcxtFuturesClient` using a `_retry_exchange_call(...)` helper that calls `run_with_retry` for `fetch_ohlcv` and `fetch_open_interest_history`, and raises a contextual error on exhaustion.
- Propagated `retry_attempts` and `retry_backoff_seconds` from `config.backtest` through the CLI into `MarketDataFetcher`, `OhlcvFetcher`, `OiFetcher`, `CoinGeckoClient`, and `CcxtFuturesClient` constructors so the same retry config applies across the fetch stack.

### Testing
- Compiled modified modules with `python -m py_compile cli/commands.py data/clients/coingecko_client.py data/exchanges/ccxt_futures_client.py data/fetchers/market_data_fetcher.py data/fetchers/ohlcv_fetcher.py data/fetchers/oi_fetcher.py utils/retry.py` and the compile succeeded. 
- Also ran `py_compile` over the repository Python files to ensure no syntax errors, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69882ca8aaf48320b55de1f6b99287ad)