### PR TITLE
Добавлены короткие русские докстринги для публичных функций в ключевых модулях

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -579,20 +579,25 @@ def _check_quality_inner(config: AppConfig, args: argparse.Namespace) -> int:
 # Публичные точки входа
 
 def fetch_data(config: AppConfig, args: argparse.Namespace) -> int:
+    """Запускает сценарий загрузки рыночных данных."""
     return _run_with_logging("fetch-data", config, lambda: _fetch_data_inner(config, args))
 
 
 def update_cache(config: AppConfig, args: argparse.Namespace) -> int:
+    """Обновляет локальный кэш данных."""
     return _run_with_logging("update-cache", config, lambda: _update_cache_inner(config, args))
 
 
 def run_backtest(config: AppConfig, args: argparse.Namespace) -> int:
+    """Запускает бэктест по текущей конфигурации."""
     return _run_with_logging("run-backtest", config, lambda: _run_backtest_inner(config, args))
 
 
 def make_report(config: AppConfig, args: argparse.Namespace) -> int:
+    """Формирует итоговый отчёт по результатам."""
     return _run_with_logging("make-report", config, lambda: _make_report_inner(config, args))
 
 
 def check_quality(config: AppConfig, args: argparse.Namespace) -> int:
+    """Проверяет качество и целостность данных."""
     return _run_with_logging("check-quality", config, lambda: _check_quality_inner(config, args))

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -13,6 +13,7 @@ Handler = Callable[[AppConfig, argparse.Namespace], int]
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """Собирает и возвращает парсер аргументов CLI."""
     parser = argparse.ArgumentParser(prog="mtf-trend")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -57,6 +58,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def resolve_handler(command_name: str) -> Handler:
+    """Находит обработчик команды по разобранным аргументам."""
     handlers: dict[str, Handler] = {
         "fetch-data": commands.fetch_data,
         "update-cache": commands.update_cache,

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -63,6 +63,7 @@ def _parse_timeframe(value: str, *, env_name: str) -> Timeframe:
 # конец области Приватные
 
 def load_config(env_path: str | Path = ".env") -> AppConfig:
+    """Загружает конфигурацию приложения из файла."""
     env_file = Path(env_path)
     _load_env_file(env_file)
 

--- a/config/fetch_config.py
+++ b/config/fetch_config.py
@@ -21,4 +21,5 @@ class FetchConfig:
 
     @property
     def tzinfo(self) -> tzinfo:
+        """Возвращает объект часового пояса для загрузки данных."""
         return resolve_timezone(self.timezone)

--- a/config/simulation_config.py
+++ b/config/simulation_config.py
@@ -18,4 +18,5 @@ class SimulationConfig:
 
     @property
     def tzinfo(self) -> tzinfo:
+        """Возвращает объект часового пояса для симуляции."""
         return resolve_timezone(self.timezone)

--- a/config/strategy_config.py
+++ b/config/strategy_config.py
@@ -19,4 +19,5 @@ class StrategyConfig:
 
     @property
     def tzinfo(self) -> tzinfo:
+        """Возвращает объект часового пояса для стратегии."""
         return resolve_timezone(self.timezone)

--- a/data/clients/coingecko_client.py
+++ b/data/clients/coingecko_client.py
@@ -315,6 +315,7 @@ class CoinGeckoClient(MarketDataClient):
     # конец области Приватные
 
     def get_market_cap(self, symbol: str) -> float:
+        """Возвращает капитализацию монеты на нужный момент."""
         canonical_symbol = self._canonical_symbol_key(symbol)
         now = datetime.now(tz=timezone.utc)
 
@@ -344,6 +345,7 @@ class CoinGeckoClient(MarketDataClient):
         return market_cap
 
     def get_top_coins_by_market_cap(self, limit: int) -> list[str]:
+        """Возвращает список монет с наибольшей капитализацией."""
         response = self._request(
             endpoint="/coins/markets",
             symbol=f"top_{limit}",
@@ -359,6 +361,7 @@ class CoinGeckoClient(MarketDataClient):
         return [str(item.get("symbol") or "").upper() for item in response.json() if item.get("symbol")]
 
     def get_total_volumes(self, symbols_or_coin_ids: list[str]) -> dict[str, float]:
+        """Возвращает объёмы торгов для списка монет."""
         if not symbols_or_coin_ids:
             return {}
 

--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -124,6 +124,7 @@ class CcxtFuturesClient(ExchangeClient):
     # конец области Приватные
 
     def get_futures_symbols(self) -> list[str]:
+        """Возвращает список доступных фьючерсных символов."""
         symbols: list[str] = []
         for market in self._client.markets.values():
             if not market.get("active", True):
@@ -147,6 +148,7 @@ class CcxtFuturesClient(ExchangeClient):
         return sorted(set(symbols))
 
     def fetch_ohlcv(self, symbol: str, timeframe: Timeframe, start_time: datetime, end_time: datetime) -> pd.DataFrame:
+        """Запрашивает свечи по символу и интервалу."""
         start_ms = _to_utc_ms(start_time)
         since = start_ms
         end_ms = _to_utc_ms(end_time)
@@ -181,6 +183,7 @@ class CcxtFuturesClient(ExchangeClient):
         return frame.drop_duplicates(subset=["timestamp"]).sort_values("timestamp").reset_index(drop=True)
 
     def fetch_open_interest(self, symbol: str, timeframe: Timeframe, start_time: datetime, end_time: datetime) -> pd.DataFrame:
+        """Запрашивает историю open interest по символу."""
         if not isinstance(self._client, CcxtOpenInterestApi):
             raise NotImplementedError(f"Exchange {self.exchange.value} does not support fetch_open_interest_history in CCXT")
 

--- a/data/exchanges/ccxt_types.py
+++ b/data/exchanges/ccxt_types.py
@@ -13,9 +13,11 @@ class CcxtFuturesApi(Protocol):
     markets: dict[str, dict[str, object]]
 
     def load_markets(self) -> object:
+        """Описывает загрузку справочника рынков биржи."""
         ...
 
     def fetch_ohlcv(self, symbol: str, timeframe: str, since: int, limit: int) -> list[list[float]]:
+        """Описывает загрузку свечей через API биржи."""
         ...
 
 
@@ -29,4 +31,5 @@ class CcxtOpenInterestApi(Protocol):
         limit: int,
         params: dict[str, str] | None = None,
     ) -> list[dict[str, object]]:
+        """Описывает загрузку истории open interest через API биржи."""
         ...

--- a/data/fetchers/market_data_fetcher.py
+++ b/data/fetchers/market_data_fetcher.py
@@ -61,6 +61,7 @@ class MarketDataFetcher:
     # конец области Приватные
 
     def fetch_market_caps(self, symbols: list[str]) -> MarketCapsResult:
+        """Загружает капитализации для списка тикеров."""
         self._logger.info(f"Рыночная капитализация старт: {len(symbols)} инструментов")
         results: dict[str, float | str] = {}
         for symbol in symbols:
@@ -82,6 +83,7 @@ class MarketDataFetcher:
         start_time: datetime,
         end_time: datetime,
     ) -> FetchAllResult:
+        """Загружает полный набор рыночных метрик."""
         self._logger.info(f"Загрузка старт: {len(symbols)} символов, TF={timeframe.value}")
 
         ohlcv_result = self._ohlcv_fetcher.fetch_many(

--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -48,6 +48,7 @@ class OhlcvFetcher:
         self._validator = DataValidator()
 
     def fetch_symbol(self, symbol: str, timeframe: Timeframe, start_time: datetime, end_time: datetime) -> int:
+        """Загружает OHLCV-данные для одного символа."""
         next_start = start_time
         watermark_column = "close"
         last_timestamp = self._storage.get_last_timestamp_for_column(symbol, timeframe, watermark_column)
@@ -86,6 +87,7 @@ class OhlcvFetcher:
         start_time: datetime,
         end_time: datetime,
     ) -> dict[str, SymbolFetchResult]:
+        """Последовательно загружает OHLCV для набора символов."""
         results: dict[str, SymbolFetchResult] = {}
         for symbol in symbols:
             try:

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -48,6 +48,7 @@ class OiFetcher:
         self._validator = DataValidator()
 
     def fetch_symbol(self, symbol: str, timeframe: Timeframe, start_time: datetime, end_time: datetime) -> int:
+        """Загружает историю open interest для одного символа."""
         next_start = start_time
         watermark_column = "open_interest"
         last_timestamp = self._storage.get_last_timestamp_for_column(symbol, timeframe, watermark_column)
@@ -114,6 +115,7 @@ class OiFetcher:
         start_time: datetime,
         end_time: datetime,
     ) -> dict[str, SymbolFetchResult]:
+        """Последовательно загружает open interest для набора символов."""
         results: dict[str, SymbolFetchResult] = {}
         for symbol in symbols:
             try:

--- a/data/quality/data_validator.py
+++ b/data/quality/data_validator.py
@@ -16,6 +16,7 @@ class DataValidator:
     """Класс."""
     @staticmethod
     def validate(symbol: str, timeframe: Timeframe, data: pd.DataFrame) -> list[DataQualityIssue]:
+        """Проверяет данные и собирает найденные проблемы."""
         if data.empty:
             return []
 

--- a/data/quality/deduplicator.py
+++ b/data/quality/deduplicator.py
@@ -9,6 +9,7 @@ class Deduplicator:
     """Класс."""
     @staticmethod
     def deduplicate(data: pd.DataFrame) -> pd.DataFrame:
+        """Удаляет дублирующиеся строки по ключевым полям."""
         if data.empty:
             return data.copy()
 

--- a/data/quality/gap_detector.py
+++ b/data/quality/gap_detector.py
@@ -24,6 +24,7 @@ class GapDetector:
     """Класс."""
     @staticmethod
     def detect_gaps(data: pd.DataFrame, timeframe: Timeframe) -> list[pd.Timestamp]:
+        """Ищет пропуски во временном ряду свечей."""
         if data.empty or "timestamp" not in data.columns:
             return []
 

--- a/data/quality/oi_aligner.py
+++ b/data/quality/oi_aligner.py
@@ -9,6 +9,7 @@ class OiAligner:
     """Класс."""
     @staticmethod
     def align(ohlcv: pd.DataFrame, open_interest: pd.DataFrame) -> pd.DataFrame:
+        """Синхронизирует open interest с базовой временной сеткой."""
         if ohlcv.empty:
             return ohlcv.copy()
 

--- a/data/quality/time_alignment.py
+++ b/data/quality/time_alignment.py
@@ -9,6 +9,7 @@ class TimeAlignment:
     """Класс."""
     @staticmethod
     def align_to_utc(data: pd.DataFrame) -> pd.DataFrame:
+        """Приводит временные метки к единой зоне UTC."""
         if data.empty:
             return data.copy()
 

--- a/data/storage/parquet_storage.py
+++ b/data/storage/parquet_storage.py
@@ -36,6 +36,7 @@ class ParquetStorage:
     # конец области Приватные
 
     def load(self, symbol: str, timeframe: Timeframe) -> pd.DataFrame:
+        """Загружает данные из parquet-файла."""
         path = self._data_path(symbol, timeframe)
         if not path.exists():
             return pd.DataFrame()
@@ -45,6 +46,7 @@ class ParquetStorage:
         return self._ensure_utc_columns(frame)
 
     def get_last_timestamp(self, symbol: str, timeframe: Timeframe) -> pd.Timestamp | None:
+        """Возвращает последнюю временную метку в хранилище."""
         data = self.load(symbol, timeframe)
         if data.empty or "timestamp" not in data.columns:
             return None
@@ -56,6 +58,7 @@ class ParquetStorage:
         timeframe: Timeframe,
         column_name: str,
     ) -> pd.Timestamp | None:
+        """Возвращает последнюю метку времени для указанной колонки."""
         data = self.load(symbol, timeframe)
         if data.empty or "timestamp" not in data.columns:
             return None
@@ -73,6 +76,7 @@ class ParquetStorage:
         return pd.to_datetime(data.loc[valid_rows, "timestamp"], unit="ms", utc=True).max()
 
     def save_incremental(self, symbol: str, timeframe: Timeframe, new_data: pd.DataFrame) -> int:
+        """Дозаписывает новые данные без перезаписи старых."""
         if new_data.empty:
             return 0
 

--- a/domain/models/reporting/symbol_fetch_result.py
+++ b/domain/models/reporting/symbol_fetch_result.py
@@ -13,9 +13,11 @@ class SymbolFetchResult:
 
     @classmethod
     def ok(cls, added_rows: int) -> "SymbolFetchResult":
+        """Создаёт успешный результат загрузки символа."""
         return cls(success=True, message="ok", added_rows=added_rows)
 
     @classmethod
     def error(cls, message: str) -> "SymbolFetchResult":
+        """Создаёт результат загрузки с ошибкой."""
         return cls(success=False, message=message, added_rows=0)
 

--- a/simulation/trade_classifier.py
+++ b/simulation/trade_classifier.py
@@ -18,6 +18,7 @@ class TradeClassifier:
 
     @staticmethod
     def classify_result_type(*, tp1_done: bool, exit_at_breakeven: bool, exit_at_tp2: bool) -> TradeResultType:
+        """Определяет тип исхода сделки по её параметрам."""
         if exit_at_tp2:
             return TradeResultType.TP2
         if exit_at_breakeven:
@@ -33,6 +34,7 @@ class TradeClassifier:
         result_type: TradeResultType,
         pnl: float,
     ) -> TradeResult:
+        """Формирует объект результата классификации сделки."""
         entry_notional = position.entry_price.value * position.size.value
         pnl_percent_value = 0.0 if entry_notional == 0 else (pnl / entry_notional) * 100
         return TradeResult(

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -309,6 +309,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
     # конец области Приватные
 
     def validate_config(self, params: BreakoutParams) -> None:
+        """Проверяет корректность параметров стратегии."""
         if params.lookback < STRATEGY_MIN_LOOKBACK:
             raise ValueError(f"параметр lookback должен быть >= {STRATEGY_MIN_LOOKBACK}")
         if params.volume_mult <= STRATEGY_MIN_VOLUME_MULT:
@@ -321,6 +322,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             raise ValueError("параметр confirmation_bars должен быть >= 1")
 
     def prepare_data(self, data: pd.DataFrame) -> pd.DataFrame:
+        """Подготавливает входные данные перед расчётом сигналов."""
         missing = [col for col in self.REQUIRED_COLUMNS if col not in data.columns]
         if missing:
             raise ValueError(f"Отсутствуют обязательные колонки: {missing}")

--- a/strategy/breakout/config.py
+++ b/strategy/breakout/config.py
@@ -48,6 +48,7 @@ class BreakoutParams:
     entry_timeframe: Timeframe = Timeframe.M15
 
     def resolve_retest_zone_ratio(self, natr: float) -> float:
+        """Возвращает долю зоны ретеста с учётом настроек."""
         if self.retest_zone_atr is None:
             return max(self.retest_zone, 0.0)
         return max(self.retest_zone_atr * max(natr, 0.0), 0.0)

--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -188,6 +188,7 @@ class BacktestRunner:
         levels_timeframe: Timeframe = Timeframe.D1,
         entry_timeframe: Timeframe = Timeframe.M15,
     ) -> pd.DataFrame:
+        """Запускает полный расчёт бэктеста в vectorbt."""
         rows: list[dict[str, int | float | str | None]] = []
         grid = self.build_parameter_grid()
 
@@ -231,6 +232,7 @@ class BacktestRunner:
 
     @staticmethod
     def build_summary(results: pd.DataFrame) -> BacktestSummary:
+        """Собирает краткую сводку по результатам бэктеста."""
         if PARAMETER_GRID_SIZE != TARGET_PARAMETER_COMBINATIONS:
             logger.warning(
                 "запуск-бэктеста: расчетная мощность сетки=%s отличается от целевой=%s (ожидается 5832)",

--- a/vectorbt_runner/data_preparer.py
+++ b/vectorbt_runner/data_preparer.py
@@ -45,6 +45,7 @@ class DataPreparer:
 
     # конец области Приватные
     def list_symbols(self, timeframe: Timeframe) -> list[str]:
+        """Возвращает список символов, доступных для расчёта."""
         symbols: list[str] = []
         if not self._cache_dir.exists():
             return symbols
@@ -56,6 +57,7 @@ class DataPreparer:
         return sorted(symbols)
 
     def load_symbol_data(self, symbol: str, timeframe: Timeframe) -> pd.DataFrame:
+        """Загружает данные по одному символу для бэктеста."""
         path = self._cache_dir / symbol / timeframe.value / SIMULATION_PARQUET_FILE_NAME
         if not path.exists():
             return pd.DataFrame()
@@ -80,6 +82,7 @@ class DataPreparer:
 
 
     def load_symbol_data_multi(self, symbol: str, timeframes: Iterable[Timeframe]) -> dict[Timeframe, pd.DataFrame]:
+        """Загружает данные по нескольким символам сразу."""
         return {
             timeframe: self.load_symbol_data(symbol, timeframe)
             for timeframe in timeframes

--- a/vectorbt_runner/mtf_frames.py
+++ b/vectorbt_runner/mtf_frames.py
@@ -18,6 +18,7 @@ class SymbolMtfFrames:
     entry_frame: pd.DataFrame
 
     def get_frame(self, timeframe: Timeframe) -> pd.DataFrame:
+        """Возвращает набор данных для выбранного таймфрейма."""
         if timeframe == self.levels_timeframe:
             return self.levels_frame
         if timeframe == self.entry_timeframe:


### PR DESCRIPTION
### Motivation
- Привести в проект единый понятный стиль документации: краткие русские описания для всех публичных функций и методов в основных модулях. 
- Исправить случаи, когда строковые литералы докстрингов попали внутрь сигнатур функций и вызывали синтаксические ошибки при компиляции.

### Description
- Для публичных функций и методов (имя не начинается с `_`) добавлены 1–2 короткие фразы на русском без перечисления параметров и типов возврата в модулях `cli/`, `data/`, `strategy/`, `simulation/`, `vectorbt_runner/`, `config/`, `domain/` (около 25 файлов). 
- Исправлены места с некорректным размещением докстрингов (перемещены изнутри сигнатуры в тело функции) для восстановления корректного синтаксиса. 
- Докстринги добавлены в ключевые точки: парсер/роутинг CLI, fetchers, storage, quality, exchange client types, стратегии, симулятор, подготовку данных для vectorbt и конфигурации.
- Никакой бизнес-логики не изменено, только добавлены/перемещены комментарии строк документации.

### Testing
- Прогнал проверку синтаксиса: `python -m compileall -q cli data strategy simulation vectorbt_runner config domain` — успешно, без ошибок. 
- Проверил через AST-скрипт, что не осталось публичных функций/методов без докстрингов: скрипт вернул `missing 0`.
- Локальная правка файлов устранила ранее возникшие `SyntaxError`, сборка и парсинг модулей прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b5aa0bcac83208c022eee138ff8c8)