### PR TITLE
Add volume_after propagation for breakout→retest evaluation

### DIFF
--- a/domain/models/level.py
+++ b/domain/models/level.py
@@ -18,6 +18,7 @@ class Level:
     shadow_ratio: float
     formation_timestamp: datetime | None = None
     volume_before: float | None = None
+    volume_after: float | None = None
 
     def __post_init__(self) -> None:
         if self.formation_time is None:
@@ -40,4 +41,8 @@ class Level:
 
         if self.volume_before is not None and self.volume_before < 0:
             msg = "Level volume_before cannot be negative."
+            raise ValueError(msg)
+
+        if self.volume_after is not None and self.volume_after < 0:
+            msg = "Level volume_after cannot be negative."
             raise ValueError(msg)

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -52,6 +52,10 @@ class PendingRetest:
     retest_low: float
     retest_high: float
     confirmation_end_idx: int
+    volume_before: float
+    volume_after: float
+    volume_threshold: float
+    volume_filter_passed: bool
 
 
 class BreakoutStrategy(BaseStrategy[BreakoutParams]):
@@ -231,13 +235,14 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                 if idx - breakout_idx > retest_window_candles:
                     pending_breakout = None
                 elif self._is_retest_candle(row=row, breakout=pending_breakout, params=params):
-                    if self._volume_regime_ok(
+                    volume_check = self._evaluate_volume_regime(
                         annotated=annotated,
                         breakout=pending_breakout,
                         breakout_idx=breakout_idx,
                         retest_idx=idx,
                         volume_mult=params.volume_mult,
-                    ) and self._extra_retest_filters_ok(
+                    )
+                    if volume_check["is_ok"] and self._extra_retest_filters_ok(
                         row=row,
                         breakout=pending_breakout,
                         params=params,
@@ -248,6 +253,10 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             retest_low=float(row["low"]),
                             retest_high=float(row["high"]),
                             confirmation_end_idx=idx + max(1, int(params.confirmation_bars)),
+                            volume_before=volume_check["v_before"],
+                            volume_after=volume_check["v_after"],
+                            volume_threshold=volume_check["threshold"],
+                            volume_filter_passed=volume_check["is_ok"],
                         )
                         pending_breakout = None
                         continue
@@ -382,6 +391,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         row: pd.Series,
         lookback: int,
         volume_before: float | None,
+        volume_after: float | None = None,
     ) -> Level:
         formation_dt = datetime_to_timezone(row["level_start_time"].to_pydatetime(), self._simulation_timezone)
         return Level(
@@ -392,6 +402,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             lookback=lookback,
             shadow_ratio=0.0,
             volume_before=volume_before,
+            volume_after=volume_after,
         )
 
     @staticmethod
@@ -419,15 +430,15 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         frame = frame.dropna(subset=["natr"]).reset_index(drop=True)
         return frame
 
-    @staticmethod
-    def _volume_regime_ok(
+    def _evaluate_volume_regime(
+        self,
         *,
         annotated: pd.DataFrame,
         breakout: PendingBreakout,
         breakout_idx: int,
         retest_idx: int,
         volume_mult: float,
-    ) -> bool:
+    ) -> dict[str, float | bool]:
         """Compare volume regime on entry timeframe candles only.
 
         Window definitions (left-inclusive, right-exclusive):
@@ -451,7 +462,12 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                 retest_timestamp,
                 volume_mult,
             )
-            return False
+            return {
+                "v_before": 0.0,
+                "v_after": 0.0,
+                "threshold": 0.0,
+                "is_ok": False,
+            }
 
         v_before = breakout.level.volume_before
         if v_before is None:
@@ -459,6 +475,17 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         v_after = float(after_slice["volume"].mean())
         threshold = v_before * volume_mult
         is_ok = v_after >= threshold
+
+        updated_level = self._build_level(
+            price=breakout.level.price.value,
+            side=breakout.side,
+            row=annotated.iloc[breakout_idx],
+            lookback=breakout.level.lookback,
+            volume_before=v_before,
+            volume_after=v_after,
+        )
+        breakout.level = updated_level
+
         if not is_ok:
             BreakoutStrategy._logger.info(
                 "volume_regime_rejected v_before=%.6f v_after=%.6f volume_mult=%.4f threshold=%.6f",
@@ -467,7 +494,12 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                 volume_mult,
                 threshold,
             )
-        return is_ok
+        return {
+            "v_before": float(v_before),
+            "v_after": v_after,
+            "threshold": threshold,
+            "is_ok": is_ok,
+        }
 
     @staticmethod
     def _is_confirmation(*, row: pd.Series, retest: PendingRetest) -> bool:


### PR DESCRIPTION
### Motivation
- Track post-breakout volume so the breakout→retest decision can use both `v_before` and `v_after` and persist the observed `v_after` back to the level snapshot for later analysis.
- Preserve constructor compatibility for `Level` while adding `volume_after` as an optional metric.
- Improve observability of volume-filter decisions by capturing numeric metrics and the filter outcome in the retest state.

### Description
- Added nullable `volume_after: float | None` to the `Level` dataclass with non-negative validation and a default of `None` to keep constructor compatibility (`domain/models/level.py`).
- Extended `PendingRetest` to store `volume_before`, `volume_after`, `volume_threshold`, and `volume_filter_passed` to record the values and decision used during the retest transition (`strategy/breakout/breakout_strategy.py`).
- Replaced the boolean-only `_volume_regime_ok` with `_evaluate_volume_regime` which returns a structured dictionary containing `v_before`, `v_after`, `threshold`, and `is_ok`, and updated the retest flow to use this result before creating `PendingRetest` (`strategy/breakout/breakout_strategy.py`).
- Persist `v_after` into the breakout-level snapshot by updating the `Level` via the extended `_build_level` (now accepts `volume_after`) and assigning it back to `breakout.level` when evaluating the volume regime (`strategy/breakout/breakout_strategy.py`).

### Testing
- Ran `python -m compileall domain/models/level.py strategy/breakout/breakout_strategy.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988d616a33083208a8b6aa6be0ed2d2)