### PR TITLE
Use full futures universe during fetch/update data loading

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -133,8 +133,9 @@ def _resolve_symbols(
         logger: Logger,
         coingecko_volume_batch_size: int,
         ignore_coingecko: bool,
+        futures_symbols_raw: list[str] | None = None,
 ) -> list[str]:
-    futures_symbols_raw = exchange_client.get_futures_symbols()
+    futures_symbols_raw = futures_symbols_raw or exchange_client.get_futures_symbols()
     futures_symbol_map = {
         normalize_symbol(symbol): symbol
         for symbol in futures_symbols_raw
@@ -264,16 +265,24 @@ def _resolve_timeframe(value: str | None, *, fallback: Timeframe, argument_name:
 def _fetch_data_inner(config: AppConfig, args: argparse.Namespace) -> int:
     logger = get_logger("fetch-data", level=config.backtest.log_level, logs_dir=config.backtest.logs_dir)
     fetcher, exchange_client, market_client = _build_fetch_stack(config)
+    futures_symbols = exchange_client.get_futures_symbols()
+    all_futures_count = len(futures_symbols)
     min_volume_usd = args.min_volume_usd if args.min_volume_usd is not None else config.fetch.min_volume_usd
     ignore_coingecko = args.ignore_coingecko if args.ignore_coingecko is not None else config.fetch.ignore_coingecko
     symbols = _resolve_symbols(
         exchange_client,
         market_client,
-        top_n=args.top_n,
+        top_n=all_futures_count,
         min_volume_usd=min_volume_usd,
         logger=logger,
         coingecko_volume_batch_size=config.fetch.coingecko_volume_batch_size,
         ignore_coingecko=ignore_coingecko,
+        futures_symbols_raw=futures_symbols,
+    )
+    logger.info(
+        "загрузка-данных: найдено фьючерсов=%s отправлено в fetch_all=%s",
+        all_futures_count,
+        len(symbols),
     )
     if not symbols:
         logger.info("загрузка-данных: не найдено символов для загрузки")
@@ -291,16 +300,24 @@ def _fetch_data_inner(config: AppConfig, args: argparse.Namespace) -> int:
 def _update_cache_inner(config: AppConfig, args: argparse.Namespace) -> int:
     logger = get_logger("update-cache", level=config.backtest.log_level, logs_dir=config.backtest.logs_dir)
     fetcher, exchange_client, market_client = _build_fetch_stack(config)
+    futures_symbols = exchange_client.get_futures_symbols()
+    all_futures_count = len(futures_symbols)
     min_volume_usd = args.min_volume_usd if args.min_volume_usd is not None else config.fetch.min_volume_usd
     ignore_coingecko = args.ignore_coingecko if args.ignore_coingecko is not None else config.fetch.ignore_coingecko
     symbols = _resolve_symbols(
         exchange_client,
         market_client,
-        top_n=args.top_n,
+        top_n=all_futures_count,
         min_volume_usd=min_volume_usd,
         logger=logger,
         coingecko_volume_batch_size=config.fetch.coingecko_volume_batch_size,
         ignore_coingecko=ignore_coingecko,
+        futures_symbols_raw=futures_symbols,
+    )
+    logger.info(
+        "обновление-кэша: найдено фьючерсов=%s отправлено в fetch_all=%s",
+        all_futures_count,
+        len(symbols),
     )
     if not symbols:
         logger.info("обновление-кэша: не найдено символов для обновления")


### PR DESCRIPTION
### Motivation

- Устранить раннюю обрезку списка символов по `top_n` при подготовке данных (OHLCV/OI/market caps) и обеспечить загрузку по полному множеству фьючерсов перед фильтрацией/ранжированием.
- Сохранять исходные биржевые формы символов (`BTC/USDT`) при нормализации через `normalize_symbol` с обратным маппингом.
- Не дублировать фильтрацию по quote-asset в CLI, так как она уже выполняется в `CcxtFuturesClient.get_futures_symbols()`.

### Description

- Добавлен необязательный параметр `futures_symbols_raw` в ` _resolve_symbols` для приема уже полученного списка фьючерсов и повторного использования его при нормализации/маппинге.
- В ` _fetch_data_inner` и ` _update_cache_inner` сначала извлекается полный список через `exchange_client.get_futures_symbols()`, затем в ` _resolve_symbols` передаётся `top_n=all_futures_count` и `futures_symbols_raw` (то есть загрузка данных выполняется по полному универсуму, а не по CLI `top_n`).
- Добавлены лог-строки в ` _fetch_data_inner` и ` _update_cache_inner`, которые сообщают `найдено фьючерсов=` и `отправлено в fetch_all=` с числами для прозрачности процесса.
- Не вносились изменения в `data/exchanges/ccxt_futures_client.py` — фильтрация по `FUTURES_SETTLEMENT_QUOTE_ASSET` уже гарантирована на стороне клиента.

### Testing

- Запущена проверка компиляции `python -m compileall cli/commands.py`, которая завершилась успешно.
- Юнит-тесты не запускались (нет добавленных тестов).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e2a6365408320bae8040e5e6016eb)