### PR TITLE
Добавить логирование traceback в OHLCV/OI fetch_many

### DIFF
--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -98,14 +98,14 @@ class OhlcvFetcher:
                 results[symbol] = SymbolFetchResult.ok(added_rows)
             except Exception as exc:
                 if isinstance(exc, ParquetCacheValidationError) or "parquet cache validation failed" in str(exc).lower():
-                    self._logger.error(
+                    self._logger.exception(
                         "cache-validation-error: source=ohlcv symbol=%s timeframe=%s cause=%s",
                         symbol,
                         timeframe.value,
                         exc,
                     )
                 msg = f"OHLCV ошибка исполнения: {symbol}: {exc}"
-                self._logger.error(msg)
+                self._logger.exception(msg)
                 results[symbol] = SymbolFetchResult.error(msg)
 
         return results

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -126,14 +126,14 @@ class OiFetcher:
                 results[symbol] = SymbolFetchResult.ok(added_rows)
             except Exception as exc:
                 if isinstance(exc, ParquetCacheValidationError) or "parquet cache validation failed" in str(exc).lower():
-                    self._logger.error(
+                    self._logger.exception(
                         "cache-validation-error: source=oi symbol=%s timeframe=%s cause=%s",
                         symbol,
                         timeframe.value,
                         exc,
                     )
                 msg = f"OI ошибка исполнения: {symbol}: {exc}"
-                self._logger.error(msg)
+                self._logger.exception(msg)
                 results[symbol] = SymbolFetchResult.error(msg)
 
         return results


### PR DESCRIPTION
### Motivation
- Обеспечить запись полного traceback в логах при ошибках загрузки данных, сохранив при этом удобочитаемый текст ошибки для итоговой сводки.
- Сохранить существующее поведение для ошибок валидации parquet-кэша (`cache-validation-error`) и не менять формат внешней отчётности.

### Description
- В `OhlcvFetcher.fetch_many` заменил `self._logger.error(...)` на `self._logger.exception(...)` для `cache-validation-error`, чтобы traceback попадал в лог, при этом оставив итоговый `msg = f"OHLCV ошибка исполнения: {symbol}: {exc}"` и `SymbolFetchResult.error(msg)` без изменений.
- В `OiFetcher.fetch_many` сделал аналогичную замену: `self._logger.exception(...)` для `cache-validation-error` и для общего сообщения об ошибке, сохранив `msg` и `SymbolFetchResult.error(msg)`.
- Изменены файлы: `data/fetchers/ohlcv_fetcher.py` и `data/fetchers/oi_fetcher.py`.

### Testing
- Запуск `python -m compileall data/fetchers/ohlcv_fetcher.py data/fetchers/oi_fetcher.py` прошёл успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69918b1aa1348320b02f211112b3ce84)