### PR TITLE
Filter symbol universe to standard USDT perpetual contracts

### DIFF
--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime, timezone
 from typing import Any, Callable, cast
 
@@ -176,7 +177,7 @@ class CcxtFuturesClient(ExchangeClient):
         for market in self._client.markets.values():
             if not market.get("active", True):
                 continue
-            if not (market.get("swap") or market.get("future")):
+            if not market.get("swap"):
                 continue
 
             quote = str(market.get("quote") or "").upper()
@@ -189,7 +190,7 @@ class CcxtFuturesClient(ExchangeClient):
                 continue
 
             symbol = str(market.get("symbol") or "")
-            if symbol:
+            if symbol and not re.search(r"-\d{4,}$", symbol):
                 symbols.append(symbol)
 
         return sorted(set(symbols))


### PR DESCRIPTION
## What changed
- Updated `CcxtFuturesClient.get_futures_symbols()` to include only **swap** markets (perpetuals), excluding dated futures.
- Added an additional guard to skip symbols matching expiry-like suffixes such as `-260626` (regex: `-\d{4,}$`).

## Why
User requested to avoid symbols like `ETH/USDT:USDT-260626` and other contracts with numeric expiry suffixes, and to keep only ordinary USDT futures that typical traders use.

## Impact
- Symbol list now excludes delivery/dated contracts and odd expiry-suffixed instruments.
- Downstream fetchers and strategy runs operate on a cleaner, retail-standard perpetual USDT universe.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cde5063dc83209958af394fdd301c)