### PR TITLE
Normalize private region blocks across Python modules

### DIFF
--- a/data/fetchers/market_data_fetcher.py
+++ b/data/fetchers/market_data_fetcher.py
@@ -24,6 +24,7 @@ from utils.logger import get_logger
 class MarketDataFetcher:
     """Координирует загрузку OHLCV/OI и получение рыночной капитализации."""
 
+    # область Приватные
     def __init__(
         self,
         ohlcv_fetcher: OhlcvFetcher,
@@ -73,6 +74,7 @@ class MarketDataFetcher:
         ok = sum(1 for value in results.market_caps.values() if isinstance(value, (int, float)))
         return total, ok, total - ok
 
+    # конец области Приватные
     def fetch_all(
         self,
         symbols: list[str],

--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -26,6 +26,7 @@ from utils.logger import get_logger
 class OhlcvFetcher:
     """Fetches and stores OHLCV incrementally for one or many symbols."""
 
+    # область Приватные
     def __init__(
         self,
         exchange_client: ExchangeClient,
@@ -35,6 +36,7 @@ class OhlcvFetcher:
         retry_backoff_seconds: float = 1.0,
         log_level: int | str = DEFAULT_LOG_LEVEL,
         logs_dir: str | Path = DEFAULT_LOGS_DIR,
+    # конец области Приватные
     ) -> None:
         self._exchange_client = exchange_client
         self._storage = storage

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -26,6 +26,7 @@ from utils.logger import get_logger
 class OiFetcher:
     """Fetches and stores open-interest data incrementally for one or many symbols."""
 
+    # область Приватные
     def __init__(
         self,
         exchange_client: ExchangeClient,
@@ -35,6 +36,7 @@ class OiFetcher:
         retry_backoff_seconds: float = 1.0,
         log_level: int | str = DEFAULT_LOG_LEVEL,
         logs_dir: str | Path = DEFAULT_LOGS_DIR,
+    # конец области Приватные
     ) -> None:
         self._exchange_client = exchange_client
         self._storage = storage

--- a/domain/models/breakout_event.py
+++ b/domain/models/breakout_event.py
@@ -19,6 +19,7 @@ class BreakoutEvent:
     volume_after: Volume
     oi_value: Volume
 
+    # область Приватные
     def __post_init__(self) -> None:
         if self.breakout_time is None:
             msg = "Breakout time is required."
@@ -27,3 +28,4 @@ class BreakoutEvent:
         if self.volume_after.value == 0:
             msg = "Breakout volume_after must be positive."
             raise ValueError(msg)
+    # конец области Приватные

--- a/domain/models/candle.py
+++ b/domain/models/candle.py
@@ -19,6 +19,7 @@ class Candle:
     volume: Volume
     open_interest: Volume
 
+    # область Приватные
     def __post_init__(self) -> None:
         if self.timestamp is None:
             msg = "Candle timestamp is required."
@@ -35,3 +36,4 @@ class Candle:
         if not (self.low.value <= self.close.value <= self.high.value):
             msg = "Candle close price must be inside [low, high]."
             raise ValueError(msg)
+    # конец области Приватные

--- a/domain/models/data_quality_issue.py
+++ b/domain/models/data_quality_issue.py
@@ -18,6 +18,7 @@ class DataQualityIssue:
     timestamp: datetime
     description: str
 
+    # область Приватные
     def __post_init__(self) -> None:
         if not self.symbol:
             msg = "DataQualityIssue symbol is required."
@@ -34,3 +35,4 @@ class DataQualityIssue:
         if not self.description:
             msg = "DataQualityIssue description is required."
             raise ValueError(msg)
+    # конец области Приватные

--- a/domain/models/level.py
+++ b/domain/models/level.py
@@ -20,6 +20,7 @@ class Level:
     volume_before: float | None = None
     volume_after: float | None = None
 
+    # область Приватные
     def __post_init__(self) -> None:
         if self.formation_time is None:
             msg = "Level formation_time is required."
@@ -46,3 +47,4 @@ class Level:
         if self.volume_after is not None and self.volume_after < 0:
             msg = "Level volume_after cannot be negative."
             raise ValueError(msg)
+    # конец области Приватные

--- a/domain/models/position.py
+++ b/domain/models/position.py
@@ -20,6 +20,7 @@ class Position:
     tp1_done: bool = False
     sl_moved_to_be: bool = False
 
+    # область Приватные
     def __post_init__(self) -> None:
         if self.entry_time is None:
             msg = "Position entry_time is required."
@@ -28,3 +29,4 @@ class Position:
         if self.size.value <= 0:
             msg = "Position size must be positive."
             raise ValueError(msg)
+    # конец области Приватные

--- a/domain/models/retest_event.py
+++ b/domain/models/retest_event.py
@@ -18,6 +18,7 @@ class RetestEvent:
     volume_retest: Volume
     oi_retest: Volume
 
+    # область Приватные
     def __post_init__(self) -> None:
         if self.retest_time is None:
             msg = "Retest time is required."
@@ -26,3 +27,4 @@ class RetestEvent:
         if self.retest_time < self.breakout_event.breakout_time:
             msg = "Retest time cannot be earlier than breakout time."
             raise ValueError(msg)
+    # конец области Приватные

--- a/domain/models/symbol_info.py
+++ b/domain/models/symbol_info.py
@@ -14,6 +14,7 @@ class SymbolInfo:
     daily_volume: Volume
     is_active: bool = True
 
+    # область Приватные
     def __post_init__(self) -> None:
         if not self.symbol:
             msg = "SymbolInfo symbol is required."
@@ -22,3 +23,4 @@ class SymbolInfo:
         if self.market_cap < 0:
             msg = "SymbolInfo market_cap cannot be negative."
             raise ValueError(msg)
+    # конец области Приватные

--- a/domain/models/trade_result.py
+++ b/domain/models/trade_result.py
@@ -20,6 +20,7 @@ class TradeResult:
     pnl: float
     pnl_percent: Percentage
 
+    # область Приватные
     def __post_init__(self) -> None:
         if self.entry_time is None or self.exit_time is None:
             msg = "Trade result entry/exit time is required."
@@ -28,3 +29,4 @@ class TradeResult:
         if self.exit_time < self.entry_time:
             msg = "Trade result exit_time cannot be earlier than entry_time."
             raise ValueError(msg)
+    # конец области Приватные

--- a/domain/models/trade_signal.py
+++ b/domain/models/trade_signal.py
@@ -19,6 +19,7 @@ class TradeSignal:
     position_side: PositionSide
     symbol: str
 
+    # область Приватные
     def __post_init__(self) -> None:
         if self.entry_time is None:
             msg = "Trade signal entry_time is required."
@@ -44,3 +45,4 @@ class TradeSignal:
         if self.position_side == PositionSide.SHORT and self.take_profit_2.value > self.take_profit_1.value:
             msg = "For SHORT, take_profit_2 must be <= take_profit_1."
             raise ValueError(msg)
+    # конец области Приватные

--- a/domain/value_objects/percentage.py
+++ b/domain/value_objects/percentage.py
@@ -12,6 +12,7 @@ class Percentage:
 
     value: float
 
+    # область Приватные
     def __post_init__(self) -> None:
         if not isfinite(self.value):
             msg = "Percentage must be a finite number."
@@ -20,3 +21,4 @@ class Percentage:
         if self.value < -100.0:
             msg = "Percentage must be greater than or equal to -100.0."
             raise ValueError(msg)
+    # конец области Приватные

--- a/domain/value_objects/price.py
+++ b/domain/value_objects/price.py
@@ -11,7 +11,9 @@ class Price:
 
     value: float
 
+    # область Приватные
     def __post_init__(self) -> None:
         if self.value < 0:
             msg = "Price cannot be negative."
             raise ValueError(msg)
+    # конец области Приватные

--- a/domain/value_objects/volume.py
+++ b/domain/value_objects/volume.py
@@ -11,7 +11,9 @@ class Volume:
 
     value: float
 
+    # область Приватные
     def __post_init__(self) -> None:
         if self.value < 0:
             msg = "Volume cannot be negative."
             raise ValueError(msg)
+    # конец области Приватные

--- a/launcher.py
+++ b/launcher.py
@@ -27,6 +27,7 @@ MODE_LABELS: dict[str, str] = {
 }
 
 
+# область Приватные
 def _force_single_thread_mode() -> None:
     single_thread_env = {
         "OMP_NUM_THREADS": "1",
@@ -117,6 +118,7 @@ def _run_batch(config: AppConfig, cli_args: argparse.Namespace, payload: dict[st
     return 0
 
 
+# конец области Приватные
 def main() -> int:
     _force_single_thread_mode()
     parser = _build_parser()

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from cli.parser import build_parser, resolve_handler
 from config import load_config
 
 
+# область Приватные
 def _force_single_thread_mode() -> None:
     """Disable library-level multithreading to avoid lockups/timeouts in long runs."""
     single_thread_env = {
@@ -21,6 +22,7 @@ def _force_single_thread_mode() -> None:
         os.environ[key] = value
 
 
+# конец области Приватные
 def main() -> int:
     _force_single_thread_mode()
     config = load_config()

--- a/utils/retry.py
+++ b/utils/retry.py
@@ -21,6 +21,7 @@ class RetryExhaustedError(Exception):
     attempts: int
     reason: str
 
+    # область Приватные
     def __str__(self) -> str:
         return (
             f"Повторы исчерпаны для операции='{self.operation}' после {self.attempts} попыток: "
@@ -28,6 +29,7 @@ class RetryExhaustedError(Exception):
         )
 
 
+    # конец области Приватные
 def run_with_retry(
     operation: str,
     call: Callable[P, R],

--- a/vectorbt_runner/data_preparer.py
+++ b/vectorbt_runner/data_preparer.py
@@ -26,6 +26,7 @@ from domain.models.trade_result import TradeResult
 from vectorbt_runner.vectorbt_inputs import VectorbtInputs
 
 
+# область Приватные
 def _to_utc_timestamp(value: object) -> pd.Timestamp:
     """Convert datetime-like values to UTC timestamp safely for aware/naive inputs."""
     timestamp = pd.Timestamp(value)
@@ -34,14 +35,17 @@ def _to_utc_timestamp(value: object) -> pd.Timestamp:
     return timestamp.tz_convert("UTC")
 
 
+# конец области Приватные
 class DataPreparer:
     """Loads cached parquet data and normalizes it for backtest processing."""
 
     REQUIRED_COLUMNS = STRATEGY_REQUIRED_COLUMNS
 
+    # область Приватные
     def __init__(self, cache_dir: Path) -> None:
         self._cache_dir = Path(cache_dir)
 
+    # конец области Приватные
     def list_symbols(self, timeframe: Timeframe) -> list[str]:
         symbols: list[str] = []
         if not self._cache_dir.exists():


### PR DESCRIPTION
### Motivation
- Привести к единому стилю регионов для приватных функций и методов по всему репозиторию чтобы улучшить читаемость и навигацию по коду.
- Обернуть приватные методы внутри классов единым регионом и добавить module-level private-регионы в файлах с топ‑уровневыми приватными функциями для консистентности структуры.

### Description
- Добавлены блоки `# область Приватные` / `# конец области Приватные` в файлы, содержащие определения `def _...`, в том числе `launcher.py`, `main.py`, `vectorbt_runner/data_preparer.py`, `data/fetchers/*`, `domain/models/*`, `domain/value_objects/*` и `utils/retry.py` (19 файлов затронуто). 
- Приватные методы в классах (fetchers, models, value objects и пр.) обёрнуты единым class-level region, а модульные приватные функции в `main.py`, `launcher.py` и `vectorbt_runner/data_preparer.py` получили module-level region.
- Стиль и размещение комментариев регионов унифицированы без изменения бизнес‑логики или поведения кода.

### Testing
- Выполнена проверка компиляции проектa с помощью `python -m compileall -q .` и ошибок компиляции не обнаружено.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a33cbd6188320bd5d09b0711f2c73)