### PR TITLE
Add multi-timeframe cache building from config defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ LOG_LEVEL=INFO
 CACHE_DIR=./cache
 TIMEZONE=Europe/Belgrade
 ```
+> Таймфреймы для сборки кэша задаются в коде конфигурации (`config/fetch_config.py`, поле `FetchConfig.timeframes`),
+> а не через параметры CLI и не через `.env`.
 
 ## Гайд «для чайников»: как запускать бота в PyCharm
 

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -370,10 +370,20 @@ def _fetch_data_inner(config: AppConfig, args: argparse.Namespace) -> int:
         return 0
 
     start_time, end_time = _fetch_period(config, args.days, getattr(args, "end_datetime", None))
-    result = fetcher.fetch_all(symbols=symbols, timeframe=config.fetch.timeframe, start_time=start_time,
-                               end_time=end_time)
-    _log_fetch_summary("fetch-data", logger, len(symbols), result.failed_symbols_count)
-    exit_code = _fetch_exit_code(result.failed_symbols_count)
+    failed_symbols: set[str] = set()
+    for timeframe in config.fetch.timeframes:
+        logger.info("загрузка-данных: сбор кэша для TF=%s", timeframe.value)
+        result = fetcher.fetch_all(symbols=symbols, timeframe=timeframe, start_time=start_time, end_time=end_time)
+        _log_fetch_summary(f"fetch-data[{timeframe.value}]", logger, len(symbols), result.failed_symbols_count)
+        failed_symbols.update(
+            symbol
+            for symbol in symbols
+            if (symbol in result.ohlcv and not result.ohlcv[symbol].success)
+            or (symbol in result.open_interest and not result.open_interest[symbol].success)
+            or isinstance(result.market_caps.market_caps.get(symbol), str)
+        )
+
+    exit_code = _fetch_exit_code(len(failed_symbols))
     _log_loaded_coins(logger, len(symbols), "loaded")
     return exit_code
 
@@ -408,10 +418,20 @@ def _update_cache_inner(config: AppConfig, args: argparse.Namespace) -> int:
         return 0
 
     start_time, end_time = _fetch_period(config, args.days, getattr(args, "end_datetime", None))
-    result = fetcher.fetch_all(symbols=symbols, timeframe=config.fetch.timeframe, start_time=start_time,
-                               end_time=end_time)
-    _log_fetch_summary("update-cache", logger, len(symbols), result.failed_symbols_count)
-    exit_code = _fetch_exit_code(result.failed_symbols_count)
+    failed_symbols: set[str] = set()
+    for timeframe in config.fetch.timeframes:
+        logger.info("обновление-кэша: сбор кэша для TF=%s", timeframe.value)
+        result = fetcher.fetch_all(symbols=symbols, timeframe=timeframe, start_time=start_time, end_time=end_time)
+        _log_fetch_summary(f"update-cache[{timeframe.value}]", logger, len(symbols), result.failed_symbols_count)
+        failed_symbols.update(
+            symbol
+            for symbol in symbols
+            if (symbol in result.ohlcv and not result.ohlcv[symbol].success)
+            or (symbol in result.open_interest and not result.open_interest[symbol].success)
+            or isinstance(result.market_caps.market_caps.get(symbol), str)
+        )
+
+    exit_code = _fetch_exit_code(len(failed_symbols))
     _log_loaded_coins(logger, len(symbols), "updated")
     return exit_code
 

--- a/config/fetch_config.py
+++ b/config/fetch_config.py
@@ -8,8 +8,8 @@ from datetime import datetime, tzinfo
 from constants import (
     DEFAULT_COINGECKO_MIN_REQUEST_INTERVAL_SECONDS,
     DEFAULT_COINGECKO_VOLUME_BATCH_SIZE,
+    DEFAULT_FETCH_TIMEFRAMES,
     DEFAULT_MIN_VOLUME_USD,
-    DEFAULT_TIMEFRAME,
     DEFAULT_TIMEZONE,
 )
 from domain.enums.timeframe import Timeframe
@@ -21,13 +21,22 @@ class FetchConfig:
     binance_api_key: str
     binance_secret_key: str
     coingecko_api_key: str
-    timeframe: Timeframe = DEFAULT_TIMEFRAME
+    timeframes: tuple[Timeframe, ...] = DEFAULT_FETCH_TIMEFRAMES
     timezone: str = DEFAULT_TIMEZONE
     min_volume_usd: float = DEFAULT_MIN_VOLUME_USD
     coingecko_min_request_interval_seconds: float = DEFAULT_COINGECKO_MIN_REQUEST_INTERVAL_SECONDS
     coingecko_volume_batch_size: int = DEFAULT_COINGECKO_VOLUME_BATCH_SIZE
     ignore_coingecko: bool = False
     anchor_datetime: datetime | None = None
+
+    def __post_init__(self) -> None:
+        if not self.timeframes:
+            raise ValueError("FetchConfig.timeframes must contain at least one timeframe")
+
+    @property
+    def timeframe(self) -> Timeframe:
+        """Возвращает основной таймфрейм для обратной совместимости."""
+        return self.timeframes[0]
 
     @property
     def tzinfo(self) -> tzinfo:

--- a/constants.py
+++ b/constants.py
@@ -10,6 +10,7 @@ from domain.enums.timeframe import Timeframe
 
 SUPPORTED_TIMEFRAMES: tuple[Timeframe, ...] = tuple(Timeframe)
 DEFAULT_TIMEFRAME = Timeframe.H1
+DEFAULT_FETCH_TIMEFRAMES: tuple[Timeframe, ...] = (Timeframe.D1, Timeframe.M15)
 
 # Лимиты АПИ
 DEFAULT_FETCH_BATCH_SIZE = 1000


### PR DESCRIPTION
## Summary
- switched fetch configuration from a single `timeframe` to `timeframes` in `FetchConfig`
- added validation and a compatibility `timeframe` property that returns the first configured TF
- introduced `DEFAULT_FETCH_TIMEFRAMES` in constants and set default cache build TFs to `D1` and `M15`
- updated `fetch-data` and `update-cache` flows to iterate over all configured timeframes and aggregate failures across runs
- documented that cache build timeframes are configured in code (`FetchConfig.timeframes`) rather than CLI params or `.env`

## Why
The cache build/update pipeline previously fetched only one timeframe. This change makes cache collection multi-timeframe and controlled by configuration, as requested.

## Validation
- `python -m compileall constants.py config/fetch_config.py cli/commands.py`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990171ca48083209f696cfc78d42fc0)