### PR TITLE
Fix fetch_open_interest CCXT argument passing

### DIFF
--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -240,6 +240,7 @@ class CcxtFuturesClient(ExchangeClient):
         start_ms = _to_utc_ms(start_time)
         since = start_ms
         end_ms = _to_utc_ms(end_time)
+        ccxt_timeframe = timeframe.value
 
         rows: list[dict[str, object]] = []
         while since <= end_ms:
@@ -249,10 +250,11 @@ class CcxtFuturesClient(ExchangeClient):
                     symbol=symbol,
                     endpoint="fetch_open_interest_history",
                     call=self._client.fetch_open_interest_history,
-                    timeframe=timeframe,
+                    args=(symbol,),
+                    timeframe=ccxt_timeframe,
                     since=since,
                     limit=DEFAULT_FETCH_BATCH_SIZE,
-                    params={"intervalTime": timeframe, "period": timeframe},
+                    params={"intervalTime": ccxt_timeframe, "period": ccxt_timeframe},
                 )
             except TypeError:
                 batch = self._retry_exchange_call(
@@ -260,7 +262,8 @@ class CcxtFuturesClient(ExchangeClient):
                     symbol=symbol,
                     endpoint="fetch_open_interest_history",
                     call=self._client.fetch_open_interest_history,
-                    timeframe=timeframe,
+                    args=(symbol,),
+                    timeframe=ccxt_timeframe,
                     since=since,
                     limit=DEFAULT_FETCH_BATCH_SIZE,
                 )


### PR DESCRIPTION
### Motivation
- Вызовы CCXT для истории open interest иногда бросали ошибки из-за отсутствующего позиционного аргумента `symbol` и из-за передачи `timeframe` в виде enum-объекта вместо строки, ожидаемой библиотекой.
- Необходимо передавать `symbol` как позиционный аргумент в фактический вызов `fetch_open_interest_history` и нормализовать `timeframe` в формат, совместимый с CCXT.

### Description
- Добавил вычисление `ccxt_timeframe = timeframe.value` и использую его при передаче `timeframe` и в `params` (`intervalTime` и `period`).
- В обоих ветвях вызова `_retry_exchange_call(...)` для `fetch_open_interest_history` добавил позиционный аргумент `args=(symbol,)` чтобы действительно передать `symbol` в `self._client.fetch_open_interest_history`.
- Обновил параметры вызова так, чтобы и основной путь, и ветка `except TypeError` использовали одинаковые совместимые с CCXT аргументы.

### Testing
- Выполнил `python -m py_compile data/exchanges/ccxt_futures_client.py` и проверка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c24ea9a5483209ad206b6b1e330f2)