### PR TITLE
Make fetch logs easier to read by formatting datetimes

### DIFF
--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -20,6 +20,7 @@ from data.storage.parquet_storage import ParquetStorage
 from domain.abstract.exchange_client import ExchangeClient
 from domain.enums.timeframe import Timeframe
 from domain.models.reporting.symbol_fetch_result import SymbolFetchResult
+from utils.formatters import format_datetime_human
 from utils.logger import get_logger
 
 
@@ -55,11 +56,13 @@ class OhlcvFetcher:
         if last_timestamp is not None:
             next_start = max(start_time, last_timestamp.to_pydatetime() + TIMEFRAME_TO_DELTA[timeframe])
 
-        watermark_display = last_timestamp.isoformat() if last_timestamp is not None else "None"
+        watermark_display = format_datetime_human(last_timestamp.to_pydatetime()) if last_timestamp is not None else "None"
+        next_start_display = format_datetime_human(next_start)
+        end_time_display = format_datetime_human(end_time)
         self._logger.info(
-            f"OHLCV водораздел: {symbol} {timeframe.value} колонка={watermark_column} последний={watermark_display} выбранный={next_start.isoformat()}"
+            f"OHLCV водораздел: {symbol} {timeframe.value} колонка={watermark_column} последний={watermark_display} выбранный={next_start_display}"
         )
-        self._logger.info(f"OHLCV старт: {symbol} {timeframe.value} {next_start.isoformat()} -> {end_time.isoformat()}")
+        self._logger.info(f"OHLCV старт: {symbol} {timeframe.value} {next_start_display} -> {end_time_display}")
         if next_start > end_time:
             self._logger.info(LOG_MSG_SKIP_UP_TO_DATE, "OHLCV", symbol)
             return 0

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -20,6 +20,7 @@ from data.storage.parquet_storage import ParquetStorage
 from domain.abstract.exchange_client import ExchangeClient
 from domain.enums.timeframe import Timeframe
 from domain.models.reporting.symbol_fetch_result import SymbolFetchResult
+from utils.formatters import format_datetime_human
 from utils.logger import get_logger
 
 
@@ -55,11 +56,13 @@ class OiFetcher:
         if last_timestamp is not None:
             next_start = max(start_time, last_timestamp.to_pydatetime() + TIMEFRAME_TO_DELTA[timeframe])
 
-        watermark_display = last_timestamp.isoformat() if last_timestamp is not None else "None"
+        watermark_display = format_datetime_human(last_timestamp.to_pydatetime()) if last_timestamp is not None else "None"
+        next_start_display = format_datetime_human(next_start)
+        end_time_display = format_datetime_human(end_time)
         self._logger.info(
-            f"OI водораздел: {symbol} {timeframe.value} колонка={watermark_column} последний={watermark_display} выбранный={next_start.isoformat()}"
+            f"OI водораздел: {symbol} {timeframe.value} колонка={watermark_column} последний={watermark_display} выбранный={next_start_display}"
         )
-        self._logger.info(f"OI старт: {symbol} {timeframe.value} {next_start.isoformat()} -> {end_time.isoformat()}")
+        self._logger.info(f"OI старт: {symbol} {timeframe.value} {next_start_display} -> {end_time_display}")
         if next_start > end_time:
             self._logger.info(LOG_MSG_SKIP_UP_TO_DATE, "OI", symbol)
             return 0

--- a/utils/formatters.py
+++ b/utils/formatters.py
@@ -44,3 +44,10 @@ def datetime_to_utc_ms(value: datetime, source_timezone_name: str | None = None)
     """Преобразует дату и время в UTC-метку времени в миллисекундах."""
     utc_dt = datetime_to_utc(value, source_timezone_name=source_timezone_name)
     return int(utc_dt.timestamp() * 1000)
+
+
+def format_datetime_human(value: datetime) -> str:
+    """Форматирует дату и время в человекочитаемый вид с часовым поясом."""
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.strftime("%d.%m.%Y %H:%M:%S %Z")


### PR DESCRIPTION
## Summary
- add `format_datetime_human` helper in `utils/formatters.py`
- update OHLCV fetch logs to print readable timestamps instead of raw ISO strings
- update OI fetch logs the same way for consistency

## Why
Current fetch logs use raw ISO timestamps (`2026-01-12T19:58:48.109928+00:00`), which are harder to scan quickly. This change makes them human-readable in log lines while preserving timezone context.

## Example
Before: `2026-01-12T19:58:48.109928+00:00`
After: `12.01.2026 19:58:48 UTC`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cdfc1c5788320a17287d86f9d969f)