### PR TITLE
Replace Series.view in timestamp normalization with safe Int64 conversion

### DIFF
--- a/data/quality/timestamp_normalization.py
+++ b/data/quality/timestamp_normalization.py
@@ -61,8 +61,12 @@ def normalize_timestamp_series(
         fallback_dt = pd.to_datetime(datetime_fallback, utc=True, errors="coerce")
         parsed = parsed.where(parsed.notna(), fallback_dt)
 
-    parsed_notna = int(parsed.notna().sum())
-    timestamp_ms = pd.Series((parsed.view("int64") // 1_000_000), index=parsed.index).where(parsed.notna())
+    parsed_notna_mask = parsed.notna()
+    parsed_notna = int(parsed_notna_mask.sum())
+    timestamp_ms = pd.Series(pd.NA, index=parsed.index, dtype="Int64")
+    timestamp_ms.loc[parsed_notna_mask] = (
+        parsed.loc[parsed_notna_mask].astype("int64") // 1_000_000
+    ).astype("Int64")
     nunique_after = int(timestamp_ms.dropna().nunique())
 
     if logger is not None:
@@ -79,4 +83,3 @@ def normalize_timestamp_series(
         )
 
     return timestamp_ms, parsed
-


### PR DESCRIPTION
### Motivation
- Replace unsafe `Series.view("int64")` usage in `normalize_timestamp_series` to avoid dtype/view compatibility issues while preserving `NaT` handling and returning a `timestamp_ms` `Series` with the original index for downstream callers.

### Description
- Use a `parsed.notna()` mask and fill a nullable `Int64` `Series` by converting only valid `parsed` values with `parsed.astype("int64") // 1_000_000`, preserving null semantics and index while keeping callers' `.astype("int64")` behavior intact.

### Testing
- Ran `python -m compileall data/quality/timestamp_normalization.py data/quality/time_alignment.py data/storage/parquet_storage.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69918ab56d9083209cef377f5d4b1440)