### PR TITLE
Handle parquet cache validation errors with tagged fetcher logs

### DIFF
--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -16,7 +16,7 @@ from data.quality.data_validator import DataValidator
 from data.quality.deduplicator import Deduplicator
 from data.quality.gap_detector import GapDetector
 from data.quality.time_alignment import TimeAlignment
-from data.storage.parquet_storage import ParquetStorage
+from data.storage.parquet_storage import ParquetCacheValidationError, ParquetStorage
 from domain.abstract.exchange_client import ExchangeClient
 from domain.enums.timeframe import Timeframe
 from domain.models.reporting.symbol_fetch_result import SymbolFetchResult
@@ -97,6 +97,13 @@ class OhlcvFetcher:
                 added_rows = self.fetch_symbol(symbol, timeframe, start_time, end_time)
                 results[symbol] = SymbolFetchResult.ok(added_rows)
             except Exception as exc:
+                if isinstance(exc, ParquetCacheValidationError) or "parquet cache validation failed" in str(exc).lower():
+                    self._logger.error(
+                        "cache-validation-error: source=ohlcv symbol=%s timeframe=%s cause=%s",
+                        symbol,
+                        timeframe.value,
+                        exc,
+                    )
                 msg = f"OHLCV ошибка исполнения: {symbol}: {exc}"
                 self._logger.error(msg)
                 results[symbol] = SymbolFetchResult.error(msg)

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -16,7 +16,7 @@ from data.quality.data_validator import DataValidator
 from data.quality.deduplicator import Deduplicator
 from data.quality.oi_aligner import OiAligner
 from data.quality.time_alignment import TimeAlignment
-from data.storage.parquet_storage import ParquetStorage
+from data.storage.parquet_storage import ParquetCacheValidationError, ParquetStorage
 from domain.abstract.exchange_client import ExchangeClient
 from domain.enums.timeframe import Timeframe
 from domain.models.reporting.symbol_fetch_result import SymbolFetchResult
@@ -125,6 +125,13 @@ class OiFetcher:
                 added_rows = self.fetch_symbol(symbol, timeframe, start_time, end_time)
                 results[symbol] = SymbolFetchResult.ok(added_rows)
             except Exception as exc:
+                if isinstance(exc, ParquetCacheValidationError) or "parquet cache validation failed" in str(exc).lower():
+                    self._logger.error(
+                        "cache-validation-error: source=oi symbol=%s timeframe=%s cause=%s",
+                        symbol,
+                        timeframe.value,
+                        exc,
+                    )
                 msg = f"OI ошибка исполнения: {symbol}: {exc}"
                 self._logger.error(msg)
                 results[symbol] = SymbolFetchResult.error(msg)

--- a/data/storage/parquet_storage.py
+++ b/data/storage/parquet_storage.py
@@ -12,6 +12,10 @@ from domain.enums.timeframe import Timeframe
 from utils.logger import get_logger
 
 
+class ParquetCacheValidationError(ValueError):
+    """Ошибка валидации записанного parquet-кэша."""
+
+
 class ParquetStorage:
     """Класс."""
     def __init__(
@@ -81,7 +85,7 @@ class ParquetStorage:
                 f"added_rows={added_rows}",
             ]
             context_parts.extend(f"{key}={value}" for key, value in details.items())
-            raise ValueError("parquet cache validation failed: " + ", ".join(context_parts))
+            raise ParquetCacheValidationError("parquet cache validation failed: " + ", ".join(context_parts))
 
         if len(written) != len(merged):
             if len(written) < previous_count or len(written) != previous_count + added_rows:


### PR DESCRIPTION
### Motivation
- Сделать явную идентификацию ошибок валидации parquet-кэша (`parquet cache validation failed`) чтобы можно было логировать их отдельно и надёжно обнаруживать в коде; это упрощает диагностику проблем записи кэша.
- Не ломать существующие контракты `MarketDataFetcher.fetch_all(...)` и суммарную отчётность по ошибкам, поэтому нужно сохранить возврат `SymbolFetchResult.error(...)` при таких ошибках.

### Description
- Добавлен новый тип исключения `ParquetCacheValidationError` и заменён ранее бросаемый `ValueError` на этот тип в `data/storage/parquet_storage.py` для всех мест, где формируется сообщение `parquet cache validation failed`.
- В `OhlcvFetcher.fetch_many(...)` добавлена явная ветка распознавания ошибок валидации кэша (по типу `ParquetCacheValidationError` с fallback-распознаванием по тексту), которая пишет отдельный `error`-лог с тегом `cache-validation-error` и полями `symbol`, `timeframe` и исходной причиной, после чего поведение по возврату `SymbolFetchResult.error(...)` сохраняется.
- Аналогичные изменения применены в `OiFetcher.fetch_many(...)` с тем же форматом логирования `cache-validation-error` и сохранением текущего результата для вызывающего кода.
- Логика подсчёта ошибок в `MarketDataFetcher.fetch_all(...)` и итоговая сводка в `_log_fetch_summary` не изменялись и по-прежнему учитывают такие случаи как неуспешные (через `success=False` / `failed_symbols_count`).

### Testing
- Запуск компиляции модифицированных модулей: `python -m compileall data/fetchers/ohlcv_fetcher.py data/fetchers/oi_fetcher.py data/storage/parquet_storage.py cli/commands.py` успешно завершился.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699182476f608320845f3c0b7c05bce8)