### PR TITLE
Убрать inline-комментарий из build_parameter_grid и перенести пояснение в docstring

### DIFF
--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -131,6 +131,8 @@ class BacktestRunner:
 
     @staticmethod
     def build_parameter_grid() -> list[BreakoutParams]:
+        """Собирает декартово произведение диапазонов параметров в полный набор конфигураций стратегии."""
+
         lookback = BREAKOUT_PARAMETER_GRID["lookback"]
         volume_mult = BREAKOUT_PARAMETER_GRID["volume_mult"]
         retest_window_hours = BREAKOUT_PARAMETER_GRID["retest_window_hours"]
@@ -145,7 +147,6 @@ class BacktestRunner:
         confirmation_bars = BREAKOUT_PARAMETER_GRID["confirmation_bars"]
         entry_trigger = BREAKOUT_PARAMETER_GRID["entry_trigger"]
 
-        # комбинации = |оглядка| × |множитель_объема| × |окно_ретеста_часы| × |зона_ретеста| × |зона_ретеста_атр| × |мин_рр| × |режим_сл| × |множитель_тп2| × |мин_доля_тела| × |мин_движение_атр| × |макс_глубина_ретеста| × |бары_подтверждения| × |триггер_входа|
         return [
             BreakoutParams(
                 lookback=int(lb),
@@ -251,4 +252,3 @@ class BacktestRunner:
             profitable_combinations=profitable,
             best_pf=best_pf,
         )
-


### PR DESCRIPTION
### Motivation
- Удалить комментарий вида `# ...` внутри метода и перенести пояснение в краткую документацию публичного метода, чтобы убрать inline-комментарии из тела `def` и сделать описание доступным через docstring.

### Description
- В `vectorbt_runner/backtest_runner.py` добавлен русскоязычный docstring к `BacktestRunner.build_parameter_grid`, а соответствующий inline-комментарий удалён из тела метода.

### Testing
- Файл скомпилирован командой `python -m compileall -q vectorbt_runner/backtest_runner.py` успешно (без ошибок).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a36fd3b088320ad24a1306b9eeaec)