### PR TITLE
Fix non-idempotent timestamp normalization in parquet cache flow

### DIFF
--- a/data/quality/timestamp_normalization.py
+++ b/data/quality/timestamp_normalization.py
@@ -34,12 +34,12 @@ def _safe_min_max(raw: pd.Series) -> tuple[object, object]:
         return as_string.min(), as_string.max()
 
 
-def _normalize_numeric_timestamp_to_ms(raw: pd.Series) -> pd.Series:
+def _normalize_numeric_timestamp_to_ms(raw: pd.Series, detected_format: str | None = None) -> pd.Series:
     numeric = pd.to_numeric(raw, errors="coerce")
     if numeric.dropna().empty:
         return pd.Series(pd.NA, index=raw.index, dtype="Int64")
 
-    detected_format = _detect_timestamp_unit(raw)
+    detected_format = detected_format or _detect_timestamp_unit(raw)
     if detected_format == "ns":
         normalized = numeric // 1_000_000
     elif detected_format == "us":
@@ -52,6 +52,50 @@ def _normalize_numeric_timestamp_to_ms(raw: pd.Series) -> pd.Series:
         normalized = pd.Series(pd.NA, index=raw.index, dtype="float64")
 
     return normalized.round().astype("Int64")
+
+
+def _select_best_unit_by_datetime_fallback(
+    raw: pd.Series,
+    datetime_fallback: pd.Series,
+    default_unit: str,
+) -> str:
+    fallback_dt = pd.to_datetime(datetime_fallback, errors="coerce", utc=True)
+    fallback_mask = fallback_dt.notna()
+    if not fallback_mask.any():
+        return default_unit
+
+    numeric = pd.to_numeric(raw, errors="coerce")
+    if numeric.loc[fallback_mask].dropna().empty:
+        return default_unit
+
+    unit_to_divider = {
+        "s": 1,
+        "ms": 1_000,
+        "us": 1_000_000,
+        "ns": 1_000_000_000,
+    }
+    if default_unit not in unit_to_divider:
+        return default_unit
+
+    best_unit = default_unit
+    best_score = None
+    fallback_ns = fallback_dt.astype("int64")
+
+    for unit in unit_to_divider:
+        parsed = pd.to_datetime(numeric, unit=unit, errors="coerce", utc=True)
+        valid_mask = parsed.notna() & fallback_mask
+        if not valid_mask.any():
+            continue
+
+        parsed_ns = parsed.astype("int64")
+        score = (parsed_ns.loc[valid_mask] - fallback_ns.loc[valid_mask]).abs().median()
+        if pd.isna(score):
+            continue
+        if best_score is None or score < best_score:
+            best_score = score
+            best_unit = unit
+
+    return best_unit
 
 
 def normalize_timestamp_series(
@@ -76,7 +120,13 @@ def normalize_timestamp_series(
         parsed = pd.to_datetime(raw, errors="coerce", utc=True)
     else:
         detected_format = _detect_timestamp_unit(raw)
-        timestamp_ms = _normalize_numeric_timestamp_to_ms(raw)
+        if datetime_fallback is not None:
+            detected_format = _select_best_unit_by_datetime_fallback(
+                raw=raw,
+                datetime_fallback=datetime_fallback,
+                default_unit=detected_format,
+            )
+        timestamp_ms = _normalize_numeric_timestamp_to_ms(raw, detected_format=detected_format)
         parsed = pd.to_datetime(timestamp_ms, unit="ms", errors="coerce", utc=True)
 
     if datetime_fallback is not None:


### PR DESCRIPTION
## Summary
- update numeric timestamp normalization to accept an explicit detected unit
- add fallback-based unit selection when `datetime` data is available
- use the selected unit in `normalize_timestamp_series` before converting to ms

## Why
Parquet cache writes could fail with `ensure_utc_non_idempotent` when low-magnitude numeric timestamps were re-normalized. This happened because heuristic unit detection could reinterpret already-normalized values on a second pass.

## Result
Normalization now prefers the unit that best matches `datetime` fallback values, making repeated normalization stable and preventing the reported cache validation crash.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e2bcb8c48320bdbb051c2057224a)