### PR TITLE
Локализация лог-сообщений и единый глоссарий лог-шаблонов

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -30,6 +30,7 @@ from constants import (
     REPORT_PROFITABLE_PF_THRESHOLD,
     REPORT_PROFIT_FACTOR_FILTER,
     REPORT_TRADES_COUNT_FILTER,
+    LOG_MSG_TASK_COMPLETED,
 )
 from data.clients.coingecko_client import CoinGeckoClient
 from data.exchanges.ccxt_futures_client import CcxtFuturesClient
@@ -87,7 +88,7 @@ def _run_with_logging(command_name: str, config: AppConfig, body: Callable[[], i
     logger.info(f"{command_name}: старт")
     try:
         code = body()
-        logger.info(f"{command_name}: завершено (code={code})")
+        logger.info(f"{LOG_MSG_TASK_COMPLETED % command_name} (code={code})")
         return code
     except Exception as exc:  # noqa: BLE001
         logger.exception(f"{command_name}: ошибка: {exc}")
@@ -169,7 +170,7 @@ def _resolve_symbols(
 
     excluded_by_liquidity = len(intersection) - len(liquid_symbols)
     logger.info(
-        "resolve-symbols: coingecko raw=%s normalized=%s; ccxt raw=%s normalized=%s; intersection=%s",
+        "resolve-symbols: coingecko сырых=%s нормализованных=%s; ccxt сырых=%s нормализованных=%s; пересечение=%s",
         len(top_symbols_raw),
         len(top_symbols_normalized),
         len(futures_symbols_raw),
@@ -177,7 +178,7 @@ def _resolve_symbols(
         len(intersection),
     )
     logger.info(
-        "resolve-symbols: liquidity filter min_volume_usd=%.2f excluded=%s final_symbols=%s",
+        "resolve-symbols: фильтр ликвидности min_volume_usd=%.2f исключено=%s итоговых_символов=%s",
         min_volume_usd,
         excluded_by_liquidity,
         len(liquid_symbols),
@@ -194,7 +195,7 @@ def _fetch_period(config: AppConfig, days: int) -> tuple[datetime, datetime]:
 def _log_fetch_summary(command_name: str, logger: Logger, total_symbols: int, failed_symbols_count: int) -> None:
     failed_ratio = (failed_symbols_count / total_symbols) if total_symbols else 0.0
     logger.info(
-        "%s: fetch summary total=%s ok=%s failed=%s failed_ratio=%.2f%%",
+        "%s: сводка загрузки всего=%s успешно=%s с ошибками=%s доля_ошибок=%.2f%%",
         command_name,
         total_symbols,
         total_symbols - failed_symbols_count,

--- a/constants.py
+++ b/constants.py
@@ -71,6 +71,12 @@ LOGGER_FILE_MAX_BYTES = 5 * 1024 * 1024
 LOGGER_FILE_BACKUP_COUNT = 5
 LOGGER_FILE_ENCODING = "utf-8"
 
+# Logging glossary (единые шаблоны)
+LOG_MSG_LOAD_ERROR = "Ошибка загрузки %s: %s"
+LOG_MSG_RETRY_EXHAUSTED = "Ретраи исчерпаны: endpoint=%s symbol=%s attempts=%s"
+LOG_MSG_SKIP_UP_TO_DATE = "%s пропуск: %s уже актуален"
+LOG_MSG_TASK_COMPLETED = "%s завершено"
+
 # Data preparer constants
 DATA_PREPARER_NUMERIC_COLUMNS = ("open", "high", "low", "close", "volume", "open_interest")
 DATA_PREPARER_EMPTY_FLOAT_DTYPE = "float64"

--- a/data/clients/coingecko_client.py
+++ b/data/clients/coingecko_client.py
@@ -29,6 +29,8 @@ from constants import (
     COINGECKO_VS_CURRENCY_USD,
     SIMULATION_COIN_SUFFIX_SLASH_USDT,
     SIMULATION_COIN_SUFFIX_USDT,
+    LOG_MSG_LOAD_ERROR,
+    LOG_MSG_RETRY_EXHAUSTED,
 )
 from domain.abstract.market_data_client import MarketDataClient
 from utils.retry import RetryExhaustedError, run_with_retry
@@ -114,7 +116,7 @@ class CoinGeckoClient(MarketDataClient):
 
             self._market_cap_cache = loaded_cache
         except (OSError, ValueError, TypeError) as exc:
-            self._logger.warning("Failed to load CoinGecko cache from %s: %s", self._cache_path, exc)
+            self._logger.warning(LOG_MSG_LOAD_ERROR, self._cache_path, exc)
             self._market_cap_cache = {}
 
     def _save_market_cap_cache(self) -> None:
@@ -179,7 +181,7 @@ class CoinGeckoClient(MarketDataClient):
             )
         except RetryExhaustedError as exc:
             raise RuntimeError(
-                f"CoinGecko retry exhausted: endpoint={endpoint} symbol={symbol} attempts={self._retry_attempts}"
+                LOG_MSG_RETRY_EXHAUSTED % (endpoint, symbol, self._retry_attempts)
             ) from exc
 
     def _candidate_has_usdt_market(self, coin_id: str, base_symbol: str) -> bool:
@@ -261,7 +263,7 @@ class CoinGeckoClient(MarketDataClient):
                     selected = usdt_candidates[0]
                     resolved_by_strategy = True
                     self._logger.info(
-                        "Resolved CoinGecko symbol '%s' via exact %s/USDT market match: %s",
+                        "Символ CoinGecko '%s' сопоставлен по точному рынку %s/USDT: %s",
                         symbol,
                         normalized.upper(),
                         selected["id"],
@@ -270,9 +272,9 @@ class CoinGeckoClient(MarketDataClient):
                     selected = usdt_candidates[0]
                     resolved_by_strategy = True
                     self._logger.warning(
-                        "Multiple CoinGecko candidates matched %s/USDT for '%s'; using deterministic fallback: %s",
-                        normalized.upper(),
+                        "Для '%s' найдено несколько кандидатов CoinGecko по %s/USDT; используется детерминированный вариант: %s",
                         symbol,
+                        normalized.upper(),
                         selected["id"],
                     )
 
@@ -282,7 +284,7 @@ class CoinGeckoClient(MarketDataClient):
                     selected = by_metrics
                     resolved_by_strategy = True
                     self._logger.info(
-                        "Resolved ambiguous CoinGecko symbol '%s' by market rank/liquidity: %s",
+                        "Неоднозначный символ CoinGecko '%s' сопоставлен по рангу/ликвидности рынка: %s",
                         symbol,
                         selected["id"],
                     )
@@ -297,7 +299,7 @@ class CoinGeckoClient(MarketDataClient):
 
                 selected = deterministic_fallback
                 self._logger.warning(
-                    "Ambiguous CoinGecko symbol '%s' unresolved by market heuristics; fallback to deterministic candidate: %s",
+                    "Неоднозначный символ CoinGecko '%s' не удалось разрешить эвристиками рынка; переход на детерминированного кандидата: %s",
                     symbol,
                     selected["id"],
                 )

--- a/data/fetchers/market_data_fetcher.py
+++ b/data/fetchers/market_data_fetcher.py
@@ -9,6 +9,7 @@ from constants import (
     DEFAULT_REQUEST_TIMEOUT_SECONDS,
     DEFAULT_LOG_LEVEL,
     DEFAULT_LOGS_DIR,
+    LOG_MSG_TASK_COMPLETED,
 )
 from data.fetchers.ohlcv_fetcher import OhlcvFetcher
 from data.fetchers.oi_fetcher import OiFetcher
@@ -54,11 +55,11 @@ class MarketDataFetcher:
                 self._logger.info(msg)
                 results[symbol] = msg
 
-        self._logger.info("MarketCap завершен")
+        self._logger.info(LOG_MSG_TASK_COMPLETED, "MarketCap")
         return MarketCapsResult(market_caps=results)
 
     def _log_stage_summary(self, stage: str, total: int, ok: int, failed: int) -> None:
-        self._logger.info("%s summary: total=%s ok=%s failed=%s", stage, total, ok, failed)
+        self._logger.info("%s сводка: всего=%s успешно=%s с ошибками=%s", stage, total, ok, failed)
 
     @staticmethod
     def _count_structured_results(results: dict[str, SymbolFetchResult]) -> tuple[int, int, int]:

--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -9,6 +9,7 @@ from constants import (
     DEFAULT_REQUEST_TIMEOUT_SECONDS,
     DEFAULT_LOG_LEVEL,
     DEFAULT_LOGS_DIR,
+    LOG_MSG_SKIP_UP_TO_DATE,
     TIMEFRAME_TO_DELTA,
 )
 from data.quality.data_validator import DataValidator
@@ -59,7 +60,7 @@ class OhlcvFetcher:
         )
         self._logger.info(f"OHLCV старт: {symbol} {timeframe.value} {next_start.isoformat()} -> {end_time.isoformat()}")
         if next_start > end_time:
-            self._logger.info(f"OHLCV пропуск: {symbol} уже актуален")
+            self._logger.info(LOG_MSG_SKIP_UP_TO_DATE, "OHLCV", symbol)
             return 0
 
         data = self._exchange_client.fetch_ohlcv(symbol, timeframe, next_start, end_time)
@@ -68,11 +69,11 @@ class OhlcvFetcher:
 
         gaps = self._gap_detector.detect_gaps(data, timeframe)
         if gaps:
-            self._logger.info(f"OHLCV gaps: {symbol} найдено {len(gaps)} пропусков")
+            self._logger.info(f"OHLCV пропуски: {symbol} найдено {len(gaps)} пропусков")
 
         issues = self._validator.validate(symbol, timeframe, data)
         if issues:
-            self._logger.info(f"OHLCV quality: {symbol} найдено {len(issues)} аномалий")
+            self._logger.info(f"OHLCV качество: {symbol} найдено {len(issues)} аномалий")
 
         added_rows = self._storage.save_incremental(symbol, timeframe, data)
         self._logger.info(f"OHLCV завершен: {symbol}, добавлено {added_rows} строк")

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -9,6 +9,7 @@ from constants import (
     DEFAULT_REQUEST_TIMEOUT_SECONDS,
     DEFAULT_LOG_LEVEL,
     DEFAULT_LOGS_DIR,
+    LOG_MSG_SKIP_UP_TO_DATE,
     TIMEFRAME_TO_DELTA,
 )
 from data.quality.data_validator import DataValidator
@@ -59,7 +60,7 @@ class OiFetcher:
         )
         self._logger.info(f"OI старт: {symbol} {timeframe.value} {next_start.isoformat()} -> {end_time.isoformat()}")
         if next_start > end_time:
-            self._logger.info(f"OI пропуск: {symbol} уже актуален")
+            self._logger.info(LOG_MSG_SKIP_UP_TO_DATE, "OI", symbol)
             return 0
 
         data = self._exchange_client.fetch_open_interest(symbol, timeframe, next_start, end_time)
@@ -100,7 +101,7 @@ class OiFetcher:
 
         issues = self._validator.validate(symbol, timeframe, data)
         if issues:
-            self._logger.info(f"OI quality: {symbol} найдено {len(issues)} аномалий")
+            self._logger.info(f"OI качество: {symbol} найдено {len(issues)} аномалий")
 
         added_rows = self._storage.save_incremental(symbol, timeframe, data)
         self._logger.info(f"OI завершен: {symbol}, добавлено {added_rows} строк")


### PR DESCRIPTION
### Motivation
- Упростить поддержку и избежать рассинхронизации текстов лог-сообщений, вынеся общие шаблоны в одно место. 
- Перевести англоязычные сообщения в затронутых модулях на русский, сохранив уровни логирования и формат параметров. 
- Сохранить существующий формат времени логгера (`%H:%M:%S`) без изменений. 

### Description
- Добавлен глоссарий шаблонов в `constants.py`: `LOG_MSG_LOAD_ERROR`, `LOG_MSG_RETRY_EXHAUSTED`, `LOG_MSG_SKIP_UP_TO_DATE`, `LOG_MSG_TASK_COMPLETED`. 
- В `data/clients/coingecko_client.py` заменены англоязычные сообщения загрузки/ретраев на русские и перенесены на использование соответствующих констант. 
- В `data/fetchers/market_data_fetcher.py` использован общий шаблон завершения задачи и переведена сводка этапов на русский; в `data/fetchers/ohlcv_fetcher.py` и `data/fetchers/oi_fetcher.py` унифицировано сообщение о пропуске через `LOG_MSG_SKIP_UP_TO_DATE` и переведены фрагменты `gaps/quality`. 
- В `cli/commands.py` подключён `LOG_MSG_TASK_COMPLETED` и скорректированы сводочные сообщения по разрешению символов и сводке загрузки, при этом все `%s`/форматные параметры и f-string конструкции сохранены. 

### Testing
- Скомпилированы изменённые модули командой `python -m compileall constants.py data/clients/coingecko_client.py data/fetchers/market_data_fetcher.py data/fetchers/ohlcv_fetcher.py data/fetchers/oi_fetcher.py cli/commands.py`, компиляция прошла успешно. 
- Проверено, что `LOGGER_DATE_FORMAT` остаётся `"%H:%M:%S"` с помощью `rg "LOGGER_DATE_FORMAT\s*=\s*\"%H:%M:%S\"" constants.py utils/logger.py`. 
- Выполнен поиск и проверка модифицированных вызовов логгера в файлах `data/`, `vectorbt_runner/` и `cli/` для подтверждения применения глоссария и перевода; в `simulation/` вызовов таких уровней не найдено.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988e3dae7948320b9397fe07e375d84)