### PR TITLE
Use all futures as default when --top-n is omitted

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -307,10 +307,11 @@ def _fetch_data_inner(config: AppConfig, args: argparse.Namespace) -> int:
     all_futures_count = len(futures_symbols)
     min_volume_usd = args.min_volume_usd if args.min_volume_usd is not None else config.fetch.min_volume_usd
     ignore_coingecko = args.ignore_coingecko if args.ignore_coingecko is not None else config.fetch.ignore_coingecko
+    top_n = args.top_n if args.top_n is not None else all_futures_count
     symbols = _resolve_symbols(
         exchange_client,
         market_client,
-        top_n=all_futures_count,
+        top_n=top_n,
         min_volume_usd=min_volume_usd,
         logger=logger,
         coingecko_volume_batch_size=config.fetch.coingecko_volume_batch_size,
@@ -344,10 +345,11 @@ def _update_cache_inner(config: AppConfig, args: argparse.Namespace) -> int:
     all_futures_count = len(futures_symbols)
     min_volume_usd = args.min_volume_usd if args.min_volume_usd is not None else config.fetch.min_volume_usd
     ignore_coingecko = args.ignore_coingecko if args.ignore_coingecko is not None else config.fetch.ignore_coingecko
+    top_n = args.top_n if args.top_n is not None else all_futures_count
     symbols = _resolve_symbols(
         exchange_client,
         market_client,
-        top_n=all_futures_count,
+        top_n=top_n,
         min_volume_usd=min_volume_usd,
         logger=logger,
         coingecko_volume_batch_size=config.fetch.coingecko_volume_batch_size,

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 
 from cli import commands
 from config import AppConfig
-from constants import DEFAULT_FETCH_DAYS, DEFAULT_MIN_VOLUME_USD, DEFAULT_QUALITY_REPORT_OUTPUT_FILE, DEFAULT_TOP_N, \
+from constants import DEFAULT_FETCH_DAYS, DEFAULT_MIN_VOLUME_USD, DEFAULT_QUALITY_REPORT_OUTPUT_FILE, \
     DEFAULT_UPDATE_DAYS
 
 Handler = Callable[[AppConfig, argparse.Namespace], int]
@@ -19,7 +19,7 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     fetch = subparsers.add_parser("fetch-data", help="Загрузка данных с бирж и CoinGecko")
-    fetch.add_argument("--top-n", type=int, default=DEFAULT_TOP_N)
+    fetch.add_argument("--top-n", type=int, default=None)
     fetch.add_argument("--days", type=int, default=DEFAULT_FETCH_DAYS)
     fetch.add_argument("--min-volume-usd", type=float, default=DEFAULT_MIN_VOLUME_USD)
     fetch.add_argument(
@@ -30,7 +30,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     update = subparsers.add_parser("update-cache", help="Инкрементальное обновление кэша")
-    update.add_argument("--top-n", type=int, default=DEFAULT_TOP_N)
+    update.add_argument("--top-n", type=int, default=None)
     update.add_argument("--days", type=int, default=DEFAULT_UPDATE_DAYS)
     update.add_argument("--min-volume-usd", type=float, default=DEFAULT_MIN_VOLUME_USD)
     update.add_argument(

--- a/launcher.py
+++ b/launcher.py
@@ -61,7 +61,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--env", default=".env", help="Путь к env-файлу")
     parser.add_argument("--mode", choices=tuple(MODE_LABELS.keys()), default=None, help="Одиночный режим запуска")
     parser.add_argument("--config", default=None, help="JSON-файл с пачкой задач")
-    parser.add_argument("--top-n", type=int, default=100, help="Количество топ монет для fetch/update")
+    parser.add_argument("--top-n", type=int, default=None, help="Количество топ монет для fetch/update")
     parser.add_argument("--min-volume-usd", type=float, default=None, help="Минимальный суточный объем в USD")
     parser.add_argument("--days", type=int, default=30, help="Число дней для fetch/update")
     parser.add_argument(
@@ -78,7 +78,11 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def _task_namespace(task: dict[str, Any], cli_args: argparse.Namespace) -> argparse.Namespace:
     return argparse.Namespace(
-        top_n=int(task.get("top_n", cli_args.top_n)),
+        top_n=(
+            int(task["top_n"])
+            if "top_n" in task and task.get("top_n") is not None
+            else cli_args.top_n
+        ),
         min_volume_usd=task.get("min_volume_usd", cli_args.min_volume_usd),
         days=int(task.get("days", cli_args.days)),
         symbols=task.get("symbols", cli_args.symbols),


### PR DESCRIPTION
## Summary
- made `--top-n` optional (`None` by default) for `fetch-data`, `update-cache`, and `launcher`
- updated fetch/update command handlers to use `all_futures_count` when `args.top_n` was not explicitly provided
- adjusted `launcher._task_namespace` to safely propagate optional `top_n` values from batch tasks

## Why
Previously CLI defaults always injected a numeric `top_n`, so the code could not distinguish between explicit and implicit values. This prevented using `all_futures_count` as the true default behavior.

## Validation
- `python -m compileall cli launcher.py`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e2e9460a083209e202c53f5f7ac4b)