### PR TITLE
Normalize OI fetch_symbol bounds to UTC-aware datetimes

### DIFF
--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -20,7 +20,7 @@ from data.storage.parquet_storage import ParquetCacheValidationError, ParquetSto
 from domain.abstract.exchange_client import ExchangeClient
 from domain.enums.timeframe import Timeframe
 from domain.models.reporting.symbol_fetch_result import SymbolFetchResult
-from utils.formatters import format_datetime_human
+from utils.formatters import datetime_to_utc, format_datetime_human
 from utils.logger import get_logger
 
 
@@ -50,24 +50,26 @@ class OiFetcher:
 
     def fetch_symbol(self, symbol: str, timeframe: Timeframe, start_time: datetime, end_time: datetime) -> int:
         """Загружает историю open interest для одного символа."""
-        next_start = start_time
+        start_time_utc = datetime_to_utc(start_time)
+        end_time_utc = datetime_to_utc(end_time)
+        next_start = start_time_utc
         watermark_column = "open_interest"
         last_timestamp = self._storage.get_last_timestamp_for_column(symbol, timeframe, watermark_column)
         if last_timestamp is not None:
-            next_start = max(start_time, last_timestamp.to_pydatetime() + TIMEFRAME_TO_DELTA[timeframe])
+            next_start = max(start_time_utc, last_timestamp.to_pydatetime() + TIMEFRAME_TO_DELTA[timeframe])
 
         watermark_display = format_datetime_human(last_timestamp.to_pydatetime()) if last_timestamp is not None else "None"
         next_start_display = format_datetime_human(next_start)
-        end_time_display = format_datetime_human(end_time)
+        end_time_display = format_datetime_human(end_time_utc)
         self._logger.info(
             f"OI водораздел: {symbol} {timeframe.value} колонка={watermark_column} последний={watermark_display} выбранный={next_start_display}"
         )
         self._logger.info(f"OI старт: {symbol} {timeframe.value} {next_start_display} -> {end_time_display}")
-        if next_start > end_time:
+        if next_start > end_time_utc:
             self._logger.info(LOG_MSG_SKIP_UP_TO_DATE, "OI", symbol)
             return 0
 
-        data = self._exchange_client.fetch_open_interest(symbol, timeframe, next_start, end_time)
+        data = self._exchange_client.fetch_open_interest(symbol, timeframe, next_start, end_time_utc)
         data = self._aligner.align_to_utc(data)
         data = self._deduplicator.deduplicate(data)
 
@@ -80,7 +82,7 @@ class OiFetcher:
             )
 
         next_start_ms = int(next_start.timestamp() * 1000)
-        end_time_ms = int(end_time.timestamp() * 1000)
+        end_time_ms = int(end_time_utc.timestamp() * 1000)
         interval_mask = (data["timestamp"] >= next_start_ms) & (data["timestamp"] <= end_time_ms)
         data = data.loc[interval_mask].copy()
 


### PR DESCRIPTION
### Motivation
- Устранить смешивание offset-naive и offset-aware датetimes в `OiFetcher.fetch_symbol` после унификации UTC-aware временных меток в `ParquetStorage`.
- Гарантировать, что все граничные сравнения и вычисления милисекундных границ выполняются в одной временной зоне (UTC) чтобы избежать ошибок типа "can't compare offset-naive and offset-aware datetimes".
- Обеспечить, чтобы вызовы к клиенту биржи получали UTC-aware `start`/`end` в одном формате.

### Description
- Добавлено нормализующее преобразование входных границ через `datetime_to_utc` и импортирована функция `datetime_to_utc` из `utils.formatters` в `data/fetchers/oi_fetcher.py`.
- `start_time`/`end_time` заменены на `start_time_utc`/`end_time_utc`, `next_start` и сравнения с watermark теперь выполняются против UTC-aware значений.
- Запрос к обмену теперь вызывается с `end_time_utc`, а `end_time_ms` вычисляется через `end_time_utc.timestamp()` чтобы все ms-ограничения брались от UTC-aware datetime.

### Testing
- Скомпилирован модуль проверкой `python -m compileall data/fetchers/oi_fetcher.py`, сборка прошла успешно.
- Проведён смоук-прогон `OiFetcher.fetch_symbol` с заглушками (stub storage / fake exchange) через небольшие скрипты, которые подтвердили, что вызов `fetch_open_interest` получает UTC-aware `start`/`end` и что интервал по `timestamp()` фильтрует строки корректно.
- Попытка полного запуска `python launcher.py --mode fetch-cache ...` для проверки на уже заполненном кэше не завершилась в этом окружении из‑за сетевой ошибки (`Network is unreachable` при обращении к API биржи), поэтому сквозной replay на реальном кэше выполнить здесь не удалось.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991db424b708320a7b222e48c785722)