### PR TITLE
Add backtest grid progress logging with ETA

### DIFF
--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from itertools import product
 from pathlib import Path
+from time import perf_counter
 
 import pandas as pd
 
@@ -35,6 +36,7 @@ from vectorbt_runner.backtest_summary import BacktestSummary
 from vectorbt_runner.mtf_frames import SymbolMtfFrames
 
 logger = logging.getLogger(__name__)
+PROGRESS_LOG_EVERY = 50
 
 
 class BacktestRunner:
@@ -195,8 +197,11 @@ class BacktestRunner:
         """Запускает полный расчёт бэктеста в vectorbt."""
         rows: list[dict[str, int | float | str | None]] = []
         grid = self.build_parameter_grid()
+        total = len(grid)
+        symbols_count = len(symbol_frames)
+        started_at = perf_counter()
 
-        for params in grid:
+        for idx, params in enumerate(grid, start=1):
             all_trades: list[TradeResult] = []
             for symbol, mtf_frames in symbol_frames.items():
                 cfg = BreakoutParams(
@@ -225,6 +230,20 @@ class BacktestRunner:
 
             row = self._build_metrics_row(params, all_trades)
             rows.append(row)
+
+            if idx % PROGRESS_LOG_EVERY == 0 or idx == total:
+                elapsed_seconds = perf_counter() - started_at
+                progress = (idx / total) * 100 if total else BACKTEST_ZERO_COUNT
+                eta_seconds = (elapsed_seconds / idx) * (total - idx) if idx else BACKTEST_ZERO_COUNT
+                logger.info(
+                    "run-progress: grid=%s/%s (%.1f%%), symbols=%s, elapsed=%ss, eta=%ss",
+                    idx,
+                    total,
+                    progress,
+                    symbols_count,
+                    int(elapsed_seconds),
+                    int(eta_seconds),
+                )
 
         results = (
             pd.DataFrame(rows)


### PR DESCRIPTION
### Motivation
- Добавить прогресс-логирование при запуске бэктеста по сетке параметров, чтобы отслеживать ход долгих прогонов и видеть примерное ETA.
- Обеспечить стабильный для `grep` формат сообщений и использование модульного логгера для попадания записей в существующие логи.

### Description
- Добавлен импорт `perf_counter` и константа `PROGRESS_LOG_EVERY = 50` для управления частотой логов. 
- В `BacktestRunner.run` вычисляются `total = len(grid)`, `symbols_count = len(symbol_frames)` и `started_at = perf_counter()` для расчёта прогресса и ETA. 
- Основной цикл заменён на `for idx, params in enumerate(grid, start=1):` и добавлено логирование каждые `PROGRESS_LOG_EVERY` итераций и на последней итерации с форматом `run-progress: grid=%s/%s (%.1f%%), symbols=%s, elapsed=%ss, eta=%ss` (используется модульный `logger = logging.getLogger(__name__)`).
- Процент выполнения и ETA высчитываются как `progress = (idx / total) * 100` и `eta_seconds = (elapsed_seconds / idx) * (total - idx)`, а `elapsed`/`eta` приводятся к целым секундам в сообщении.

### Testing
- Выполнена компиляция файла командой `python -m compileall vectorbt_runner/backtest_runner.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990a22365cc832088d272f4c62c073c)