### PR TITLE
Add structured parquet cache validation logging

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -90,7 +90,11 @@ def _build_fetch_stack(config: AppConfig) -> tuple[MarketDataFetcher, CcxtFuture
         retry_attempts=config.backtest.retry_attempts,
         retry_backoff_seconds=config.backtest.retry_backoff_seconds,
     )
-    storage = ParquetStorage(base_dir=config.backtest.cache_dir)
+    storage = ParquetStorage(
+        base_dir=config.backtest.cache_dir,
+        log_level=config.backtest.log_level,
+        logs_dir=config.backtest.logs_dir,
+    )
     ohlcv_fetcher = OhlcvFetcher(
         exchange_client=exchange_client,
         storage=storage,

--- a/data/storage/parquet_storage.py
+++ b/data/storage/parquet_storage.py
@@ -2,18 +2,30 @@
 
 from __future__ import annotations
 
+from logging import INFO
 from pathlib import Path
 from urllib.parse import quote, unquote
 
 import pandas as pd
 
 from domain.enums.timeframe import Timeframe
+from utils.logger import get_logger
 
 
 class ParquetStorage:
     """Класс."""
-    def __init__(self, base_dir: str | Path = "cache") -> None:
+    def __init__(
+        self,
+        base_dir: str | Path = "cache",
+        log_level: int | str = INFO,
+        logs_dir: str | Path = "logs",
+    ) -> None:
         self._base_dir = Path(base_dir)
+        self._logger = get_logger(
+            name="parquet-storage",
+            level=log_level,
+            logs_dir=logs_dir,
+        )
 
     # region Приватные
 
@@ -213,6 +225,34 @@ class ParquetStorage:
         merged = self._ensure_utc_columns(merged)
         merged = merged.drop_duplicates(subset=["timestamp"], keep="last").sort_values("timestamp")
         merged.to_parquet(path, index=False)
-        self._validate_written_cache(symbol, timeframe, previous_count, incoming, merged)
+        incoming_rows = len(incoming)
+        final_rows = len(merged)
+        added_rows = max(final_rows - previous_count, 0)
 
-        return max(len(merged) - previous_count, 0)
+        try:
+            self._validate_written_cache(symbol, timeframe, previous_count, incoming, merged)
+        except Exception as exc:
+            self._logger.error(
+                "parquet-cache-validation: validation=error symbol=%s timeframe=%s path=%s previous_count=%s incoming_rows=%s added_rows=%s final_rows=%s reason=%s",
+                symbol,
+                timeframe.value,
+                path,
+                previous_count,
+                incoming_rows,
+                added_rows,
+                final_rows,
+                str(exc),
+            )
+            raise
+
+        self._logger.info(
+            "parquet-cache-validation: validation=ok symbol=%s timeframe=%s previous_count=%s incoming_rows=%s added_rows=%s final_rows=%s",
+            symbol,
+            timeframe.value,
+            previous_count,
+            incoming_rows,
+            added_rows,
+            final_rows,
+        )
+
+        return added_rows


### PR DESCRIPTION
### Motivation
- Make parquet cache write validation observable and distinguishable in logs so operational issues are easier to detect and triage.
- Emit structured, searchable messages for both validation failures and successes to capture key metrics for each write attempt.
- Ensure storage logs follow the same logging contour as the rest of the `update-cache` flow.

### Description
- Added a dedicated logger to `ParquetStorage` via `utils.logger.get_logger` and new constructor parameters `log_level` and `logs_dir` (defaults `INFO`/`logs`).
- Wrapped the call to `_validate_written_cache(...)` inside `save_incremental(...)` with `try/except` to log a structured error line prefixed with `parquet-cache-validation:` containing `symbol`, `timeframe`, `path`, `previous_count`, `incoming_rows`, `added_rows`, `final_rows`, and `reason`, then re-raise the exception.
- On successful validation, log an `info` line prefixed with `parquet-cache-validation:` and key metrics (`symbol`, `timeframe`, `previous_count`, `incoming_rows`, `added_rows`, `final_rows`).
- Updated `_build_fetch_stack` in `cli/commands.py` to pass `log_level` and `logs_dir` into `ParquetStorage` so storage logs use the same logging configuration as the command.

### Testing
- Ran `python -m py_compile data/storage/parquet_storage.py cli/commands.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699181d4f7788320ad3c82a520cef355)