### PR TITLE
Add multi-timeframe breakout strategy flow (D1 levels + M15 entries)

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -40,6 +40,7 @@ from data.quality.data_validator import DataValidator
 from data.quality.gap_detector import GapDetector
 from data.storage.parquet_storage import ParquetStorage
 from domain.enums.exchange import Exchange
+from domain.enums.timeframe import Timeframe
 from domain.models.reporting.backtest_report import BacktestReport
 from domain.models.reporting.backtest_summary import BacktestSummary
 from domain.models.reporting.optimal_parameter_ranges import OptimalParameterRanges
@@ -230,10 +231,17 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
         return 0
 
     symbol_frames = {
-        symbol: preparer.load_symbol_data(symbol, config.fetch.timeframe)
+        symbol: {
+            "1d": preparer.load_symbol_data(symbol, Timeframe.D1),
+            "15m": preparer.load_symbol_data(symbol, Timeframe.M15),
+        }
         for symbol in symbols
     }
-    symbol_frames = {k: v for k, v in symbol_frames.items() if not v.empty}
+    symbol_frames = {
+        symbol: frames
+        for symbol, frames in symbol_frames.items()
+        if not frames["1d"].empty and not frames["15m"].empty
+    }
     if not symbol_frames:
         logger.info("run-backtest: не удалось подготовить данные")
         return 0

--- a/strategy/base_strategy.py
+++ b/strategy/base_strategy.py
@@ -27,3 +27,13 @@ class BaseStrategy(ABC, Generic[StrategyParamsT]):
     @abstractmethod
     def generate_events(self, data: pd.DataFrame, params: StrategyParamsT) -> list[TradeResult]:
         """Run strategy simulation and return closed trades."""
+
+    @abstractmethod
+    def generate_events_multi_tf(
+        self,
+        *,
+        higher_tf_data: pd.DataFrame,
+        lower_tf_data: pd.DataFrame,
+        params: StrategyParamsT,
+    ) -> list[TradeResult]:
+        """Run strategy simulation using dedicated higher/lower timeframe data."""

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -80,17 +80,51 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         return prepared
 
     def generate_events(self, data: pd.DataFrame, params: BreakoutParams) -> list[TradeResult]:
-        """Generate closed trades from historical candles.
+        """Backward-compatible wrapper for single-timeframe callers."""
+        return self.generate_events_multi_tf(
+            higher_tf_data=data,
+            lower_tf_data=data,
+            params=params,
+        )
 
-        Signals are always created on a retest candle and queued for execution on the
-        next candle open via ``pending_signal``. If data ends before that next candle
-        appears, the strategy works in **strict mode**: it does not force an entry on
-        the last candle and records the skipped signal with
-        ``signal_not_executed_end_of_data`` in logs.
-        """
+    def generate_events_multi_tf(
+        self,
+        *,
+        higher_tf_data: pd.DataFrame,
+        lower_tf_data: pd.DataFrame,
+        params: BreakoutParams,
+    ) -> list[TradeResult]:
+        """Generate trades from higher-TF levels and lower-TF breakout/retest logic."""
         self.validate_config(params)
-        prepared = self.prepare_data(data)
-        if len(prepared) < params.lookback + STRATEGY_MIN_LOOKBACK_BUFFER:
+        higher_prepared = self.prepare_data(higher_tf_data)
+        lower_prepared = self.prepare_data(lower_tf_data)
+        self._logger.info(
+            "breakout_generate_events symbol=%s levels_tf=%s entry_tf=%s",
+            params.symbol,
+            params.levels_timeframe.value,
+            params.entry_timeframe.value,
+        )
+        if len(higher_prepared) < params.lookback + STRATEGY_MIN_LOOKBACK_BUFFER:
+            return []
+        if len(lower_prepared) < STRATEGY_MIN_LOOKBACK_BUFFER:
+            return []
+
+        higher_levels = higher_prepared[["datetime", "high", "volume"]].copy()
+        higher_levels["level_high"] = higher_levels["high"].rolling(window=params.lookback).max().shift(1)
+        higher_levels["avg_volume"] = higher_levels["volume"].rolling(window=params.lookback).mean().shift(1)
+        higher_levels = higher_levels.dropna(subset=["level_high", "avg_volume"]).sort_values("datetime")
+        if higher_levels.empty:
+            return []
+
+        lower_prepared = lower_prepared.sort_values("datetime").reset_index(drop=True)
+        annotated = pd.merge_asof(
+            lower_prepared,
+            higher_levels[["datetime", "level_high", "avg_volume"]],
+            on="datetime",
+            direction="backward",
+        )
+        annotated = annotated.dropna(subset=["level_high", "avg_volume"]).reset_index(drop=True)
+        if annotated.empty:
             return []
 
         sim = StatefulPositionSimulator(
@@ -104,8 +138,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         pending_signal: TradeSignal | None = None
         pending_breakout: PendingBreakout | None = None
 
-        for idx in range(params.lookback, len(prepared)):
-            row = prepared.iloc[idx]
+        for idx in range(len(annotated)):
+            row = annotated.iloc[idx]
             candle = self._to_candle(row)
 
             if sim.position is None and pending_signal is not None:
@@ -140,8 +174,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             risk = max(breakout_close - stop, breakout_close * STRATEGY_RISK_FLOOR)
                             tp1 = breakout_close + risk * params.min_rr
                             tp2 = breakout_close + risk * params.min_rr * params.tp2_mult
-                            entry_idx = min(idx + 1, len(prepared) - 1)
-                            entry_row = prepared.iloc[entry_idx]
+                            entry_idx = min(idx + 1, len(annotated) - 1)
+                            entry_row = annotated.iloc[entry_idx]
                             pending_signal = TradeSignal(
                                 entry_price=Price(breakout_close),
                                 entry_time=datetime_to_timezone(
@@ -157,10 +191,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             pending_breakout = None
                             continue
 
-                rolling = prepared.iloc[idx - params.lookback : idx]
-                level_high = float(rolling["high"].max())
-                avg_volume = float(rolling["volume"].mean())
-
+                level_high = float(row["level_high"])
+                avg_volume = float(row["avg_volume"])
                 breakout = row["close"] > level_high
                 volume_ok = row["volume"] >= avg_volume * params.volume_mult
                 if breakout and volume_ok:
@@ -173,14 +205,16 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
 
         if pending_signal is not None:
             self._logger.info(
-                "signal_not_executed_end_of_data symbol=%s entry_time=%s entry_price=%.8f",
+                "signal_not_executed_end_of_data symbol=%s levels_tf=%s entry_tf=%s entry_time=%s entry_price=%.8f",
                 params.symbol,
+                params.levels_timeframe.value,
+                params.entry_timeframe.value,
                 pending_signal.entry_time.isoformat(),
                 pending_signal.entry_price.value,
             )
 
         if sim.position is not None:
-            final_row = prepared.iloc[-1]
+            final_row = annotated.iloc[-1]
             final_time = datetime_to_timezone(final_row["datetime"].to_pydatetime(), self._simulation_timezone)
             trades.append(sim.close_position(price=float(final_row["close"]), exit_time=final_time))
 

--- a/strategy/breakout/config.py
+++ b/strategy/breakout/config.py
@@ -16,6 +16,7 @@ from constants import (
     BREAKOUT_VOLUME_MULT_VALUES,
 )
 from domain.enums.sl_mode import SLMode
+from domain.enums.timeframe import Timeframe
 
 TARGET_PARAMETER_COMBINATIONS = BREAKOUT_TARGET_PARAMETER_COMBINATIONS
 
@@ -30,6 +31,8 @@ class BreakoutParams:
     sl_mode: SLMode
     tp2_mult: float
     symbol: str
+    levels_timeframe: Timeframe = Timeframe.D1
+    entry_timeframe: Timeframe = Timeframe.M15
 
 
 BREAKOUT_PARAMETER_GRID: dict[str, list[float | int | SLMode]] = {

--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -71,13 +71,13 @@ class BacktestRunner:
             )
         ]
 
-    def run(self, strategy: BaseStrategy[BreakoutParams], symbol_frames: dict[str, pd.DataFrame]) -> pd.DataFrame:
+    def run(self, strategy: BaseStrategy[BreakoutParams], symbol_frames: dict[str, dict[str, pd.DataFrame]]) -> pd.DataFrame:
         rows: list[dict[str, int | float | str]] = []
         grid = self.build_parameter_grid()
 
         for params in grid:
             all_trades: list[TradeResult] = []
-            for symbol, frame in symbol_frames.items():
+            for symbol, frames_by_tf in symbol_frames.items():
                 cfg = BreakoutParams(
                     lookback=params.lookback,
                     volume_mult=params.volume_mult,
@@ -88,7 +88,15 @@ class BacktestRunner:
                     tp2_mult=params.tp2_mult,
                     symbol=symbol,
                 )
-                trades = strategy.generate_events(frame, cfg)
+                higher_tf_key = cfg.levels_timeframe.value
+                lower_tf_key = cfg.entry_timeframe.value
+                if higher_tf_key not in frames_by_tf or lower_tf_key not in frames_by_tf:
+                    continue
+                trades = strategy.generate_events_multi_tf(
+                    higher_tf_data=frames_by_tf[higher_tf_key],
+                    lower_tf_data=frames_by_tf[lower_tf_key],
+                    params=cfg,
+                )
                 all_trades.extend(trades)
 
             row = self._build_metrics_row(params, all_trades)


### PR DESCRIPTION
### Motivation
- Allow strategies to operate with separate higher- and lower-timeframe inputs so that level calculation (e.g. daily) and entry detection (e.g. 15m) are decoupled.
- Make timeframes configurable in strategy params instead of hardcoding TFs, and surface both TFs in logs for debugging and verification.

### Description
- Extended the base strategy contract with `generate_events_multi_tf(...)` that accepts `higher_tf_data` and `lower_tf_data` alongside `params` (`strategy/base_strategy.py`).
- Implemented a multi-timeframe flow in the breakout strategy so that daily levels/avg-volume are computed from `higher_tf_data`, lower-TF candles are aligned to the last confirmed higher-TF level via `merge_asof`, and breakout/retest logic runs on `lower_tf_data`; `generate_events(...)` now delegates to the new multi-TF method for backward compatibility (`strategy/breakout/breakout_strategy.py`).
- Added explicit timeframe parameters to breakout config with defaults `levels_timeframe=Timeframe.D1` and `entry_timeframe=Timeframe.M15` (`strategy/breakout/config.py`).
- Updated the backtest pipeline and CLI to load and pass separate TF frames: `BacktestRunner.run(...)` now expects `symbol_frames: dict[str, dict[str, pd.DataFrame]]` and calls `generate_events_multi_tf(...)` using the `levels_timeframe`/`entry_timeframe` keys; CLI now loads both `1d` and `15m` frames per symbol and filters symbols lacking either (`vectorbt_runner/backtest_runner.py`, `cli/commands.py`).
- Strategy logs now include both TFs (e.g. `levels_tf=1d entry_tf=15m`) when generating events or reporting unexecuted signals (`strategy/breakout/breakout_strategy.py`).

### Testing
- Ran `python -m compileall strategy vectorbt_runner cli` to validate syntax and module imports, and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69885a39f2d88320a60ae45cdd6f461b)