### PR TITLE
Move private helper functions above public CLI entrypoints in cli/commands.py

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -58,26 +58,6 @@ from utils.symbols import normalize_symbol
 from vectorbt_runner import BacktestRunner, DataPreparer, SymbolMtfFrames
 
 
-def fetch_data(config: AppConfig, args: argparse.Namespace) -> int:
-    return _run_with_logging("fetch-data", config, lambda: _fetch_data_inner(config, args))
-
-
-def update_cache(config: AppConfig, args: argparse.Namespace) -> int:
-    return _run_with_logging("update-cache", config, lambda: _update_cache_inner(config, args))
-
-
-def run_backtest(config: AppConfig, args: argparse.Namespace) -> int:
-    return _run_with_logging("run-backtest", config, lambda: _run_backtest_inner(config, args))
-
-
-def make_report(config: AppConfig, args: argparse.Namespace) -> int:
-    return _run_with_logging("make-report", config, lambda: _make_report_inner(config, args))
-
-
-def check_quality(config: AppConfig, args: argparse.Namespace) -> int:
-    return _run_with_logging("check-quality", config, lambda: _check_quality_inner(config, args))
-
-
 # область Приватные
 
 def _run_with_logging(command_name: str, config: AppConfig, body: Callable[[], int]) -> int:
@@ -595,3 +575,24 @@ def _check_quality_inner(config: AppConfig, args: argparse.Namespace) -> int:
 
 
 # конец области Приватные
+
+# Публичные точки входа
+
+def fetch_data(config: AppConfig, args: argparse.Namespace) -> int:
+    return _run_with_logging("fetch-data", config, lambda: _fetch_data_inner(config, args))
+
+
+def update_cache(config: AppConfig, args: argparse.Namespace) -> int:
+    return _run_with_logging("update-cache", config, lambda: _update_cache_inner(config, args))
+
+
+def run_backtest(config: AppConfig, args: argparse.Namespace) -> int:
+    return _run_with_logging("run-backtest", config, lambda: _run_backtest_inner(config, args))
+
+
+def make_report(config: AppConfig, args: argparse.Namespace) -> int:
+    return _run_with_logging("make-report", config, lambda: _make_report_inner(config, args))
+
+
+def check_quality(config: AppConfig, args: argparse.Namespace) -> int:
+    return _run_with_logging("check-quality", config, lambda: _check_quality_inner(config, args))


### PR DESCRIPTION
### Motivation
- Упорядочить файл так, чтобы все приватные хелперы находились в начале, а публичные точки входа — в конце, для лучшей читаемости и поддерживаемости кода.

### Description
- Перенёс приватные функции (например, `_run_with_logging`, `_build_fetch_stack`, `_resolve_symbols`, `_fetch_data_inner` и другие) в верхнюю часть файла `cli/commands.py` в область `# область Приватные` без изменения сигнатур и логики.
- Переместил публичные точки входа `fetch_data`, `update_cache`, `run_backtest`, `make_report`, `check_quality` в конец файла под заголовком `# Публичные точки входа`.
- Обновил/сохранил маркеры приватного региона так, чтобы он покрывал все приватные функции в верхней части файла.
- Никакой функциональной логики не изменялось, изменён только порядок функций и секционирование файла.

### Testing
- Выполнена проверка синтаксиса файла командой `python -m py_compile cli/commands.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b5684e0a08320a9d78ee84c7d89ac)