### PR TITLE
Use Price.value for pending signal log

### DIFF
--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -176,7 +176,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                 "signal_not_executed_end_of_data symbol=%s entry_time=%s entry_price=%.8f",
                 params.symbol,
                 pending_signal.entry_time.isoformat(),
-                float(pending_signal.entry_price),
+                pending_signal.entry_price.value,
             )
 
         if sim.position is not None:


### PR DESCRIPTION
### Motivation
- Исправить логирование пропущенного сигнала, чтобы читать числовое значение из `Price` value object напрямую вместо приведения `Price` к `float` (устранить неправильное/ненужное `float(pending_signal.entry_price)`).

### Description
- В `strategy/breakout/breakout_strategy.py` в лог-сообщении `signal_not_executed_end_of_data` заменено `float(pending_signal.entry_price)` на `pending_signal.entry_price.value`.
- Были выполнены быстрые поиски по коду на предмет похожих вызовов `float(...)` для полей `Price`/`Volume` и дополнительных замен не потребовалось.

### Testing
- Скомпилирован файл с помощью `python -m compileall strategy/breakout/breakout_strategy.py`, сборка прошла успешно. 
- Выполнен поиск по коду (`rg`) для обнаружения аналогичных случаев, дополнительных мест не найдено.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69883ca9b64c8320a698df4ebc64fc87)