### PR TITLE
Refactor breakout state and CCXT helper types into dedicated modules

### DIFF
--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import Any, Callable, Protocol, TypedDict, cast, runtime_checkable
+from typing import Any, Callable, cast
 
 import pandas as pd
 
@@ -20,6 +20,7 @@ from constants import (
 from domain.abstract.exchange_client import ExchangeClient
 from domain.enums.exchange import Exchange
 from domain.enums.timeframe import Timeframe
+from data.exchanges.ccxt_types import CcxtClientOptions, CcxtFuturesApi, CcxtOpenInterestApi
 from utils.retry import RetryExhaustedError, run_with_retry
 
 try:
@@ -27,32 +28,6 @@ try:
 except ImportError:  # pragma: no cover
     ccxt = None
 
-
-class CcxtClientOptions(TypedDict):
-    defaultType: str
-
-
-class CcxtFuturesApi(Protocol):
-    markets: dict[str, dict[str, object]]
-
-    def load_markets(self) -> object:
-        ...
-
-    def fetch_ohlcv(self, symbol: str, timeframe: str, since: int, limit: int) -> list[list[float]]:
-        ...
-
-
-@runtime_checkable
-class CcxtOpenInterestApi(Protocol):
-    def fetch_open_interest_history(
-        self,
-        symbol: str,
-        timeframe: str,
-        since: int,
-        limit: int,
-        params: dict[str, str] | None = None,
-    ) -> list[dict[str, object]]:
-        ...
 
 # region Private
 

--- a/data/exchanges/ccxt_types.py
+++ b/data/exchanges/ccxt_types.py
@@ -1,0 +1,32 @@
+"""CCXT protocol/type declarations for futures exchange client."""
+
+from __future__ import annotations
+
+from typing import Protocol, TypedDict, runtime_checkable
+
+
+class CcxtClientOptions(TypedDict):
+    defaultType: str
+
+
+class CcxtFuturesApi(Protocol):
+    markets: dict[str, dict[str, object]]
+
+    def load_markets(self) -> object:
+        ...
+
+    def fetch_ohlcv(self, symbol: str, timeframe: str, since: int, limit: int) -> list[list[float]]:
+        ...
+
+
+@runtime_checkable
+class CcxtOpenInterestApi(Protocol):
+    def fetch_open_interest_history(
+        self,
+        symbol: str,
+        timeframe: str,
+        since: int,
+        limit: int,
+        params: dict[str, str] | None = None,
+    ) -> list[dict[str, object]]:
+        ...

--- a/strategy/breakout/__init__.py
+++ b/strategy/breakout/__init__.py
@@ -1,0 +1,7 @@
+"""Breakout strategy package exports."""
+
+from strategy.breakout.breakout_strategy import BreakoutStrategy
+from strategy.breakout.pending_breakout import PendingBreakout
+from strategy.breakout.pending_retest import PendingRetest
+
+__all__ = ["BreakoutStrategy", "PendingBreakout", "PendingRetest"]

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
 
 import pandas as pd
@@ -33,30 +32,10 @@ from simulation.position_simulator import StatefulPositionSimulator
 from simulation.trade_classifier import TradeClassifier
 from strategy.base_strategy import BaseStrategy
 from strategy.breakout.config import BreakoutParams
+from strategy.breakout.pending_breakout import PendingBreakout
+from strategy.breakout.pending_retest import PendingRetest
 from utils.formatters import datetime_to_timezone, utc_ms_to_local_datetime
 from vectorbt_runner.mtf_frames import SymbolMtfFrames
-
-
-@dataclass(slots=True)
-class PendingBreakout:
-    breakout_idx: int
-    level: Level
-    breakout_extreme: float
-    side: PositionSide
-    level_start_time: pd.Timestamp
-
-
-@dataclass(slots=True)
-class PendingRetest:
-    breakout: PendingBreakout
-    retest_idx: int
-    retest_low: float
-    retest_high: float
-    confirmation_end_idx: int
-    volume_before: float
-    volume_after: float
-    volume_threshold: float
-    volume_filter_passed: bool
 
 
 class BreakoutStrategy(BaseStrategy[BreakoutParams]):

--- a/strategy/breakout/pending_breakout.py
+++ b/strategy/breakout/pending_breakout.py
@@ -1,0 +1,19 @@
+"""Pending breakout state model for breakout strategy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+from domain.enums.position_side import PositionSide
+from domain.models.level import Level
+
+
+@dataclass(slots=True)
+class PendingBreakout:
+    breakout_idx: int
+    level: Level
+    breakout_extreme: float
+    side: PositionSide
+    level_start_time: pd.Timestamp

--- a/strategy/breakout/pending_retest.py
+++ b/strategy/breakout/pending_retest.py
@@ -1,0 +1,20 @@
+"""Pending retest state model for breakout strategy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from strategy.breakout.pending_breakout import PendingBreakout
+
+
+@dataclass(slots=True)
+class PendingRetest:
+    breakout: PendingBreakout
+    retest_idx: int
+    retest_low: float
+    retest_high: float
+    confirmation_end_idx: int
+    volume_before: float
+    volume_after: float
+    volume_threshold: float
+    volume_filter_passed: bool


### PR DESCRIPTION
### Motivation
- Reduce module size and separate state models from strategy logic by extracting `PendingBreakout` and `PendingRetest` dataclasses into dedicated modules.  
- Centralize CCXT-related typing/protocol declarations to a single place to improve reuse and clarity.  
- Ensure package public API remains consistent while making internal structure clearer.

### Description
- Moved `PendingBreakout` to `strategy/breakout/pending_breakout.py` and `PendingRetest` to `strategy/breakout/pending_retest.py` and removed their local definitions from `strategy/breakout/breakout_strategy.py`.  
- Updated `strategy/breakout/breakout_strategy.py` to import `PendingBreakout` and `PendingRetest` from the new modules.  
- Added `strategy/breakout/__init__.py` to export `BreakoutStrategy`, `PendingBreakout`, and `PendingRetest` via `__all__` to preserve the public package API.  
- Extracted CCXT helper types (`CcxtClientOptions`, `CcxtFuturesApi`, `CcxtOpenInterestApi`) into `data/exchanges/ccxt_types.py` and updated `data/exchanges/ccxt_futures_client.py` to import those types.

### Testing
- Ran `python -m compileall strategy/breakout data/exchanges` which completed successfully.  
- Attempted runtime import validation of the modified exports, but the environment lacks `pandas`, so full runtime import verification could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988f20c8db88320855fba43f2d14186)