### PR TITLE
Add launcher.py for interactive/param/config runs and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,58 @@ CACHE_DIR=./cache
 TIMEZONE=Europe/Belgrade
 ```
 
-## Базовые CLI-команды
+## Запуск без ручного ввода CLI-команд
+
+Добавлен `launcher.py`: можно запускать режим по параметрам или через JSON-конфиг сценария.
+
+### 1) Интерактивный запуск (выбор режима по номеру)
+
+```bash
+python launcher.py
+```
+
+Доступные режимы:
+- сбор кэша;
+- обновление кэша;
+- анализ кэша стратегией (бектест);
+- построение отчета;
+- проверка качества кэша.
+
+### 2) Запуск конкретного режима через параметры
+
+```bash
+python launcher.py --mode fetch-cache --top-n 100 --days 30
+python launcher.py --mode update-cache --top-n 100 --days 7
+python launcher.py --mode analyze-cache --symbols BTC/USDT ETH/USDT
+python launcher.py --mode make-report --input ./results/backtest_results.csv --output ./results/report.json
+python launcher.py --mode check-quality --symbols BTC/USDT ETH/USDT --output ./results/quality_report.json
+```
+
+### 3) Запуск цепочки задач через JSON-конфиг
+
+Пример `run_config.json`:
+
+```json
+{
+  "env_path": ".env",
+  "continue_on_error": false,
+  "tasks": [
+    { "mode": "fetch-cache", "top_n": 100, "days": 30 },
+    { "mode": "update-cache", "top_n": 100, "days": 7 },
+    { "mode": "analyze-cache", "symbols": ["BTC/USDT", "ETH/USDT"] },
+    { "mode": "make-report", "output": "./results/report.json" },
+    { "mode": "check-quality", "output": "./results/quality_report.json" }
+  ]
+}
+```
+
+Запуск:
+
+```bash
+python launcher.py --config run_config.json
+```
+
+## Базовые CLI-команды (старый способ)
 
 ```bash
 python main.py fetch-data --top-n 100 --days 30

--- a/launcher.py
+++ b/launcher.py
@@ -1,0 +1,144 @@
+"""Упрощенный запуск сценариев проекта без ручного ввода CLI-команд."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from cli import commands
+from config import AppConfig, load_config
+
+
+MODE_FETCH_CACHE = "fetch-cache"
+MODE_UPDATE_CACHE = "update-cache"
+MODE_BACKTEST = "analyze-cache"
+MODE_REPORT = "make-report"
+MODE_QUALITY = "check-quality"
+
+MODE_LABELS: dict[str, str] = {
+    MODE_FETCH_CACHE: "Сбор кэша",
+    MODE_UPDATE_CACHE: "Обновление кэша",
+    MODE_BACKTEST: "Анализ кэша стратегией",
+    MODE_REPORT: "Построение отчета",
+    MODE_QUALITY: "Проверка качества кэша",
+}
+
+
+def _force_single_thread_mode() -> None:
+    single_thread_env = {
+        "OMP_NUM_THREADS": "1",
+        "OPENBLAS_NUM_THREADS": "1",
+        "MKL_NUM_THREADS": "1",
+        "VECLIB_MAXIMUM_THREADS": "1",
+        "NUMEXPR_NUM_THREADS": "1",
+    }
+    for key, value in single_thread_env.items():
+        os.environ[key] = value
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="launcher", description="Запуск режимов без прямого ввода CLI-команд")
+    parser.add_argument("--env", default=".env", help="Путь к env-файлу")
+    parser.add_argument("--mode", choices=tuple(MODE_LABELS.keys()), default=None, help="Одиночный режим запуска")
+    parser.add_argument("--config", default=None, help="JSON-файл с пачкой задач")
+    parser.add_argument("--top-n", type=int, default=100, help="Количество топ монет для fetch/update")
+    parser.add_argument("--days", type=int, default=30, help="Число дней для fetch/update")
+    parser.add_argument("--symbols", nargs="*", default=None, help="Список символов для backtest/check-quality")
+    parser.add_argument("--input", default=None, help="Входной CSV для отчета")
+    parser.add_argument("--output", default=None, help="Выходной путь JSON/CSV")
+    return parser
+
+
+def _task_namespace(task: dict[str, Any], cli_args: argparse.Namespace) -> SimpleNamespace:
+    return SimpleNamespace(
+        top_n=int(task.get("top_n", cli_args.top_n)),
+        days=int(task.get("days", cli_args.days)),
+        symbols=task.get("symbols", cli_args.symbols),
+        input=task.get("input", cli_args.input),
+        output=task.get("output", cli_args.output),
+    )
+
+
+def _run_mode(config: AppConfig, mode: str, task_args: SimpleNamespace) -> int:
+    handlers = {
+        MODE_FETCH_CACHE: commands.fetch_data,
+        MODE_UPDATE_CACHE: commands.update_cache,
+        MODE_BACKTEST: commands.run_backtest,
+        MODE_REPORT: commands.make_report,
+        MODE_QUALITY: commands.check_quality,
+    }
+    return handlers[mode](config, task_args)
+
+
+def _prompt_menu() -> str:
+    print("Выберите режим запуска:")
+    modes = list(MODE_LABELS.items())
+    for index, (_, label) in enumerate(modes, start=1):
+        print(f"  {index}. {label}")
+
+    while True:
+        raw = input("Введите номер режима: ").strip()
+        if raw.isdigit() and 1 <= int(raw) <= len(modes):
+            return modes[int(raw) - 1][0]
+        print("Некорректный номер. Попробуйте снова.")
+
+
+def _load_tasks(config_path: Path) -> dict[str, Any]:
+    return json.loads(config_path.read_text(encoding="utf-8"))
+
+
+def _run_batch(config: AppConfig, cli_args: argparse.Namespace, payload: dict[str, Any]) -> int:
+    tasks = payload.get("tasks", [])
+    if not tasks:
+        print("В config-файле нет задач: ключ tasks пуст.")
+        return 1
+
+    continue_on_error = bool(payload.get("continue_on_error", False))
+
+    for index, task in enumerate(tasks, start=1):
+        mode = str(task.get("mode", "")).strip()
+        if mode not in MODE_LABELS:
+            print(f"[{index}] Неизвестный режим '{mode}'")
+            if continue_on_error:
+                continue
+            return 1
+
+        print(f"[{index}] {MODE_LABELS[mode]}: старт")
+        task_args = _task_namespace(task, cli_args)
+        code = _run_mode(config, mode, task_args)
+        print(f"[{index}] {MODE_LABELS[mode]}: завершено с code={code}")
+
+        if code != 0 and not continue_on_error:
+            return code
+
+    return 0
+
+
+def main() -> int:
+    _force_single_thread_mode()
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    config_payload = None
+    env_path = args.env
+
+    if args.config:
+        config_payload = _load_tasks(Path(args.config))
+        env_path = str(config_payload.get("env_path", env_path))
+
+    app_config = load_config(env_path)
+
+    if config_payload:
+        return _run_batch(app_config, args, config_payload)
+
+    mode = args.mode or _prompt_menu()
+    task_args = _task_namespace({}, args)
+    return _run_mode(app_config, mode, task_args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Упростить запуск типовых сценариев (сбор/обновление кэша, бектест, отчеты, проверка качества) без ручного набора подкоманд `main.py` в терминале.
- Добавить возможность пакетного выполнения цепочек задач через JSON-конфиг и интерактивный выбор режима для удобства оператора.

### Description
- Добавлен `launcher.py`, реализующий интерактивное меню, запуск одного режима через `--mode` и пакетный запуск через `--config` JSON, и маппинг режимов на существующие обработчики (`fetch-data`, `update-cache`, `run-backtest`, `make-report`, `check-quality`).
- Сохранена логика принудительного single-thread режима аналогично `main.py`, и задачи преобразуются в `SimpleNamespace` для передачи в обработчики.
- Обновлён `README.md` с примерами использования `launcher.py` (интерактивный запуск, параметры, пример `run_config.json`).

### Testing
- Выполнена статическая проверка компиляции Python через `python -m py_compile launcher.py main.py`, и она прошла успешно.
- Попытка запустить `python launcher.py --help` в CI завершилась ошибкой импорта из-за отсутствующей зависимости `pandas`, поэтому полное рантайм-тестирование не было выполнено.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988545e4e948320a5ccfe4fd7cf085a)