### PR TITLE
Перевод комментариев, регионов и логов на русский язык

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -78,7 +78,7 @@ def check_quality(config: AppConfig, args: argparse.Namespace) -> int:
     return _run_with_logging("check-quality", config, lambda: _check_quality_inner(config, args))
 
 
-# region Private
+# область Приватные
 
 def _run_with_logging(command_name: str, config: AppConfig, body: Callable[[], int]) -> int:
     logger = get_logger(
@@ -245,7 +245,7 @@ def _fetch_data_inner(config: AppConfig, args: argparse.Namespace) -> int:
         logger=logger,
     )
     if not symbols:
-        logger.info("fetch-data: не найдено символов для загрузки")
+        logger.info("загрузка-данных: не найдено символов для загрузки")
         return 0
 
     start_time, end_time = _fetch_period(config, args.days)
@@ -268,7 +268,7 @@ def _update_cache_inner(config: AppConfig, args: argparse.Namespace) -> int:
         logger=logger,
     )
     if not symbols:
-        logger.info("update-cache: не найдено символов для обновления")
+        logger.info("обновление-кэша: не найдено символов для обновления")
         return 0
 
     start_time, end_time = _fetch_period(config, args.days)
@@ -300,7 +300,7 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
     preparer = DataPreparer(config.backtest.cache_dir)
     symbols = args.symbols or preparer.list_symbols(entry_timeframe)
     if not symbols:
-        logger.info("run-backtest: нет данных в кэше")
+        logger.info("запуск-бектеста: нет данных в кэше")
         return 0
 
     symbol_frames: dict[str, SymbolMtfFrames] = {}
@@ -317,7 +317,7 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
             entry_frame=entry_frame,
         )
     if not symbol_frames:
-        logger.info("run-backtest: не удалось подготовить данные")
+        logger.info("запуск-бектеста: не удалось подготовить данные")
         return 0
 
     strategy = BreakoutStrategy(
@@ -363,11 +363,11 @@ def _make_report_inner(config: AppConfig, args: argparse.Namespace) -> int:
     ]
     missing_columns = [column for column in required_columns if column not in frame.columns]
     if missing_columns:
-        logger.error("make-report: отсутствуют обязательные колонки: %s", ", ".join(missing_columns))
+        logger.error("подготовка-отчета: отсутствуют обязательные колонки: %s", ", ".join(missing_columns))
         return 1
 
     if frame.empty:
-        logger.info("make-report: пустой файл результатов")
+        logger.info("подготовка-отчета: пустой файл результатов")
         return 1
 
     filtered = frame[(frame["trades_count"] >= REPORT_TRADES_COUNT_FILTER) & (frame["profit_factor"] > REPORT_PROFIT_FACTOR_FILTER)].copy()
@@ -525,7 +525,7 @@ def _check_quality_inner(config: AppConfig, args: argparse.Namespace) -> int:
     preparer = DataPreparer(config.backtest.cache_dir)
     symbols = args.symbols or preparer.list_symbols(config.fetch.timeframe)
     if not symbols:
-        logger.info("check-quality: нет данных для проверки")
+        logger.info("проверка-качества: нет данных для проверки")
         return 0
 
     validator = DataValidator()
@@ -540,7 +540,7 @@ def _check_quality_inner(config: AppConfig, args: argparse.Namespace) -> int:
     for symbol in symbols:
         frame = preparer.load_symbol_data(symbol, config.fetch.timeframe)
         if frame.empty:
-            logger.info(f"check-quality: {symbol} пропущен, пустой датасет")
+            logger.info(f"проверка-качества: {symbol} пропущен, пустой датасет")
             continue
 
         issues = validator.validate(symbol, config.fetch.timeframe, frame)
@@ -589,9 +589,9 @@ def _check_quality_inner(config: AppConfig, args: argparse.Namespace) -> int:
     output_path = Path(args.output) if args.output else config.backtest.results_dir / DEFAULT_QUALITY_REPORT_OUTPUT_FILE
     _save_quality_report(report, output_path)
 
-    logger.info(f"check-quality: итог issues={report.summary.issues_total} gaps={report.summary.gaps_total}")
-    logger.info(f"check-quality: отчет сохранен {output_path}")
+    logger.info(f"проверка-качества: итог проблемы={report.summary.issues_total} пропуски={report.summary.gaps_total}")
+    logger.info(f"проверка-качества: отчет сохранен {output_path}")
     return 0
 
 
-# endregion Private
+# конец области Приватные

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -36,7 +36,7 @@ __all__ = [
 ]
 
 
-# region Private
+# область Приватные
 
 def _load_env_file(env_path: Path) -> None:
     if not env_path.exists():
@@ -60,7 +60,7 @@ def _parse_timeframe(value: str, *, env_name: str) -> Timeframe:
     supported = ", ".join(tf.value for tf in Timeframe)
     raise ValueError(f"Invalid {env_name}: {value}. Supported values: {supported}")
 
-# endregion Private
+# конец области Приватные
 
 def load_config(env_path: str | Path = ".env") -> AppConfig:
     env_file = Path(env_path)

--- a/constants.py
+++ b/constants.py
@@ -11,21 +11,21 @@ from domain.enums.sl_mode import SLMode
 SUPPORTED_TIMEFRAMES: tuple[Timeframe, ...] = tuple(Timeframe)
 DEFAULT_TIMEFRAME = Timeframe.H1
 
-# API limits
+# Лимиты АПИ
 DEFAULT_FETCH_BATCH_SIZE = 1000
 DEFAULT_RETRY_ATTEMPTS = 3
 DEFAULT_RETRY_BACKOFF_SECONDS = 1.0
 MILLISECONDS_IN_SECOND = 1000
 
-# Timeouts (seconds)
+# Таймауты (секунды)
 HTTP_TIMEOUT_SECONDS = 30
 EXCHANGE_TIMEOUT_SECONDS = 20
 COINGECKO_TIMEOUT_SECONDS = 20
 
-# Fetcher defaults
+# Значения по умолчанию для загрузчиков
 DEFAULT_REQUEST_TIMEOUT_SECONDS = 60
 
-# Fetching domain constants
+# Константы домена загрузки
 TIMEFRAME_TO_DELTA = {
     Timeframe.M1: timedelta(minutes=1),
     Timeframe.M5: timedelta(minutes=5),
@@ -44,7 +44,7 @@ FUTURES_SETTLEMENT_QUOTE_ASSET = "USDT"
 SIMULATION_COIN_SUFFIX_SLASH_USDT = "/usdt"
 SIMULATION_COIN_SUFFIX_USDT = "usdt"
 
-# CoinGecko constants
+# Константы КоинГекко
 COINGECKO_BASE_URL = "https://api.coingecko.com/api/v3"
 COINGECKO_HEADER_ACCEPT_KEY = "accept"
 COINGECKO_HEADER_ACCEPT_JSON = "application/json"
@@ -60,7 +60,7 @@ COINGECKO_PARAM_SPARKLINE = "sparkline"
 COINGECKO_SPARKLINE_FALSE = "false"
 COINGECKO_DEFAULT_PAGE = 1
 
-# Logger constants
+# Константы логгера
 LOGGER_DATE_FORMAT = "%H:%M:%S"
 LOGGER_MESSAGE_FORMAT = "%(asctime)s %(message)s"
 LOGGER_COLOR_RESET = "\033[0m"
@@ -71,13 +71,13 @@ LOGGER_FILE_MAX_BYTES = 5 * 1024 * 1024
 LOGGER_FILE_BACKUP_COUNT = 5
 LOGGER_FILE_ENCODING = "utf-8"
 
-# Logging glossary (единые шаблоны)
+# Глоссарий логирования (единые шаблоны)
 LOG_MSG_LOAD_ERROR = "Ошибка загрузки %s: %s"
 LOG_MSG_RETRY_EXHAUSTED = "Ретраи исчерпаны: endpoint=%s symbol=%s attempts=%s"
 LOG_MSG_SKIP_UP_TO_DATE = "%s пропуск: %s уже актуален"
 LOG_MSG_TASK_COMPLETED = "%s завершено"
 
-# Data preparer constants
+# Константы подготовщика данных
 DATA_PREPARER_NUMERIC_COLUMNS = ("open", "high", "low", "close", "volume", "open_interest")
 DATA_PREPARER_EMPTY_FLOAT_DTYPE = "float64"
 DATA_PREPARER_EMPTY_BOOL_DTYPE = "bool"
@@ -85,7 +85,7 @@ DATA_PREPARER_TRADE_COLUMNS = ("entry_time", "exit_time", "pnl", "pnl_percent", 
 SIMULATION_ZERO_VALUE = 0.0
 SIMULATION_UNIT_INCREMENT = 1.0
 
-# Breakout grid constants
+# Константы сетки пробоя
 BREAKOUT_LOOKBACK_VALUES = (8, 13, 21)
 BREAKOUT_VOLUME_MULT_VALUES = (1.2, 1.5, 2.0)
 BREAKOUT_RETEST_WINDOW_VALUES = (12, 24, 36, 48)
@@ -97,19 +97,19 @@ BREAKOUT_ENTRY_TRIGGER_VALUES = (EntryTrigger.IMMEDIATE, EntryTrigger.PRICE_CONF
 BREAKOUT_TP2_MULT_VALUES = (1.5, 2.0, 2.5)
 BREAKOUT_MIN_BODY_RATIO_VALUES = (0.4,)
 BREAKOUT_MIN_MOVE_ATR_VALUES = (0.5,)
-# Backward-compatible alias for legacy imports.
+# Обратносуместимый алиас для старых импортов.
 BREAKOUT_MIN_MOVE_FROM_BREAKOUT_VALUES = BREAKOUT_MIN_MOVE_ATR_VALUES
 BREAKOUT_MAX_RETEST_DEPTH_VALUES = (1.0,)
 BREAKOUT_CONFIRMATION_BARS_VALUES = (2,)
 BREAKOUT_TARGET_PARAMETER_COMBINATIONS = 5832
 
-# Trading defaults
+# Значения по умолчанию для торговли
 DEFAULT_COMMISSION_RATE = 0.0004
 DEFAULT_SLIPPAGE = 0.0005
 DEFAULT_SPREAD = 0.0
 TP1_CLOSE_RATIO = 0.5
 
-# Strategy domain constants
+# Константы домена стратегии
 STRATEGY_REQUIRED_COLUMNS = ("timestamp", "open", "high", "low", "close", "volume")
 STRATEGY_MIN_LOOKBACK = 5
 STRATEGY_MIN_LOOKBACK_BUFFER = 5
@@ -119,12 +119,12 @@ STRATEGY_MIN_TP2_MULT = 1.0
 STRATEGY_RISK_FLOOR = 0.002
 STRATEGY_POSITION_SIZE = 1.0
 STRATEGY_DEFAULT_OPEN_INTEREST = 0.0
-# Price floor epsilon for ratio calculations in breakout candle geometry.
+# Эпсилон нижней границы цены для расчетов отношений в геометрии свечи пробоя.
 STRATEGY_PRICE_EPSILON = 1e-12
-# ATR/NATR floor epsilon to avoid zero thresholds in retest filters.
+# Эпсилон нижней границы АТР/НАТР, чтобы избегать нулевых порогов в фильтрах ретеста.
 STRATEGY_NATR_EPSILON = 1e-12
 
-# Reporting domain constants
+# Константы домена отчетности
 REPORT_TRADES_COUNT_FILTER = 30
 REPORT_PROFIT_FACTOR_FILTER = 1.0
 REPORT_PROFITABLE_PF_THRESHOLD = 1.0
@@ -137,7 +137,7 @@ QUALITY_SEVERITY_WARNING = "WARNING"
 QUALITY_SEVERITY_CRITICAL = "CRITICAL"
 QUALITY_SEVERITY_INFO = "INFO"
 
-# Backtest domain constants
+# Константы домена бектеста
 BACKTEST_EMPTY_PF = 0.0
 BACKTEST_EMPTY_PNL_PERCENT = 0.0
 BACKTEST_EMPTY_WIN_RATE = 0.0
@@ -150,7 +150,7 @@ BACKTEST_ROUND_MAX_DD = 6
 BACKTEST_PF_FALLBACK_WHEN_NO_LOSSES = 99.0
 BACKTEST_PROFITABLE_PF_THRESHOLD = 1.0
 
-# Simulation/vectorbt domain constants
+# Константы домена симуляции/векторбт
 SIMULATION_VECTORBT_DIRECTION = "longonly"
 SIMULATION_INIT_CASH = 100.0
 SIMULATION_SIZE = 1.0
@@ -164,17 +164,17 @@ SIMULATION_DATETIME_UNIT_MS = "ms"
 SIMULATION_TIMEZONE_UTC = "UTC"
 SIMULATION_PARQUET_FILE_NAME = "data.parquet"
 
-# Data quality thresholds
+# Пороги качества данных
 SPREAD_TO_CLOSE_WARNING_THRESHOLD = 0.3
 OI_STALE_RATIO_THRESHOLD = 0.98
-# Minimal number of aligned OI comparisons before stale-ratio evaluation is meaningful.
+# Минимальное число выровненных сравнений ОИ, при котором оценка доли застоя имеет смысл.
 OI_STALE_MIN_OBSERVATIONS = 3
 
-# Simulation thresholds
-# Absolute tolerance for classifying BE/TP2 exits by close price proximity.
+# Пороги симуляции
+# Абсолютная погрешность для классификации выходов безубыток/ТП2 по близости цены закрытия.
 SIMULATION_PRICE_COMPARISON_EPSILON = 1e-8
 
-# Runtime defaults
+# Значения по умолчанию для рантайма
 DEFAULT_LOG_LEVEL = "INFO"
 DEFAULT_TIMEZONE = "Europe/Belgrade"
 DEFAULT_CACHE_DIR = "./cache"
@@ -184,15 +184,15 @@ DEFAULT_BACKTEST_OUTPUT_FILE = "backtest_results.csv"
 DEFAULT_REPORT_OUTPUT_FILE = "report.json"
 DEFAULT_QUALITY_REPORT_OUTPUT_FILE = "quality_report.json"
 
-# CLI defaults
+# Значения по умолчанию для интерфейса командной строки
 DEFAULT_TOP_N = 50
 DEFAULT_FETCH_DAYS = 60
 DEFAULT_UPDATE_DAYS = 7
 DEFAULT_MIN_VOLUME_USD = 20_000_000.0
 
-# Service defaults
+# Значения по умолчанию для сервиса
 
-# Error codes
+# Коды ошибок
 ERROR_CODE_INVALID_CONFIG = "E_CFG_001"
 ERROR_CODE_FETCH_FAILED = "E_FETCH_001"
 ERROR_CODE_SIMULATION_FAILED = "E_SIM_001"

--- a/data/clients/coingecko_client.py
+++ b/data/clients/coingecko_client.py
@@ -59,7 +59,7 @@ class CoinGeckoClient(MarketDataClient):
         self._retry_backoff_seconds = retry_backoff_seconds
         self._load_market_cap_cache()
 
-    # region Private
+    # область Приватные
 
     @staticmethod
     def _normalize_symbol(symbol: str) -> str:
@@ -313,7 +313,7 @@ class CoinGeckoClient(MarketDataClient):
 
         return self._symbol_to_id[canonical_symbol]
 
-    # endregion Private
+    # конец области Приватные
 
     def get_market_cap(self, symbol: str) -> float:
         canonical_symbol = self._canonical_symbol_key(symbol)

--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -29,7 +29,7 @@ except ImportError:  # pragma: no cover
     ccxt = None
 
 
-# region Private
+# область Приватные
 
 def _to_utc_ms(value: datetime) -> int:
     if value.tzinfo is None:
@@ -38,7 +38,7 @@ def _to_utc_ms(value: datetime) -> int:
         value = value.astimezone(timezone.utc)
     return int(value.timestamp() * MILLISECONDS_IN_SECOND)
 
-# endregion Private
+# конец области Приватные
 
 
 class CcxtFuturesClient(ExchangeClient):
@@ -70,7 +70,7 @@ class CcxtFuturesClient(ExchangeClient):
         )
         self._client.load_markets()
 
-    # region Private
+    # область Приватные
 
     @staticmethod
     def _build_client(
@@ -96,7 +96,7 @@ class CcxtFuturesClient(ExchangeClient):
             params["options"] = CcxtClientOptions(defaultType=CCXT_MARKET_TYPE_SWAP)
             return ccxt.okx(cast(Any, params))
 
-    # endregion Private
+    # конец области Приватные
 
     def _retry_exchange_call(
         self,

--- a/data/storage/parquet_storage.py
+++ b/data/storage/parquet_storage.py
@@ -15,7 +15,7 @@ class ParquetStorage:
     def __init__(self, base_dir: str | Path = "cache") -> None:
         self._base_dir = Path(base_dir)
 
-    # region Private
+    # область Приватные
 
     def _data_path(self, symbol: str, timeframe: Timeframe) -> Path:
         return self._base_dir / symbol / timeframe.value / "data.parquet"
@@ -34,7 +34,7 @@ class ParquetStorage:
         normalized["datetime"] = ts
         return normalized
 
-    # endregion Private
+    # конец области Приватные
 
     def load(self, symbol: str, timeframe: Timeframe) -> pd.DataFrame:
         path = self._data_path(symbol, timeframe)

--- a/simulation/order_processor.py
+++ b/simulation/order_processor.py
@@ -15,7 +15,7 @@ class OrderProcessor:
     commission_rate: float
     slippage: float
 
-    # region Private
+    # область Приватные
 
     def _apply_slippage(self, price: float, *, is_buy: bool) -> float:
         multiplier = 1 + self.slippage if is_buy else 1 - self.slippage
@@ -24,7 +24,7 @@ class OrderProcessor:
     def _commission(self, notional: float) -> float:
         return notional * self.commission_rate
 
-    # endregion Private
+    # конец области Приватные
 
     def execute_entry(self, candle_open: float, side: PositionSide, size: float) -> Fill:
         """Execute market entry at candle open with adverse slippage and commission."""

--- a/simulation/position_simulator.py
+++ b/simulation/position_simulator.py
@@ -36,7 +36,7 @@ class StatefulPositionSimulator(PositionSimulator):
     _closed_size: float = 0.0
     _last_exit_price: float = 0.0
 
-    # region Private
+    # область Приватные
 
     def _open_from_pending_signal(self, candle: Candle) -> None:
         signal = self._pending_signal
@@ -139,7 +139,7 @@ class StatefulPositionSimulator(PositionSimulator):
         self.position = None
         return trade_result
 
-    # endregion Private
+    # конец области Приватные
 
     def register_signal(self, signal: TradeSignal, size: float) -> None:
         """Store signal; position will be opened by market order on next processed candle open."""
@@ -168,7 +168,7 @@ class StatefulPositionSimulator(PositionSimulator):
     def close_position(self, price: float, exit_time: datetime) -> TradeResult:
         """Close remaining position at given price and close timestamp, then return classified trade result."""
         if self.position is None:
-            msg = "No active position to close."
+            msg = "Нет активной позиции для закрытия."
             raise RuntimeError(msg)
 
         remaining_size = self.position.size.value - self._closed_size
@@ -194,6 +194,6 @@ class StatefulPositionSimulator(PositionSimulator):
     def update_stop(self, new_stop: float) -> None:
         """Update stop-loss level for active position."""
         if self.position is None:
-            msg = "No active position to update stop for."
+            msg = "Нет активной позиции для обновления стопа."
             raise RuntimeError(msg)
         self.position.stop_loss = Price(new_stop)

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -284,7 +284,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
 
         return trades
 
-    # region Private
+    # область Приватные
 
     def _to_candle(self, row: pd.Series) -> Candle:
         return Candle(
@@ -553,4 +553,4 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         tp2 = entry_price - risk * min_rr * tp2_mult
         return tp1, tp2
 
-    # endregion Private
+    # конец области Приватные

--- a/utils/retry.py
+++ b/utils/retry.py
@@ -43,7 +43,7 @@ def run_with_retry(
 ) -> R:
     """Execute callable with retries and structured logs for each attempt."""
     if attempts < 1:
-        raise ValueError("attempts must be >= 1")
+        raise ValueError("attempts должно быть >= 1")
 
     target_logger = logger or logging.getLogger(__name__)
     endpoint_value = endpoint or "n/a"
@@ -53,7 +53,7 @@ def run_with_retry(
         try:
             result = call(*args, **kwargs)
             target_logger.info(
-                "retry operation=%s attempt=%s/%s endpoint=%s symbol=%s result=success",
+                "повтор операция=%s попытка=%s/%s эндпоинт=%s символ=%s результат=успех",
                 operation,
                 attempt_number,
                 attempts,
@@ -64,7 +64,7 @@ def run_with_retry(
         except retriable_exceptions as exc:
             is_last = attempt_number >= attempts
             target_logger.warning(
-                "retry operation=%s attempt=%s/%s endpoint=%s symbol=%s result=failure reason=%s",
+                "повтор операция=%s попытка=%s/%s эндпоинт=%s символ=%s результат=ошибка причина=%s",
                 operation,
                 attempt_number,
                 attempts,

--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -56,7 +56,7 @@ class BacktestRunner:
         confirmation_bars = BREAKOUT_PARAMETER_GRID["confirmation_bars"]
         entry_trigger = BREAKOUT_PARAMETER_GRID["entry_trigger"]
 
-        # combos = |lookback| × |volume_mult| × |retest_window_hours| × |retest_zone| × |retest_zone_atr| × |min_rr| × |sl_mode| × |tp2_mult| × |min_body_ratio| × |min_move_atr| × |max_retest_depth| × |confirmation_bars| × |entry_trigger|
+        # комбинации = |оглядка| × |множитель_объема| × |окно_ретеста_часы| × |зона_ретеста| × |зона_ретеста_атр| × |мин_рр| × |режим_сл| × |множитель_тп2| × |мин_доля_тела| × |мин_движение_атр| × |макс_глубина_ретеста| × |бары_подтверждения| × |триггер_входа|
         return [
             BreakoutParams(
                 lookback=int(lb),
@@ -163,7 +163,7 @@ class BacktestRunner:
             best_pf=best_pf,
         )
 
-    # region Private
+    # область Приватные
 
     @staticmethod
     def _build_metrics_row(params: BreakoutParams, trades: list[TradeResult]) -> dict[str, int | float | str | None]:
@@ -250,4 +250,4 @@ class BacktestRunner:
         self._results_dir.mkdir(parents=True, exist_ok=True)
         results.to_csv(self._results_dir / self._results_file_name, index=False)
 
-    # endregion Private
+    # конец области Приватные


### PR DESCRIPTION
### Motivation
- Привести комментарии, метки регионов и текстовые сообщения логов к единому русскому языку для удобства локальной поддержки и чтения кода.

### Description
- Переведены заголовки секций и поясняющие комментарии в `constants.py` (напр., `# API limits` → `# Лимиты АПИ`, уточнены формулировки порогов/эпсилонов и пр.).
- Переведены маркеры регионов `# region`/`# endregion` на `# область Приватные`/`# конец области Приватные` в нескольких модулях (`config/__init__.py`, `data/clients/coingecko_client.py`, `data/exchanges/ccxt_futures_client.py`, `data/storage/parquet_storage.py`, `simulation/order_processor.py`, `simulation/position_simulator.py`, `strategy/breakout/breakout_strategy.py`, `vectorbt_runner/backtest_runner.py`).
- Локализованы строковые сообщения логирования и описания ошибок в `utils/retry.py`, `cli/commands.py`, `simulation/position_simulator.py` и части CLI-логов (`fetch-data`, `update-cache`, `run-backtest`, `make-report`, `check-quality`) на русский язык.

### Testing
- Запущена компиляция байткода для всего проекта командой `python -m compileall -q .`, которая завершилась успешно.
- Автоматических тестов не запускалось дополнительно (в PR внесены только текстовые правки комментариев/логов и маркеров регионов).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a24690cfc83209df4d963894b51a2)