### PR TITLE
Remove datetime/timestamp normalization migration flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ python launcher.py --config run_config.json
 Можно зафиксировать «текущий момент» для `fetch-data` и `update-cache`, чтобы получать повторяемые выборки:
 
 ```env
-FETCH_ANCHOR_DATETIME=2025-01-31T23:59:59+03:00
+FETCH_ANCHOR_DATETIME=2025-01-31T23:59:59
 ```
 
 Тогда параметр `--days` будет отсчитываться назад именно от `FETCH_ANCHOR_DATETIME`, а не от реального `now`.
@@ -242,11 +242,11 @@ FETCH_ANCHOR_DATETIME=2025-01-31T23:59:59+03:00
 Дополнительно можно переопределить это значение через CLI (приоритет выше env):
 
 ```bash
-python main.py fetch-data --top-n 100 --days 30 --end-datetime 2025-01-31T23:59:59+03:00
-python main.py update-cache --top-n 100 --days 7 --end-datetime 2025-01-31T23:59:59+03:00
+python main.py fetch-data --top-n 100 --days 30 --end-datetime 2025-01-31T23:59:59
+python main.py update-cache --top-n 100 --days 7 --end-datetime 2025-01-31T23:59:59
 ```
 
-Поддерживается ISO-формат даты/времени (`YYYY-MM-DD` или `YYYY-MM-DDTHH:MM:SS±HH:MM`).
+Поддерживается ISO-формат даты/времени (`YYYY-MM-DD` или `YYYY-MM-DDTHH:MM:SS`).
 
 ## Базовые CLI-команды (старый способ)
 

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -287,7 +287,7 @@ def _parse_iso_datetime(
     except ValueError as error:
         raise ValueError(
             f"Некорректный формат {argument_name}: {value}. "
-            f"Ожидается ISO дата/дата-время, например 2025-01-31 или 2025-01-31T23:59:59+03:00"
+            f"Ожидается ISO дата/дата-время, например 2025-01-31 или 2025-01-31T23:59:59"
         ) from error
 
     return parsed
@@ -919,81 +919,6 @@ def _clear_cache_inner(config: AppConfig, args: argparse.Namespace) -> int:
     return 0
 
 
-def _migrate_cache_timestamps_inner(config: AppConfig, args: argparse.Namespace) -> int:
-    logger = get_logger(
-        "migrate-cache-timestamps",
-        level=config.backtest.log_level,
-        logs_dir=config.backtest.logs_dir,
-    )
-
-    storage = ParquetStorage(
-        base_dir=config.backtest.cache_dir,
-        log_level=config.backtest.log_level,
-        logs_dir=config.backtest.logs_dir,
-    )
-
-    requested_symbols = set(args.symbols or [])
-    requested_timeframes = set(args.timeframes or [])
-
-    cache_root = config.backtest.cache_dir
-    parquet_paths = sorted(cache_root.glob("*/*/data.parquet"))
-    if not parquet_paths:
-        logger.info("миграция-кэша: parquet-файлы не найдены в %s", cache_root)
-        return 0
-
-    migrated = 0
-    skipped = 0
-    failed = 0
-
-    for path in parquet_paths:
-        symbol_encoded = path.parent.parent.name
-        timeframe_raw = path.parent.name
-        symbol = storage.decode_symbol_from_path(symbol_encoded)
-
-        if requested_symbols and symbol not in requested_symbols:
-            skipped += 1
-            continue
-        if requested_timeframes and timeframe_raw not in requested_timeframes:
-            skipped += 1
-            continue
-
-        try:
-            timeframe = Timeframe(timeframe_raw)
-        except ValueError:
-            skipped += 1
-            logger.warning("миграция-кэша: пропуск файла с неподдерживаемым таймфреймом path=%s", path)
-            continue
-
-        try:
-            rows = storage.migrate_cache_file(symbol=symbol, timeframe=timeframe)
-            migrated += 1
-            logger.info(
-                "миграция-кэша: ok symbol=%s timeframe=%s path=%s rows=%s",
-                symbol,
-                timeframe.value,
-                path,
-                rows,
-            )
-        except Exception as exc:
-            failed += 1
-            logger.error(
-                "миграция-кэша: error symbol=%s timeframe=%s path=%s reason=%s",
-                symbol,
-                timeframe.value,
-                path,
-                exc,
-            )
-
-    logger.info(
-        "миграция-кэша: итог migrated=%s skipped=%s failed=%s root=%s",
-        migrated,
-        skipped,
-        failed,
-        cache_root,
-    )
-    return 1 if failed else 0
-
-
 def _plot_daily_levels_inner(config: AppConfig, args: argparse.Namespace) -> int:
     logger = get_logger("plot-daily-levels", level=config.backtest.log_level, logs_dir=config.backtest.logs_dir)
 
@@ -1279,15 +1204,6 @@ def check_quality(config: AppConfig, args: argparse.Namespace) -> int:
 def clear_cache(config: AppConfig, args: argparse.Namespace) -> int:
     """Очищает директорию локального кэша и пересоздаёт её."""
     return _run_with_logging("clear-cache", config, lambda: _clear_cache_inner(config, args))
-
-
-def migrate_cache_timestamps(config: AppConfig, args: argparse.Namespace) -> int:
-    """Мигрирует parquet-кэш в канонический timestamp(ms)-формат без преобразования таймзон."""
-    return _run_with_logging(
-        "migrate-cache-timestamps",
-        config,
-        lambda: _migrate_cache_timestamps_inner(config, args),
-    )
 
 
 def plot_daily_levels(config: AppConfig, args: argparse.Namespace) -> int:

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -89,7 +89,7 @@ def _parse_anchor_datetime(value: str | None, *, env_name: str) -> datetime | No
     except ValueError as error:
         raise ValueError(
             f"Invalid {env_name}: {value}. Expected ISO date/datetime, for example "
-            f"2025-01-31 or 2025-01-31T23:59:59+03:00"
+            f"2025-01-31 or 2025-01-31T23:59:59"
         ) from error
 
     return parsed

--- a/data/storage/parquet_storage.py
+++ b/data/storage/parquet_storage.py
@@ -160,17 +160,3 @@ class ParquetStorage:
 
         tmp_path.replace(path)
         return max(len(merged) - previous_count, 0)
-
-    def migrate_cache_file(self, symbol: str, timeframe: Timeframe) -> int:
-        path = self._data_path(symbol, timeframe)
-        if not path.exists():
-            return 0
-
-        raw = pd.read_parquet(path)
-        if raw.empty:
-            return 0
-
-        prepared = self._ensure_columns(raw)
-        prepared = prepared.drop_duplicates(subset=["timestamp"], keep="last").sort_values("timestamp")
-        prepared.to_parquet(path, index=False)
-        return len(prepared)

--- a/utils/formatters.py
+++ b/utils/formatters.py
@@ -1,19 +1,8 @@
-"""Вспомогательные функции форматирования даты и времени без конвертации таймзон."""
+"""Вспомогательные функции форматирования даты и времени."""
 
 from __future__ import annotations
 
 from datetime import datetime
-
-
-def timestamp_ms_to_datetime(timestamp_ms: int | float) -> datetime:
-    """Преобразует Unix timestamp в миллисекундах в datetime без дополнительных преобразований."""
-    return datetime.fromtimestamp(float(timestamp_ms) / 1000.0)
-
-
-
-def datetime_to_timestamp_ms(value: datetime) -> int:
-    """Возвращает Unix timestamp в миллисекундах без дополнительных преобразований."""
-    return int(value.timestamp() * 1000)
 
 
 def format_datetime_human(value: datetime) -> str:


### PR DESCRIPTION
### Motivation
- Упростить поведение работы со временем: оставить данные времени в том виде, в котором их даёт биржа, без попыток «нормализации»/миграции таймштампов и без маппинга таймзон.
- Удалить код и команды, которые выполняли единоразовую миграцию/нормализацию parquet-кэша, чтобы избежать неявных преобразований времени.

### Description
- Удалён весь внутренний flow и публичная точка входа CLI `migrate-cache-timestamps` из `cli/commands.py` (удалён `_migrate_cache_timestamps_inner` и соответствующий экспорт). 
- Удалён метод `ParquetStorage.migrate_cache_file` из `data/storage/parquet_storage.py`, который выполнял отдельную нормализацию/перезапись parquet-файлов.
- Упрощён `utils/formatters.py` — удалены хелперы `timestamp_ms_to_datetime` и `datetime_to_timestamp_ms`, оставлен только `format_datetime_human` для человекочитаемого вывода.
- Обновлены справочные/паразитные тексты и подсказки формата дат в `README.md`, `config/__init__.py` и `cli/commands.py`, чтобы не поощрять указание смещений таймзоны в примерах (теперь примеры используют `YYYY-MM-DD` или `YYYY-MM-DDTHH:MM:SS`).

### Testing
- Выполнена проверка компиляции: `python -m compileall -q .` — успешно.
- Выполнен поиск по репозиторию на предмет следов миграции/таймзон и примеров со смещением: `rg -n "migrate-cache-timestamps|migrate_cache_timestamps|migrate_cache_file|\+03:00|±HH:MM" README.md cli/commands.py config/__init__.py data/storage/parquet_storage.py utils/formatters.py` — никаких оставшихся следов не найдено.
- Внесённые изменения закоммичены в рабочий набор (commit `e718f72`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991ebd3678c8320b7d2779d440017ca)