### PR TITLE
Add explicit levels/entry timeframe configuration for backtests

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -190,6 +190,19 @@ def _fetch_exit_code(failed_symbols_count: int, critical_fail_threshold: int = 1
     return 1 if failed_symbols_count >= critical_fail_threshold else 0
 
 
+def _resolve_timeframe(value: str | None, *, fallback: Timeframe, argument_name: str) -> Timeframe:
+    if value is None:
+        return fallback
+
+    normalized = value.strip().lower()
+    for timeframe in Timeframe:
+        if timeframe.value == normalized:
+            return timeframe
+
+    supported = ", ".join(tf.value for tf in Timeframe)
+    raise ValueError(f"Invalid {argument_name}: {value}. Supported values: {supported}")
+
+
 def _fetch_data_inner(config: AppConfig, args: argparse.Namespace) -> int:
     logger = get_logger("fetch-data", level=config.backtest.log_level, logs_dir=config.backtest.logs_dir)
     fetcher, exchange_client, market_client = _build_fetch_stack(config)
@@ -224,20 +237,41 @@ def _update_cache_inner(config: AppConfig, args: argparse.Namespace) -> int:
 
 def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
     logger = get_logger("run-backtest", level=config.backtest.log_level, logs_dir=config.backtest.logs_dir)
+    levels_timeframe = _resolve_timeframe(
+        getattr(args, "levels_tf", None),
+        fallback=config.strategy.levels_timeframe,
+        argument_name="--levels-tf",
+    )
+    entry_timeframe = _resolve_timeframe(
+        getattr(args, "entry_tf", None),
+        fallback=config.strategy.entry_timeframe,
+        argument_name="--entry-tf",
+    )
+    logger.info(
+        "run-backtest: явный запуск, уровни: %s, входы: %s",
+        levels_timeframe.value,
+        entry_timeframe.value,
+    )
+
     preparer = DataPreparer(config.backtest.cache_dir)
-    symbols = args.symbols or preparer.list_symbols(config.fetch.timeframe)
+    symbols = args.symbols or preparer.list_symbols(entry_timeframe)
     if not symbols:
         logger.info("run-backtest: нет данных в кэше")
         return 0
 
     symbol_frames: dict[str, SymbolMtfFrames] = {}
     for symbol in symbols:
-        frames_by_tf = preparer.load_symbol_data_multi(symbol, [Timeframe.D1, Timeframe.M15])
-        d1_frame = frames_by_tf.get(Timeframe.D1, pd.DataFrame())
-        m15_frame = frames_by_tf.get(Timeframe.M15, pd.DataFrame())
-        if d1_frame.empty or m15_frame.empty:
+        frames_by_tf = preparer.load_symbol_data_multi(symbol, [levels_timeframe, entry_timeframe])
+        levels_frame = frames_by_tf.get(levels_timeframe, pd.DataFrame())
+        entry_frame = frames_by_tf.get(entry_timeframe, pd.DataFrame())
+        if levels_frame.empty or entry_frame.empty:
             continue
-        symbol_frames[symbol] = SymbolMtfFrames(d1_frame=d1_frame, m15_frame=m15_frame)
+        symbol_frames[symbol] = SymbolMtfFrames(
+            levels_timeframe=levels_timeframe,
+            entry_timeframe=entry_timeframe,
+            levels_frame=levels_frame,
+            entry_frame=entry_frame,
+        )
     if not symbol_frames:
         logger.info("run-backtest: не удалось подготовить данные")
         return 0
@@ -249,7 +283,12 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
         simulation_timezone=config.simulation.timezone,
     )
     runner = BacktestRunner(config.backtest.results_dir, config.backtest.results_file_name)
-    results = runner.run(strategy, symbol_frames)
+    results = runner.run(
+        strategy,
+        symbol_frames,
+        levels_timeframe=levels_timeframe,
+        entry_timeframe=entry_timeframe,
+    )
     summary = runner.build_summary(results)
     logger.info(
         "run-backtest: total=%s profitable=%s best_pf=%.4f",

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -26,6 +26,16 @@ def build_parser() -> argparse.ArgumentParser:
 
     run_bt = subparsers.add_parser("run-backtest", help="Запуск бектеста по данным в кэше")
     run_bt.add_argument("--symbols", nargs="*", default=None, help="Список символов, например BTC/USDT ETH/USDT")
+    run_bt.add_argument(
+        "--levels-tf",
+        default=None,
+        help="Таймфрейм уровней (например 1d). Приоритетнее LEVELS_TIMEFRAME из env",
+    )
+    run_bt.add_argument(
+        "--entry-tf",
+        default=None,
+        help="Таймфрейм входов (например 15m). Приоритетнее ENTRY_TIMEFRAME из env",
+    )
 
     report = subparsers.add_parser("make-report", help="Сформировать JSON-отчет по результатам бектеста")
     report.add_argument("--input", default=None, help="Путь к CSV с результатами")

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -10,6 +10,7 @@ from config.backtest_config import BacktestConfig
 from config.fetch_config import FetchConfig
 from config.simulation_config import SimulationConfig
 from config.strategy_config import StrategyConfig
+from domain.enums.timeframe import Timeframe
 from constants import (
     DEFAULT_BACKTEST_OUTPUT_FILE,
     DEFAULT_CACHE_DIR,
@@ -50,6 +51,14 @@ def _load_env_file(env_path: Path) -> None:
         os.environ.setdefault(key, value)
 
 
+def _parse_timeframe(value: str, *, env_name: str) -> Timeframe:
+    normalized = value.strip().lower()
+    for timeframe in Timeframe:
+        if timeframe.value == normalized:
+            return timeframe
+    supported = ", ".join(tf.value for tf in Timeframe)
+    raise ValueError(f"Invalid {env_name}: {value}. Supported values: {supported}")
+
 # endregion Private
 
 def load_config(env_path: str | Path = ".env") -> AppConfig:
@@ -69,8 +78,19 @@ def load_config(env_path: str | Path = ".env") -> AppConfig:
         timezone=fetch_timezone,
     )
 
+    strategy_levels_timeframe = _parse_timeframe(
+        os.getenv("LEVELS_TIMEFRAME", Timeframe.D1.value),
+        env_name="LEVELS_TIMEFRAME",
+    )
+    strategy_entry_timeframe = _parse_timeframe(
+        os.getenv("ENTRY_TIMEFRAME", Timeframe.M15.value),
+        env_name="ENTRY_TIMEFRAME",
+    )
+
     strategy_config = StrategyConfig(
         timezone=strategy_timezone,
+        levels_timeframe=strategy_levels_timeframe,
+        entry_timeframe=strategy_entry_timeframe,
     )
 
     simulation_config = SimulationConfig(

--- a/config/strategy_config.py
+++ b/config/strategy_config.py
@@ -14,6 +14,8 @@ from utils.formatters import resolve_timezone
 class StrategyConfig:
     timezone: str = DEFAULT_TIMEZONE
     default_timeframe: Timeframe = DEFAULT_TIMEFRAME
+    levels_timeframe: Timeframe = Timeframe.D1
+    entry_timeframe: Timeframe = Timeframe.M15
 
     @property
     def tzinfo(self) -> tzinfo:

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -19,6 +19,7 @@ from constants import (
     STRATEGY_RISK_FLOOR,
 )
 from domain.enums.position_side import PositionSide
+from domain.enums.timeframe import Timeframe
 from domain.models.candle import Candle
 from domain.models.trade_result import TradeResult
 from domain.models.trade_signal import TradeSignal
@@ -83,7 +84,12 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
     def generate_events(self, data: pd.DataFrame, params: BreakoutParams) -> list[TradeResult]:
         """Backward-compatible wrapper for single-timeframe callers."""
         return self.generate_events_multi_tf(
-            mtf_frames=SymbolMtfFrames(d1_frame=data, m15_frame=data),
+            mtf_frames=SymbolMtfFrames(
+                levels_timeframe=Timeframe.D1,
+                entry_timeframe=Timeframe.M15,
+                levels_frame=data,
+                entry_frame=data,
+            ),
             params=params,
         )
 

--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -22,6 +22,7 @@ from constants import (
     BACKTEST_ZERO_COUNT,
 )
 from domain.enums.trade_result_type import TradeResultType
+from domain.enums.timeframe import Timeframe
 from domain.models.trade_result import TradeResult
 from strategy.base_strategy import BaseStrategy
 from strategy.breakout.config import BREAKOUT_PARAMETER_GRID, PARAMETER_GRID_SIZE, TARGET_PARAMETER_COMBINATIONS, BreakoutParams
@@ -72,7 +73,14 @@ class BacktestRunner:
             )
         ]
 
-    def run(self, strategy: BaseStrategy[BreakoutParams], symbol_frames: dict[str, SymbolMtfFrames]) -> pd.DataFrame:
+    def run(
+        self,
+        strategy: BaseStrategy[BreakoutParams],
+        symbol_frames: dict[str, SymbolMtfFrames],
+        *,
+        levels_timeframe: Timeframe = Timeframe.D1,
+        entry_timeframe: Timeframe = Timeframe.M15,
+    ) -> pd.DataFrame:
         rows: list[dict[str, int | float | str]] = []
         grid = self.build_parameter_grid()
 
@@ -88,6 +96,8 @@ class BacktestRunner:
                     sl_mode=params.sl_mode,
                     tp2_mult=params.tp2_mult,
                     symbol=symbol,
+                    levels_timeframe=levels_timeframe,
+                    entry_timeframe=entry_timeframe,
                 )
                 trades = strategy.generate_events_multi_tf(
                     mtf_frames=mtf_frames,

--- a/vectorbt_runner/mtf_frames.py
+++ b/vectorbt_runner/mtf_frames.py
@@ -13,13 +13,18 @@ from domain.enums.timeframe import Timeframe
 class SymbolMtfFrames:
     """Normalized pair of frames required by breakout MTF mode."""
 
-    d1_frame: pd.DataFrame
-    m15_frame: pd.DataFrame
+    levels_timeframe: Timeframe
+    entry_timeframe: Timeframe
+    levels_frame: pd.DataFrame
+    entry_frame: pd.DataFrame
 
     def get_frame(self, timeframe: Timeframe) -> pd.DataFrame:
-        if timeframe == Timeframe.D1:
-            return self.d1_frame
-        if timeframe == Timeframe.M15:
-            return self.m15_frame
-        msg = f"Unsupported timeframe for SymbolMtfFrames: {timeframe.value}"
+        if timeframe == self.levels_timeframe:
+            return self.levels_frame
+        if timeframe == self.entry_timeframe:
+            return self.entry_frame
+        msg = (
+            "Unsupported timeframe for SymbolMtfFrames: "
+            f"{timeframe.value}. Available: {self.levels_timeframe.value}, {self.entry_timeframe.value}"
+        )
         raise ValueError(msg)


### PR DESCRIPTION
### Motivation
- Make backtest runs explicit about which timeframes are used for level detection and entries so runs are reproducible and can be overridden per-invocation.
- Allow both environment-level defaults and higher-priority CLI overrides to support CI/automation and ad-hoc runs.

### Description
- Added `levels_timeframe` and `entry_timeframe` fields to `StrategyConfig` with defaults `D1` and `M15` (`config/strategy_config.py`).
- Wired env loading and validation in `config/__init__.py` reading `LEVELS_TIMEFRAME` and `ENTRY_TIMEFRAME` via a `_parse_timeframe` helper that validates against `Timeframe`.
- Extended CLI parser (`cli/parser.py`) with `--levels-tf` and `--entry-tf` optional arguments and added `_resolve_timeframe` in `cli/commands.py` to prefer CLI values over env/config.
- Made the backtest flow explicit in `cli/commands.py`: resolve timeframes, log the chosen pair (`уровни`, `входы`), load cache for those exact timeframes, and pass them into `BacktestRunner.run`.
- Generalized `SymbolMtfFrames` to carry configured timeframe pair and corresponding frames, and propagated timeframe parameters into `vectorbt_runner/backtest_runner.py` and `BreakoutParams` usage; preserved the single-timeframe wrapper in `strategy/breakout/breakout_strategy.py` to remain backward-compatible.

### Testing
- Ran module compilation as a smoke-check with `python -m compileall config cli strategy vectorbt_runner`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69885e23590c8320a87254f1916720bd)