### PR TITLE
Убрать нормализацию datetime/timestamp в проверке качества данных

### DIFF
--- a/data/quality/data_validator.py
+++ b/data/quality/data_validator.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime
-
 import pandas as pd
 
 from constants import SPREAD_TO_CLOSE_WARNING_THRESHOLD
@@ -30,7 +28,7 @@ class DataValidator:
                     timeframe=timeframe,
                     issue_type=issue_type,
                     severity=severity,
-                    timestamp=datetime.fromtimestamp(0),
+                    timestamp=0,
                     description=description,
                 )
             )
@@ -43,12 +41,12 @@ class DataValidator:
             )
             return issues
 
-        ts = pd.to_datetime(normalized["timestamp"], unit="ms", errors="coerce")
+        ts = pd.to_numeric(normalized["timestamp"], errors="coerce")
         if ts.notna().sum() == 0:
             add_dataset_issue(
                 "invalid_timestamp_series",
                 DataQualitySeverity.ERROR,
-                "Колонка timestamp не распознана (все значения NaT): данные нельзя валидировать по времени, дальнейшие проверки остановлены.",
+                "Колонка timestamp не распознана как числовая серия: данные нельзя валидировать по времени, дальнейшие проверки остановлены.",
             )
             return issues
 
@@ -61,7 +59,7 @@ class DataValidator:
         def add_issue(pos: int, issue_type: str, severity: DataQualitySeverity, description: str) -> None:
             if pd.isna(ts.iloc[pos]):
                 return
-            tstamp = ts.iloc[pos].to_pydatetime()
+            tstamp = int(ts.iloc[pos])
             issues.append(
                 DataQualityIssue(
                     symbol=symbol,

--- a/data/quality/gap_detector.py
+++ b/data/quality/gap_detector.py
@@ -2,37 +2,42 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
-
 import pandas as pd
 
+from constants import MILLISECONDS_IN_SECOND, TIMEFRAME_TO_DELTA
 from domain.enums.timeframe import Timeframe
 
-_TIMEFRAME_TO_DELTA = {
-    Timeframe.M1: timedelta(minutes=1),
-    Timeframe.M5: timedelta(minutes=5),
-    Timeframe.M15: timedelta(minutes=15),
-    Timeframe.M30: timedelta(minutes=30),
-    Timeframe.H1: timedelta(hours=1),
-    Timeframe.H4: timedelta(hours=4),
-    Timeframe.D1: timedelta(days=1),
-    Timeframe.W1: timedelta(weeks=1),
+_TIMEFRAME_TO_MS = {
+    timeframe: int(delta.total_seconds() * MILLISECONDS_IN_SECOND)
+    for timeframe, delta in TIMEFRAME_TO_DELTA.items()
 }
 
 
 class GapDetector:
     """Класс."""
     @staticmethod
-    def detect_gaps(data: pd.DataFrame, timeframe: Timeframe) -> list[pd.Timestamp]:
-        """Ищет пропуски во временном ряду свечей."""
+    def detect_gaps(data: pd.DataFrame, timeframe: Timeframe) -> list[int]:
+        """Ищет пропуски во временном ряду свечей по исходным меткам времени биржи."""
         if data.empty or "timestamp" not in data.columns:
             return []
 
-        ts = pd.DatetimeIndex(pd.to_datetime(data["timestamp"], unit="ms", errors="coerce").dropna())
-        ts = ts.sort_values().drop_duplicates()
-        if ts.empty:
+        timestamps = pd.to_numeric(data["timestamp"], errors="coerce").dropna().astype("int64")
+        if timestamps.empty:
             return []
 
-        expected = pd.date_range(start=ts[0], end=ts[-1], freq=_TIMEFRAME_TO_DELTA[timeframe])
-        missing = expected.difference(ts)
-        return list(missing)
+        ts = sorted(set(timestamps.tolist()))
+        step = _TIMEFRAME_TO_MS[timeframe]
+        if step <= 0:
+            return []
+
+        missing: list[int] = []
+        for prev, curr in zip(ts, ts[1:]):
+            gap = curr - prev
+            if gap <= step:
+                continue
+            next_expected = prev + step
+            while next_expected < curr:
+                missing.append(next_expected)
+                next_expected += step
+
+        return missing

--- a/domain/models/data_quality_issue.py
+++ b/domain/models/data_quality_issue.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 
 from domain.enums.data_quality_severity import DataQualitySeverity
 from domain.enums.timeframe import Timeframe
@@ -15,7 +14,7 @@ class DataQualityIssue:
     timeframe: Timeframe
     issue_type: str
     severity: DataQualitySeverity
-    timestamp: datetime
+    timestamp: int
     description: str
 
     # region Приватные
@@ -30,6 +29,10 @@ class DataQualityIssue:
 
         if self.timestamp is None:
             msg = "DataQualityIssue timestamp is required."
+            raise ValueError(msg)
+
+        if self.timestamp < 0:
+            msg = "DataQualityIssue timestamp must be >= 0."
             raise ValueError(msg)
 
         if not self.description:


### PR DESCRIPTION
### Motivation
- Упростить обработку временных меток: использовать значения `timestamp` «как пришли с биржи» без преобразований в `datetime`, без таймзон и маппингов между представлениями времени.
- Исключить скрытую логику нормализации, которая приводила к неоднозначностям и зависимости от pandas `DatetimeIndex`/`date_range`.

### Description
- Перевёл модель `DataQualityIssue.timestamp` с `datetime` на `int` (epoch ms) и добавил проверку, что значение неотрицательное, чтобы отражать биржевой формат меток времени.
- В `DataValidator.validate` убрал вызов `pd.to_datetime(..., unit="ms")` и теперь проверка/сбор ивентов использует числовую серию `timestamp` через `pd.to_numeric`, а timestamp в issue сохраняется как `int`.
- В `GapDetector.detect_gaps` заменил работу с `DatetimeIndex`/`date_range` на анализ исходных числовых `timestamp` и вычисление ожидаемых шагов в миллисекундах на основе `TIMEFRAME_TO_DELTA`.
- Изменены файлы: `data/quality/data_validator.py`, `data/quality/gap_detector.py`, `domain/models/data_quality_issue.py`.

### Testing
- Выполнена компиляция модулей командой `python -m compileall data/quality domain/models`, компиляция прошла успешно.
- Модификации проходят статическую проверку синтаксиса (модули импортируются/компилируются без ошибок).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991ee0270a883209a47ac07a6ad739a)