### PR TITLE
Fix launcher task args typing to match command handlers

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -6,7 +6,6 @@ import argparse
 import json
 import os
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any
 
 from cli import commands
@@ -53,8 +52,8 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _task_namespace(task: dict[str, Any], cli_args: argparse.Namespace) -> SimpleNamespace:
-    return SimpleNamespace(
+def _task_namespace(task: dict[str, Any], cli_args: argparse.Namespace) -> argparse.Namespace:
+    return argparse.Namespace(
         top_n=int(task.get("top_n", cli_args.top_n)),
         days=int(task.get("days", cli_args.days)),
         symbols=task.get("symbols", cli_args.symbols),
@@ -63,7 +62,7 @@ def _task_namespace(task: dict[str, Any], cli_args: argparse.Namespace) -> Simpl
     )
 
 
-def _run_mode(config: AppConfig, mode: str, task_args: SimpleNamespace) -> int:
+def _run_mode(config: AppConfig, mode: str, task_args: argparse.Namespace) -> int:
     handlers = {
         MODE_FETCH_CACHE: commands.fetch_data,
         MODE_UPDATE_CACHE: commands.update_cache,


### PR DESCRIPTION
### Motivation
- Static type checking reported a mismatch where task arguments were created as `types.SimpleNamespace` but command handlers expect `argparse.Namespace`, so types needed to be aligned to remove the warning.

### Description
- In `launcher.py` replaced the `SimpleNamespace` usage with `argparse.Namespace` for `_task_namespace`, updated `_run_mode` annotation to accept `argparse.Namespace`, and removed the now-unused `SimpleNamespace` import.

### Testing
- Ran `python -m compileall launcher.py` to verify the module compiles successfully and the change does not break import-time code, and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a21ecfe7c8320a4005101cf86b781)