### PR TITLE
Cache and reuse annotated multi‑TF data to avoid repeated preparation

### DIFF
--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -44,6 +44,18 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
     """Стратегия пробоя/ретеста с подтверждением продолжения и проверкой режима объема."""
 
     REQUIRED_COLUMNS = STRATEGY_REQUIRED_COLUMNS
+    ANNOTATED_COLUMNS = [
+        "datetime",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "level_high",
+        "level_low",
+        "level_start_time",
+        "natr",
+    ]
     _logger = logging.getLogger(__name__)
 
     def __init__(self, *, commission_rate: float, slippage: float, strategy_timezone: str, simulation_timezone: str) -> None:
@@ -340,6 +352,58 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         prepared = prepared.dropna(subset=["open", "high", "low", "close", "volume"])
         return prepared
 
+    def prepare_multi_tf_data(
+        self,
+        *,
+        mtf_frames: SymbolMtfFrames,
+        levels_timeframe: Timeframe,
+        entry_timeframe: Timeframe,
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """Готовит базовые фреймы старшего/младшего ТФ для дальнейшего аннотирования."""
+        higher_prepared = self.prepare_data(mtf_frames.get_frame(levels_timeframe))
+        lower_prepared = self.prepare_data(mtf_frames.get_frame(entry_timeframe))
+        return (
+            higher_prepared[["datetime", "high", "low"]].copy(),
+            lower_prepared[["datetime", "open", "high", "low", "close", "volume"]].copy(),
+        )
+
+    def prepare_annotated_multi_tf_data(
+        self,
+        *,
+        prepared_multi_tf: tuple[pd.DataFrame, pd.DataFrame],
+        lookback: int,
+    ) -> pd.DataFrame:
+        """Строит аннотированный фрейм (уровни + NATR), готовый к проходу сигналов."""
+        higher_base, lower_base = prepared_multi_tf
+        if len(higher_base) < lookback + STRATEGY_MIN_LOOKBACK_BUFFER:
+            return pd.DataFrame(columns=self.ANNOTATED_COLUMNS)
+        if len(lower_base) < STRATEGY_MIN_LOOKBACK_BUFFER:
+            return pd.DataFrame(columns=self.ANNOTATED_COLUMNS)
+
+        higher_levels = higher_base.copy()
+        higher_levels["level_high"] = higher_levels["high"].rolling(window=lookback).max().shift(1)
+        higher_levels["level_low"] = higher_levels["low"].rolling(window=lookback).min().shift(1)
+        higher_levels["level_start_time"] = higher_levels["datetime"]
+        higher_levels = higher_levels.dropna(subset=["level_high", "level_low"]).sort_values("datetime")
+        if higher_levels.empty:
+            return pd.DataFrame(columns=self.ANNOTATED_COLUMNS)
+
+        annotated = pd.merge_asof(
+            lower_base.sort_values("datetime").reset_index(drop=True),
+            higher_levels[["datetime", "level_high", "level_low", "level_start_time"]],
+            on="datetime",
+            direction="backward",
+        )
+        annotated = annotated.dropna(subset=["level_high", "level_low", "level_start_time"]).reset_index(drop=True)
+        if annotated.empty:
+            return pd.DataFrame(columns=self.ANNOTATED_COLUMNS)
+
+        annotated = self._append_natr(annotated=annotated, atr_window=lookback)
+        if annotated.empty:
+            return pd.DataFrame(columns=self.ANNOTATED_COLUMNS)
+
+        return annotated[self.ANNOTATED_COLUMNS].copy()
+
     def generate_events(self, data: pd.DataFrame, params: BreakoutParams) -> list[TradeResult]:
         """Обратносовместимая обертка для вызовов с одним таймфреймом."""
         return self.generate_events_multi_tf(
@@ -357,42 +421,26 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         *,
         mtf_frames: SymbolMtfFrames,
         params: BreakoutParams,
+        annotated: pd.DataFrame | None = None,
     ) -> list[TradeResult]:
         """Генерирует сделки по уровням старшего ТФ и логике пробоя/ретеста младшего ТФ."""
         self.validate_config(params)
-        higher_prepared = self.prepare_data(mtf_frames.get_frame(params.levels_timeframe))
-        lower_prepared = self.prepare_data(mtf_frames.get_frame(params.entry_timeframe))
         self._logger.info(
             "генерация_сигналов_пробой символ=%s тф_уровней=%s тф_входа=%s",
             params.symbol,
             params.levels_timeframe.value,
             params.entry_timeframe.value,
         )
-        if len(higher_prepared) < params.lookback + STRATEGY_MIN_LOOKBACK_BUFFER:
-            return []
-        if len(lower_prepared) < STRATEGY_MIN_LOOKBACK_BUFFER:
-            return []
-
-        higher_levels = higher_prepared[["datetime", "high", "low"]].copy()
-        higher_levels["level_high"] = higher_levels["high"].rolling(window=params.lookback).max().shift(1)
-        higher_levels["level_low"] = higher_levels["low"].rolling(window=params.lookback).min().shift(1)
-        higher_levels["level_start_time"] = higher_levels["datetime"]
-        higher_levels = higher_levels.dropna(subset=["level_high", "level_low"]).sort_values("datetime")
-        if higher_levels.empty:
-            return []
-
-        lower_prepared = lower_prepared.sort_values("datetime").reset_index(drop=True)
-        annotated = pd.merge_asof(
-            lower_prepared,
-            higher_levels[["datetime", "level_high", "level_low", "level_start_time"]],
-            on="datetime",
-            direction="backward",
-        )
-        annotated = annotated.dropna(subset=["level_high", "level_low", "level_start_time"]).reset_index(drop=True)
-        if annotated.empty:
-            return []
-
-        annotated = self._append_natr(annotated=annotated, atr_window=params.lookback)
+        if annotated is None:
+            prepared_multi_tf = self.prepare_multi_tf_data(
+                mtf_frames=mtf_frames,
+                levels_timeframe=params.levels_timeframe,
+                entry_timeframe=params.entry_timeframe,
+            )
+            annotated = self.prepare_annotated_multi_tf_data(
+                prepared_multi_tf=prepared_multi_tf,
+                lookback=params.lookback,
+            )
         if annotated.empty:
             return []
 

--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -25,13 +25,14 @@ from constants import (
 from domain.enums.timeframe import Timeframe
 from domain.enums.trade_result_type import TradeResultType
 from domain.models.trade_result import TradeResult
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from strategy.base_strategy import BaseStrategy
 
 from strategy.breakout.config import BREAKOUT_PARAMETER_GRID, PARAMETER_GRID_SIZE, TARGET_PARAMETER_COMBINATIONS, \
     BreakoutParams
+from strategy.breakout.breakout_strategy import BreakoutStrategy
 from vectorbt_runner.backtest_summary import BacktestSummary
 from vectorbt_runner.mtf_frames import SymbolMtfFrames
 
@@ -197,9 +198,26 @@ class BacktestRunner:
         """Запускает полный расчёт бэктеста в vectorbt."""
         rows: list[dict[str, int | float | str | None]] = []
         grid = self.build_parameter_grid()
+        lookbacks = sorted({params.lookback for params in grid})
         total = len(grid)
         symbols_count = len(symbol_frames)
         started_at = perf_counter()
+
+        prepared_symbol_data: dict[str, dict[int, pd.DataFrame]] = {}
+        if isinstance(strategy, BreakoutStrategy):
+            for symbol, mtf_frames in symbol_frames.items():
+                prepared_multi_tf = strategy.prepare_multi_tf_data(
+                    mtf_frames=mtf_frames,
+                    levels_timeframe=levels_timeframe,
+                    entry_timeframe=entry_timeframe,
+                )
+                prepared_symbol_data[symbol] = {
+                    lookback: strategy.prepare_annotated_multi_tf_data(
+                        prepared_multi_tf=prepared_multi_tf,
+                        lookback=lookback,
+                    )
+                    for lookback in lookbacks
+                }
 
         for idx, params in enumerate(grid, start=1):
             all_trades: list[TradeResult] = []
@@ -222,10 +240,18 @@ class BacktestRunner:
                     levels_timeframe=levels_timeframe,
                     entry_timeframe=entry_timeframe,
                 )
-                trades = strategy.generate_events_multi_tf(
-                    mtf_frames=mtf_frames,
-                    params=cfg,
-                )
+                if isinstance(strategy, BreakoutStrategy):
+                    prepared_annotated = prepared_symbol_data[symbol][params.lookback]
+                    trades = strategy.generate_events_multi_tf(
+                        mtf_frames=mtf_frames,
+                        params=cfg,
+                        annotated=prepared_annotated,
+                    )
+                else:
+                    trades = cast("BaseStrategy[BreakoutParams]", strategy).generate_events_multi_tf(
+                        mtf_frames=mtf_frames,
+                        params=cfg,
+                    )
                 all_trades.extend(trades)
 
             row = self._build_metrics_row(params, all_trades)


### PR DESCRIPTION
### Motivation
- Reduce redundant per-combination preprocessing in `BacktestRunner.run` by preparing heavy multi‑TF annotations once per symbol/lookback instead of on every grid iteration.
- Lower memory pressure by keeping only minimal columns needed for signal generation during reuse.

### Description
- Added `ANNOTATED_COLUMNS` and two new methods on `BreakoutStrategy`: `prepare_multi_tf_data(...)` which performs one‑time base normalization for higher/lower frames and `prepare_annotated_multi_tf_data(...)` which builds a lookback‑specific `annotated` frame (levels + `natr`) containing only the minimal columns required for signal processing.
- Made `generate_events_multi_tf(...)` accept an optional `annotated` DataFrame and skip the original `prepare_data`/`merge_asof`/`_append_natr` path when a prepared frame is provided, keeping backward compatibility when `annotated` is not supplied.
- Updated `BacktestRunner.run(...)` to precompute a `symbol -> lookback -> annotated` cache before the grid loop and pass the precomputed annotated frames into the strategy when available, with a fallback path for non-`BreakoutStrategy` strategies.
- Kept the annotated frames trimmed to the minimal set of columns (`datetime`, OHLCV, `level_high`, `level_low`, `level_start_time`, `natr`) to limit memory usage.

### Testing
- Compiled modified modules successfully with `python -m compileall strategy/breakout/breakout_strategy.py vectorbt_runner/backtest_runner.py` which succeeded.
- Attempt to run a full metric parity check could not be performed in this environment because `pandas` is unavailable, so `profit_factor`/`trades_count` parity against the previous logic was not validated here.
- No automated tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990a2fba9d08320bdbd0ce45c3df0ac)