### PR TITLE
Parametrize StrategyPlotter MTF frame selection by input timeframes

### DIFF
--- a/vectorbt_runner/strategy_plotter.py
+++ b/vectorbt_runner/strategy_plotter.py
@@ -39,12 +39,17 @@ class StrategyPlotter:
         return f"{start}_{end}"
 
     @staticmethod
-    def _build_mtf_frames(symbol_data: dict[Timeframe, pd.DataFrame]) -> SymbolMtfFrames:
+    def _build_mtf_frames(
+        symbol_data: dict[Timeframe, pd.DataFrame],
+        *,
+        levels_timeframe: Timeframe,
+        entry_timeframe: Timeframe,
+    ) -> SymbolMtfFrames:
         return SymbolMtfFrames(
-            levels_timeframe=Timeframe.D1,
-            entry_timeframe=Timeframe.M15,
-            levels_frame=symbol_data.get(Timeframe.D1, pd.DataFrame()),
-            entry_frame=symbol_data.get(Timeframe.M15, pd.DataFrame()),
+            levels_timeframe=levels_timeframe,
+            entry_timeframe=entry_timeframe,
+            levels_frame=symbol_data.get(levels_timeframe, pd.DataFrame()),
+            entry_frame=symbol_data.get(entry_timeframe, pd.DataFrame()),
         )
 
     def _load_annotated(self, symbol: str, params: BreakoutParams) -> pd.DataFrame:
@@ -52,7 +57,11 @@ class StrategyPlotter:
             symbol,
             (params.levels_timeframe, params.entry_timeframe),
         )
-        mtf_frames = self._build_mtf_frames(symbol_data)
+        mtf_frames = self._build_mtf_frames(
+            symbol_data,
+            levels_timeframe=params.levels_timeframe,
+            entry_timeframe=params.entry_timeframe,
+        )
         prepared = self._strategy.prepare_multi_tf_data(
             mtf_frames=mtf_frames,
             levels_timeframe=params.levels_timeframe,


### PR DESCRIPTION
### Motivation
- Убрать хардкод таймфреймов в `StrategyPlotter` и использовать таймфреймы, переданные в параметрах, чтобы `levels_frame` и `entry_frame` брался из `symbol_data` по ключам запрошенных таймфреймов.

### Description
- Обновлена сигнатура `StrategyPlotter._build_mtf_frames` и теперь метод принимает `levels_timeframe` и `entry_timeframe` и использует их для полей `levels_timeframe`, `entry_timeframe`, `levels_frame` и `entry_frame` в `SymbolMtfFrames` (внесено в `vectorbt_runner/strategy_plotter.py`).
- В методе `_load_annotated` передаём `params.levels_timeframe` и `params.entry_timeframe` в вызов `_build_mtf_frames` вместо предыдущего использования значений по умолчанию.
- Проверены места вызова `_build_mtf_frames` в репозитории и обновлена единственная точка вызова под новую сигнатуру.

### Testing
- Выполнен `python -m compileall vectorbt_runner/strategy_plotter.py`, компиляция прошла успешно.
- Проверен поиск вызовов через `rg "_build_mtf_frames\(|build_mtf_frames" -n` и подтверждено, что единственный вызов обновлён.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69916c605dc083208636cc73c5b3f2d5)