### PR TITLE
Unify timestamp normalization in quality and storage flows

### DIFF
--- a/data/quality/time_alignment.py
+++ b/data/quality/time_alignment.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
+from logging import getLogger
+
 import pandas as pd
+
+from data.quality.timestamp_normalization import normalize_timestamp_series
+
+
+logger = getLogger("time-alignment")
 
 
 class TimeAlignment:
@@ -16,16 +23,25 @@ class TimeAlignment:
         aligned = data.copy()
 
         if "timestamp" in aligned.columns:
-            ts = pd.to_datetime(aligned["timestamp"], unit="ms", utc=True, errors="coerce")
+            timestamp_ms, ts = normalize_timestamp_series(
+                timestamp_series=aligned["timestamp"],
+                datetime_fallback=aligned.get("datetime"),
+                logger=logger,
+                log_prefix="time-alignment-normalization",
+            )
         elif "datetime" in aligned.columns:
-            ts = pd.to_datetime(aligned["datetime"], utc=True, errors="coerce")
+            timestamp_ms, ts = normalize_timestamp_series(
+                timestamp_series=aligned["datetime"],
+                logger=logger,
+                log_prefix="time-alignment-normalization",
+            )
         else:
             msg = "DataFrame must contain 'timestamp' or 'datetime' column"
             raise ValueError(msg)
 
         aligned = aligned.loc[ts.notna()].copy()
         ts = ts.loc[ts.notna()]
-        aligned["timestamp"] = (ts.astype("int64") // 1_000_000).astype("int64")
+        aligned["timestamp"] = timestamp_ms.loc[ts.index].astype("int64")
         aligned["datetime"] = ts
 
         return aligned.sort_values("timestamp").reset_index(drop=True)

--- a/data/quality/timestamp_normalization.py
+++ b/data/quality/timestamp_normalization.py
@@ -1,0 +1,82 @@
+"""Модуль нормализации временных меток."""
+
+from __future__ import annotations
+
+from logging import Logger
+
+import pandas as pd
+from pandas.api.types import is_datetime64_any_dtype
+
+
+def _detect_timestamp_unit(raw: pd.Series) -> str:
+    numeric = pd.to_numeric(raw, errors="coerce").dropna()
+    if numeric.empty:
+        return "datetime-like"
+
+    abs_max = float(numeric.abs().max())
+    if abs_max >= 1e17:
+        return "ns"
+    if abs_max >= 1e14:
+        return "us"
+    if abs_max >= 1e11:
+        return "ms"
+    return "s"
+
+
+def _safe_min_max(raw: pd.Series) -> tuple[object, object]:
+    non_na = raw.dropna()
+    if non_na.empty:
+        return None, None
+    try:
+        return non_na.min(), non_na.max()
+    except TypeError:
+        as_string = non_na.astype(str)
+        return as_string.min(), as_string.max()
+
+
+def normalize_timestamp_series(
+    timestamp_series: pd.Series,
+    datetime_fallback: pd.Series | None = None,
+    logger: Logger | None = None,
+    log_prefix: str = "timestamp-normalization",
+) -> tuple[pd.Series, pd.Series]:
+    """Нормализует временные метки к UTC datetime и int64 milliseconds."""
+    raw = timestamp_series.copy()
+    raw_dtype = str(raw.dtype)
+    raw_min, raw_max = _safe_min_max(raw)
+    nunique_before = int(raw.dropna().nunique())
+
+    if is_datetime64_any_dtype(raw):
+        detected_format = "datetime-like"
+        parsed = pd.to_datetime(raw, utc=True, errors="coerce")
+    else:
+        detected_format = _detect_timestamp_unit(raw)
+        if detected_format == "datetime-like":
+            parsed = pd.to_datetime(raw, utc=True, errors="coerce")
+        else:
+            numeric = pd.to_numeric(raw, errors="coerce")
+            parsed = pd.to_datetime(numeric, unit=detected_format, utc=True, errors="coerce")
+
+    if datetime_fallback is not None:
+        fallback_dt = pd.to_datetime(datetime_fallback, utc=True, errors="coerce")
+        parsed = parsed.where(parsed.notna(), fallback_dt)
+
+    parsed_notna = int(parsed.notna().sum())
+    timestamp_ms = pd.Series((parsed.view("int64") // 1_000_000), index=parsed.index).where(parsed.notna())
+    nunique_after = int(timestamp_ms.dropna().nunique())
+
+    if logger is not None:
+        logger.info(
+            "%s: raw_dtype=%s raw_min=%s raw_max=%s detected_format=%s parsed_notna=%s nunique_before=%s nunique_after=%s",
+            log_prefix,
+            raw_dtype,
+            raw_min,
+            raw_max,
+            detected_format,
+            parsed_notna,
+            nunique_before,
+            nunique_after,
+        )
+
+    return timestamp_ms, parsed
+

--- a/data/storage/parquet_storage.py
+++ b/data/storage/parquet_storage.py
@@ -8,6 +8,7 @@ from urllib.parse import quote, unquote
 
 import pandas as pd
 
+from data.quality.timestamp_normalization import normalize_timestamp_series
 from domain.enums.timeframe import Timeframe
 from utils.logger import get_logger
 
@@ -47,17 +48,21 @@ class ParquetStorage:
         symbol_path = self.encode_symbol_for_path(symbol)
         return self._base_dir / symbol_path / timeframe.value / "data.parquet"
 
-    @staticmethod
-    def _ensure_utc_columns(data: pd.DataFrame) -> pd.DataFrame:
+    def _ensure_utc_columns(self, data: pd.DataFrame) -> pd.DataFrame:
         normalized = data.copy()
         if "timestamp" not in normalized.columns:
             raise ValueError("data must contain 'timestamp' column")
 
-        ts = pd.to_datetime(normalized["timestamp"], unit="ms", utc=True, errors="coerce")
+        timestamp_ms, ts = normalize_timestamp_series(
+            timestamp_series=normalized["timestamp"],
+            datetime_fallback=normalized.get("datetime"),
+            logger=self._logger,
+            log_prefix="parquet-storage-normalization",
+        )
         normalized = normalized.loc[ts.notna()].copy()
         ts = ts.loc[ts.notna()]
 
-        normalized["timestamp"] = (ts.astype("int64") // 1_000_000).astype("int64")
+        normalized["timestamp"] = timestamp_ms.loc[ts.index].astype("int64")
         normalized["datetime"] = ts
         return normalized
 


### PR DESCRIPTION
### Motivation
- Устранить дублирование логики нормализации временных меток между `TimeAlignment` и `ParquetStorage` и сделать поведение единым. 
- Гарантировать, что после нормализации `timestamp` всегда представлен как миллисекунды `int64`, а `datetime` синхронизирован с ним. 
- Добавить диагностические логи для быстрого обнаружения аномалий форматов временных меток в проде.

### Description
- Вынесена общая функция `normalize_timestamp_series` в новый файл `data/quality/timestamp_normalization.py`, реализована детекция формата входа (datetime-like, s, ms, us, ns) и конвертация в UTC `datetime64[ns, UTC]` и в миллисекунды `int64`.
- Обновлён `data/quality/time_alignment.py::TimeAlignment.align_to_utc` для использования `normalize_timestamp_series` с опциональным `datetime`-fallback. 
- Обновлён `data/storage/parquet_storage.py::_ensure_utc_columns` для использования той же функции и логгера экземпляра, и приведены `timestamp`/`datetime` к единому источнику правды.
- Добавлены диагностические логи (`raw_dtype`, `raw_min/raw_max`, `detected_format`, `parsed_notna`, `nunique_before`, `nunique_after`) внутри `normalize_timestamp_series`.
- Изменённые файлы: `data/quality/timestamp_normalization.py`, `data/quality/time_alignment.py`, `data/storage/parquet_storage.py`.

### Testing
- Выполнена статическая проверка компиляции: `python -m compileall data/quality/timestamp_normalization.py data/quality/time_alignment.py data/storage/parquet_storage.py` (успешно).
- Запуск простого runtime-smoke скрипта для проверки нормализации завершился ошибкой из-за отсутствия зависимости `pandas` в текущем окружении (`ModuleNotFoundError: No module named 'pandas'`).
- Изменения закоммичены (commit message: "Unify timestamp normalization across alignment and storage").

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699187346cb48320b88c5c31a0a0a99f)