### PR TITLE
Add cache-based average daily volume liquidity filter

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -38,6 +38,7 @@ from data.exchanges.ccxt_futures_client import CcxtFuturesClient
 from data.fetchers.market_data_fetcher import MarketDataFetcher
 from data.fetchers.ohlcv_fetcher import OhlcvFetcher
 from data.fetchers.oi_fetcher import OiFetcher
+from data.liquidity.daily_volume_ranker import DailyVolumeRanker
 from data.quality.data_validator import DataValidator
 from data.quality.gap_detector import GapDetector
 from data.storage.parquet_storage import ParquetStorage
@@ -133,6 +134,8 @@ def _resolve_symbols(
         logger: Logger,
         coingecko_volume_batch_size: int,
         ignore_coingecko: bool,
+        cache_dir: Path,
+        liquidity_timeframe: Timeframe,
         futures_symbols_raw: list[str] | None = None,
 ) -> list[str]:
     futures_symbols_raw = futures_symbols_raw or exchange_client.get_futures_symbols()
@@ -143,13 +146,45 @@ def _resolve_symbols(
     exchange_symbols_normalized = sorted(futures_symbol_map)
 
     if ignore_coingecko:
-        selected_symbols = exchange_symbols_normalized[:top_n]
-        logger.info(
-            "подбор-символов: CoinGecko отключен, всего на бирже=%s → выбрано top_n=%s (без фильтра ликвидности)",
-            len(exchange_symbols_normalized),
-            len(selected_symbols),
+        ranker = DailyVolumeRanker(cache_dir=cache_dir)
+        symbols_raw = [futures_symbol_map[symbol] for symbol in exchange_symbols_normalized]
+        avg_daily_volumes = ranker.calculate_avg_daily_volume_usd(
+            symbols=symbols_raw,
+            timeframe=liquidity_timeframe,
+            logger=logger,
         )
-        return [futures_symbol_map[symbol] for symbol in selected_symbols]
+        avg_daily_volumes_normalized = {
+            normalize_symbol(raw_symbol): volume
+            for raw_symbol, volume in avg_daily_volumes.items()
+        }
+        ranked_symbols = sorted(
+            avg_daily_volumes_normalized,
+            key=lambda symbol: (avg_daily_volumes_normalized[symbol], symbol),
+            reverse=True,
+        )
+        ranked_top_symbols = ranked_symbols[:top_n]
+
+        liquid_symbols: list[str] = []
+        for symbol in ranked_top_symbols:
+            avg_daily_volume_usd = avg_daily_volumes_normalized.get(symbol, 0.0)
+            if avg_daily_volume_usd >= min_volume_usd:
+                liquid_symbols.append(symbol)
+
+        excluded_by_liquidity = len(ranked_top_symbols) - len(liquid_symbols)
+        logger.info(
+            "подбор-символов: CoinGecko отключен, всего на бирже=%s → доступно в кэше=%s → после ранжирования top_n=%s → после фильтра ликвидности=%s",
+            len(exchange_symbols_normalized),
+            len(avg_daily_volumes_normalized),
+            len(ranked_top_symbols),
+            len(liquid_symbols),
+        )
+        logger.info(
+            "подбор-символов: фильтр ликвидности по среднедневному объёму (мин_avg_daily_volume_usd=%.2f) исключено=%s итоговых_символов=%s",
+            min_volume_usd,
+            excluded_by_liquidity,
+            len(liquid_symbols),
+        )
+        return [futures_symbol_map[symbol] for symbol in liquid_symbols]
 
     market_caps_by_symbol = market_client.get_market_caps(exchange_symbols_normalized)
     ranked_symbols = sorted(
@@ -277,6 +312,8 @@ def _fetch_data_inner(config: AppConfig, args: argparse.Namespace) -> int:
         logger=logger,
         coingecko_volume_batch_size=config.fetch.coingecko_volume_batch_size,
         ignore_coingecko=ignore_coingecko,
+        cache_dir=config.backtest.cache_dir,
+        liquidity_timeframe=config.fetch.timeframe,
         futures_symbols_raw=futures_symbols,
     )
     logger.info(
@@ -312,6 +349,8 @@ def _update_cache_inner(config: AppConfig, args: argparse.Namespace) -> int:
         logger=logger,
         coingecko_volume_batch_size=config.fetch.coingecko_volume_batch_size,
         ignore_coingecko=ignore_coingecko,
+        cache_dir=config.backtest.cache_dir,
+        liquidity_timeframe=config.fetch.timeframe,
         futures_symbols_raw=futures_symbols,
     )
     logger.info(

--- a/data/liquidity/__init__.py
+++ b/data/liquidity/__init__.py
@@ -1,0 +1,6 @@
+"""Инструменты для расчёта ликвидности."""
+
+from data.liquidity.daily_volume_ranker import DailyVolumeRanker
+
+__all__ = ["DailyVolumeRanker"]
+

--- a/data/liquidity/daily_volume_ranker.py
+++ b/data/liquidity/daily_volume_ranker.py
@@ -1,0 +1,79 @@
+"""Расчёт среднедневного объёма торгов в USD по кэшу OHLCV."""
+
+from __future__ import annotations
+
+from logging import Logger
+from pathlib import Path
+
+import pandas as pd
+
+from domain.enums.timeframe import Timeframe
+from vectorbt_runner.data_preparer import DataPreparer
+
+
+class DailyVolumeRanker:
+    """Ранжирует символы по среднему дневному USD-объёму из кэша."""
+
+    def __init__(self, cache_dir: Path) -> None:
+        self._preparer = DataPreparer(cache_dir)
+
+    def calculate_avg_daily_volume_usd(
+            self,
+            symbols: list[str],
+            timeframe: Timeframe,
+            logger: Logger,
+    ) -> dict[str, float]:
+        """Возвращает средний дневной USD-объём по каждому символу."""
+        result: dict[str, float] = {}
+
+        for symbol in symbols:
+            frame = self._preparer.load_symbol_data(symbol, timeframe)
+            if frame.empty:
+                logger.info(
+                    "ликвидность-кэш: символ=%s исключён: отсутствуют данные в кэше (%s)",
+                    symbol,
+                    timeframe.value,
+                )
+                continue
+
+            if "datetime" not in frame.columns or "close" not in frame.columns or "volume" not in frame.columns:
+                logger.info(
+                    "ликвидность-кэш: символ=%s исключён: отсутствуют обязательные колонки для расчёта",
+                    symbol,
+                )
+                continue
+
+            normalized = frame.copy()
+            normalized["datetime"] = pd.to_datetime(normalized["datetime"], utc=True, errors="coerce")
+            normalized = normalized.dropna(subset=["datetime", "close", "volume"])
+            if normalized.empty:
+                logger.info(
+                    "ликвидность-кэш: символ=%s исключён: после очистки не осталось валидных строк",
+                    symbol,
+                )
+                continue
+
+            normalized["date"] = normalized["datetime"].dt.floor("D")
+            normalized["daily_volume_usd"] = normalized["close"] * normalized["volume"]
+
+            daily_volume = normalized.groupby("date", as_index=True)["daily_volume_usd"].sum(min_count=1).dropna()
+            if daily_volume.empty:
+                logger.info(
+                    "ликвидность-кэш: символ=%s исключён: не удалось посчитать дневной USD-объём",
+                    symbol,
+                )
+                continue
+
+            avg_daily_volume_usd = float(daily_volume.mean())
+            if avg_daily_volume_usd <= 0:
+                logger.info(
+                    "ликвидность-кэш: символ=%s исключён: среднедневной объём <= 0 (%.6f)",
+                    symbol,
+                    avg_daily_volume_usd,
+                )
+                continue
+
+            result[symbol] = avg_daily_volume_usd
+
+        return result
+


### PR DESCRIPTION
### Motivation

- Provide a fallback liquidity filter that uses local cached OHLCV when CoinGecko is disabled or unavailable, so symbol selection can still be filtered by USD liquidity without external API calls.
- Reuse the existing `min_volume_usd` threshold as the minimum average daily USD volume for the cache-based branch.

### Description

- Added `DailyVolumeRanker` in `data/liquidity/daily_volume_ranker.py` that loads cached OHLCV via `DataPreparer`, computes per-row USD volume (`close * volume`), aggregates by date and returns `dict[symbol, avg_daily_volume_usd]`, skipping symbols with missing/invalid data and logging clear reasons.
- Exported the ranker in `data/liquidity/__init__.py`.
- Replaced the `ignore_coingecko=True` branch in `_resolve_symbols` (in `cli/commands.py`) with cache-based ranking and filtering by `avg_daily_volume_usd`, keeping `min_volume_usd` as the minimum average-daily-volume threshold and adapting log messages accordingly.
- Propagated `cache_dir` and `liquidity_timeframe` into `_resolve_symbols` from the `fetch-data` and `update-cache` flows so cached data is read from the configured cache and timeframe.

### Testing

- Ran `python -m compileall cli/commands.py data/liquidity/daily_volume_ranker.py data/liquidity/__init__.py` and compilation succeeded.
- Changes were committed and basic static import/compilation checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e2b7182a083209b1b33f2ee8dbd2b)