### PR TITLE
Логирование покрытия сделками в бэктесте и расширение CLI-итога

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -536,12 +536,22 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
         entry_timeframe=entry_timeframe,
     )
     summary = runner.build_summary(results)
+    combinations_with_trades = int((results["trades_count"] > 0).sum()) if not results.empty else 0
+    total_trades = int(results["trades_count"].sum()) if not results.empty else 0
     logger.info(
-        "запуск-бэктеста: всего=%s прибыльных=%s лучший_pf=%.4f",
+        "запуск-бэктеста: всего=%s прибыльных=%s лучший_pf=%.4f комбинаций_со_сделками=%s",
         summary.total_combinations,
         summary.profitable_combinations,
         summary.best_pf,
+        combinations_with_trades,
     )
+    if summary.best_pf == 0 and total_trades == 0:
+        logger.warning(
+            "запуск-бэктеста: отсутствуют сделки по всем комбинациям; проверьте достаточность истории для levels_tf=%s и соответствие таймфреймов в кэше (%s/%s)",
+            levels_timeframe.value,
+            levels_timeframe.value,
+            entry_timeframe.value,
+        )
     return 0
 
 

--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -276,6 +276,23 @@ class BacktestRunner:
             .sort_values("profit_factor", ascending=BACKTEST_SORT_ASCENDING)
             .reset_index(drop=True)
         )
+
+        combinations_with_trades = int((results["trades_count"] > BACKTEST_ZERO_COUNT).sum()) if not results.empty else BACKTEST_ZERO_COUNT
+        combinations_without_trades = int((results["trades_count"] == BACKTEST_ZERO_COUNT).sum()) if not results.empty else BACKTEST_ZERO_COUNT
+        total_trades = int(results["trades_count"].sum()) if not results.empty else BACKTEST_ZERO_COUNT
+        no_trades_share = (
+            combinations_without_trades / len(results)
+            if not results.empty
+            else BACKTEST_ZERO_COUNT
+        )
+        logger.info(
+            "запуск-бэктеста: покрытие сделками: со_сделками=%s без_сделок=%s всего_сделок=%s доля_без_сделок=%.4f",
+            combinations_with_trades,
+            combinations_without_trades,
+            total_trades,
+            no_trades_share,
+        )
+
         self._save_results(results)
         return results
 


### PR DESCRIPTION
### Motivation
- Добавить видимость того, какие параметры сетки действительно генерируют сделки и какую часть комбинаций остаётся без сделок. 
- Предоставить подсказку пользователю в случае полного отсутствия сделок, чтобы он проверил достаточность истории для `levels_tf` и соответствие таймфреймов в кэше.

### Description
- В `BacktestRunner.run` после формирования `results` добавлен расчёт и логирование метрик покрытия сделками: число комбинаций с `trades_count > 0`, число комбинаций с `trades_count == 0`, суммарное число сделок (`sum(trades_count)`) и доля комбинаций без сделок; лог пишет строку с этими значениями. 
- В `_run_backtest_inner` (файл `cli/commands.py`) расширен финальный лог для вывода `комбинаций_со_сделками` рядом с `всего/прибыльных/лучший_pf`. 
- Добавлено отдельное предупреждение в CLI, если `best_pf == 0` и `sum(trades_count) == 0`, с подсказкой проверить `levels_tf` и соответствие таймфреймов в кэше. 
- Изменённые файлы: `vectorbt_runner/backtest_runner.py`, `cli/commands.py`.

### Testing
- Выполнена компиляция изменённых модулей командой `python -m compileall cli/commands.py vectorbt_runner/backtest_runner.py`, которая прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990aa0dbae48320946e5970d0dc3291)