### PR TITLE
Extract OI and epsilon thresholds into named constants

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -18,6 +18,7 @@ from config import AppConfig
 from constants import (
     DEFAULT_QUALITY_REPORT_OUTPUT_FILE,
     DEFAULT_REPORT_OUTPUT_FILE,
+    OI_STALE_MIN_OBSERVATIONS,
     OI_STALE_RATIO_THRESHOLD,
     QUALITY_OI_ALIGNMENT_LEADING_GAPS_ISSUE,
     QUALITY_OI_ALIGNMENT_MISSING_VALUES_ISSUE,
@@ -413,8 +414,6 @@ def _make_report_inner(config: AppConfig, args: argparse.Namespace) -> int:
 
 
 def _collect_oi_alignment_issues(frame: pd.DataFrame) -> list[dict[str, str]]:
-    min_stale_observations = 3
-
     if "open_interest" not in frame.columns:
         return [
             {
@@ -454,7 +453,7 @@ def _collect_oi_alignment_issues(frame: pd.DataFrame) -> list[dict[str, str]]:
         comparison_mask = aligned_valid_mask & aligned_valid_mask.shift(1, fill_value=False)
         compared_observations = int(comparison_mask.sum())
 
-        if compared_observations >= min_stale_observations:
+        if compared_observations >= OI_STALE_MIN_OBSERVATIONS:
             stale_ratio = (aligned_oi.diff().eq(0) & comparison_mask).sum() / compared_observations
         else:
             stale_ratio = 0.0

--- a/constants.py
+++ b/constants.py
@@ -119,6 +119,10 @@ STRATEGY_MIN_TP2_MULT = 1.0
 STRATEGY_RISK_FLOOR = 0.002
 STRATEGY_POSITION_SIZE = 1.0
 STRATEGY_DEFAULT_OPEN_INTEREST = 0.0
+# Price floor epsilon for ratio calculations in breakout candle geometry.
+STRATEGY_PRICE_EPSILON = 1e-12
+# ATR/NATR floor epsilon to avoid zero thresholds in retest filters.
+STRATEGY_NATR_EPSILON = 1e-12
 
 # Reporting domain constants
 REPORT_TRADES_COUNT_FILTER = 30
@@ -163,6 +167,12 @@ SIMULATION_PARQUET_FILE_NAME = "data.parquet"
 # Data quality thresholds
 SPREAD_TO_CLOSE_WARNING_THRESHOLD = 0.3
 OI_STALE_RATIO_THRESHOLD = 0.98
+# Minimal number of aligned OI comparisons before stale-ratio evaluation is meaningful.
+OI_STALE_MIN_OBSERVATIONS = 3
+
+# Simulation thresholds
+# Absolute tolerance for classifying BE/TP2 exits by close price proximity.
+SIMULATION_PRICE_COMPARISON_EPSILON = 1e-8
 
 # Runtime defaults
 DEFAULT_LOG_LEVEL = "INFO"

--- a/simulation/position_simulator.py
+++ b/simulation/position_simulator.py
@@ -14,7 +14,7 @@ from domain.models.trade_result import TradeResult
 from domain.models.trade_signal import TradeSignal
 from domain.value_objects.price import Price
 from domain.value_objects.volume import Volume
-from constants import TP1_CLOSE_RATIO
+from constants import SIMULATION_PRICE_COMPARISON_EPSILON, TP1_CLOSE_RATIO
 from simulation.order_processor import OrderProcessor
 from simulation.trade_classifier import TradeClassifier
 from utils.formatters import datetime_to_timezone
@@ -171,8 +171,6 @@ class StatefulPositionSimulator(PositionSimulator):
             msg = "No active position to close."
             raise RuntimeError(msg)
 
-        price_eps = 1e-8
-
         remaining_size = self.position.size.value - self._closed_size
         if remaining_size > 0:
             self._close_leg(size=remaining_size, target_price=price)
@@ -180,8 +178,8 @@ class StatefulPositionSimulator(PositionSimulator):
         result_type = self.trade_classifier.classify_result_type(
             tp1_done=self.position.tp1_done,
             exit_at_breakeven=self.position.sl_moved_to_be
-            and math.isclose(price, self.position.stop_loss.value, abs_tol=price_eps),
-            exit_at_tp2=math.isclose(price, self.position.take_profit_2.value, abs_tol=price_eps),
+            and math.isclose(price, self.position.stop_loss.value, abs_tol=SIMULATION_PRICE_COMPARISON_EPSILON),
+            exit_at_tp2=math.isclose(price, self.position.take_profit_2.value, abs_tol=SIMULATION_PRICE_COMPARISON_EPSILON),
         )
         trade_result = self.trade_classifier.build_result(
             position=self.position,

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -10,10 +10,12 @@ from constants import (
     STRATEGY_DEFAULT_OPEN_INTEREST,
     STRATEGY_MIN_LOOKBACK,
     STRATEGY_MIN_LOOKBACK_BUFFER,
+    STRATEGY_NATR_EPSILON,
     STRATEGY_MIN_RR,
     STRATEGY_MIN_TP2_MULT,
     STRATEGY_MIN_VOLUME_MULT,
     STRATEGY_POSITION_SIZE,
+    STRATEGY_PRICE_EPSILON,
     STRATEGY_REQUIRED_COLUMNS,
     STRATEGY_RISK_FLOOR,
 )
@@ -314,7 +316,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
     def _body_ratio(row: pd.Series) -> float:
         high = float(row["high"])
         low = float(row["low"])
-        spread = max(high - low, 1e-12)
+        spread = max(high - low, STRATEGY_PRICE_EPSILON)
         return abs(float(row["close"]) - float(row["open"])) / spread
 
     def _is_retest_candle(self, *, row: pd.Series, breakout: PendingBreakout, params: BreakoutParams) -> bool:
@@ -340,15 +342,15 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         return float(row["close"]) < float(row["open"]) and float(row["close"]) < zone_top
 
     def _extra_retest_filters_ok(self, *, row: pd.Series, breakout: PendingBreakout, params: BreakoutParams) -> bool:
-        natr = max(float(row.get("natr", 0.0)), 1e-12)
+        natr = max(float(row.get("natr", 0.0)), STRATEGY_NATR_EPSILON)
         if breakout.side == PositionSide.LONG:
-            move = (float(row["close"]) - float(row["low"])) / max(float(row["close"]), 1e-12)
+            move = (float(row["close"]) - float(row["low"])) / max(float(row["close"]), STRATEGY_PRICE_EPSILON)
             level_price = breakout.level.price.value
-            depth = max(0.0, (level_price - float(row["low"])) / max(level_price, 1e-12))
+            depth = max(0.0, (level_price - float(row["low"])) / max(level_price, STRATEGY_PRICE_EPSILON))
         else:
-            move = (float(row["high"]) - float(row["close"])) / max(float(row["close"]), 1e-12)
+            move = (float(row["high"]) - float(row["close"])) / max(float(row["close"]), STRATEGY_PRICE_EPSILON)
             level_price = breakout.level.price.value
-            depth = max(0.0, (float(row["high"]) - level_price) / max(level_price, 1e-12))
+            depth = max(0.0, (float(row["high"]) - level_price) / max(level_price, STRATEGY_PRICE_EPSILON))
         min_move_threshold = params.min_move_atr * natr
         max_depth_threshold = params.max_retest_depth * natr
         return move >= min_move_threshold and depth <= max_depth_threshold


### PR DESCRIPTION
### Motivation
- Убрать магические литералы и дать говорящие имена порогам/эпсилонам, чтобы улучшить читаемость и стабильность логики при проверках stale OI, геометрии свечей и сравнении цен в симуляторе.

### Description
- Добавлены именованные константы в `constants.py`: `OI_STALE_MIN_OBSERVATIONS`, `STRATEGY_PRICE_EPSILON`, `STRATEGY_NATR_EPSILON` и `SIMULATION_PRICE_COMPARISON_EPSILON` с короткими комментариями назначения рядом с определениями.
- Заменены литералы в коде на новые константы: в `cli/commands.py` удалён локальный `min_stale_observations = 3` и используется `OI_STALE_MIN_OBSERVATIONS`, в `strategy/breakout/breakout_strategy.py` значения `1e-12` заменены на `STRATEGY_PRICE_EPSILON`/`STRATEGY_NATR_EPSILON` и соответствующие константы импортированы, в `simulation/position_simulator.py` литерал `1e-8` заменён на `SIMULATION_PRICE_COMPARISON_EPSILON` и импортирован.
- Комментарии рядом с новыми константами поясняют назначение каждой пороговой переменной, чтобы сохранить читаемость и избежать регрессий при дальнейшем изменении значений.

### Testing
- Выполнена автоматическая компиляция изменённых модулей командой `python -m compileall constants.py cli/commands.py strategy/breakout/breakout_strategy.py simulation/position_simulator.py`, сборка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698979d78d54832096c023e3f978bfa3)