### PR TITLE
Pass symbol to CCXT fetch_ohlcv via retry wrapper

### DIFF
--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -106,12 +106,14 @@ class CcxtFuturesClient(ExchangeClient):
         symbol: str,
         endpoint: str,
         call: Callable[..., object],
+        args: tuple[object, ...] = (),
         **kwargs: object,
     ) -> object:
         try:
             return run_with_retry(
-                operation=operation,
-                call=call,
+                operation,
+                call,
+                *args,
                 attempts=self._retry_attempts,
                 backoff_seconds=self._retry_backoff_seconds,
                 retriable_exceptions=(Exception,),
@@ -131,12 +133,14 @@ class CcxtFuturesClient(ExchangeClient):
         operation: str,
         endpoint: str,
         call: Callable[..., object],
+        args: tuple[object, ...] = (),
         **kwargs: object,
     ) -> object:
         try:
             return run_with_retry(
-                operation=operation,
-                call=call,
+                operation,
+                call,
+                *args,
                 attempts=self._retry_attempts,
                 backoff_seconds=self._retry_backoff_seconds,
                 retriable_exceptions=(Exception,),
@@ -204,6 +208,7 @@ class CcxtFuturesClient(ExchangeClient):
                 symbol=symbol,
                 endpoint="fetch_ohlcv",
                 call=self._client.fetch_ohlcv,
+                args=(symbol,),
                 timeframe=timeframe,
                 since=since,
                 limit=DEFAULT_FETCH_BATCH_SIZE,


### PR DESCRIPTION
### Motivation
- The CCXT `fetch_ohlcv` call requires a `symbol` positional parameter and previously the retry wrapper only logged the symbol without forwarding it to the actual call. 

### Description
- Add an `args: tuple[object, ...]` parameter to `CcxtFuturesClient._retry_exchange_call` and `_retry_exchange_startup_call` and forward positional arguments into `run_with_retry` so `call(*args, **kwargs)` receives them. 
- Update `CcxtFuturesClient.fetch_ohlcv` to pass the market symbol as a positional argument using `args=(symbol,)` when invoking the retry wrapper so `self._client.fetch_ohlcv` receives the required `symbol` argument. 
- Keep retry logging behavior unchanged while ensuring the actual CCXT method gets the proper positional parameter. 

### Testing
- Ran `python -m py_compile data/exchanges/ccxt_futures_client.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b9e82d4c083209dc28563a8bb97e9)