### PR TITLE
Add explicit unreachable raise after retry loop

### DIFF
--- a/utils/retry.py
+++ b/utils/retry.py
@@ -80,3 +80,9 @@ def run_with_retry(
                 sleep_seconds += random.uniform(0.0, jitter_seconds)
             if sleep_seconds > 0:
                 time.sleep(sleep_seconds)
+
+    raise RetryExhaustedError(
+        operation=operation,
+        attempts=attempts,
+        reason="retry loop exited unexpectedly",
+    )


### PR DESCRIPTION
### Motivation
- Silence static analysis warning about "Missing return statement on some paths" for `run_with_retry` by ensuring all code paths raise or return. 
- Provide an explicit unreachable fallback that does not alter normal retry behavior and only serves as a safety net for type/checker tools.

### Description
- Added a final fallback `raise RetryExhaustedError(...)` after the `for attempt_number in range(...)` loop with the reason string `"retry loop exited unexpectedly"` in `run_with_retry`.
- Preserved all existing retry-loop logic, including successful `return`, last-attempt `RetryExhaustedError(..., reason=str(exc))`, and backoff/jitter/sleep behavior.

### Testing
- Validated the file contents after the change by printing the updated `utils/retry.py` and confirmed the fallback `raise` is present and formatted as expected (command output showed the new lines).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69883b6779d083208135b64ea54ea60f)