### PR TITLE
Remove datetime normalization and timezone remapping from data flow

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -8,7 +8,7 @@ import json
 import shutil
 from collections import Counter
 from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta, tzinfo
+from datetime import datetime, timedelta
 from logging import Logger
 from pathlib import Path
 from typing import Callable
@@ -56,7 +56,6 @@ from domain.models.reporting.quality_symbol_stats import QualitySymbolStats
 from domain.models.reporting.trade_results_distribution import TradeResultsDistribution
 from strategy.breakout.breakout_strategy import BreakoutStrategy
 from strategy.breakout.config import TARGET_PARAMETER_COMBINATIONS, BreakoutParams
-from utils.formatters import datetime_to_utc
 from utils.logger import get_logger
 from utils.retry import RetryExhaustedError
 from utils.symbols import normalize_symbol
@@ -281,7 +280,6 @@ def _parse_iso_datetime(
         value: str,
         *,
         argument_name: str,
-        target_timezone: tzinfo,
 ) -> datetime:
     normalized_value = value.strip().replace("Z", "+00:00")
     try:
@@ -292,34 +290,29 @@ def _parse_iso_datetime(
             f"Ожидается ISO дата/дата-время, например 2025-01-31 или 2025-01-31T23:59:59+03:00"
         ) from error
 
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=target_timezone)
-    return parsed.astimezone(target_timezone)
+    return parsed
 
 
 def _resolve_fetch_anchor_datetime(config: AppConfig, end_datetime_raw: datetime | str | None) -> datetime:
     if isinstance(end_datetime_raw, datetime):
-        if end_datetime_raw.tzinfo is None:
-            return end_datetime_raw.replace(tzinfo=config.fetch.tzinfo)
-        return end_datetime_raw.astimezone(config.fetch.tzinfo)
+        return end_datetime_raw
 
     if isinstance(end_datetime_raw, str):
         return _parse_iso_datetime(
             end_datetime_raw,
             argument_name="--end-datetime",
-            target_timezone=config.fetch.tzinfo,
         )
 
     if config.fetch.anchor_datetime is not None:
         return config.fetch.anchor_datetime
 
-    return datetime.now(tz=config.fetch.tzinfo)
+    return datetime.now()
 
 
 def _fetch_period(config: AppConfig, days: int, end_datetime_raw: datetime | str | None = None) -> tuple[datetime, datetime]:
     local_end = _resolve_fetch_anchor_datetime(config, end_datetime_raw)
     local_start = local_end - timedelta(days=days)
-    return datetime_to_utc(local_start), datetime_to_utc(local_end)
+    return local_start, local_end
 
 
 @dataclass(frozen=True, slots=True)

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -71,22 +71,6 @@ def build_parser() -> argparse.ArgumentParser:
 
     subparsers.add_parser("clear-cache", help="Полная очистка директории кэша")
 
-    migrate_cache = subparsers.add_parser(
-        "migrate-cache-timestamps",
-        help="Миграция parquet-кэша в канонический timestamp(ms UTC) формат",
-    )
-    migrate_cache.add_argument(
-        "--symbols",
-        nargs="*",
-        default=None,
-        help="Список символов для миграции; по умолчанию мигрируются все",
-    )
-    migrate_cache.add_argument(
-        "--timeframes",
-        nargs="*",
-        default=None,
-        help="Список таймфреймов (например 1m 15m 1h); по умолчанию мигрируются все",
-    )
 
     plot_daily_levels = subparsers.add_parser(
         "plot-daily-levels",
@@ -130,7 +114,6 @@ def resolve_handler(command_name: str) -> Handler:
         "make-report": commands.make_report,
         "check-quality": commands.check_quality,
         "clear-cache": commands.clear_cache,
-        "migrate-cache-timestamps": commands.migrate_cache_timestamps,
         "plot-daily-levels": commands.plot_daily_levels,
         "plot-retests": commands.plot_retests,
     }

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -29,7 +29,6 @@ from constants import (
     DEFAULT_LIQUIDITY_SKIP_ERROR_RATIO_THRESHOLD,
 )
 from domain.enums.timeframe import Timeframe
-from utils.formatters import resolve_timezone
 
 __all__ = [
     "AppConfig",
@@ -78,7 +77,7 @@ def _parse_bool(value: str | None, *, default: bool = False) -> bool:
     raise ValueError(f"Invalid boolean value: {value}")
 
 
-def _parse_anchor_datetime(value: str | None, *, timezone_name: str, env_name: str) -> datetime | None:
+def _parse_anchor_datetime(value: str | None, *, env_name: str) -> datetime | None:
     if value is None:
         return None
 
@@ -95,10 +94,7 @@ def _parse_anchor_datetime(value: str | None, *, timezone_name: str, env_name: s
             f"2025-01-31 or 2025-01-31T23:59:59+03:00"
         ) from error
 
-    target_tz = resolve_timezone(timezone_name)
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=target_tz)
-    return parsed.astimezone(target_tz)
+    return parsed
 
 
 # endregion Приватные
@@ -140,7 +136,6 @@ def load_config(env_path: str | Path = ".env") -> AppConfig:
         ignore_coingecko=_parse_bool(os.getenv("IGNORE_COINGECKO"), default=False),
         anchor_datetime=_parse_anchor_datetime(
             os.getenv("FETCH_ANCHOR_DATETIME"),
-            timezone_name=fetch_timezone,
             env_name="FETCH_ANCHOR_DATETIME",
         ),
     )

--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Callable, cast
 
 import pandas as pd
@@ -34,9 +34,7 @@ except ImportError:  # pragma: no cover
 
 # region Приватные
 
-def _to_utc_ms(value: datetime) -> int:
-    if value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
+def _to_exchange_ms(value: datetime) -> int:
     return int(value.timestamp() * MILLISECONDS_IN_SECOND)
 
 # endregion Приватные
@@ -197,9 +195,9 @@ class CcxtFuturesClient(ExchangeClient):
     def fetch_ohlcv(self, symbol: str, timeframe: Timeframe, start_time: datetime, end_time: datetime) -> pd.DataFrame:
         """Запрашивает свечи по символу и интервалу."""
         self._ensure_markets_loaded()
-        start_ms = _to_utc_ms(start_time)
+        start_ms = _to_exchange_ms(start_time)
         since = start_ms
-        end_ms = _to_utc_ms(end_time)
+        end_ms = _to_exchange_ms(end_time)
 
         all_rows: list[list[float]] = []
         while since <= end_ms:
@@ -237,9 +235,9 @@ class CcxtFuturesClient(ExchangeClient):
         if not isinstance(self._client, CcxtOpenInterestApi):
             raise NotImplementedError(f"Exchange {self.exchange.value} does not support fetch_open_interest_history in CCXT")
 
-        start_ms = _to_utc_ms(start_time)
+        start_ms = _to_exchange_ms(start_time)
         since = start_ms
-        end_ms = _to_utc_ms(end_time)
+        end_ms = _to_exchange_ms(end_time)
         ccxt_timeframe = timeframe.value
         timeframe_ms = int(TIMEFRAME_TO_DELTA[timeframe].total_seconds() * MILLISECONDS_IN_SECOND)
         oi_limit = min(DEFAULT_FETCH_BATCH_SIZE, 500) if self.exchange == Exchange.BINANCE else DEFAULT_FETCH_BATCH_SIZE

--- a/simulation/position_simulator.py
+++ b/simulation/position_simulator.py
@@ -17,7 +17,6 @@ from domain.value_objects.price import Price
 from domain.value_objects.volume import Volume
 from simulation.order_processor import OrderProcessor
 from simulation.trade_classifier import TradeClassifier
-from utils.formatters import datetime_to_timezone
 
 
 @dataclass(slots=True)
@@ -46,7 +45,7 @@ class StatefulPositionSimulator(PositionSimulator):
         fill = self.order_processor.execute_entry(candle.open.value, self.side, self._pending_size)
         self.position = Position(
             entry_price=Price(fill.price),
-            entry_time=datetime_to_timezone(candle.timestamp, self.simulation_timezone),
+            entry_time=candle.timestamp,
             size=Volume(self._pending_size),
             stop_loss=signal.stop_loss,
             take_profit_1=signal.take_profit_1,
@@ -132,7 +131,7 @@ class StatefulPositionSimulator(PositionSimulator):
         trade_result = self.trade_classifier.build_result(
             position=self.position,
             exit_price=self._last_exit_price,
-            exit_time=datetime_to_timezone(candle.timestamp, self.simulation_timezone),
+            exit_time=candle.timestamp,
             result_type=result_type,
             pnl=self._realized_pnl,
         )
@@ -184,7 +183,7 @@ class StatefulPositionSimulator(PositionSimulator):
         trade_result = self.trade_classifier.build_result(
             position=self.position,
             exit_price=self._last_exit_price,
-            exit_time=datetime_to_timezone(exit_time, self.simulation_timezone),
+            exit_time=exit_time,
             result_type=result_type,
             pnl=self._realized_pnl,
         )

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -37,7 +37,6 @@ from strategy.base_strategy import BaseStrategy
 from strategy.breakout.config import BreakoutParams
 from strategy.breakout.pending_breakout import PendingBreakout
 from strategy.breakout.pending_retest import PendingRetest
-from utils.formatters import datetime_to_timezone, utc_ms_to_local_datetime
 from vectorbt_runner.mtf_frames import SymbolMtfFrames
 
 
@@ -86,7 +85,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
 
     def _to_candle(self, row: pd.Series) -> Candle:
         return Candle(
-            timestamp=datetime_to_timezone(row["datetime"].to_pydatetime(), self._simulation_timezone),
+            timestamp=row["datetime"].to_pydatetime(),
             open=Price(float(row["open"])),
             high=Price(float(row["high"])),
             low=Price(float(row["low"])),
@@ -378,9 +377,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             raise ValueError(f"Отсутствуют обязательные колонки: {missing}")
 
         prepared = data.copy()
-        prepared["datetime"] = pd.to_numeric(prepared["timestamp"], errors="coerce").map(
-            lambda value: utc_ms_to_local_datetime(value, self._strategy_timezone) if pd.notna(value) else pd.NaT
-        )
+        prepared["datetime"] = pd.to_datetime(prepared["timestamp"], unit="ms", errors="coerce")
         prepared = prepared.dropna(subset=["datetime"])
         prepared = prepared.sort_values("datetime").reset_index(drop=True)
 
@@ -841,7 +838,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
 
         if active_sim is not None and active_sim.position is not None:
             final_row = annotated.iloc[-1]
-            final_time = datetime_to_timezone(final_row["datetime"].to_pydatetime(), self._simulation_timezone)
+            final_time = final_row["datetime"].to_pydatetime()
             trades.append(active_sim.close_position(price=float(final_row["close"]), exit_time=final_time))
 
         diagnostics["trades_generated"] = len(trades)

--- a/vectorbt_runner/data_preparer.py
+++ b/vectorbt_runner/data_preparer.py
@@ -28,11 +28,8 @@ from vectorbt_runner.vectorbt_inputs import VectorbtInputs
 
 
 # region Приватные
-def _to_utc_timestamp(value: object) -> pd.Timestamp:
-    timestamp = pd.Timestamp(value)
-    if timestamp.tz is None:
-        return timestamp.tz_localize("UTC")
-    return timestamp.tz_convert("UTC")
+def _to_timestamp(value: object) -> pd.Timestamp:
+    return pd.Timestamp(value)
 
 
 # endregion Приватные
@@ -71,7 +68,7 @@ class DataPreparer:
 
         normalized = frame.copy()
         normalized["symbol"] = symbol
-        normalized["datetime"] = pd.to_datetime(normalized["timestamp"], unit=SIMULATION_DATETIME_UNIT_MS, utc=True, errors="coerce")
+        normalized["datetime"] = pd.to_datetime(normalized["timestamp"], unit=SIMULATION_DATETIME_UNIT_MS, errors="coerce")
         normalized = normalized.dropna(subset=["datetime"])
 
         numeric_cols = [col for col in DATA_PREPARER_NUMERIC_COLUMNS if col in normalized.columns]
@@ -94,7 +91,7 @@ class DataPreparer:
     def prepare_vectorbt_inputs(trades: list[TradeResult], initial_price: float = SIMULATION_PRICE_INIT) -> VectorbtInputs:
         """Метод."""
         if not trades:
-            index = pd.DatetimeIndex([], tz=SIMULATION_TIMEZONE_UTC)
+            index = pd.DatetimeIndex([])
             empty_float = pd.Series([], index=index, dtype=DATA_PREPARER_EMPTY_FLOAT_DTYPE)
             empty_bool = pd.Series([], index=index, dtype=DATA_PREPARER_EMPTY_BOOL_DTYPE)
             trades_frame = pd.DataFrame(columns=DATA_PREPARER_TRADE_COLUMNS)
@@ -109,8 +106,8 @@ class DataPreparer:
         trades_sorted = sorted(trades, key=lambda trade: (trade.entry_time, trade.exit_time))
         trade_rows = [
             {
-                "entry_time": _to_utc_timestamp(trade.entry_time),
-                "exit_time": _to_utc_timestamp(trade.exit_time),
+                "entry_time": _to_timestamp(trade.entry_time),
+                "exit_time": _to_timestamp(trade.exit_time),
                 "pnl": float(trade.pnl),
                 "pnl_percent": float(trade.pnl_percent.value),
                 "result_type": trade.result_type.value,
@@ -120,8 +117,7 @@ class DataPreparer:
         trades_frame = pd.DataFrame(trade_rows)
 
         timeline = pd.DatetimeIndex(
-            sorted(set(trades_frame["entry_time"].tolist() + trades_frame["exit_time"].tolist())),
-            tz=SIMULATION_TIMEZONE_UTC,
+            sorted(set(trades_frame["entry_time"].tolist() + trades_frame["exit_time"].tolist()))
         )
         close = pd.Series(initial_price, index=timeline, dtype=DATA_PREPARER_EMPTY_FLOAT_DTYPE)
         entries = pd.Series(False, index=timeline, dtype=DATA_PREPARER_EMPTY_BOOL_DTYPE)


### PR DESCRIPTION
## Summary
- removed timezone remapping during fetch period resolution and now pass datetimes through as-is
- stopped anchor datetime parsing from converting values into configured timezones
- removed strategy/simulation datetime conversions to configured timezones and kept raw exchange timestamps
- stopped vectorbt input preparation from forcing UTC-localization/conversion
- removed `migrate-cache-timestamps` CLI command from parser/handler registry
- updated CCXT request window conversion helper to avoid implicit UTC normalization

## Validation
- `python -m py_compile cli/commands.py cli/parser.py config/__init__.py data/exchanges/ccxt_futures_client.py simulation/position_simulator.py strategy/breakout/breakout_strategy.py vectorbt_runner/data_preparer.py`

## Notes
- Tests were not added (per request).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e85fd9a48320be8918dd40f0d328)