### PR TITLE
Убрать нормализацию дат/таймштампов в exchange-fetch пайплайне

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -38,7 +38,7 @@ TIMEFRAME_TO_DELTA = {
 }
 
 OHLCV_FRAME_COLUMNS = ("timestamp", "open", "high", "low", "close", "volume")
-OPEN_INTEREST_FRAME_COLUMNS = ("timestamp", "open_interest", "datetime")
+OPEN_INTEREST_FRAME_COLUMNS = ("timestamp", "open_interest")
 CCXT_MARKET_TYPE_SWAP = "swap"
 FUTURES_SETTLEMENT_QUOTE_ASSET = "USDT"
 SIMULATION_COIN_SUFFIX_SLASH_USDT = "/usdt"

--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime
 from typing import Any, Callable, cast
 
 import pandas as pd
@@ -30,14 +29,6 @@ try:
     import ccxt  # type: ignore
 except ImportError:  # pragma: no cover
     ccxt = None
-
-
-# region Приватные
-
-def _to_exchange_ms(value: datetime) -> int:
-    return int(value.timestamp() * MILLISECONDS_IN_SECOND)
-
-# endregion Приватные
 
 
 class CcxtFuturesClient(ExchangeClient):
@@ -192,15 +183,19 @@ class CcxtFuturesClient(ExchangeClient):
 
         return sorted(set(symbols))
 
-    def fetch_ohlcv(self, symbol: str, timeframe: Timeframe, start_time: datetime, end_time: datetime) -> pd.DataFrame:
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        timeframe: Timeframe,
+        start_timestamp_ms: int,
+        end_timestamp_ms: int,
+    ) -> pd.DataFrame:
         """Запрашивает свечи по символу и интервалу."""
         self._ensure_markets_loaded()
-        start_ms = _to_exchange_ms(start_time)
-        since = start_ms
-        end_ms = _to_exchange_ms(end_time)
+        since = start_timestamp_ms
 
         all_rows: list[list[float]] = []
-        while since <= end_ms:
+        while since <= end_timestamp_ms:
             batch = self._retry_exchange_call(
                 operation="ccxt_fetch_ohlcv",
                 symbol=symbol,
@@ -217,7 +212,7 @@ class CcxtFuturesClient(ExchangeClient):
                 break
             all_rows.extend(batch)
             last_ts = int(batch[-1][0])
-            if last_ts >= end_ms:
+            if last_ts >= end_timestamp_ms:
                 break
             since = last_ts + 1
 
@@ -225,26 +220,32 @@ class CcxtFuturesClient(ExchangeClient):
         if frame.empty:
             return frame
 
-        frame = frame.loc[(frame["timestamp"] >= start_ms) & (frame["timestamp"] <= end_ms)]
-        frame["datetime"] = pd.to_datetime(frame["timestamp"], unit="ms")
+        frame = frame.loc[
+            (frame["timestamp"] >= start_timestamp_ms)
+            & (frame["timestamp"] <= end_timestamp_ms)
+        ]
         return frame.drop_duplicates(subset=["timestamp"]).sort_values("timestamp").reset_index(drop=True)
 
-    def fetch_open_interest(self, symbol: str, timeframe: Timeframe, start_time: datetime, end_time: datetime) -> pd.DataFrame:
+    def fetch_open_interest(
+        self,
+        symbol: str,
+        timeframe: Timeframe,
+        start_timestamp_ms: int,
+        end_timestamp_ms: int,
+    ) -> pd.DataFrame:
         """Запрашивает историю open interest по символу."""
         self._ensure_markets_loaded()
         if not isinstance(self._client, CcxtOpenInterestApi):
             raise NotImplementedError(f"Exchange {self.exchange.value} does not support fetch_open_interest_history in CCXT")
 
-        start_ms = _to_exchange_ms(start_time)
-        since = start_ms
-        end_ms = _to_exchange_ms(end_time)
+        since = start_timestamp_ms
         ccxt_timeframe = timeframe.value
         timeframe_ms = int(TIMEFRAME_TO_DELTA[timeframe].total_seconds() * MILLISECONDS_IN_SECOND)
         oi_limit = min(DEFAULT_FETCH_BATCH_SIZE, 500) if self.exchange == Exchange.BINANCE else DEFAULT_FETCH_BATCH_SIZE
 
         rows: list[dict[str, object]] = []
-        while since <= end_ms:
-            request_end_ms = min(end_ms, since + timeframe_ms * oi_limit - 1)
+        while since <= end_timestamp_ms:
+            request_end_ms = min(end_timestamp_ms, since + timeframe_ms * oi_limit - 1)
             params: dict[str, object] | None = None
             if self.exchange == Exchange.BINANCE:
                 params = {
@@ -282,7 +283,7 @@ class CcxtFuturesClient(ExchangeClient):
 
             rows.extend(batch)
             last_ts = int(batch[-1].get("timestamp") or 0)
-            if last_ts >= end_ms:
+            if last_ts >= end_timestamp_ms:
                 break
             if last_ts < since:
                 since = request_end_ms + 1
@@ -300,7 +301,9 @@ class CcxtFuturesClient(ExchangeClient):
         else:
             frame["open_interest"] = pd.to_numeric(frame.get("openInterest"), errors="coerce")
 
-        frame = frame.loc[(frame["timestamp"] >= start_ms) & (frame["timestamp"] <= end_ms)]
-        frame["datetime"] = pd.to_datetime(frame["timestamp"], unit="ms")
+        frame = frame.loc[
+            (frame["timestamp"] >= start_timestamp_ms)
+            & (frame["timestamp"] <= end_timestamp_ms)
+        ]
         frame = frame[list(OPEN_INTEREST_FRAME_COLUMNS)]
         return frame.drop_duplicates(subset=["timestamp"]).sort_values("timestamp").reset_index(drop=True)

--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -19,7 +19,6 @@ from data.storage.parquet_storage import ParquetCacheValidationError, ParquetSto
 from domain.abstract.exchange_client import ExchangeClient
 from domain.enums.timeframe import Timeframe
 from domain.models.reporting.symbol_fetch_result import SymbolFetchResult
-from utils.formatters import format_datetime_human
 from utils.logger import get_logger
 
 
@@ -48,26 +47,29 @@ class OhlcvFetcher:
 
     def fetch_symbol(self, symbol: str, timeframe: Timeframe, start_time: datetime, end_time: datetime) -> int:
         """Загружает OHLCV-данные для одного символа."""
-        start_time_raw = start_time
-        end_time_raw = end_time
-        next_start = start_time_raw
+        start_timestamp_ms = int(start_time.timestamp() * 1000)
+        end_timestamp_ms = int(end_time.timestamp() * 1000)
+        next_start_ms = start_timestamp_ms
         watermark_column = "close"
-        last_timestamp = self._storage.get_last_timestamp_for_column(symbol, timeframe, watermark_column)
-        if last_timestamp is not None:
-            next_start = max(start_time_raw, last_timestamp.to_pydatetime() + TIMEFRAME_TO_DELTA[timeframe])
+        last_timestamp_ms = self._storage.get_last_timestamp_for_column(symbol, timeframe, watermark_column)
+        if last_timestamp_ms is not None:
+            timeframe_ms = int(TIMEFRAME_TO_DELTA[timeframe].total_seconds() * 1000)
+            next_start_ms = max(start_timestamp_ms, last_timestamp_ms + timeframe_ms)
 
-        watermark_display = format_datetime_human(last_timestamp.to_pydatetime()) if last_timestamp is not None else "None"
-        next_start_display = format_datetime_human(next_start)
-        end_time_display = format_datetime_human(end_time_raw)
         self._logger.info(
-            f"OHLCV водораздел: {symbol} {timeframe.value} колонка={watermark_column} последний={watermark_display} выбранный={next_start_display}"
+            "OHLCV водораздел: %s %s колонка=%s последний_ms=%s выбранный_ms=%s",
+            symbol,
+            timeframe.value,
+            watermark_column,
+            last_timestamp_ms,
+            next_start_ms,
         )
-        self._logger.info(f"OHLCV старт: {symbol} {timeframe.value} {next_start_display} -> {end_time_display}")
-        if next_start > end_time_raw:
+        self._logger.info("OHLCV старт: %s %s %s -> %s", symbol, timeframe.value, next_start_ms, end_timestamp_ms)
+        if next_start_ms > end_timestamp_ms:
             self._logger.info(LOG_MSG_SKIP_UP_TO_DATE, "OHLCV", symbol)
             return 0
 
-        data = self._exchange_client.fetch_ohlcv(symbol, timeframe, next_start, end_time_raw)
+        data = self._exchange_client.fetch_ohlcv(symbol, timeframe, next_start_ms, end_timestamp_ms)
         data = self._deduplicator.deduplicate(data)
 
         gaps = self._gap_detector.detect_gaps(data, timeframe)

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -19,7 +19,6 @@ from data.storage.parquet_storage import ParquetCacheValidationError, ParquetSto
 from domain.abstract.exchange_client import ExchangeClient
 from domain.enums.timeframe import Timeframe
 from domain.models.reporting.symbol_fetch_result import SymbolFetchResult
-from utils.formatters import format_datetime_human
 from utils.logger import get_logger
 
 
@@ -48,26 +47,29 @@ class OiFetcher:
 
     def fetch_symbol(self, symbol: str, timeframe: Timeframe, start_time: datetime, end_time: datetime) -> int:
         """Загружает историю open interest для одного символа."""
-        start_time_raw = start_time
-        end_time_raw = end_time
-        next_start = start_time_raw
+        start_timestamp_ms = int(start_time.timestamp() * 1000)
+        end_timestamp_ms = int(end_time.timestamp() * 1000)
+        next_start_ms = start_timestamp_ms
         watermark_column = "open_interest"
-        last_timestamp = self._storage.get_last_timestamp_for_column(symbol, timeframe, watermark_column)
-        if last_timestamp is not None:
-            next_start = max(start_time_raw, last_timestamp.to_pydatetime() + TIMEFRAME_TO_DELTA[timeframe])
+        last_timestamp_ms = self._storage.get_last_timestamp_for_column(symbol, timeframe, watermark_column)
+        if last_timestamp_ms is not None:
+            timeframe_ms = int(TIMEFRAME_TO_DELTA[timeframe].total_seconds() * 1000)
+            next_start_ms = max(start_timestamp_ms, last_timestamp_ms + timeframe_ms)
 
-        watermark_display = format_datetime_human(last_timestamp.to_pydatetime()) if last_timestamp is not None else "None"
-        next_start_display = format_datetime_human(next_start)
-        end_time_display = format_datetime_human(end_time_raw)
         self._logger.info(
-            f"OI водораздел: {symbol} {timeframe.value} колонка={watermark_column} последний={watermark_display} выбранный={next_start_display}"
+            "OI водораздел: %s %s колонка=%s последний_ms=%s выбранный_ms=%s",
+            symbol,
+            timeframe.value,
+            watermark_column,
+            last_timestamp_ms,
+            next_start_ms,
         )
-        self._logger.info(f"OI старт: {symbol} {timeframe.value} {next_start_display} -> {end_time_display}")
-        if next_start > end_time_raw:
+        self._logger.info("OI старт: %s %s %s -> %s", symbol, timeframe.value, next_start_ms, end_timestamp_ms)
+        if next_start_ms > end_timestamp_ms:
             self._logger.info(LOG_MSG_SKIP_UP_TO_DATE, "OI", symbol)
             return 0
 
-        data = self._exchange_client.fetch_open_interest(symbol, timeframe, next_start, end_time_raw)
+        data = self._exchange_client.fetch_open_interest(symbol, timeframe, next_start_ms, end_timestamp_ms)
         data = self._deduplicator.deduplicate(data)
 
         if "timestamp" not in data.columns:
@@ -78,15 +80,13 @@ class OiFetcher:
                 f"OI fetch_symbol: отсутствует колонка 'timestamp' в непустом OI для {symbol} {timeframe.value}"
             )
 
-        next_start_ms = int(next_start.timestamp() * 1000)
-        end_time_ms = int(end_time_raw.timestamp() * 1000)
-        interval_mask = (data["timestamp"] >= next_start_ms) & (data["timestamp"] <= end_time_ms)
+        interval_mask = (data["timestamp"] >= next_start_ms) & (data["timestamp"] <= end_timestamp_ms)
         data = data.loc[interval_mask].copy()
 
         ohlcv = self._storage.load(symbol, timeframe)
         if not ohlcv.empty and "timestamp" in ohlcv.columns:
             ohlcv_interval = ohlcv.loc[
-                (ohlcv["timestamp"] >= next_start_ms) & (ohlcv["timestamp"] <= end_time_ms), ["timestamp"]
+                (ohlcv["timestamp"] >= next_start_ms) & (ohlcv["timestamp"] <= end_timestamp_ms), ["timestamp"]
             ].copy()
             if not ohlcv_interval.empty:
                 aligned = self._oi_aligner.align(ohlcv_interval, data)
@@ -100,7 +100,7 @@ class OiFetcher:
                 data = aligned[["timestamp", "open_interest"]]
 
         if not data.empty and "timestamp" in data.columns:
-            data = data.loc[(data["timestamp"] >= next_start_ms) & (data["timestamp"] <= end_time_ms)].copy()
+            data = data.loc[(data["timestamp"] >= next_start_ms) & (data["timestamp"] <= end_timestamp_ms)].copy()
 
         issues = self._validator.validate(symbol, timeframe, data)
         if issues:

--- a/data/storage/parquet_storage.py
+++ b/data/storage/parquet_storage.py
@@ -95,19 +95,23 @@ class ParquetStorage:
             return frame
         return self._ensure_columns(frame)
 
-    def get_last_timestamp(self, symbol: str, timeframe: Timeframe) -> pd.Timestamp | None:
+    def get_last_timestamp(self, symbol: str, timeframe: Timeframe) -> int | None:
         data = self.load(symbol, timeframe)
         if data.empty or "timestamp" not in data.columns:
             return None
-        return pd.to_datetime(data["timestamp"], unit="ms", errors="coerce").max()
 
-    def get_last_timestamp_for_column(self, symbol: str, timeframe: Timeframe, column_name: str) -> pd.Timestamp | None:
+        timestamps = pd.to_numeric(data["timestamp"], errors="coerce").dropna()
+        if timestamps.empty:
+            return None
+        return int(timestamps.max())
+
+    def get_last_timestamp_for_column(self, symbol: str, timeframe: Timeframe, column_name: str) -> int | None:
         data = self.load(symbol, timeframe)
         if data.empty or "timestamp" not in data.columns:
             return None
 
         if column_name == "timestamp":
-            return pd.to_datetime(data["timestamp"], unit="ms", errors="coerce").max()
+            return self.get_last_timestamp(symbol, timeframe)
 
         if column_name not in data.columns:
             return None
@@ -116,7 +120,10 @@ class ParquetStorage:
         if not valid_rows.any():
             return None
 
-        return pd.to_datetime(data.loc[valid_rows, "timestamp"], unit="ms", errors="coerce").max()
+        timestamps = pd.to_numeric(data.loc[valid_rows, "timestamp"], errors="coerce").dropna()
+        if timestamps.empty:
+            return None
+        return int(timestamps.max())
 
     def save_incremental(self, symbol: str, timeframe: Timeframe, new_data: pd.DataFrame) -> int:
         if new_data.empty:

--- a/domain/abstract/exchange_client.py
+++ b/domain/abstract/exchange_client.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from datetime import datetime
-
 import pandas as pd
 
 from domain.enums.timeframe import Timeframe
@@ -17,8 +15,8 @@ class ExchangeClient(ABC):
         self,
         symbol: str,
         timeframe: Timeframe,
-        start_time: datetime,
-        end_time: datetime,
+        start_timestamp_ms: int,
+        end_timestamp_ms: int,
     ) -> pd.DataFrame:
         """Метод."""
     @abstractmethod
@@ -26,8 +24,8 @@ class ExchangeClient(ABC):
         self,
         symbol: str,
         timeframe: Timeframe,
-        start_time: datetime,
-        end_time: datetime,
+        start_timestamp_ms: int,
+        end_timestamp_ms: int,
     ) -> pd.DataFrame:
         """Метод."""
     @abstractmethod


### PR DESCRIPTION
### Motivation
- Упростить поведение загрузки данных: работать с таймштампами ровно так, как их возвращает биржа, без преобразований `datetime`/таймзон/нормализаций. 
- Убрать места, где происходил неявный маппинг времени между разными представлениями, чтобы исключить рассинхронизированные водоразделы и побочные эффекты при фильтрации.

### Description
- Интерфейс `ExchangeClient` переписан на работу с сырыми Unix-таймштампами в миллисекундах (`start_timestamp_ms` / `end_timestamp_ms`).
- `CcxtFuturesClient` теперь пагинирует, фильтрует и отфильтровывает батчи полностью по миллисекундам и больше не конструирует `datetime` в ответах fetch-методов.
- `OhlcvFetcher` и `OiFetcher` переведены на вычисления границ загрузки и водоразделов в `ms`, логирование показывает `*_ms` вместо форматированных `datetime`, и вызовы к клиенту передают raw ms.
- `ParquetStorage` изменил поведение чтения watermark: методы `get_last_timestamp`/`get_last_timestamp_for_column` возвращают `int | None` (raw ms) и больше не выполняют `pd.to_datetime`, а также упрощена схема OI (`OPEN_INTEREST_FRAME_COLUMNS` убран `datetime`).

### Testing
- Выполнена статическая проверка сборки через `python -m compileall domain data cli config utils strategy vectorbt_runner main.py launcher.py` и компиляция прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991ecad19b88320a37d82b503221b37)