### PR TITLE
Remove docstrings and inline private comments from underscore-prefixed methods

### DIFF
--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -35,7 +35,6 @@ class OhlcvFetcher:
         retry_backoff_seconds: float = 1.0,
         log_level: int | str = DEFAULT_LOG_LEVEL,
         logs_dir: str | Path = DEFAULT_LOGS_DIR,
-    # конец области Приватные
     ) -> None:
         self._exchange_client = exchange_client
         self._storage = storage

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -35,7 +35,6 @@ class OiFetcher:
         retry_backoff_seconds: float = 1.0,
         log_level: int | str = DEFAULT_LOG_LEVEL,
         logs_dir: str | Path = DEFAULT_LOGS_DIR,
-    # конец области Приватные
     ) -> None:
         self._exchange_client = exchange_client
         self._storage = storage

--- a/main.py
+++ b/main.py
@@ -10,7 +10,6 @@ from config import load_config
 
 # область Приватные
 def _force_single_thread_mode() -> None:
-    """Метод."""
     single_thread_env = {
         "OMP_NUM_THREADS": "1",
         "OPENBLAS_NUM_THREADS": "1",

--- a/vectorbt_runner/data_preparer.py
+++ b/vectorbt_runner/data_preparer.py
@@ -28,7 +28,6 @@ from vectorbt_runner.vectorbt_inputs import VectorbtInputs
 
 # область Приватные
 def _to_utc_timestamp(value: object) -> pd.Timestamp:
-    """Метод."""
     timestamp = pd.Timestamp(value)
     if timestamp.tz is None:
         return timestamp.tz_localize("UTC")


### PR DESCRIPTION
### Motivation
- Привести код в соответствие с требованием убрать описания поведения приватной логики из docstring'ов и из комментариев внутри тела/сигнатур приватных методов.
- Исключить утечку описаний поведения в приватных функциях, оставив только код и типизацию для методов, имена которых начинаются с `_`.

### Description
- Удалены докстринги из приватной функции `main._force_single_thread_mode` (оставлена только типизация и реализация).
- Удалены докстринги из приватной функции `vectorbt_runner.data_preparer._to_utc_timestamp` (оставлена только типизация и реализация).
- Убраны внутренние inline-комментарии `# конец области Приватные`, которые находились внутри сигнатуры/тела приватных `__init__` в `data/fetchers/oi_fetcher.py` и `data/fetchers/ohlcv_fetcher.py`, чтобы в приватной логике не оставалось описаний в виде комментариев.
- Изменения минимальны и ограничены указанными файлами: `main.py`, `vectorbt_runner/data_preparer.py`, `data/fetchers/oi_fetcher.py`, `data/fetchers/ohlcv_fetcher.py`.

### Testing
- Выполнен поиск определений приватных функций с помощью `rg -n "def _[A-Za-z0-9_]*\("` и проверено, что целевые функции найдены; команда выполнилась успешно.
- Прогон AST-проверки на наличие docstring'ов у функций, начинающихся с `_`, с помощью Python-скрипта, который подтвердил отсутствие docstring'ов в целевых функциях (`OK`).
- Прогон AST-проверки на наличие строк-комментариев внутри тел/сигнатур приватных функций с помощью Python-скрипта, который подтвердил отсутствие таких комментариев (`OK`).
- Все автоматизированные проверки, запущенные в репозитории, прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b5825d77c83209200aa4eebf64b43)