### PR TITLE
Fix Windows-unsafe cache paths for futures symbols

### DIFF
--- a/data/storage/parquet_storage.py
+++ b/data/storage/parquet_storage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from urllib.parse import quote, unquote
 
 import pandas as pd
 
@@ -16,8 +17,19 @@ class ParquetStorage:
 
     # region Приватные
 
+    @staticmethod
+    def encode_symbol_for_path(symbol: str) -> str:
+        """Преобразует биржевой символ в безопасное имя каталога."""
+        return quote(str(symbol), safe="")
+
+    @staticmethod
+    def decode_symbol_from_path(value: str) -> str:
+        """Восстанавливает исходный биржевой символ из имени каталога."""
+        return unquote(str(value))
+
     def _data_path(self, symbol: str, timeframe: Timeframe) -> Path:
-        return self._base_dir / symbol / timeframe.value / "data.parquet"
+        symbol_path = self.encode_symbol_for_path(symbol)
+        return self._base_dir / symbol_path / timeframe.value / "data.parquet"
 
     @staticmethod
     def _ensure_utc_columns(data: pd.DataFrame) -> pd.DataFrame:

--- a/vectorbt_runner/data_preparer.py
+++ b/vectorbt_runner/data_preparer.py
@@ -21,6 +21,7 @@ from constants import (
     SIMULATION_ZERO_VALUE,
     STRATEGY_REQUIRED_COLUMNS,
 )
+from data.storage.parquet_storage import ParquetStorage
 from domain.enums.timeframe import Timeframe
 from domain.models.trade_result import TradeResult
 from vectorbt_runner.vectorbt_inputs import VectorbtInputs
@@ -53,12 +54,13 @@ class DataPreparer:
         for symbol_dir in self._cache_dir.iterdir():
             path = symbol_dir / timeframe.value / SIMULATION_PARQUET_FILE_NAME
             if symbol_dir.is_dir() and path.exists():
-                symbols.append(symbol_dir.name)
+                symbols.append(ParquetStorage.decode_symbol_from_path(symbol_dir.name))
         return sorted(symbols)
 
     def load_symbol_data(self, symbol: str, timeframe: Timeframe) -> pd.DataFrame:
         """Загружает данные по одному символу для бэктеста."""
-        path = self._cache_dir / symbol / timeframe.value / SIMULATION_PARQUET_FILE_NAME
+        symbol_path = ParquetStorage.encode_symbol_for_path(symbol)
+        path = self._cache_dir / symbol_path / timeframe.value / SIMULATION_PARQUET_FILE_NAME
         if not path.exists():
             return pd.DataFrame()
 


### PR DESCRIPTION
## Summary
- encode exchange symbols before using them as cache directory names in `ParquetStorage`
- decode encoded directory names when listing symbols for backtesting
- load symbol data using encoded symbol path, preserving original symbol strings in data

## Problem
On Windows, futures symbols like `AAVE/USDT:USDT` failed during cache fetch with:
`[WinError 123] The filename, directory name, or volume label syntax is incorrect`

The cache path was built directly from the raw symbol, which includes path-unsafe characters (`/`, `:`).

## Fix details
- Added `ParquetStorage.encode_symbol_for_path` and `decode_symbol_from_path` using URL-style percent encoding.
- Updated `_data_path` to always use encoded symbol directory names.
- Updated `DataPreparer.list_symbols` to decode directory names back to user-facing symbols.
- Updated `DataPreparer.load_symbol_data` to resolve paths via encoded symbol names.

## Validation
- `python -m py_compile data/storage/parquet_storage.py vectorbt_runner/data_preparer.py`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd8458424832096672e2265fd32d0)