### PR TITLE
Handle --ignore-coingecko cold-start with bootstrap symbol selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,9 @@ python main.py update-cache --top-n 100 --days 7 --end-datetime 2025-01-31T23:59
 python main.py fetch-data --top-n 100 --days 30
 python main.py fetch-data --top-n 100 --days 30 --ignore-coingecko
 python main.py update-cache --top-n 100 --days 7 --ignore-coingecko
+
+# При --ignore-coingecko команда автоматически использует bootstrap mode (без фильтра ликвидности),
+# если кэш объёмов ещё не прогрет; после прогрева применяется cache-liquidity mode.
 python main.py run-backtest
 python main.py make-report
 python main.py check-quality

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -164,6 +164,22 @@ def _resolve_symbols(
             if symbol in avg_daily_volumes_normalized
         ]
 
+        min_cache_ready_symbols = min(top_n, len(exchange_symbols_normalized))
+        is_cold_start = len(symbols_with_volume) < min_cache_ready_symbols
+        if is_cold_start:
+            bootstrap_symbols = exchange_symbols_normalized[:top_n]
+            logger.info(
+                "подбор-символов: кэш пуст, выполняется bootstrap без фильтра ликвидности (режим=bootstrap mode)"
+            )
+            logger.info(
+                "подбор-символов: CoinGecko отключен, всего на бирже=%s → в кэше с объёмом=%s (порог готовности=%s) → после bootstrap top_n=%s",
+                len(exchange_symbols_normalized),
+                len(symbols_with_volume),
+                min_cache_ready_symbols,
+                len(bootstrap_symbols),
+            )
+            return [futures_symbol_map[symbol] for symbol in bootstrap_symbols]
+
         liquid_symbols = [
             symbol
             for symbol in symbols_with_volume
@@ -177,7 +193,7 @@ def _resolve_symbols(
         ranked_top_symbols = ranked_liquid_symbols[:top_n]
 
         logger.info(
-            "подбор-символов: CoinGecko отключен, всего на бирже=%s → прошли расчёт объёма=%s → после фильтра ликвидности=%s → после top_n=%s",
+            "подбор-символов: CoinGecko отключен (режим=cache-liquidity mode), всего на бирже=%s → прошли расчёт объёма=%s → после фильтра ликвидности=%s → после top_n=%s",
             len(exchange_symbols_normalized),
             len(symbols_with_volume),
             len(liquid_symbols),


### PR DESCRIPTION
### Motivation
- When `--ignore-coingecko` is used and the cache has no valid daily-volume data, symbol resolution could return an empty set and `fetch_all` would be 0, preventing cache warm-up; a bootstrap fallback is needed so initial runs can populate the cache.

### Description
- Added cold-start detection in `_resolve_symbols(...)` for `ignore_coingecko` by computing `min_cache_ready_symbols = min(top_n, len(exchange_symbols_normalized))` and checking if `len(symbols_with_volume) < min_cache_ready_symbols`.
- On cold start return a bootstrap list of `top_n` symbols drawn from `exchange_symbols_normalized` (mapped via `futures_symbol_map`) without applying the `DailyVolumeRanker` liquidity filter and log a `bootstrap mode` message.
- Preserved the existing cache-based path and added an explicit `cache-liquidity mode` marker to the existing info log to distinguish modes.
- Updated `README.md` to document that `--ignore-coingecko` will use `bootstrap mode` when the volume cache is not warmed; modified files: `cli/commands.py`, `README.md`.

### Testing
- Ran `python -m compileall cli/commands.py README.md` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69903135b5f88320bf973074304393de)