### PR TITLE
Add typed multi-timeframe data flow (SymbolMtfFrames) and multi-load helper

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -53,7 +53,7 @@ from strategy.breakout.config import TARGET_PARAMETER_COMBINATIONS
 from utils.formatters import datetime_to_utc
 from utils.logger import get_logger
 from utils.symbols import normalize_symbol
-from vectorbt_runner import BacktestRunner, DataPreparer
+from vectorbt_runner import BacktestRunner, DataPreparer, SymbolMtfFrames
 
 
 def fetch_data(config: AppConfig, args: argparse.Namespace) -> int:
@@ -230,18 +230,14 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
         logger.info("run-backtest: нет данных в кэше")
         return 0
 
-    symbol_frames = {
-        symbol: {
-            "1d": preparer.load_symbol_data(symbol, Timeframe.D1),
-            "15m": preparer.load_symbol_data(symbol, Timeframe.M15),
-        }
-        for symbol in symbols
-    }
-    symbol_frames = {
-        symbol: frames
-        for symbol, frames in symbol_frames.items()
-        if not frames["1d"].empty and not frames["15m"].empty
-    }
+    symbol_frames: dict[str, SymbolMtfFrames] = {}
+    for symbol in symbols:
+        frames_by_tf = preparer.load_symbol_data_multi(symbol, [Timeframe.D1, Timeframe.M15])
+        d1_frame = frames_by_tf.get(Timeframe.D1, pd.DataFrame())
+        m15_frame = frames_by_tf.get(Timeframe.M15, pd.DataFrame())
+        if d1_frame.empty or m15_frame.empty:
+            continue
+        symbol_frames[symbol] = SymbolMtfFrames(d1_frame=d1_frame, m15_frame=m15_frame)
     if not symbol_frames:
         logger.info("run-backtest: не удалось подготовить данные")
         return 0

--- a/strategy/base_strategy.py
+++ b/strategy/base_strategy.py
@@ -8,6 +8,7 @@ from typing import Generic, TypeVar
 import pandas as pd
 
 from domain.models.trade_result import TradeResult
+from vectorbt_runner.mtf_frames import SymbolMtfFrames
 
 
 StrategyParamsT = TypeVar("StrategyParamsT")
@@ -32,8 +33,7 @@ class BaseStrategy(ABC, Generic[StrategyParamsT]):
     def generate_events_multi_tf(
         self,
         *,
-        higher_tf_data: pd.DataFrame,
-        lower_tf_data: pd.DataFrame,
+        mtf_frames: SymbolMtfFrames,
         params: StrategyParamsT,
     ) -> list[TradeResult]:
         """Run strategy simulation using dedicated higher/lower timeframe data."""

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -30,6 +30,7 @@ from simulation.trade_classifier import TradeClassifier
 from strategy.base_strategy import BaseStrategy
 from strategy.breakout.config import BreakoutParams
 from utils.formatters import datetime_to_timezone, utc_ms_to_local_datetime
+from vectorbt_runner.mtf_frames import SymbolMtfFrames
 
 
 @dataclass(slots=True)
@@ -82,22 +83,20 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
     def generate_events(self, data: pd.DataFrame, params: BreakoutParams) -> list[TradeResult]:
         """Backward-compatible wrapper for single-timeframe callers."""
         return self.generate_events_multi_tf(
-            higher_tf_data=data,
-            lower_tf_data=data,
+            mtf_frames=SymbolMtfFrames(d1_frame=data, m15_frame=data),
             params=params,
         )
 
     def generate_events_multi_tf(
         self,
         *,
-        higher_tf_data: pd.DataFrame,
-        lower_tf_data: pd.DataFrame,
+        mtf_frames: SymbolMtfFrames,
         params: BreakoutParams,
     ) -> list[TradeResult]:
         """Generate trades from higher-TF levels and lower-TF breakout/retest logic."""
         self.validate_config(params)
-        higher_prepared = self.prepare_data(higher_tf_data)
-        lower_prepared = self.prepare_data(lower_tf_data)
+        higher_prepared = self.prepare_data(mtf_frames.get_frame(params.levels_timeframe))
+        lower_prepared = self.prepare_data(mtf_frames.get_frame(params.entry_timeframe))
         self._logger.info(
             "breakout_generate_events symbol=%s levels_tf=%s entry_tf=%s",
             params.symbol,

--- a/vectorbt_runner/__init__.py
+++ b/vectorbt_runner/__init__.py
@@ -3,11 +3,13 @@
 from vectorbt_runner.backtest_runner import BacktestRunner
 from vectorbt_runner.backtest_summary import BacktestSummary
 from vectorbt_runner.data_preparer import DataPreparer
+from vectorbt_runner.mtf_frames import SymbolMtfFrames
 from vectorbt_runner.vectorbt_inputs import VectorbtInputs
 
 __all__ = [
     "BacktestRunner",
     "BacktestSummary",
     "DataPreparer",
+    "SymbolMtfFrames",
     "VectorbtInputs",
 ]

--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -26,6 +26,7 @@ from domain.models.trade_result import TradeResult
 from strategy.base_strategy import BaseStrategy
 from strategy.breakout.config import BREAKOUT_PARAMETER_GRID, PARAMETER_GRID_SIZE, TARGET_PARAMETER_COMBINATIONS, BreakoutParams
 from vectorbt_runner.backtest_summary import BacktestSummary
+from vectorbt_runner.mtf_frames import SymbolMtfFrames
 
 
 logger = logging.getLogger(__name__)
@@ -71,13 +72,13 @@ class BacktestRunner:
             )
         ]
 
-    def run(self, strategy: BaseStrategy[BreakoutParams], symbol_frames: dict[str, dict[str, pd.DataFrame]]) -> pd.DataFrame:
+    def run(self, strategy: BaseStrategy[BreakoutParams], symbol_frames: dict[str, SymbolMtfFrames]) -> pd.DataFrame:
         rows: list[dict[str, int | float | str]] = []
         grid = self.build_parameter_grid()
 
         for params in grid:
             all_trades: list[TradeResult] = []
-            for symbol, frames_by_tf in symbol_frames.items():
+            for symbol, mtf_frames in symbol_frames.items():
                 cfg = BreakoutParams(
                     lookback=params.lookback,
                     volume_mult=params.volume_mult,
@@ -88,13 +89,8 @@ class BacktestRunner:
                     tp2_mult=params.tp2_mult,
                     symbol=symbol,
                 )
-                higher_tf_key = cfg.levels_timeframe.value
-                lower_tf_key = cfg.entry_timeframe.value
-                if higher_tf_key not in frames_by_tf or lower_tf_key not in frames_by_tf:
-                    continue
                 trades = strategy.generate_events_multi_tf(
-                    higher_tf_data=frames_by_tf[higher_tf_key],
-                    lower_tf_data=frames_by_tf[lower_tf_key],
+                    mtf_frames=mtf_frames,
                     params=cfg,
                 )
                 all_trades.extend(trades)

--- a/vectorbt_runner/data_preparer.py
+++ b/vectorbt_runner/data_preparer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Iterable
 
 import pandas as pd
 
@@ -74,6 +75,13 @@ class DataPreparer:
         normalized = normalized.dropna(subset=["open", "high", "low", "close", "volume"])
         normalized = normalized.sort_values("datetime").drop_duplicates(subset=["timestamp"], keep="last")
         return normalized.reset_index(drop=True)
+
+
+    def load_symbol_data_multi(self, symbol: str, timeframes: Iterable[Timeframe]) -> dict[Timeframe, pd.DataFrame]:
+        return {
+            timeframe: self.load_symbol_data(symbol, timeframe)
+            for timeframe in timeframes
+        }
 
     @staticmethod
     def prepare_vectorbt_inputs(trades: list[TradeResult], initial_price: float = SIMULATION_PRICE_INIT) -> VectorbtInputs:

--- a/vectorbt_runner/mtf_frames.py
+++ b/vectorbt_runner/mtf_frames.py
@@ -1,0 +1,25 @@
+"""Typed containers for multi-timeframe symbol data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+from domain.enums.timeframe import Timeframe
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolMtfFrames:
+    """Normalized pair of frames required by breakout MTF mode."""
+
+    d1_frame: pd.DataFrame
+    m15_frame: pd.DataFrame
+
+    def get_frame(self, timeframe: Timeframe) -> pd.DataFrame:
+        if timeframe == Timeframe.D1:
+            return self.d1_frame
+        if timeframe == Timeframe.M15:
+            return self.m15_frame
+        msg = f"Unsupported timeframe for SymbolMtfFrames: {timeframe.value}"
+        raise ValueError(msg)


### PR DESCRIPTION
### Motivation
- Упростить и типизировать поток данных для MTF-бэктестов, чтобы исключить случайную передачу только одного фрейма в режимe multi-timeframe. 
- Сделать загрузку нескольких ТФ для одного символа более атомарной и явной для CLI подготовки данных.

### Description
- Добавлен `SymbolMtfFrames` dataclass с полями `d1_frame` и `m15_frame` и методом `get_frame` для маппинга `Timeframe -> DataFrame` (файл `vectorbt_runner/mtf_frames.py`).
- В `DataPreparer` добавлен метод `load_symbol_data_multi(symbol, timeframes)` для одновременной загрузки набора таймфреймов (файл `vectorbt_runner/data_preparer.py`).
- В CLI (`_run_backtest_inner` в `cli/commands.py`) для каждого символа теперь собираются `d1_frame` и `m15_frame` через `load_symbol_data_multi`, символы с пустым любым фреймом отбрасываются и в раннер передаётся `dict[str, SymbolMtfFrames]`.
- Изменён интерфейс раннера `BacktestRunner.run` чтобы принимать `symbol_frames: dict[str, SymbolMtfFrames]` и обновлён вызов стратегии для передачи `mtf_frames` вместо нестрогого словаря (файл `vectorbt_runner/backtest_runner.py`).
- Обновлён контракт стратегии в `BaseStrategy.generate_events_multi_tf` чтобы принимать `mtf_frames: SymbolMtfFrames`, и адаптирован `BreakoutStrategy` для чтения нужных фреймов через `mtf_frames.get_frame(...)` с сохранением обратной совместимости через обёртку в `generate_events` (файлы `strategy/base_strategy.py` и `strategy/breakout/breakout_strategy.py`).
- Экспорт `SymbolMtfFrames` добавлен в `vectorbt_runner.__init__.py`.

### Testing
- Запущена автоматическая проверка компиляции модулей командой `python -m compileall cli strategy vectorbt_runner`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69885b923d9c832090fff85091e330e6)