### PR TITLE
Handle transient Windows file lock during market cap cache save

### DIFF
--- a/data/clients/coingecko_client.py
+++ b/data/clients/coingecko_client.py
@@ -170,7 +170,15 @@ class CoinGeckoClient(MarketDataClient):
         temp_file.close()
         try:
             cache_frame.to_parquet(temp_path, index=False)
-            os.replace(temp_path, self._cache_path)
+            replace_attempts = 5
+            for attempt in range(1, replace_attempts + 1):
+                try:
+                    os.replace(temp_path, self._cache_path)
+                    break
+                except PermissionError:
+                    if attempt == replace_attempts:
+                        raise
+                    time.sleep(0.1 * attempt)
         finally:
             if temp_path.exists():
                 temp_path.unlink()


### PR DESCRIPTION
## Summary
- add retry logic around `os.replace` in `CoinGeckoClient._save_market_cap_cache`
- retry up to 5 times with short incremental backoff when `PermissionError` occurs
- keep existing temp file cleanup behavior unchanged

## Why
On Windows, cache target files can be briefly locked by antivirus/indexer/other processes, causing intermittent `WinError 5` during atomic replace. Retrying the replace mitigates transient lock contention while preserving atomic writes.

## Impact
- improves robustness of `fetch-data` / cache write path on Windows
- no behavior change on successful first-attempt replace

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b9aa8eb488320a39b58724e9f6a50)