### PR TITLE
Unify timestamp pipeline and remove timezone casting in data flow

### DIFF
--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -37,8 +37,6 @@ except ImportError:  # pragma: no cover
 def _to_utc_ms(value: datetime) -> int:
     if value.tzinfo is None:
         value = value.replace(tzinfo=timezone.utc)
-    else:
-        value = value.astimezone(timezone.utc)
     return int(value.timestamp() * MILLISECONDS_IN_SECOND)
 
 # endregion Приватные
@@ -230,7 +228,7 @@ class CcxtFuturesClient(ExchangeClient):
             return frame
 
         frame = frame.loc[(frame["timestamp"] >= start_ms) & (frame["timestamp"] <= end_ms)]
-        frame["datetime"] = pd.to_datetime(frame["timestamp"], unit="ms", utc=True)
+        frame["datetime"] = pd.to_datetime(frame["timestamp"], unit="ms")
         return frame.drop_duplicates(subset=["timestamp"]).sort_values("timestamp").reset_index(drop=True)
 
     def fetch_open_interest(self, symbol: str, timeframe: Timeframe, start_time: datetime, end_time: datetime) -> pd.DataFrame:
@@ -305,6 +303,6 @@ class CcxtFuturesClient(ExchangeClient):
             frame["open_interest"] = pd.to_numeric(frame.get("openInterest"), errors="coerce")
 
         frame = frame.loc[(frame["timestamp"] >= start_ms) & (frame["timestamp"] <= end_ms)]
-        frame["datetime"] = pd.to_datetime(frame["timestamp"], unit="ms", utc=True)
+        frame["datetime"] = pd.to_datetime(frame["timestamp"], unit="ms")
         frame = frame[list(OPEN_INTEREST_FRAME_COLUMNS)]
         return frame.drop_duplicates(subset=["timestamp"]).sort_values("timestamp").reset_index(drop=True)

--- a/data/liquidity/daily_volume_ranker.py
+++ b/data/liquidity/daily_volume_ranker.py
@@ -44,7 +44,7 @@ class DailyVolumeRanker:
                 continue
 
             normalized = frame.copy()
-            normalized["datetime"] = pd.to_datetime(normalized["datetime"], utc=True, errors="coerce")
+            normalized["datetime"] = pd.to_datetime(normalized["datetime"], errors="coerce")
             normalized = normalized.dropna(subset=["datetime", "close", "volume"])
             if normalized.empty:
                 logger.info(

--- a/data/quality/data_validator.py
+++ b/data/quality/data_validator.py
@@ -43,7 +43,7 @@ class DataValidator:
             )
             return issues
 
-        ts = pd.to_datetime(normalized["timestamp"], unit="ms", utc=True, errors="coerce")
+        ts = pd.to_datetime(normalized["timestamp"], unit="ms", errors="coerce")
         if ts.notna().sum() == 0:
             add_dataset_issue(
                 "invalid_timestamp_series",
@@ -61,7 +61,7 @@ class DataValidator:
         def add_issue(pos: int, issue_type: str, severity: DataQualitySeverity, description: str) -> None:
             if pd.isna(ts.iloc[pos]):
                 return
-            tstamp = ts.iloc[pos].to_pydatetime().astimezone(timezone.utc)
+            tstamp = ts.iloc[pos].to_pydatetime()
             issues.append(
                 DataQualityIssue(
                     symbol=symbol,

--- a/data/quality/gap_detector.py
+++ b/data/quality/gap_detector.py
@@ -28,7 +28,7 @@ class GapDetector:
         if data.empty or "timestamp" not in data.columns:
             return []
 
-        ts = pd.DatetimeIndex(pd.to_datetime(data["timestamp"], unit="ms", utc=True, errors="coerce").dropna())
+        ts = pd.DatetimeIndex(pd.to_datetime(data["timestamp"], unit="ms", errors="coerce").dropna())
         ts = ts.sort_values().drop_duplicates()
         if ts.empty:
             return []

--- a/data/quality/time_alignment.py
+++ b/data/quality/time_alignment.py
@@ -16,7 +16,7 @@ class TimeAlignment:
     """Класс."""
     @staticmethod
     def align_to_utc(data: pd.DataFrame) -> pd.DataFrame:
-        """Приводит временные метки к единой зоне UTC."""
+        """Приводит временные метки к единому числовому формату timestamp(ms)."""
         if data.empty:
             return data.copy()
 

--- a/data/quality/timestamp_normalization.py
+++ b/data/quality/timestamp_normalization.py
@@ -34,6 +34,26 @@ def _safe_min_max(raw: pd.Series) -> tuple[object, object]:
         return as_string.min(), as_string.max()
 
 
+def _normalize_numeric_timestamp_to_ms(raw: pd.Series) -> pd.Series:
+    numeric = pd.to_numeric(raw, errors="coerce")
+    if numeric.dropna().empty:
+        return pd.Series(pd.NA, index=raw.index, dtype="Int64")
+
+    detected_format = _detect_timestamp_unit(raw)
+    if detected_format == "ns":
+        normalized = numeric // 1_000_000
+    elif detected_format == "us":
+        normalized = numeric // 1_000
+    elif detected_format == "ms":
+        normalized = numeric
+    elif detected_format == "s":
+        normalized = numeric * 1_000
+    else:
+        normalized = pd.Series(pd.NA, index=raw.index, dtype="float64")
+
+    return normalized.round().astype("Int64")
+
+
 def normalize_timestamp_series(
     timestamp_series: pd.Series,
     datetime_fallback: pd.Series | None = None,
@@ -48,25 +68,27 @@ def normalize_timestamp_series(
 
     if is_datetime64_any_dtype(raw):
         detected_format = "datetime-like"
-        parsed = pd.to_datetime(raw, utc=True, errors="coerce")
+        parsed = pd.to_datetime(raw, errors="coerce")
+        timestamp_ms = pd.Series(pd.NA, index=parsed.index, dtype="Int64")
+        parsed_notna_mask = parsed.notna()
+        timestamp_ms.loc[parsed_notna_mask] = (
+            parsed.loc[parsed_notna_mask].astype("int64") // 1_000_000
+        ).astype("Int64")
     else:
         detected_format = _detect_timestamp_unit(raw)
-        if detected_format == "datetime-like":
-            parsed = pd.to_datetime(raw, utc=True, errors="coerce")
-        else:
-            numeric = pd.to_numeric(raw, errors="coerce")
-            parsed = pd.to_datetime(numeric, unit=detected_format, utc=True, errors="coerce")
+        timestamp_ms = _normalize_numeric_timestamp_to_ms(raw)
+        parsed = pd.to_datetime(timestamp_ms, unit="ms", errors="coerce")
 
     if datetime_fallback is not None:
-        fallback_dt = pd.to_datetime(datetime_fallback, utc=True, errors="coerce")
+        fallback_dt = pd.to_datetime(datetime_fallback, errors="coerce")
         parsed = parsed.where(parsed.notna(), fallback_dt)
+        parsed_notna_mask = parsed.notna()
+        timestamp_ms.loc[parsed_notna_mask] = (
+            parsed.loc[parsed_notna_mask].astype("int64") // 1_000_000
+        ).astype("Int64")
 
     parsed_notna_mask = parsed.notna()
     parsed_notna = int(parsed_notna_mask.sum())
-    timestamp_ms = pd.Series(pd.NA, index=parsed.index, dtype="Int64")
-    timestamp_ms.loc[parsed_notna_mask] = (
-        parsed.loc[parsed_notna_mask].astype("int64") // 1_000_000
-    ).astype("Int64")
     nunique_after = int(timestamp_ms.dropna().nunique())
 
     if logger is not None:

--- a/data/storage/parquet_storage.py
+++ b/data/storage/parquet_storage.py
@@ -118,14 +118,14 @@ class ParquetStorage:
         if written["timestamp"].isna().any():
             _raise_validation_error("null_timestamp", null_count=int(written["timestamp"].isna().sum()))
 
-        parsed_written_timestamps = pd.to_datetime(written["timestamp"], unit="ms", utc=True, errors="coerce")
+        parsed_written_timestamps = pd.to_datetime(written["timestamp"], unit="ms", errors="coerce")
         if parsed_written_timestamps.isna().any():
             _raise_validation_error(
                 "invalid_timestamp_values",
                 invalid_count=int(parsed_written_timestamps.isna().sum()),
             )
 
-        parsed_datetime = pd.to_datetime(written["datetime"], utc=True, errors="coerce")
+        parsed_datetime = pd.to_datetime(written["datetime"], errors="coerce")
         if parsed_datetime.isna().any():
             _raise_validation_error("invalid_datetime_values", invalid_count=int(parsed_datetime.isna().sum()))
 
@@ -191,7 +191,7 @@ class ParquetStorage:
                 )
 
             sampled_row = written_batch_rows.sample(n=1, random_state=42).iloc[0]
-            sampled_timestamp = pd.to_datetime(sampled_row["timestamp"], unit="ms", utc=True, errors="coerce")
+            sampled_timestamp = pd.to_datetime(sampled_row["timestamp"], unit="ms", errors="coerce")
             if pd.isna(sampled_timestamp):
                 _raise_validation_error(
                     "sampled_timestamp_unparseable",
@@ -227,7 +227,7 @@ class ParquetStorage:
         data = self.load(symbol, timeframe)
         if data.empty or "timestamp" not in data.columns:
             return None
-        return pd.to_datetime(data["timestamp"], unit="ms", utc=True).max()
+        return pd.to_datetime(data["timestamp"], unit="ms").max()
 
     def get_last_timestamp_for_column(
         self,
@@ -241,7 +241,7 @@ class ParquetStorage:
             return None
 
         if column_name == "timestamp":
-            return pd.to_datetime(data["timestamp"], unit="ms", utc=True).max()
+            return pd.to_datetime(data["timestamp"], unit="ms").max()
 
         if column_name not in data.columns:
             return None
@@ -250,7 +250,7 @@ class ParquetStorage:
         if not valid_rows.any():
             return None
 
-        return pd.to_datetime(data.loc[valid_rows, "timestamp"], unit="ms", utc=True).max()
+        return pd.to_datetime(data.loc[valid_rows, "timestamp"], unit="ms").max()
 
     def save_incremental(self, symbol: str, timeframe: Timeframe, new_data: pd.DataFrame) -> int:
         """Дозаписывает новые данные без перезаписи старых."""


### PR DESCRIPTION
## Summary
- reworked `normalize_timestamp_series` to normalize numeric timestamps directly into milliseconds without timezone conversion round-trips
- added explicit numeric-to-ms normalization for `ns/us/ms/s` inputs to keep timestamp handling deterministic and idempotent
- removed `utc=True` coercions in data-processing/storage/validation paths so the project consistently operates on received timestamps
- updated exchange, storage, validator, gap detection, and liquidity ranking paths to use timezone-agnostic datetime parsing when datetime views are needed

## Why
Logs showed timestamp canonicalization collapsing unique values and causing `timestamp_canonicalization_mismatch` in parquet cache validation. The root cause was inconsistent timestamp canonicalization via timezone-aware datetime conversion in multiple layers.

## Validation
- `python -m compileall data/quality/timestamp_normalization.py data/storage/parquet_storage.py data/quality/time_alignment.py data/exchanges/ccxt_futures_client.py data/quality/data_validator.py data/quality/gap_detector.py data/liquidity/daily_volume_ranker.py`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69918d3243508320a0c4e15456f9b8b2)