### PR TITLE
Unify run-backtest logger across strategy and runner

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -536,6 +536,7 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
         slippage=config.simulation.slippage,
         strategy_timezone=config.strategy.timezone,
         simulation_timezone=config.simulation.timezone,
+        logger=logger,
     )
     runner = BacktestRunner(
         config.backtest.results_dir,

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -56,14 +56,24 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         "level_start_time",
         "natr",
     ]
-    _logger = logging.getLogger(__name__)
-
-    def __init__(self, *, commission_rate: float, slippage: float, strategy_timezone: str, simulation_timezone: str) -> None:
+    def __init__(
+        self,
+        *,
+        commission_rate: float,
+        slippage: float,
+        strategy_timezone: str,
+        simulation_timezone: str,
+        logger: logging.Logger | None = None,
+    ) -> None:
         self._commission_rate = commission_rate
         self._slippage = slippage
         self._strategy_timezone = strategy_timezone
         self._simulation_timezone = simulation_timezone
+        self._logger = logger or logging.getLogger(__name__)
         self._last_generation_diagnostics: dict[str, object] = {}
+
+    def set_logger(self, logger: logging.Logger) -> None:
+        self._logger = logger
 
     def consume_last_generation_diagnostics(self) -> dict[str, object]:
         """Возвращает диагностику последней генерации сигналов и очищает буфер."""
@@ -220,7 +230,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             (annotated["datetime"] >= breakout_timestamp) & (annotated["datetime"] < retest_timestamp)
         ]
         if before_slice.empty or after_slice.empty:
-            BreakoutStrategy._logger.debug(
+            self._logger.debug(
                 "режим_объема_отклонен_пустое_окно время_формирования=%s время_пробоя=%s время_ретеста=%s множитель_объема=%.4f",
                 breakout.level_start_time,
                 breakout_timestamp,
@@ -252,7 +262,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         breakout.level = updated_level
 
         if not is_ok:
-            BreakoutStrategy._logger.info(
+            self._logger.info(
                 "режим_объема_отклонен объем_до=%.6f объем_после=%.6f множитель_объема=%.4f порог=%.6f",
                 v_before,
                 v_after,
@@ -526,7 +536,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             if pending_retest is not None:
                 if params.entry_trigger == EntryTrigger.IMMEDIATE:
                     entry_idx = pending_retest.retest_idx + 1
-                    BreakoutStrategy._logger.info(
+                    self._logger.info(
                         "signal built from retest symbol=%s datetime=%s side=%s entry_trigger=%s entry_idx=%s retest_idx=%s breakout_idx=%s",
                         params.symbol,
                         row["datetime"],
@@ -547,7 +557,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
 
                 if idx > pending_retest.confirmation_end_idx:
                     diagnostics["retest_confirmation_expired"] += 1
-                    BreakoutStrategy._logger.info(
+                    self._logger.info(
                         "retest_confirmation_expired symbol=%s confirmation_end_idx=%s idx=%s candle_time=%s",
                         params.symbol,
                         pending_retest.confirmation_end_idx,
@@ -558,7 +568,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                     continue
                 if self._is_confirmation(row=row, retest=pending_retest):
                     entry_idx = idx + 1
-                    BreakoutStrategy._logger.info(
+                    self._logger.info(
                         "signal built from retest symbol=%s datetime=%s side=%s entry_trigger=%s entry_idx=%s retest_idx=%s breakout_idx=%s",
                         params.symbol,
                         row["datetime"],
@@ -578,7 +588,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                     continue
                 if idx == pending_retest.confirmation_end_idx:
                     diagnostics["retest_confirmation_not_received"] += 1
-                    BreakoutStrategy._logger.info(
+                    self._logger.info(
                         "retest_confirmation_not_received symbol=%s confirmation_end_idx=%s idx=%s candle_time=%s",
                         params.symbol,
                         pending_retest.confirmation_end_idx,
@@ -594,7 +604,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                     diagnostics["breakout_retest_window_expired"] += 1
                     pending_breakout = None
                 elif self._is_retest_candle(row=row, breakout=pending_breakout, params=params):
-                    BreakoutStrategy._logger.debug(
+                    self._logger.debug(
                         "retest_candle_detected symbol=%s datetime=%s side=%s level=%.8f breakout_idx=%s retest_idx=%s",
                         params.symbol,
                         row["datetime"],
@@ -628,7 +638,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             volume_threshold=volume_check["threshold"],
                             volume_filter_passed=volume_check["is_ok"],
                         )
-                        BreakoutStrategy._logger.info(
+                        self._logger.info(
                             "retest accepted -> pending_retest created symbol=%s datetime=%s side=%s level=%.8f breakout_idx=%s retest_idx=%s entry_trigger=%s entry_idx=%s",
                             params.symbol,
                             row["datetime"],
@@ -643,7 +653,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                         continue
                     if not bool(volume_check["is_ok"]):
                         diagnostics["retest_rejected_by_volume"] += 1
-                        BreakoutStrategy._logger.info(
+                        self._logger.info(
                             "retest_rejected_by_volume symbol=%s datetime=%s side=%s level=%.8f breakout_idx=%s retest_idx=%s v_before=%.6f v_after=%.6f threshold=%.6f volume_mult=%.4f volume_filter_passed=false",
                             params.symbol,
                             row["datetime"],
@@ -658,7 +668,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                         )
                     else:
                         diagnostics["retest_rejected_by_extra_filters"] += 1
-                        BreakoutStrategy._logger.info(
+                        self._logger.info(
                             "retest_rejected_by_extra_filters symbol=%s datetime=%s side=%s level=%.8f breakout_idx=%s retest_idx=%s body_ratio=%.6f body_ratio_min=%.6f move_atr=%.6f move_atr_threshold=%.6f max_retest_depth=%.6f max_retest_depth_threshold=%.6f natr=%.6f",
                             params.symbol,
                             row["datetime"],
@@ -721,7 +731,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
 
         if pending_signal is not None:
             diagnostics["signal_not_filled_end_of_data"] += 1
-            BreakoutStrategy._logger.info(
+            self._logger.info(
                 "сигнал_не_исполнен_конец_данных символ=%s тф_уровней=%s тф_входа=%s время_входа=%s цена_входа=%.8f",
                 params.symbol,
                 params.levels_timeframe.value,

--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -242,6 +242,31 @@ class BacktestRunner:
                 counter.get("retest_confirmation_expired", BACKTEST_ZERO_COUNT),
             )
 
+        breakdown_by_params: dict[str, Counter[str]] = defaultdict(Counter)
+        for (_, params_signature), counter in problematic:
+            breakdown_by_params[params_signature].update(counter)
+
+        sorted_by_params = sorted(
+            breakdown_by_params.items(),
+            key=lambda item: (
+                sum(item[1].get(name, BACKTEST_ZERO_COUNT) for name in ZERO_ENTRY_REJECTION_KEYS),
+                item[1].get("retests_found", BACKTEST_ZERO_COUNT),
+            ),
+            reverse=True,
+        )
+        params_detail_limit = min(DIAGNOSTIC_TOP_N, len(sorted_by_params))
+        for params_signature, counter in sorted_by_params[:params_detail_limit]:
+            self._logger.info(
+                "запуск-бэктеста: проблемный_ключ_параметров params=%s retests_found=%s trades_generated=%s retest_rejected_by_volume=%s retest_rejected_by_extra_filters=%s retest_confirmation_not_received=%s retest_confirmation_expired=%s",
+                params_signature,
+                counter.get("retests_found", BACKTEST_ZERO_COUNT),
+                counter.get("trades_generated", BACKTEST_ZERO_COUNT),
+                counter.get("retest_rejected_by_volume", BACKTEST_ZERO_COUNT),
+                counter.get("retest_rejected_by_extra_filters", BACKTEST_ZERO_COUNT),
+                counter.get("retest_confirmation_not_received", BACKTEST_ZERO_COUNT),
+                counter.get("retest_confirmation_expired", BACKTEST_ZERO_COUNT),
+            )
+
     # endregion Приватные
 
     @staticmethod
@@ -316,6 +341,7 @@ class BacktestRunner:
         rejection_diagnostics_total: Counter[str] = Counter()
         rejection_diagnostics_by_key: dict[tuple[str, str], Counter[str]] = defaultdict(Counter)
         if isinstance(strategy, BreakoutStrategy):
+            strategy.set_logger(self._logger)
             for symbol, mtf_frames in symbol_frames.items():
                 prepared_multi_tf = strategy.prepare_multi_tf_data(
                     mtf_frames=mtf_frames,


### PR DESCRIPTION
### Motivation
- Обеспечить единый logger для цепочки `run-backtest -> BacktestRunner -> BreakoutStrategy` чтобы все сообщения прогресса и диагностик были в одном потоке и легко сопоставимы.
- Сделать возможным передачу логгера в стратегию вместо использования жесткого class-level логгера для гибкости и консистентности логов.
- Аггрегировать причины `0 trades` по ключам параметров на уровне INFO, чтобы важные диагностические сводки были видны без включения DEBUG.

### Description
- Добавлен параметр `logger: logging.Logger | None = None` в конструктор `BreakoutStrategy` и метод `set_logger`, а также перевод внутренних вызовов логирования на `self._logger` вместо class-level логгера. 
- В CLI при создании `BreakoutStrategy` теперь прокидывается `run-backtest` logger (из `get_logger`).
- В `BacktestRunner.run` принудительно вызывается `strategy.set_logger(self._logger)` перед подготовкой данных, чтобы стратегия использовала тот же logger что и runner, и добавлена агрегация по параметрам для случаев `0 trades` с выводом INFO-логов `проблемный_ключ_параметров`.
- Обновлены соответствующие сообщения/диагностики и добавлен блок, который сводит и логирует причину отказов по сигнатурам параметров (с выводом до `DIAGNOSTIC_TOP_N`).

### Testing
- Скомпилированы измененные модули командой `python -m compileall strategy/breakout/breakout_strategy.py cli/commands.py vectorbt_runner/backtest_runner.py` и компиляция прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990b7b428b88320ae9ff3509ed6bbd1)