### PR TITLE
Skip invalid coin_id filtering when CoinGecko analysis is disabled

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -347,6 +347,7 @@ def _fetch_data_inner(config: AppConfig, args: argparse.Namespace) -> int:
     all_futures_count = len(futures_symbols)
     min_volume_usd = args.min_volume_usd if args.min_volume_usd is not None else config.fetch.min_volume_usd
     ignore_coingecko = args.ignore_coingecko if args.ignore_coingecko is not None else config.fetch.ignore_coingecko
+    market_client.set_skip_invalid_coin_id_filter(ignore_coingecko)
     top_n = args.top_n if args.top_n is not None else all_futures_count
     symbols = _resolve_symbols(
         exchange_client,
@@ -395,6 +396,7 @@ def _update_cache_inner(config: AppConfig, args: argparse.Namespace) -> int:
     all_futures_count = len(futures_symbols)
     min_volume_usd = args.min_volume_usd if args.min_volume_usd is not None else config.fetch.min_volume_usd
     ignore_coingecko = args.ignore_coingecko if args.ignore_coingecko is not None else config.fetch.ignore_coingecko
+    market_client.set_skip_invalid_coin_id_filter(ignore_coingecko)
     top_n = args.top_n if args.top_n is not None else all_futures_count
     symbols = _resolve_symbols(
         exchange_client,

--- a/data/clients/coingecko_client.py
+++ b/data/clients/coingecko_client.py
@@ -55,6 +55,7 @@ class CoinGeckoClient(MarketDataClient):
         retry_attempts: int = 3,
         retry_backoff_seconds: float = 1.0,
         min_request_interval_seconds: float = 1.0,
+        skip_invalid_coin_id_filter: bool = False,
     ) -> None:
         self._api_key = api_key
         self._cache_ttl = timedelta(hours=cache_ttl_hours)
@@ -67,8 +68,12 @@ class CoinGeckoClient(MarketDataClient):
         self._retry_attempts = retry_attempts
         self._retry_backoff_seconds = retry_backoff_seconds
         self._min_request_interval_seconds = max(0.0, float(min_request_interval_seconds))
+        self._skip_invalid_coin_id_filter = bool(skip_invalid_coin_id_filter)
         self._last_request_monotonic: float | None = None
         self._load_market_cap_cache()
+
+    def set_skip_invalid_coin_id_filter(self, value: bool) -> None:
+        self._skip_invalid_coin_id_filter = bool(value)
 
     # region Приватные
 
@@ -127,7 +132,7 @@ class CoinGeckoClient(MarketDataClient):
                         coin_id = item
 
             normalized_coin_id = str(coin_id).strip().lower()
-            if self._is_valid_coin_id(normalized_coin_id):
+            if self._skip_invalid_coin_id_filter or self._is_valid_coin_id(normalized_coin_id):
                 coin_ids_by_input[item] = normalized_coin_id
             else:
                 self._logger.warning("Пропуск невалидного coin_id для '%s': %s", item, coin_id)


### PR DESCRIPTION
### Motivation
- When CoinGecko-based analysis is disabled (`ignore_coingecko`), symbols were still being filtered out by the client's strict `coin_id` validation and logging warnings, reducing the symbol set unexpectedly. 
- The goal is to bypass that validation in the CoinGecko-disabled mode so symbols are not excluded by the regex check and unnecessary warnings are avoided.

### Description
- Added a new boolean flag `skip_invalid_coin_id_filter` to `CoinGeckoClient.__init__` and a setter `set_skip_invalid_coin_id_filter` to toggle the behavior at runtime in `data/clients/coingecko_client.py`.
- Modified `_resolve_coin_ids_by_input` to accept coin ids when `skip_invalid_coin_id_filter` is true, i.e. it now uses `if self._skip_invalid_coin_id_filter or self._is_valid_coin_id(...)` before filtering.
- Wired the flag into the CLI flow by calling `market_client.set_skip_invalid_coin_id_filter(ignore_coingecko)` in both `_fetch_data_inner` and `_update_cache_inner` in `cli/commands.py` so the client bypasses validation when `ignore_coingecko` is enabled.
- Changes are confined to `data/clients/coingecko_client.py` and `cli/commands.py`.

### Testing
- Ran a syntax/compile check with `python -m compileall data/clients/coingecko_client.py cli/commands.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69902b30cc488320960eeb5a893770b9)