### PR TITLE
Fail-fast abort for systemic OHLCV/OI fetch errors and reduce duplicate fetch logs

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -333,20 +333,28 @@ class FetchSummary:
         return (self.failed_symbols / self.total_symbols) if self.total_symbols else 0.0
 
 
-def _log_fetch_summary(command_name: str, logger: Logger, total_symbols: int, failed_symbols_count: int) -> FetchSummary:
+def _log_fetch_summary(
+    command_name: str,
+    logger: Logger,
+    total_symbols: int,
+    failed_symbols_count: int,
+    *,
+    emit_log: bool = True,
+) -> FetchSummary:
     summary = FetchSummary(
         total_symbols=total_symbols,
         success_symbols=total_symbols - failed_symbols_count,
         failed_symbols=failed_symbols_count,
     )
-    logger.info(
-        "%s: сводка загрузки всего=%s успешно=%s с ошибками=%s доля_ошибок=%.2f%%",
-        command_name,
-        summary.total_symbols,
-        summary.success_symbols,
-        summary.failed_symbols,
-        summary.failed_ratio * 100,
-    )
+    if emit_log:
+        logger.info(
+            "%s: сводка загрузки всего=%s успешно=%s с ошибками=%s доля_ошибок=%.2f%%",
+            command_name,
+            summary.total_symbols,
+            summary.success_symbols,
+            summary.failed_symbols,
+            summary.failed_ratio * 100,
+        )
     return summary
 
 
@@ -442,6 +450,7 @@ def _fetch_data_inner(config: AppConfig, args: argparse.Namespace) -> int:
             logger,
             len(symbols),
             result.failed_symbols_count,
+            emit_log=(not ignore_coingecko or timeframe == config.fetch.timeframe),
         )
         failed_symbols.update(
             symbol

--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -92,7 +92,7 @@ class OhlcvFetcher:
     ) -> dict[str, SymbolFetchResult]:
         """Последовательно загружает OHLCV для набора символов."""
         results: dict[str, SymbolFetchResult] = {}
-        for symbol in symbols:
+        for index, symbol in enumerate(symbols):
             try:
                 added_rows = self.fetch_symbol(symbol, timeframe, start_time, end_time)
                 results[symbol] = SymbolFetchResult.ok(added_rows)
@@ -108,4 +108,32 @@ class OhlcvFetcher:
                 self._logger.exception(msg)
                 results[symbol] = SymbolFetchResult.error(msg)
 
+                if self._is_system_error(exc):
+                    diagnostic_message = (
+                        "OHLCV fail-fast: системная ошибка, прерывание обработки TF "
+                        f"{timeframe.value} после {symbol}: {exc}"
+                    )
+                    remaining_symbols = symbols[index + 1 :]
+                    self._logger.warning(
+                        "fetch-abort-system-error: source=ohlcv timeframe=%s failure_symbol=%s remaining=%s cause=%s",
+                        timeframe.value,
+                        symbol,
+                        len(remaining_symbols),
+                        exc,
+                    )
+                    for remaining_symbol in remaining_symbols:
+                        results[remaining_symbol] = SymbolFetchResult.error(diagnostic_message)
+                    break
+
         return results
+
+    @staticmethod
+    def _is_system_error(exc: Exception) -> bool:
+        message = str(exc).lower()
+        signatures = (
+            "normalize",
+            "timestamp normalization",
+            "tz-naive",
+            "tz-aware",
+        )
+        return isinstance(exc, AttributeError) or any(signature in message for signature in signatures)

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -120,7 +120,7 @@ class OiFetcher:
     ) -> dict[str, SymbolFetchResult]:
         """Последовательно загружает open interest для набора символов."""
         results: dict[str, SymbolFetchResult] = {}
-        for symbol in symbols:
+        for index, symbol in enumerate(symbols):
             try:
                 added_rows = self.fetch_symbol(symbol, timeframe, start_time, end_time)
                 results[symbol] = SymbolFetchResult.ok(added_rows)
@@ -136,4 +136,32 @@ class OiFetcher:
                 self._logger.exception(msg)
                 results[symbol] = SymbolFetchResult.error(msg)
 
+                if self._is_system_error(exc):
+                    diagnostic_message = (
+                        "OI fail-fast: системная ошибка, прерывание обработки TF "
+                        f"{timeframe.value} после {symbol}: {exc}"
+                    )
+                    remaining_symbols = symbols[index + 1 :]
+                    self._logger.warning(
+                        "fetch-abort-system-error: source=oi timeframe=%s failure_symbol=%s remaining=%s cause=%s",
+                        timeframe.value,
+                        symbol,
+                        len(remaining_symbols),
+                        exc,
+                    )
+                    for remaining_symbol in remaining_symbols:
+                        results[remaining_symbol] = SymbolFetchResult.error(diagnostic_message)
+                    break
+
         return results
+
+    @staticmethod
+    def _is_system_error(exc: Exception) -> bool:
+        message = str(exc).lower()
+        signatures = (
+            "normalize",
+            "timestamp normalization",
+            "tz-naive",
+            "tz-aware",
+        )
+        return isinstance(exc, AttributeError) or any(signature in message for signature in signatures)


### PR DESCRIPTION
### Motivation
- Уменьшить шум логов и предотвратить каскадные ошибки при появлении «системной» ошибки нормализации timestamp в оркестрационном слое загрузки данных.
- Обеспечить раннюю остановку обработки текущего timeframe при явно системной ошибке и дать единое диагностическое сообщение для оставшихся символов.

### Description
- В `OhlcvFetcher.fetch_many` добавлен fail-fast: при первом системном исключении цикл по символам для текущего `timeframe` прерывается, оставшиеся символы помечаются как failed с единым диагностическим сообщением, и эмитируется warning-лог `fetch-abort-system-error` с источником, timeframe, символом отказа, количеством оставшихся и причиной; добавлен классификатор `_is_system_error` (учитывает `AttributeError` и подписи, связанные с нормализацией timestamp). 
- Аналогичное поведение реализовано в `OiFetcher.fetch_many` с теми же условиями маркировки и логирования.
- В `cli/commands.py` добавлен параметр `emit_log` в `_log_fetch_summary` и вызов изменён так, чтобы при bootstrap-режиме (`ignore_coingecko=true`) сводки логировались только для liquidity `timeframe`, при этом данные сводки остаются доступными для принятия решений (логика `ohlcv_cache_failed` → `2` не изменена).
- Минимизация повторяющихся логов выполнена без изменения существующей модели exit-code и без изменения семантики `FetchAllResult`/`SymbolFetchResult`.

### Testing
- Выполнена компиляция файлов для проверки синтаксиса: `python -m py_compile cli/commands.py data/fetchers/ohlcv_fetcher.py data/fetchers/oi_fetcher.py`, компиляция прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69918b83086483209f60edbd357777c0)