### PR TITLE
Unify UTC handling for timestamp normalization and parquet storage

### DIFF
--- a/data/quality/timestamp_normalization.py
+++ b/data/quality/timestamp_normalization.py
@@ -60,7 +60,12 @@ def normalize_timestamp_series(
     logger: Logger | None = None,
     log_prefix: str = "timestamp-normalization",
 ) -> tuple[pd.Series, pd.Series]:
-    """Нормализует временные метки к UTC datetime и int64 milliseconds."""
+    """Нормализует временные метки к UTC.
+
+    Возвращает:
+    * parsed: timezone-aware серия `datetime64[ns, UTC]`.
+    * timestamp_ms: unix timestamp в миллисекундах (UTC) как `Int64`.
+    """
     raw = timestamp_series.copy()
     raw_dtype = str(raw.dtype)
     raw_min, raw_max = _safe_min_max(raw)
@@ -68,24 +73,21 @@ def normalize_timestamp_series(
 
     if is_datetime64_any_dtype(raw):
         detected_format = "datetime-like"
-        parsed = pd.to_datetime(raw, errors="coerce")
-        timestamp_ms = pd.Series(pd.NA, index=parsed.index, dtype="Int64")
-        parsed_notna_mask = parsed.notna()
-        timestamp_ms.loc[parsed_notna_mask] = (
-            parsed.loc[parsed_notna_mask].astype("int64") // 1_000_000
-        ).astype("Int64")
+        parsed = pd.to_datetime(raw, errors="coerce", utc=True)
     else:
         detected_format = _detect_timestamp_unit(raw)
         timestamp_ms = _normalize_numeric_timestamp_to_ms(raw)
-        parsed = pd.to_datetime(timestamp_ms, unit="ms", errors="coerce")
+        parsed = pd.to_datetime(timestamp_ms, unit="ms", errors="coerce", utc=True)
 
     if datetime_fallback is not None:
-        fallback_dt = pd.to_datetime(datetime_fallback, errors="coerce")
+        fallback_dt = pd.to_datetime(datetime_fallback, errors="coerce", utc=True)
         parsed = parsed.where(parsed.notna(), fallback_dt)
-        parsed_notna_mask = parsed.notna()
-        timestamp_ms.loc[parsed_notna_mask] = (
-            parsed.loc[parsed_notna_mask].astype("int64") // 1_000_000
-        ).astype("Int64")
+
+    timestamp_ms = pd.Series(pd.NA, index=parsed.index, dtype="Int64")
+    parsed_notna_mask = parsed.notna()
+    timestamp_ms.loc[parsed_notna_mask] = (
+        parsed.loc[parsed_notna_mask].astype("int64") // 1_000_000
+    ).astype("Int64")
 
     parsed_notna_mask = parsed.notna()
     parsed_notna = int(parsed_notna_mask.sum())

--- a/data/storage/parquet_storage.py
+++ b/data/storage/parquet_storage.py
@@ -63,7 +63,7 @@ class ParquetStorage:
         ts = ts.loc[ts.notna()]
 
         normalized["timestamp"] = timestamp_ms.loc[ts.index].astype("int64")
-        normalized["datetime"] = ts
+        normalized["datetime"] = pd.to_datetime(ts, errors="coerce", utc=True)
         return normalized
 
     def _validate_written_cache(
@@ -118,14 +118,14 @@ class ParquetStorage:
         if written["timestamp"].isna().any():
             _raise_validation_error("null_timestamp", null_count=int(written["timestamp"].isna().sum()))
 
-        parsed_written_timestamps = pd.to_datetime(written["timestamp"], unit="ms", errors="coerce")
+        parsed_written_timestamps = pd.to_datetime(written["timestamp"], unit="ms", errors="coerce", utc=True)
         if parsed_written_timestamps.isna().any():
             _raise_validation_error(
                 "invalid_timestamp_values",
                 invalid_count=int(parsed_written_timestamps.isna().sum()),
             )
 
-        parsed_datetime = pd.to_datetime(written["datetime"], errors="coerce")
+        parsed_datetime = pd.to_datetime(written["datetime"], errors="coerce", utc=True)
         if parsed_datetime.isna().any():
             _raise_validation_error("invalid_datetime_values", invalid_count=int(parsed_datetime.isna().sum()))
 
@@ -231,7 +231,7 @@ class ParquetStorage:
                 )
 
             sampled_row = written_batch_rows.sample(n=1, random_state=42).iloc[0]
-            sampled_timestamp = pd.to_datetime(sampled_row["timestamp"], unit="ms", errors="coerce")
+            sampled_timestamp = pd.to_datetime(sampled_row["timestamp"], unit="ms", errors="coerce", utc=True)
             if pd.isna(sampled_timestamp):
                 _raise_validation_error(
                     "sampled_timestamp_unparseable",
@@ -337,9 +337,18 @@ class ParquetStorage:
         merged = self._ensure_utc_columns(merged)
         merged_rechecked = self._ensure_utc_columns(merged)
         if not merged["timestamp"].reset_index(drop=True).equals(merged_rechecked["timestamp"].reset_index(drop=True)):
+            merged_ts = merged["timestamp"].reset_index(drop=True)
+            merged_rechecked_ts = merged_rechecked["timestamp"].reset_index(drop=True)
+            mismatch_mask = merged_ts.ne(merged_rechecked_ts) & ~(merged_ts.isna() & merged_rechecked_ts.isna())
+            mismatch_sample = pd.DataFrame(
+                {"merged": merged_ts, "merged_rechecked": merged_rechecked_ts}
+            ).loc[mismatch_mask].head(10).to_dict("records")
             raise ParquetCacheValidationError(
                 "parquet cache validation failed: reason=ensure_utc_non_idempotent, "
-                f"symbol={symbol}, timeframe={timeframe.value}, path={path}"
+                f"symbol={symbol}, timeframe={timeframe.value}, path={path}, "
+                f"merged_min={merged_ts.min()}, merged_max={merged_ts.max()}, "
+                f"merged_rechecked_min={merged_rechecked_ts.min()}, merged_rechecked_max={merged_rechecked_ts.max()}, "
+                f"mismatch_sample={mismatch_sample}"
             )
         merged = merged_rechecked
         merged_nunique_before_dedup = int(merged["timestamp"].nunique())


### PR DESCRIPTION
### Motivation

- Избежать смешения timezone-aware и naive-типов времени в процессе нормализации и хранения, чтобы исключить рассинхронизацию временных меток.
- Устранить расхождения между промежуточными и финальными `timestamp_ms` за счёт пересчёта только после формирования окончательного `parsed`.
- Облегчить диагностику падений идемпотентности при сохранении, добавив минимальную статистику и примеры расхождений.

### Description

- В `normalize_timestamp_series` все вызовы `pd.to_datetime` унифицированы с `utc=True` для ветки datetime-like, парсинга numeric-ms и fallback, а docstring обновлён и явно указывает, что `parsed` — `datetime64[ns, UTC]`, а `timestamp_ms` — unix-ms UTC как `Int64`.
- Пересчёт `timestamp_ms` вынесен в единый блок после применения fallback и теперь всегда выполняется через `parsed.loc[...].astype("int64") // 1_000_000` для консистентности.
- В `data/storage/parquet_storage.py` `_ensure_utc_columns` принудительно приводит колонку `datetime` к UTC-aware формату через `pd.to_datetime(..., utc=True)` и остальные проверки/парсинги `datetime`/`timestamp` валидации также переведены на `utc=True`.
- В `save_incremental` при падении проверки идемпотентности расширена диагностическая информация: добавлены `min`/`max` для `merged` и `merged_rechecked` по `timestamp` и sample записей с расхождениями (до 10 записей) для ускорения отладки.

### Testing

- Запущена компиляция модифицированных модулей: `python -m compileall data/quality/timestamp_normalization.py data/storage/parquet_storage.py`, сборка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e1f19bb48320ac649d0e5887e846)