### PR TITLE
Add anchor datetime support for fetch/update periods

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,26 @@ python launcher.py --mode clear-cache
 python launcher.py --config run_config.json
 ```
 
+
+### Фиксация конца периода загрузки (повторяемые прогоны)
+
+Можно зафиксировать «текущий момент» для `fetch-data` и `update-cache`, чтобы получать повторяемые выборки:
+
+```env
+FETCH_ANCHOR_DATETIME=2025-01-31T23:59:59+03:00
+```
+
+Тогда параметр `--days` будет отсчитываться назад именно от `FETCH_ANCHOR_DATETIME`, а не от реального `now`.
+
+Дополнительно можно переопределить это значение через CLI (приоритет выше env):
+
+```bash
+python main.py fetch-data --top-n 100 --days 30 --end-datetime 2025-01-31T23:59:59+03:00
+python main.py update-cache --top-n 100 --days 7 --end-datetime 2025-01-31T23:59:59+03:00
+```
+
+Поддерживается ISO-формат даты/времени (`YYYY-MM-DD` или `YYYY-MM-DDTHH:MM:SS±HH:MM`).
+
 ## Базовые CLI-команды (старый способ)
 
 ```bash

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -8,7 +8,7 @@ import json
 import shutil
 from collections import Counter
 from dataclasses import asdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, tzinfo
 from logging import Logger
 from pathlib import Path
 from typing import Callable
@@ -255,8 +255,47 @@ def _resolve_symbols(
     return [futures_symbol_map[symbol] for symbol in liquid_symbols]
 
 
-def _fetch_period(config: AppConfig, days: int) -> tuple[datetime, datetime]:
-    local_end = datetime.now(tz=config.fetch.tzinfo)
+def _parse_iso_datetime(
+        value: str,
+        *,
+        argument_name: str,
+        target_timezone: tzinfo,
+) -> datetime:
+    normalized_value = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized_value)
+    except ValueError as error:
+        raise ValueError(
+            f"Некорректный формат {argument_name}: {value}. "
+            f"Ожидается ISO дата/дата-время, например 2025-01-31 или 2025-01-31T23:59:59+03:00"
+        ) from error
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=target_timezone)
+    return parsed.astimezone(target_timezone)
+
+
+def _resolve_fetch_anchor_datetime(config: AppConfig, end_datetime_raw: datetime | str | None) -> datetime:
+    if isinstance(end_datetime_raw, datetime):
+        if end_datetime_raw.tzinfo is None:
+            return end_datetime_raw.replace(tzinfo=config.fetch.tzinfo)
+        return end_datetime_raw.astimezone(config.fetch.tzinfo)
+
+    if isinstance(end_datetime_raw, str):
+        return _parse_iso_datetime(
+            end_datetime_raw,
+            argument_name="--end-datetime",
+            target_timezone=config.fetch.tzinfo,
+        )
+
+    if config.fetch.anchor_datetime is not None:
+        return config.fetch.anchor_datetime
+
+    return datetime.now(tz=config.fetch.tzinfo)
+
+
+def _fetch_period(config: AppConfig, days: int, end_datetime_raw: datetime | str | None = None) -> tuple[datetime, datetime]:
+    local_end = _resolve_fetch_anchor_datetime(config, end_datetime_raw)
     local_start = local_end - timedelta(days=days)
     return datetime_to_utc(local_start), datetime_to_utc(local_end)
 
@@ -330,7 +369,7 @@ def _fetch_data_inner(config: AppConfig, args: argparse.Namespace) -> int:
         logger.info("загрузка-данных: не найдено символов для загрузки")
         return 0
 
-    start_time, end_time = _fetch_period(config, args.days)
+    start_time, end_time = _fetch_period(config, args.days, getattr(args, "end_datetime", None))
     result = fetcher.fetch_all(symbols=symbols, timeframe=config.fetch.timeframe, start_time=start_time,
                                end_time=end_time)
     _log_fetch_summary("fetch-data", logger, len(symbols), result.failed_symbols_count)
@@ -368,7 +407,7 @@ def _update_cache_inner(config: AppConfig, args: argparse.Namespace) -> int:
         logger.info("обновление-кэша: не найдено символов для обновления")
         return 0
 
-    start_time, end_time = _fetch_period(config, args.days)
+    start_time, end_time = _fetch_period(config, args.days, getattr(args, "end_datetime", None))
     result = fetcher.fetch_all(symbols=symbols, timeframe=config.fetch.timeframe, start_time=start_time,
                                end_time=end_time)
     _log_fetch_summary("update-cache", logger, len(symbols), result.failed_symbols_count)

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -22,6 +22,7 @@ def build_parser() -> argparse.ArgumentParser:
     fetch.add_argument("--top-n", type=int, default=None)
     fetch.add_argument("--days", type=int, default=DEFAULT_FETCH_DAYS)
     fetch.add_argument("--min-volume-usd", type=float, default=DEFAULT_MIN_VOLUME_USD)
+    fetch.add_argument("--end-datetime", default=None, help="Якорная дата/время окончания периода в ISO формате")
     fetch.add_argument(
         "--ignore-coingecko",
         action="store_true",
@@ -33,6 +34,7 @@ def build_parser() -> argparse.ArgumentParser:
     update.add_argument("--top-n", type=int, default=None)
     update.add_argument("--days", type=int, default=DEFAULT_UPDATE_DAYS)
     update.add_argument("--min-volume-usd", type=float, default=DEFAULT_MIN_VOLUME_USD)
+    update.add_argument("--end-datetime", default=None, help="Якорная дата/время окончания периода в ISO формате")
     update.add_argument(
         "--ignore-coingecko",
         action="store_true",

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from datetime import datetime
 from pathlib import Path
 
 from config.app_config import AppConfig
@@ -27,6 +28,7 @@ from constants import (
     DEFAULT_COINGECKO_VOLUME_BATCH_SIZE,
 )
 from domain.enums.timeframe import Timeframe
+from utils.formatters import resolve_timezone
 
 __all__ = [
     "AppConfig",
@@ -75,6 +77,29 @@ def _parse_bool(value: str | None, *, default: bool = False) -> bool:
     raise ValueError(f"Invalid boolean value: {value}")
 
 
+def _parse_anchor_datetime(value: str | None, *, timezone_name: str, env_name: str) -> datetime | None:
+    if value is None:
+        return None
+
+    raw_value = value.strip()
+    if not raw_value:
+        return None
+
+    normalized_value = raw_value.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized_value)
+    except ValueError as error:
+        raise ValueError(
+            f"Invalid {env_name}: {value}. Expected ISO date/datetime, for example "
+            f"2025-01-31 or 2025-01-31T23:59:59+03:00"
+        ) from error
+
+    target_tz = resolve_timezone(timezone_name)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=target_tz)
+    return parsed.astimezone(target_tz)
+
+
 # endregion Приватные
 
 def load_config(env_path: str | Path = ".env") -> AppConfig:
@@ -106,6 +131,11 @@ def load_config(env_path: str | Path = ".env") -> AppConfig:
             int(os.getenv("COINGECKO_VOLUME_BATCH_SIZE", str(DEFAULT_COINGECKO_VOLUME_BATCH_SIZE))),
         ),
         ignore_coingecko=_parse_bool(os.getenv("IGNORE_COINGECKO"), default=False),
+        anchor_datetime=_parse_anchor_datetime(
+            os.getenv("FETCH_ANCHOR_DATETIME"),
+            timezone_name=fetch_timezone,
+            env_name="FETCH_ANCHOR_DATETIME",
+        ),
     )
 
     strategy_levels_timeframe = _parse_timeframe(

--- a/config/fetch_config.py
+++ b/config/fetch_config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import tzinfo
+from datetime import datetime, tzinfo
 
 from constants import (
     DEFAULT_COINGECKO_MIN_REQUEST_INTERVAL_SECONDS,
@@ -27,6 +27,7 @@ class FetchConfig:
     coingecko_min_request_interval_seconds: float = DEFAULT_COINGECKO_MIN_REQUEST_INTERVAL_SECONDS
     coingecko_volume_batch_size: int = DEFAULT_COINGECKO_VOLUME_BATCH_SIZE
     ignore_coingecko: bool = False
+    anchor_datetime: datetime | None = None
 
     @property
     def tzinfo(self) -> tzinfo:

--- a/launcher.py
+++ b/launcher.py
@@ -66,6 +66,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--top-n", type=int, default=None, help="Количество топ монет для fetch/update")
     parser.add_argument("--min-volume-usd", type=float, default=None, help="Минимальный суточный объем в USD")
     parser.add_argument("--days", type=int, default=30, help="Число дней для fetch/update")
+    parser.add_argument("--end-datetime", default=None, help="Якорная дата/время окончания периода в ISO формате")
     parser.add_argument(
         "--ignore-coingecko",
         action="store_true",
@@ -87,6 +88,7 @@ def _task_namespace(task: dict[str, Any], cli_args: argparse.Namespace) -> argpa
         ),
         min_volume_usd=task.get("min_volume_usd", cli_args.min_volume_usd),
         days=int(task.get("days", cli_args.days)),
+        end_datetime=task.get("end_datetime", cli_args.end_datetime),
         symbols=task.get("symbols", cli_args.symbols),
         input=task.get("input", cli_args.input),
         output=task.get("output", cli_args.output),


### PR DESCRIPTION
### Motivation

- Provide a way to fix the end of the fetch/update time window for repeatable runs and testing by introducing an anchor datetime configurable via env or CLI.
- Ensure parsed anchor times respect the fetch timezone and give a clear error for invalid formats.

### Description

- Added `anchor_datetime: datetime | None` to `FetchConfig` to hold a fixed end moment for fetch periods (`config/fetch_config.py`).
- Implemented parsing and validation of the `FETCH_ANCHOR_DATETIME` env variable in `load_config` with ISO parsing, `Z`→`+00:00` normalization, timezone normalization to `FETCH_TIMEZONE`, and a helpful `ValueError` on bad format (`config/__init__.py`).
- Updated period calculation in `cli/commands.py`: added `_parse_iso_datetime` and `_resolve_fetch_anchor_datetime`, changed `_fetch_period` to accept an `end_datetime_raw` parameter and use precedence `--end-datetime` → `FETCH_ANCHOR_DATETIME` → now, then convert start/end to UTC via `datetime_to_utc`.
- Added `--end-datetime` option to `fetch-data` and `update-cache` in `cli/parser.py` and added `--end-datetime` propagation in `launcher.py` (`_build_parser` and `_task_namespace`) so CLI override has priority over env.
- Documented usage in `README.md` with an example `.env` entry and CLI examples for reproducible runs.

### Testing

- Compiled updated modules with `python -m compileall config cli launcher.py` and the compilation finished without errors.
- Verified env parsing with a valid value using `load_config` and observed `cfg.fetch.anchor_datetime.isoformat()` returned the expected ISO timestamp.
- Verified invalid `FETCH_ANCHOR_DATETIME` raises a `ValueError` with a clear message by calling `load_config` with a bad value.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e31d8991c8320887e3c3d32d545f9)