### PR TITLE
Stop normalizing datetimes/timestamps — preserve exchange-provided values

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ COINGECKO_VOLUME_BATCH_SIZE=40
 IGNORE_COINGECKO=false
 LOG_LEVEL=INFO
 CACHE_DIR=./cache
-TIMEZONE=Europe/Belgrade
 ```
 > Таймфреймы для сборки кэша задаются в коде конфигурации (`config/fetch_config.py`, поле `FetchConfig.timeframes`),
 > а не через параметры CLI и не через `.env`.

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -281,9 +281,9 @@ def _parse_iso_datetime(
         *,
         argument_name: str,
 ) -> datetime:
-    normalized_value = value.strip().replace("Z", "+00:00")
+    raw_value = value.strip()
     try:
-        parsed = datetime.fromisoformat(normalized_value)
+        parsed = datetime.fromisoformat(raw_value)
     except ValueError as error:
         raise ValueError(
             f"Некорректный формат {argument_name}: {value}. "
@@ -592,8 +592,6 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
     strategy = BreakoutStrategy(
         commission_rate=config.simulation.commission_rate,
         slippage=config.simulation.slippage,
-        strategy_timezone=config.strategy.timezone,
-        simulation_timezone=config.simulation.timezone,
         logger=logger,
     )
     runner = BacktestRunner(
@@ -1030,8 +1028,6 @@ def _plot_daily_levels_inner(config: AppConfig, args: argparse.Namespace) -> int
     strategy = BreakoutStrategy(
         commission_rate=config.simulation.commission_rate,
         slippage=config.simulation.slippage,
-        strategy_timezone=config.strategy.timezone,
-        simulation_timezone=config.simulation.timezone,
         logger=logger,
     )
     plotter = StrategyPlotter(data_preparer=preparer, strategy=strategy)
@@ -1154,8 +1150,6 @@ def _plot_retests_inner(config: AppConfig, args: argparse.Namespace) -> int:
     strategy = BreakoutStrategy(
         commission_rate=config.simulation.commission_rate,
         slippage=config.simulation.slippage,
-        strategy_timezone=config.strategy.timezone,
-        simulation_timezone=config.simulation.timezone,
         logger=logger,
     )
     plotter = StrategyPlotter(data_preparer=preparer, strategy=strategy)
@@ -1288,7 +1282,7 @@ def clear_cache(config: AppConfig, args: argparse.Namespace) -> int:
 
 
 def migrate_cache_timestamps(config: AppConfig, args: argparse.Namespace) -> int:
-    """Мигрирует parquet-кэш в канонический timestamp(ms UTC)-формат."""
+    """Мигрирует parquet-кэш в канонический timestamp(ms)-формат без преобразования таймзон."""
     return _run_with_logging(
         "migrate-cache-timestamps",
         config,

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -20,7 +20,6 @@ from constants import (
     DEFAULT_RETRY_BACKOFF_SECONDS,
     DEFAULT_RESULTS_DIR,
     DEFAULT_SLIPPAGE,
-    DEFAULT_TIMEZONE,
     DEFAULT_SPREAD,
     DEFAULT_LOGS_DIR,
     DEFAULT_MIN_VOLUME_USD,
@@ -85,9 +84,8 @@ def _parse_anchor_datetime(value: str | None, *, env_name: str) -> datetime | No
     if not raw_value:
         return None
 
-    normalized_value = raw_value.replace("Z", "+00:00")
     try:
-        parsed = datetime.fromisoformat(normalized_value)
+        parsed = datetime.fromisoformat(raw_value)
     except ValueError as error:
         raise ValueError(
             f"Invalid {env_name}: {value}. Expected ISO date/datetime, for example "
@@ -104,17 +102,11 @@ def load_config(env_path: str | Path = ".env") -> AppConfig:
     env_file = Path(env_path)
     _load_env_file(env_file)
 
-    default_timezone = os.getenv("TIMEZONE", DEFAULT_TIMEZONE)
-
-    fetch_timezone = os.getenv("FETCH_TIMEZONE", default_timezone)
-    strategy_timezone = os.getenv("STRATEGY_TIMEZONE", default_timezone)
-    simulation_timezone = os.getenv("SIMULATION_TIMEZONE", default_timezone)
 
     fetch_config = FetchConfig(
         binance_api_key=os.getenv("BINANCE_API_KEY", ""),
         binance_secret_key=os.getenv("BINANCE_SECRET_KEY", ""),
         coingecko_api_key=os.getenv("COINGECKO_API_KEY", ""),
-        timezone=fetch_timezone,
         min_volume_usd=float(
             os.getenv("MIN_VOLUME_USD", os.getenv("FETCH_MIN_VOLUME_USD", str(DEFAULT_MIN_VOLUME_USD)))),
         coingecko_min_request_interval_seconds=float(
@@ -150,7 +142,6 @@ def load_config(env_path: str | Path = ".env") -> AppConfig:
     )
 
     strategy_config = StrategyConfig(
-        timezone=strategy_timezone,
         levels_timeframe=strategy_levels_timeframe,
         entry_timeframe=strategy_entry_timeframe,
     )
@@ -159,7 +150,6 @@ def load_config(env_path: str | Path = ".env") -> AppConfig:
         commission_rate=float(os.getenv("COMMISSION_RATE", str(DEFAULT_COMMISSION_RATE))),
         slippage=float(os.getenv("SLIPPAGE", str(DEFAULT_SLIPPAGE))),
         spread=float(os.getenv("SPREAD", str(DEFAULT_SPREAD))),
-        timezone=simulation_timezone,
     )
 
     backtest_config = BacktestConfig(

--- a/config/fetch_config.py
+++ b/config/fetch_config.py
@@ -11,7 +11,6 @@ from constants import (
     DEFAULT_FETCH_TIMEFRAMES,
     DEFAULT_LIQUIDITY_SKIP_ERROR_RATIO_THRESHOLD,
     DEFAULT_MIN_VOLUME_USD,
-    DEFAULT_TIMEZONE,
 )
 from domain.enums.timeframe import Timeframe
 
@@ -22,7 +21,6 @@ class FetchConfig:
     binance_secret_key: str
     coingecko_api_key: str
     timeframes: tuple[Timeframe, ...] = DEFAULT_FETCH_TIMEFRAMES
-    timezone: str = DEFAULT_TIMEZONE
     min_volume_usd: float = DEFAULT_MIN_VOLUME_USD
     coingecko_min_request_interval_seconds: float = DEFAULT_COINGECKO_MIN_REQUEST_INTERVAL_SECONDS
     coingecko_volume_batch_size: int = DEFAULT_COINGECKO_VOLUME_BATCH_SIZE

--- a/config/simulation_config.py
+++ b/config/simulation_config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from constants import DEFAULT_COMMISSION_RATE, DEFAULT_SLIPPAGE, DEFAULT_SPREAD, DEFAULT_TIMEZONE
+from constants import DEFAULT_COMMISSION_RATE, DEFAULT_SLIPPAGE, DEFAULT_SPREAD
 
 
 @dataclass(slots=True)
@@ -12,4 +12,3 @@ class SimulationConfig:
     commission_rate: float = DEFAULT_COMMISSION_RATE
     slippage: float = DEFAULT_SLIPPAGE
     spread: float = DEFAULT_SPREAD
-    timezone: str = DEFAULT_TIMEZONE

--- a/config/strategy_config.py
+++ b/config/strategy_config.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from constants import DEFAULT_TIMEZONE
 from domain.enums.timeframe import Timeframe
 
 
 @dataclass(slots=True)
 class StrategyConfig:
-    timezone: str = DEFAULT_TIMEZONE
     levels_timeframe: Timeframe = Timeframe.D1
     entry_timeframe: Timeframe = Timeframe.M15

--- a/constants.py
+++ b/constants.py
@@ -175,7 +175,6 @@ SIMULATION_PRICE_COMPARISON_EPSILON = 1e-8
 
 # Значения по умолчанию для рантайма
 DEFAULT_LOG_LEVEL = "INFO"
-DEFAULT_TIMEZONE = "Europe/Belgrade"
 DEFAULT_CACHE_DIR = "./cache"
 DEFAULT_LOGS_DIR = "./logs"
 DEFAULT_RESULTS_DIR = "./cache/results"

--- a/data/quality/data_validator.py
+++ b/data/quality/data_validator.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime
 
 import pandas as pd
 
@@ -30,7 +30,7 @@ class DataValidator:
                     timeframe=timeframe,
                     issue_type=issue_type,
                     severity=severity,
-                    timestamp=datetime.fromtimestamp(0, tz=timezone.utc),
+                    timestamp=datetime.fromtimestamp(0),
                     description=description,
                 )
             )

--- a/data/quality/gap_detector.py
+++ b/data/quality/gap_detector.py
@@ -33,6 +33,6 @@ class GapDetector:
         if ts.empty:
             return []
 
-        expected = pd.date_range(start=ts[0], end=ts[-1], freq=_TIMEFRAME_TO_DELTA[timeframe], tz="UTC")
+        expected = pd.date_range(start=ts[0], end=ts[-1], freq=_TIMEFRAME_TO_DELTA[timeframe])
         missing = expected.difference(ts)
         return list(missing)

--- a/data/quality/time_alignment.py
+++ b/data/quality/time_alignment.py
@@ -9,8 +9,8 @@ class TimeAlignment:
     """Класс."""
 
     @staticmethod
-    def align_to_utc(data: pd.DataFrame) -> pd.DataFrame:
-        """Возвращает данные без нормализации временных меток."""
+    def sort_by_exchange_timestamp(data: pd.DataFrame) -> pd.DataFrame:
+        """Сортирует данные по биржевым временным полям без преобразований."""
         if data.empty:
             return data.copy()
 

--- a/instruction.md
+++ b/instruction.md
@@ -116,7 +116,6 @@ BINANCE_SECRET_KEY=секрет
 COINGECKO_API_KEY=ключ
 LOG_LEVEL=INFO
 CACHE_DIR=./cache
-TIMEZONE=Europe/Belgrade
 MAX_CONCURRENT_REQUESTS=10
 COMMISSION_RATE=0.0004
 SLIPPAGE=0.0005
@@ -126,7 +125,7 @@ SLIPPAGE=0.0005
 
 - Все конфигурационные классы как датаклассы
 - Группировка: FetchConfig, StrategyConfig, SimulationConfig, BacktestConfig
-- Настройки временных зон, комиссий, спредов
+- Настройки комиссий и спредов
 - Пути к данным и кэшам
 
 #### **Файл `constants.py`:**

--- a/simulation/position_simulator.py
+++ b/simulation/position_simulator.py
@@ -26,7 +26,6 @@ class StatefulPositionSimulator(PositionSimulator):
     side: PositionSide
     order_processor: OrderProcessor
     trade_classifier: TradeClassifier
-    simulation_timezone: str
 
     position: Position | None = None
     _pending_signal: TradeSignal | None = None

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -61,14 +61,10 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         *,
         commission_rate: float,
         slippage: float,
-        strategy_timezone: str,
-        simulation_timezone: str,
         logger: logging.Logger | None = None,
     ) -> None:
         self._commission_rate = commission_rate
         self._slippage = slippage
-        self._strategy_timezone = strategy_timezone
-        self._simulation_timezone = simulation_timezone
         self._logger = logger or logging.getLogger(__name__)
         self._last_generation_diagnostics: dict[str, object] = {}
 
@@ -516,7 +512,6 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                     side=pending_signal.position_side,
                     order_processor=OrderProcessor(commission_rate=self._commission_rate, slippage=self._slippage),
                     trade_classifier=TradeClassifier(),
-                    simulation_timezone=self._simulation_timezone,
                 )
                 active_sim.register_signal(pending_signal, size=STRATEGY_POSITION_SIZE)
                 pending_signal = None

--- a/utils/formatters.py
+++ b/utils/formatters.py
@@ -4,30 +4,15 @@ from __future__ import annotations
 
 from datetime import datetime
 
-DEFAULT_STORAGE_TIMEZONE = None
 
-
-def utc_ms_to_local_datetime(timestamp_ms: int | float, timezone_name: str) -> datetime:
-    """Преобразует метку времени в миллисекундах в datetime без нормализации часового пояса."""
-    _ = timezone_name
+def timestamp_ms_to_datetime(timestamp_ms: int | float) -> datetime:
+    """Преобразует Unix timestamp в миллисекундах в datetime без дополнительных преобразований."""
     return datetime.fromtimestamp(float(timestamp_ms) / 1000.0)
 
 
-def datetime_to_timezone(value: datetime, timezone_name: str) -> datetime:
-    """Возвращает исходный datetime без конвертации между часовыми поясами."""
-    _ = timezone_name
-    return value
 
-
-def datetime_to_utc(value: datetime, source_timezone_name: str | None = None) -> datetime:
-    """Возвращает исходный datetime без нормализации в UTC."""
-    _ = source_timezone_name
-    return value
-
-
-def datetime_to_utc_ms(value: datetime, source_timezone_name: str | None = None) -> int:
-    """Возвращает Unix timestamp в миллисекундах без преобразований таймзоны."""
-    _ = source_timezone_name
+def datetime_to_timestamp_ms(value: datetime) -> int:
+    """Возвращает Unix timestamp в миллисекундах без дополнительных преобразований."""
     return int(value.timestamp() * 1000)
 
 


### PR DESCRIPTION
### Motivation
- Убрать любую логику, которая автоматически мапит или конвертирует временные метки и таймзоны, и работать с теми датами/временем, что пришли от биржи.
- Упростить конфигурацию и runtime, исключив центральные поля таймзоны и межсистемные маппинги времени.
- Обеспечить, чтобы quality/processing шаги сортировали и проверяли ряды по оригинальным биржевым `timestamp`/`datetime` без принудительной конвертации в UTC.

### Description
- Убраны timezone-поля и связанное чтение env-переменных из `load_config`: удалены поля таймзоны из `FetchConfig`, `StrategyConfig`, `SimulationConfig` и снято чтение `TIMEZONE` / `*_TIMEZONE` в `config/__init__.py`.
- Откатил нормализацию `Z -> +00:00` для ISO-парсинга в CLI и конфиге; теперь используется парсинг сырой строки через `datetime.fromisoformat` (функции `_parse_iso_datetime` / `_parse_anchor_datetime`).
- Переименовал/пересемантизировал выравниватель времени: `TimeAlignment.align_to_utc` → `TimeAlignment.sort_by_exchange_timestamp` и убрал поведение с принудительным UTC-конвертом.
- Упростил утилиты форматирования времени в `utils/formatters.py` до `timestamp_ms_to_datetime` и `datetime_to_timestamp_ms` без таймзонной логики.
- Удалил передачу таймзон в места инициализации стратегии/симулятора: `BreakoutStrategy` и `StatefulPositionSimulator` больше не принимают `strategy_timezone`/`simulation_timezone`, и все вызовы обновлены.
- Обновлены проверки качества и детекторы пропусков, чтобы не создавать/требовать UTC-aware объектов (`data/quality/data_validator.py`, `data/quality/gap_detector.py`).
- Обновлены документация/README/guide, чтобы исключить примеры с `TIMEZONE` и упоминания централизованной таймзоны.

### Testing
- Выполнена статическая сборка: `python -m compileall -q .` — успешно (проверка синтаксиса/компиляции прошла).
- Попытка запуска `python main.py --help` завершилась ошибкой окружения: `ModuleNotFoundError: No module named 'pandas'`, что не связано с внесёнными изменениями и блокирует интерактивную проверку поведения, зависящего от `pandas`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991ea5566048320b66707d39aec8c6c)