### PR TITLE
Rank exchange symbols by market cap before liquidity filtering

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -133,22 +133,26 @@ def _resolve_symbols(
         logger: Logger,
         coingecko_volume_batch_size: int,
 ) -> list[str]:
-    top_symbols_raw = [f"{symbol}/USDT" for symbol in market_client.get_top_coins_by_market_cap(limit=top_n)]
     futures_symbols_raw = exchange_client.get_futures_symbols()
-
-    top_symbols_normalized = {normalize_symbol(symbol) for symbol in top_symbols_raw}
     futures_symbol_map = {
         normalize_symbol(symbol): symbol
         for symbol in futures_symbols_raw
     }
+    exchange_symbols_normalized = sorted(futures_symbol_map)
 
-    intersection = sorted(top_symbols_normalized.intersection(futures_symbol_map))
+    market_caps_by_symbol = market_client.get_market_caps(exchange_symbols_normalized)
+    ranked_symbols = sorted(
+        exchange_symbols_normalized,
+        key=lambda symbol: (market_caps_by_symbol.get(symbol, 0.0), symbol),
+        reverse=True,
+    )
+    ranked_top_symbols = ranked_symbols[:top_n]
+
     volumes_by_symbol: dict[str, float] = {}
     symbols_skipped_by_api_errors = 0
-    symbol_pairs = [f"{symbol}/USDT" for symbol in intersection]
 
-    for start in range(0, len(symbol_pairs), coingecko_volume_batch_size):
-        batch = symbol_pairs[start:start + coingecko_volume_batch_size]
+    for start in range(0, len(ranked_top_symbols), coingecko_volume_batch_size):
+        batch = ranked_top_symbols[start:start + coingecko_volume_batch_size]
         try:
             volumes_by_symbol.update(market_client.get_total_volumes(batch))
         except (RuntimeError, RetryExhaustedError) as exc:
@@ -173,23 +177,20 @@ def _resolve_symbols(
                 continue
             raise
 
-    symbols_with_volume = [symbol for symbol in intersection if f"{symbol}/USDT" in volumes_by_symbol]
+    symbols_with_volume = [symbol for symbol in ranked_top_symbols if symbol in volumes_by_symbol]
 
     liquid_symbols: list[str] = []
     for symbol in symbols_with_volume:
-        symbol_pair = f"{symbol}/USDT"
-        total_volume = volumes_by_symbol.get(symbol_pair, 0.0)
+        total_volume = volumes_by_symbol.get(symbol, 0.0)
         if total_volume >= min_volume_usd:
             liquid_symbols.append(symbol)
 
     excluded_by_liquidity = len(symbols_with_volume) - len(liquid_symbols)
     logger.info(
-        "подбор-символов: коингекко сырых=%s нормализованных=%s; ccxt сырых=%s нормализованных=%s; пересечение=%s",
-        len(top_symbols_raw),
-        len(top_symbols_normalized),
-        len(futures_symbols_raw),
-        len(futures_symbol_map),
-        len(intersection),
+        "подбор-символов: всего на бирже=%s → после ранжирования top_n=%s → после фильтра ликвидности=%s",
+        len(exchange_symbols_normalized),
+        len(ranked_top_symbols),
+        len(liquid_symbols),
     )
     logger.info(
         "подбор-символов: пропущено символов из-за ошибок внешнего API=%s",

--- a/data/clients/coingecko_client.py
+++ b/data/clients/coingecko_client.py
@@ -544,6 +544,56 @@ class CoinGeckoClient(MarketDataClient):
 
         return [str(item.get("symbol") or "").upper() for item in response.json() if item.get("symbol")]
 
+    def get_market_caps(self, symbols_or_coin_ids: list[str]) -> dict[str, float]:
+        """Возвращает капитализации для списка монет."""
+        if not symbols_or_coin_ids:
+            return {}
+
+        requested = [str(item).strip() for item in symbols_or_coin_ids if str(item).strip()]
+        if not requested:
+            return {}
+
+        coin_ids_by_input: dict[str, str] = {}
+        for item in requested:
+            if "/" in item:
+                coin_ids_by_input[item] = self._resolve_coin_id(item)
+                continue
+
+            canonical_symbol = self._canonical_symbol_key(item)
+            known_coin_id = self._symbol_to_id.get(canonical_symbol)
+            if known_coin_id:
+                coin_ids_by_input[item] = known_coin_id
+                continue
+
+            try:
+                coin_ids_by_input[item] = self._resolve_coin_id(item)
+            except ValueError:
+                coin_ids_by_input[item] = item
+
+        response = self._request(
+            endpoint="/coins/markets",
+            symbol="market_cap_batch",
+            params={
+                COINGECKO_VS_CURRENCY_KEY: COINGECKO_VS_CURRENCY_USD,
+                COINGECKO_PARAM_IDS: ",".join(sorted(set(coin_ids_by_input.values()))),
+                COINGECKO_ORDER_KEY: COINGECKO_ORDER_MARKET_CAP_DESC,
+                COINGECKO_PARAM_PER_PAGE: len(coin_ids_by_input),
+                COINGECKO_PARAM_PAGE: COINGECKO_DEFAULT_PAGE,
+                COINGECKO_PARAM_SPARKLINE: COINGECKO_SPARKLINE_FALSE,
+            },
+        )
+        payload = response.json()
+        market_caps_by_coin_id = {
+            str(item.get("id") or ""): float(item.get("market_cap") or 0.0)
+            for item in payload
+            if item.get("id")
+        }
+
+        return {
+            input_name: market_caps_by_coin_id.get(coin_id, 0.0)
+            for input_name, coin_id in coin_ids_by_input.items()
+        }
+
     def get_total_volumes(self, symbols_or_coin_ids: list[str]) -> dict[str, float]:
         """Возвращает объёмы торгов для списка монет."""
         if not symbols_or_coin_ids:

--- a/domain/abstract/market_data_client.py
+++ b/domain/abstract/market_data_client.py
@@ -7,12 +7,19 @@ from abc import ABC, abstractmethod
 
 class MarketDataClient(ABC):
     """Класс."""
+
     @abstractmethod
     def get_market_cap(self, symbol: str) -> float:
         """Метод."""
+
     @abstractmethod
     def get_top_coins_by_market_cap(self, limit: int) -> list[str]:
         """Метод."""
+
+    @abstractmethod
+    def get_market_caps(self, symbols_or_coin_ids: list[str]) -> dict[str, float]:
+        """Метод."""
+
     @abstractmethod
     def get_total_volumes(self, symbols_or_coin_ids: list[str]) -> dict[str, float]:
         """Метод."""


### PR DESCRIPTION
### Motivation
- Сделать подбор символов более релевантным биржевому universe, ранжируя именно те фьючерсные символы, что доступны на бирже, по рыночной капитализации перед применением фильтров ликвидности.
- Избежать зависимости от заранее сформированного top-N от CoinGecko, когда часть этих символов может отсутствовать на бирже.
- Добавить эффективный батч-эндпоинт для получения капитализаций, опирающийся на уже существующую логику разрешения CoinGecko ID.

### Description
- В `cli/commands.py` в `def _resolve_symbols(...)` заменена воронка: сначала получаем полный список фьючерсных символов через `exchange_client.get_futures_symbols()`, строим нормализованный маппинг `normalized -> original`, затем вызываем батч-метод капитализаций и ранжируем только биржевые (нормализованные) символы по `market_cap`, берём `top_n`, и уже по ним выполняем существующий фильтр ликвидности через `get_total_volumes` и `min_volume_usd`, при этом изменилось логирование воронки на: "всего на бирже → после ранжирования top_n → после фильтра ликвидности".
- В `data/clients/coingecko_client.py` добавлен метод `get_market_caps(symbols_or_coin_ids: list[str]) -> dict[str, float]`, который использует `_resolve_coin_id` для входных значений, делает запрос к `/coins/markets` с `ids=...` и возвращает маппинг входного имени → `market_cap`.
- В `domain/abstract/market_data_client.py` обновлён абстрактный контракт клиента рынка данных — добавлен метод `get_market_caps(...)` в интерфейс `MarketDataClient`.

### Testing
- Запущена компиляция модифицированных модулей с помощью `python -m compileall cli/commands.py data/clients/coingecko_client.py domain/abstract/market_data_client.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cda736e948320b95ed923b7d15b1e)