### PR TITLE
Structured per-symbol fetch results, aggregated failure summary, and CLI exit codes

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -173,6 +173,22 @@ def _fetch_period(config: AppConfig, days: int) -> tuple[datetime, datetime]:
     return datetime_to_utc(local_start), datetime_to_utc(local_end)
 
 
+def _log_fetch_summary(command_name: str, logger: Logger, total_symbols: int, failed_symbols_count: int) -> None:
+    failed_ratio = (failed_symbols_count / total_symbols) if total_symbols else 0.0
+    logger.info(
+        "%s: fetch summary total=%s ok=%s failed=%s failed_ratio=%.2f%%",
+        command_name,
+        total_symbols,
+        total_symbols - failed_symbols_count,
+        failed_symbols_count,
+        failed_ratio * 100,
+    )
+
+
+def _fetch_exit_code(failed_symbols_count: int, critical_fail_threshold: int = 1) -> int:
+    return 1 if failed_symbols_count >= critical_fail_threshold else 0
+
+
 def _fetch_data_inner(config: AppConfig, args: argparse.Namespace) -> int:
     logger = get_logger("fetch-data", level=config.backtest.log_level, logs_dir=config.backtest.logs_dir)
     fetcher, exchange_client, market_client = _build_fetch_stack(config)
@@ -182,9 +198,11 @@ def _fetch_data_inner(config: AppConfig, args: argparse.Namespace) -> int:
         return 0
 
     start_time, end_time = _fetch_period(config, args.days)
-    fetcher.fetch_all(symbols=symbols, timeframe=config.fetch.timeframe, start_time=start_time, end_time=end_time)
-    logger.info(f"fetch-data: загружено symbols={len(symbols)}")
-    return 0
+    result = fetcher.fetch_all(symbols=symbols, timeframe=config.fetch.timeframe, start_time=start_time, end_time=end_time)
+    _log_fetch_summary("fetch-data", logger, len(symbols), result.failed_symbols_count)
+    exit_code = _fetch_exit_code(result.failed_symbols_count)
+    logger.info(f"fetch-data: загружено symbols={len(symbols)}; code={exit_code}")
+    return exit_code
 
 
 def _update_cache_inner(config: AppConfig, args: argparse.Namespace) -> int:
@@ -196,9 +214,11 @@ def _update_cache_inner(config: AppConfig, args: argparse.Namespace) -> int:
         return 0
 
     start_time, end_time = _fetch_period(config, args.days)
-    fetcher.fetch_all(symbols=symbols, timeframe=config.fetch.timeframe, start_time=start_time, end_time=end_time)
-    logger.info(f"update-cache: обновлено symbols={len(symbols)}")
-    return 0
+    result = fetcher.fetch_all(symbols=symbols, timeframe=config.fetch.timeframe, start_time=start_time, end_time=end_time)
+    _log_fetch_summary("update-cache", logger, len(symbols), result.failed_symbols_count)
+    exit_code = _fetch_exit_code(result.failed_symbols_count)
+    logger.info(f"update-cache: обновлено symbols={len(symbols)}; code={exit_code}")
+    return exit_code
 
 
 def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:

--- a/data/fetchers/market_data_fetcher.py
+++ b/data/fetchers/market_data_fetcher.py
@@ -16,6 +16,7 @@ from domain.abstract.market_data_client import MarketDataClient
 from domain.enums.timeframe import Timeframe
 from domain.models.reporting.fetch_all_result import FetchAllResult
 from domain.models.reporting.market_caps_result import MarketCapsResult
+from domain.models.reporting.symbol_fetch_result import SymbolFetchResult
 from utils.logger import get_logger
 
 
@@ -56,6 +57,19 @@ class MarketDataFetcher:
         self._logger.info("MarketCap завершен")
         return MarketCapsResult(market_caps=results)
 
+    def _log_stage_summary(self, stage: str, total: int, ok: int, failed: int) -> None:
+        self._logger.info("%s summary: total=%s ok=%s failed=%s", stage, total, ok, failed)
+
+    def _count_structured_results(self, results: dict[str, SymbolFetchResult]) -> tuple[int, int, int]:
+        total = len(results)
+        ok = sum(1 for result in results.values() if result.success)
+        return total, ok, total - ok
+
+    def _count_market_caps_results(self, results: MarketCapsResult) -> tuple[int, int, int]:
+        total = len(results.market_caps)
+        ok = sum(1 for value in results.market_caps.values() if isinstance(value, (int, float)))
+        return total, ok, total - ok
+
     def fetch_all(
         self,
         symbols: list[str],
@@ -79,10 +93,32 @@ class MarketDataFetcher:
         )
 
         market_caps = self.fetch_market_caps(symbols)
+
+        ohlcv_total, ohlcv_ok, ohlcv_failed = self._count_structured_results(ohlcv_result)
+        oi_total, oi_ok, oi_failed = self._count_structured_results(oi_result)
+        mcap_total, mcap_ok, mcap_failed = self._count_market_caps_results(market_caps)
+
+        self._log_stage_summary("OHLCV", ohlcv_total, ohlcv_ok, ohlcv_failed)
+        self._log_stage_summary("OI", oi_total, oi_ok, oi_failed)
+        self._log_stage_summary("MarketCap", mcap_total, mcap_ok, mcap_failed)
+
+        failed_symbols_count = len(
+            {
+                symbol
+                for symbol in symbols
+                if (symbol in ohlcv_result and not ohlcv_result[symbol].success)
+                or (symbol in oi_result and not oi_result[symbol].success)
+                or isinstance(market_caps.market_caps.get(symbol), str)
+            }
+        )
+        has_errors = failed_symbols_count > 0
+
         self._logger.info("Загрузка завершена")
 
         return FetchAllResult(
             ohlcv=ohlcv_result,
             open_interest=oi_result,
             market_caps=market_caps,
+            failed_symbols_count=failed_symbols_count,
+            has_errors=has_errors,
         )

--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -18,6 +18,7 @@ from data.quality.time_alignment import TimeAlignment
 from data.storage.parquet_storage import ParquetStorage
 from domain.abstract.exchange_client import ExchangeClient
 from domain.enums.timeframe import Timeframe
+from domain.models.reporting.symbol_fetch_result import SymbolFetchResult
 from utils.logger import get_logger
 
 
@@ -83,14 +84,15 @@ class OhlcvFetcher:
         timeframe: Timeframe,
         start_time: datetime,
         end_time: datetime,
-    ) -> dict[str, int | str]:
-        results: dict[str, int | str] = {}
+    ) -> dict[str, SymbolFetchResult]:
+        results: dict[str, SymbolFetchResult] = {}
         for symbol in symbols:
             try:
-                results[symbol] = self.fetch_symbol(symbol, timeframe, start_time, end_time)
+                added_rows = self.fetch_symbol(symbol, timeframe, start_time, end_time)
+                results[symbol] = SymbolFetchResult.ok(added_rows)
             except Exception as exc:  # noqa: BLE001
                 msg = f"OHLCV ошибка исполнения: {symbol}: {exc}"
                 self._logger.info(msg)
-                results[symbol] = msg
+                results[symbol] = SymbolFetchResult.error(msg)
 
         return results

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -18,6 +18,7 @@ from data.quality.time_alignment import TimeAlignment
 from data.storage.parquet_storage import ParquetStorage
 from domain.abstract.exchange_client import ExchangeClient
 from domain.enums.timeframe import Timeframe
+from domain.models.reporting.symbol_fetch_result import SymbolFetchResult
 from utils.logger import get_logger
 
 
@@ -111,14 +112,15 @@ class OiFetcher:
         timeframe: Timeframe,
         start_time: datetime,
         end_time: datetime,
-    ) -> dict[str, int | str]:
-        results: dict[str, int | str] = {}
+    ) -> dict[str, SymbolFetchResult]:
+        results: dict[str, SymbolFetchResult] = {}
         for symbol in symbols:
             try:
-                results[symbol] = self.fetch_symbol(symbol, timeframe, start_time, end_time)
+                added_rows = self.fetch_symbol(symbol, timeframe, start_time, end_time)
+                results[symbol] = SymbolFetchResult.ok(added_rows)
             except Exception as exc:  # noqa: BLE001
                 msg = f"OI ошибка исполнения: {symbol}: {exc}"
                 self._logger.info(msg)
-                results[symbol] = msg
+                results[symbol] = SymbolFetchResult.error(msg)
 
         return results

--- a/domain/models/reporting/__init__.py
+++ b/domain/models/reporting/__init__.py
@@ -9,6 +9,7 @@ from domain.models.reporting.market_caps_result import MarketCapsResult
 from domain.models.reporting.quality_report import QualityReport
 from domain.models.reporting.quality_summary import QualitySummary
 from domain.models.reporting.quality_symbol_stats import QualitySymbolStats
+from domain.models.reporting.symbol_fetch_result import SymbolFetchResult
 
 __all__ = [
     "BacktestReport",
@@ -20,4 +21,5 @@ __all__ = [
     "QualityReport",
     "QualitySummary",
     "QualitySymbolStats",
+    "SymbolFetchResult",
 ]

--- a/domain/models/reporting/fetch_all_result.py
+++ b/domain/models/reporting/fetch_all_result.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from domain.models.reporting.market_caps_result import MarketCapsResult
+from domain.models.reporting.symbol_fetch_result import SymbolFetchResult
 
 
 @dataclass(frozen=True, slots=True)
 class FetchAllResult:
-    ohlcv: dict[str, int | str]
-    open_interest: dict[str, int | str]
+    ohlcv: dict[str, SymbolFetchResult]
+    open_interest: dict[str, SymbolFetchResult]
     market_caps: MarketCapsResult
+    failed_symbols_count: int
+    has_errors: bool

--- a/domain/models/reporting/symbol_fetch_result.py
+++ b/domain/models/reporting/symbol_fetch_result.py
@@ -1,0 +1,21 @@
+"""Per-symbol fetch execution status."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolFetchResult:
+    success: bool
+    message: str
+    added_rows: int = 0
+
+    @classmethod
+    def ok(cls, added_rows: int) -> "SymbolFetchResult":
+        return cls(success=True, message="ok", added_rows=added_rows)
+
+    @classmethod
+    def error(cls, message: str) -> "SymbolFetchResult":
+        return cls(success=False, message=message, added_rows=0)
+


### PR DESCRIPTION
### Motivation
- Unify and make fetch outcomes machine-readable by replacing mixed `int | str` returns with a structured per-symbol status.
- Provide an overall aggregated fetch status so callers (including the CLI) can detect and react to critical failures.
- Improve observability by logging explicit summaries and failure ratios for each subsystem (OHLCV, OI, MarketCap).

### Description
- Added `SymbolFetchResult` DTO with `success`, `message`, and `added_rows` and exported it from reporting models (`domain/models/reporting/symbol_fetch_result.py`).
- Changed `OhlcvFetcher.fetch_many` and `OiFetcher.fetch_many` to return `dict[str, SymbolFetchResult]` and produce `SymbolFetchResult.ok(...)` / `SymbolFetchResult.error(...)` instead of `int | str` results (`data/fetchers/ohlcv_fetcher.py`, `data/fetchers/oi_fetcher.py`).
- Extended `FetchAllResult` with `failed_symbols_count` and `has_errors` and switched its OHLCV/OI fields to `dict[str, SymbolFetchResult]` (`domain/models/reporting/fetch_all_result.py`).
- Updated `MarketDataFetcher.fetch_all` to aggregate subsystem statuses, compute per-stage `total/ok/failed` and log summaries, and to populate `failed_symbols_count`/`has_errors` in the returned `FetchAllResult` (`data/fetchers/market_data_fetcher.py`).
- Updated CLI fetch commands by adding `_log_fetch_summary` and `_fetch_exit_code`, and made `_fetch_data_inner` and `_update_cache_inner` log failed-symbol ratios and return a non-zero exit code when critical failures are present (default threshold >= 1) (`cli/commands.py`).

### Testing
- Ran `python -m compileall domain data cli` and the codebase compiled without errors.
- Ran targeted compilation `python -m compileall cli/commands.py data/fetchers domain/models/reporting` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69882dcdff5c8320bcc9eac144985f7b)