### PR TITLE
Use raw exchange timestamps without datetime normalization

### DIFF
--- a/data/liquidity/daily_volume_ranker.py
+++ b/data/liquidity/daily_volume_ranker.py
@@ -36,27 +36,28 @@ class DailyVolumeRanker:
                 )
                 continue
 
-            if "datetime" not in frame.columns or "close" not in frame.columns or "volume" not in frame.columns:
+            if "timestamp" not in frame.columns or "close" not in frame.columns or "volume" not in frame.columns:
                 logger.info(
                     "ликвидность-кэш: символ=%s исключён: отсутствуют обязательные колонки для расчёта",
                     symbol,
                 )
                 continue
 
-            normalized = frame.copy()
-            normalized["datetime"] = pd.to_datetime(normalized["datetime"], errors="coerce")
-            normalized = normalized.dropna(subset=["datetime", "close", "volume"])
-            if normalized.empty:
+            prepared = frame.copy()
+            prepared["timestamp"] = pd.to_numeric(prepared["timestamp"], errors="coerce")
+            prepared = prepared.dropna(subset=["timestamp", "close", "volume"])
+            if prepared.empty:
                 logger.info(
                     "ликвидность-кэш: символ=%s исключён: после очистки не осталось валидных строк",
                     symbol,
                 )
                 continue
 
-            normalized["date"] = normalized["datetime"].dt.floor("D")
-            normalized["daily_volume_usd"] = normalized["close"] * normalized["volume"]
+            prepared["timestamp"] = prepared["timestamp"].astype("int64")
+            prepared["day_bucket"] = prepared["timestamp"] // 86_400_000
+            prepared["daily_volume_usd"] = prepared["close"] * prepared["volume"]
 
-            daily_volume = normalized.groupby("date", as_index=True)["daily_volume_usd"].sum(min_count=1).dropna()
+            daily_volume = prepared.groupby("day_bucket", as_index=True)["daily_volume_usd"].sum(min_count=1).dropna()
             if daily_volume.empty:
                 logger.info(
                     "ликвидность-кэш: символ=%s исключён: не удалось посчитать дневной USD-объём",

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -45,7 +45,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
 
     REQUIRED_COLUMNS = STRATEGY_REQUIRED_COLUMNS
     ANNOTATED_COLUMNS = [
-        "datetime",
+        "timestamp",
         "open",
         "high",
         "low",
@@ -81,7 +81,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
 
     def _to_candle(self, row: pd.Series) -> Candle:
         return Candle(
-            timestamp=row["datetime"].to_pydatetime(),
+            timestamp=pd.to_datetime(row["timestamp"], unit="ms").to_pydatetime(),
             open=Price(float(row["open"])),
             high=Price(float(row["high"])),
             low=Price(float(row["low"])),
@@ -170,7 +170,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         volume_before: float | None,
         volume_after: float | None = None,
     ) -> Level:
-        formation_dt = row["level_start_time"].to_pydatetime()
+        formation_dt = pd.to_datetime(row["level_start_time"], unit="ms").to_pydatetime()
         return Level(
             price=Price(price),
             level_type=LevelType.RESISTANCE if side == PositionSide.LONG else LevelType.SUPPORT,
@@ -183,9 +183,9 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         )
 
     @staticmethod
-    def _average_volume_before(*, annotated: pd.DataFrame, breakout_idx: int, level_start_time: pd.Timestamp) -> float | None:
+    def _average_volume_before(*, annotated: pd.DataFrame, breakout_idx: int, level_start_time: int) -> float | None:
         before_slice = annotated.iloc[:breakout_idx]
-        before_slice = before_slice[before_slice["datetime"] >= level_start_time]
+        before_slice = before_slice[before_slice["timestamp"] >= level_start_time]
         if before_slice.empty:
             return None
         return float(before_slice["volume"].mean())
@@ -216,14 +216,14 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         retest_idx: int,
         volume_mult: float,
     ) -> dict[str, float | bool]:
-        breakout_timestamp = annotated.iloc[breakout_idx]["datetime"]
-        retest_timestamp = annotated.iloc[retest_idx]["datetime"]
+        breakout_timestamp = annotated.iloc[breakout_idx]["timestamp"]
+        retest_timestamp = annotated.iloc[retest_idx]["timestamp"]
 
         before_slice = annotated[
-            (annotated["datetime"] >= breakout.level_start_time) & (annotated["datetime"] < breakout_timestamp)
+            (annotated["timestamp"] >= breakout.level_start_time) & (annotated["timestamp"] < breakout_timestamp)
         ]
         after_slice = annotated[
-            (annotated["datetime"] >= breakout_timestamp) & (annotated["datetime"] < retest_timestamp)
+            (annotated["timestamp"] >= breakout_timestamp) & (annotated["timestamp"] < retest_timestamp)
         ]
         if before_slice.empty or after_slice.empty:
             self._logger.debug(
@@ -308,7 +308,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         )
         return TradeSignal(
             entry_price=Price(entry_price),
-            entry_time=entry_row["datetime"].to_pydatetime(),
+            entry_time=pd.to_datetime(entry_row["timestamp"], unit="ms").to_pydatetime(),
             stop_loss=Price(float(stop)),
             take_profit_1=Price(float(tp1)),
             take_profit_2=Price(float(tp2)),
@@ -370,9 +370,10 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             raise ValueError(f"Отсутствуют обязательные колонки: {missing}")
 
         prepared = data.copy()
-        prepared["datetime"] = pd.to_datetime(prepared["timestamp"], unit="ms", errors="coerce")
-        prepared = prepared.dropna(subset=["datetime"])
-        prepared = prepared.sort_values("datetime").reset_index(drop=True)
+        prepared["timestamp"] = pd.to_numeric(prepared["timestamp"], errors="coerce")
+        prepared = prepared.dropna(subset=["timestamp"])
+        prepared["timestamp"] = prepared["timestamp"].astype("int64")
+        prepared = prepared.sort_values("timestamp").reset_index(drop=True)
 
         for col in ("open", "high", "low", "close", "volume"):
             prepared[col] = pd.to_numeric(prepared[col], errors="coerce")
@@ -390,8 +391,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         higher_prepared = self.prepare_data(mtf_frames.get_frame(levels_timeframe))
         lower_prepared = self.prepare_data(mtf_frames.get_frame(entry_timeframe))
         return (
-            higher_prepared[["datetime", "high", "low"]].copy(),
-            lower_prepared[["datetime", "open", "high", "low", "close", "volume"]].copy(),
+            higher_prepared[["timestamp", "high", "low"]].copy(),
+            lower_prepared[["timestamp", "open", "high", "low", "close", "volume"]].copy(),
         )
 
     def prepare_annotated_multi_tf_data(
@@ -410,15 +411,15 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         higher_levels = higher_base.copy()
         higher_levels["level_high"] = higher_levels["high"].rolling(window=lookback).max().shift(1)
         higher_levels["level_low"] = higher_levels["low"].rolling(window=lookback).min().shift(1)
-        higher_levels["level_start_time"] = higher_levels["datetime"]
-        higher_levels = higher_levels.dropna(subset=["level_high", "level_low"]).sort_values("datetime")
+        higher_levels["level_start_time"] = higher_levels["timestamp"]
+        higher_levels = higher_levels.dropna(subset=["level_high", "level_low"]).sort_values("timestamp")
         if higher_levels.empty:
             return pd.DataFrame(columns=self.ANNOTATED_COLUMNS)
 
         annotated = pd.merge_asof(
-            lower_base.sort_values("datetime").reset_index(drop=True),
-            higher_levels[["datetime", "level_high", "level_low", "level_start_time"]],
-            on="datetime",
+            lower_base.sort_values("timestamp").reset_index(drop=True),
+            higher_levels[["timestamp", "level_high", "level_low", "level_start_time"]],
+            on="timestamp",
             direction="backward",
         )
         annotated = annotated.dropna(subset=["level_high", "level_low", "level_start_time"]).reset_index(drop=True)
@@ -536,15 +537,15 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             level_price=pending_retest.breakout.level.price.value,
                             retest_low=pending_retest.retest_low,
                             retest_high=pending_retest.retest_high,
-                            retest_start_time=pd.Timestamp(annotated.iloc[pending_retest.retest_start_idx]["datetime"]),
-                            retest_end_time=pd.Timestamp(annotated.iloc[pending_retest.retest_end_idx]["datetime"]),
+                            retest_start_time=pd.to_datetime(annotated.iloc[pending_retest.retest_start_idx]["timestamp"], unit="ms"),
+                            retest_end_time=pd.to_datetime(annotated.iloc[pending_retest.retest_end_idx]["timestamp"], unit="ms"),
                             status="confirmed",
                         )
                     )
                     self._logger.info(
                         "signal built from retest symbol=%s datetime=%s side=%s entry_trigger=%s entry_idx=%s retest_idx=%s breakout_idx=%s",
                         params.symbol,
-                        row["datetime"],
+                        row["timestamp"],
                         pending_retest.breakout.side.value,
                         params.entry_trigger.value,
                         entry_idx,
@@ -570,8 +571,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             level_price=pending_retest.breakout.level.price.value,
                             retest_low=pending_retest.retest_low,
                             retest_high=pending_retest.retest_high,
-                            retest_start_time=pd.Timestamp(annotated.iloc[pending_retest.retest_start_idx]["datetime"]),
-                            retest_end_time=pd.Timestamp(annotated.iloc[pending_retest.retest_end_idx]["datetime"]),
+                            retest_start_time=pd.to_datetime(annotated.iloc[pending_retest.retest_start_idx]["timestamp"], unit="ms"),
+                            retest_end_time=pd.to_datetime(annotated.iloc[pending_retest.retest_end_idx]["timestamp"], unit="ms"),
                             status="confirmation_expired",
                         )
                     )
@@ -580,7 +581,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                         params.symbol,
                         pending_retest.confirmation_end_idx,
                         idx,
-                        row["datetime"],
+                        row["timestamp"],
                     )
                     pending_retest = None
                     continue
@@ -594,15 +595,15 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             level_price=pending_retest.breakout.level.price.value,
                             retest_low=pending_retest.retest_low,
                             retest_high=pending_retest.retest_high,
-                            retest_start_time=pd.Timestamp(annotated.iloc[pending_retest.retest_start_idx]["datetime"]),
-                            retest_end_time=pd.Timestamp(annotated.iloc[pending_retest.retest_end_idx]["datetime"]),
+                            retest_start_time=pd.to_datetime(annotated.iloc[pending_retest.retest_start_idx]["timestamp"], unit="ms"),
+                            retest_end_time=pd.to_datetime(annotated.iloc[pending_retest.retest_end_idx]["timestamp"], unit="ms"),
                             status="confirmed",
                         )
                     )
                     self._logger.info(
                         "signal built from retest symbol=%s datetime=%s side=%s entry_trigger=%s entry_idx=%s retest_idx=%s breakout_idx=%s",
                         params.symbol,
-                        row["datetime"],
+                        row["timestamp"],
                         pending_retest.breakout.side.value,
                         params.entry_trigger.value,
                         entry_idx,
@@ -627,8 +628,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             level_price=pending_retest.breakout.level.price.value,
                             retest_low=pending_retest.retest_low,
                             retest_high=pending_retest.retest_high,
-                            retest_start_time=pd.Timestamp(annotated.iloc[pending_retest.retest_start_idx]["datetime"]),
-                            retest_end_time=pd.Timestamp(annotated.iloc[pending_retest.retest_end_idx]["datetime"]),
+                            retest_start_time=pd.to_datetime(annotated.iloc[pending_retest.retest_start_idx]["timestamp"], unit="ms"),
+                            retest_end_time=pd.to_datetime(annotated.iloc[pending_retest.retest_end_idx]["timestamp"], unit="ms"),
                             status="confirmation_not_received",
                         )
                     )
@@ -637,7 +638,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                         params.symbol,
                         pending_retest.confirmation_end_idx,
                         idx,
-                        row["datetime"],
+                        row["timestamp"],
                     )
                     pending_retest = None
                 continue
@@ -651,7 +652,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                     self._logger.debug(
                         "retest_candle_detected symbol=%s datetime=%s side=%s level=%.8f breakout_idx=%s retest_idx=%s",
                         params.symbol,
-                        row["datetime"],
+                        row["timestamp"],
                         pending_breakout.side.value,
                         pending_breakout.level.price.value,
                         breakout_idx,
@@ -687,7 +688,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                         self._logger.info(
                             "retest accepted -> pending_retest created symbol=%s datetime=%s side=%s level=%.8f breakout_idx=%s retest_idx=%s entry_trigger=%s entry_idx=%s",
                             params.symbol,
-                            row["datetime"],
+                            row["timestamp"],
                             pending_breakout.side.value,
                             pending_breakout.level.price.value,
                             breakout_idx,
@@ -706,15 +707,15 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                                 level_price=pending_breakout.level.price.value,
                                 retest_low=float(row["low"]),
                                 retest_high=float(row["high"]),
-                                retest_start_time=pd.Timestamp(row["datetime"]),
-                                retest_end_time=pd.Timestamp(row["datetime"]),
+                                retest_start_time=pd.to_datetime(row["timestamp"], unit="ms"),
+                                retest_end_time=pd.to_datetime(row["timestamp"], unit="ms"),
                                 status="rejected_by_volume",
                             )
                         )
                         self._logger.info(
                             "retest_rejected_by_volume symbol=%s datetime=%s side=%s level=%.8f breakout_idx=%s retest_idx=%s v_before=%.6f v_after=%.6f threshold=%.6f volume_mult=%.4f volume_filter_passed=false",
                             params.symbol,
-                            row["datetime"],
+                            row["timestamp"],
                             pending_breakout.side.value,
                             pending_breakout.level.price.value,
                             breakout_idx,
@@ -733,15 +734,15 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                                 level_price=pending_breakout.level.price.value,
                                 retest_low=float(row["low"]),
                                 retest_high=float(row["high"]),
-                                retest_start_time=pd.Timestamp(row["datetime"]),
-                                retest_end_time=pd.Timestamp(row["datetime"]),
+                                retest_start_time=pd.to_datetime(row["timestamp"], unit="ms"),
+                                retest_end_time=pd.to_datetime(row["timestamp"], unit="ms"),
                                 status="rejected_by_extra_filters",
                             )
                         )
                         self._logger.info(
                             "retest_rejected_by_extra_filters symbol=%s datetime=%s side=%s level=%.8f breakout_idx=%s retest_idx=%s body_ratio=%.6f body_ratio_min=%.6f move_atr=%.6f move_atr_threshold=%.6f max_retest_depth=%.6f max_retest_depth_threshold=%.6f natr=%.6f",
                             params.symbol,
-                            row["datetime"],
+                            row["timestamp"],
                             pending_breakout.side.value,
                             pending_breakout.level.price.value,
                             breakout_idx,
@@ -822,15 +823,15 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                     level_price=pending_retest.breakout.level.price.value,
                     retest_low=pending_retest.retest_low,
                     retest_high=pending_retest.retest_high,
-                    retest_start_time=pd.Timestamp(annotated.iloc[pending_retest.retest_start_idx]["datetime"]),
-                    retest_end_time=pd.Timestamp(annotated.iloc[pending_retest.retest_end_idx]["datetime"]),
+                    retest_start_time=pd.to_datetime(annotated.iloc[pending_retest.retest_start_idx]["timestamp"], unit="ms"),
+                    retest_end_time=pd.to_datetime(annotated.iloc[pending_retest.retest_end_idx]["timestamp"], unit="ms"),
                     status="pending_end_of_data",
                 )
             )
 
         if active_sim is not None and active_sim.position is not None:
             final_row = annotated.iloc[-1]
-            final_time = final_row["datetime"].to_pydatetime()
+            final_time = pd.to_datetime(final_row["timestamp"], unit="ms").to_pydatetime()
             trades.append(active_sim.close_position(price=float(final_row["close"]), exit_time=final_time))
 
         diagnostics["trades_generated"] = len(trades)

--- a/strategy/breakout/pending_breakout.py
+++ b/strategy/breakout/pending_breakout.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import pandas as pd
-
 from domain.enums.position_side import PositionSide
 from domain.models.level import Level
 
@@ -16,4 +14,4 @@ class PendingBreakout:
     level: Level
     breakout_extreme: float
     side: PositionSide
-    level_start_time: pd.Timestamp
+    level_start_time: int

--- a/vectorbt_runner/data_preparer.py
+++ b/vectorbt_runner/data_preparer.py
@@ -12,7 +12,6 @@ from constants import (
     DATA_PREPARER_EMPTY_FLOAT_DTYPE,
     DATA_PREPARER_NUMERIC_COLUMNS,
     DATA_PREPARER_TRADE_COLUMNS,
-    SIMULATION_DATETIME_UNIT_MS,
     SIMULATION_PARQUET_FILE_NAME,
     SIMULATION_PNL_PERCENT_DIVISOR,
     SIMULATION_PRICE_INIT,
@@ -65,18 +64,19 @@ class DataPreparer:
         if missing:
             return pd.DataFrame()
 
-        normalized = frame.copy()
-        normalized["symbol"] = symbol
-        normalized["datetime"] = pd.to_datetime(normalized["timestamp"], unit=SIMULATION_DATETIME_UNIT_MS, errors="coerce")
-        normalized = normalized.dropna(subset=["datetime"])
+        prepared = frame.copy()
+        prepared["symbol"] = symbol
+        prepared["timestamp"] = pd.to_numeric(prepared["timestamp"], errors="coerce")
+        prepared = prepared.dropna(subset=["timestamp"])
+        prepared["timestamp"] = prepared["timestamp"].astype("int64")
 
-        numeric_cols = [col for col in DATA_PREPARER_NUMERIC_COLUMNS if col in normalized.columns]
+        numeric_cols = [col for col in DATA_PREPARER_NUMERIC_COLUMNS if col in prepared.columns]
         for col in numeric_cols:
-            normalized[col] = pd.to_numeric(normalized[col], errors="coerce")
+            prepared[col] = pd.to_numeric(prepared[col], errors="coerce")
 
-        normalized = normalized.dropna(subset=["open", "high", "low", "close", "volume"])
-        normalized = normalized.sort_values("datetime").drop_duplicates(subset=["timestamp"], keep="last")
-        return normalized.reset_index(drop=True)
+        prepared = prepared.dropna(subset=["open", "high", "low", "close", "volume"])
+        prepared = prepared.sort_values("timestamp").drop_duplicates(subset=["timestamp"], keep="last")
+        return prepared.reset_index(drop=True)
 
 
     def load_symbol_data_multi(self, symbol: str, timeframes: Iterable[Timeframe]) -> dict[Timeframe, pd.DataFrame]:

--- a/vectorbt_runner/strategy_plotter.py
+++ b/vectorbt_runner/strategy_plotter.py
@@ -34,8 +34,8 @@ class StrategyPlotter:
     def _format_date_range(annotated: pd.DataFrame) -> str:
         if annotated.empty:
             return "empty"
-        start = pd.Timestamp(annotated["datetime"].iloc[0]).strftime("%Y%m%d")
-        end = pd.Timestamp(annotated["datetime"].iloc[-1]).strftime("%Y%m%d")
+        start = pd.to_datetime(annotated["timestamp"].iloc[0], unit="ms").strftime("%Y%m%d")
+        end = pd.to_datetime(annotated["timestamp"].iloc[-1], unit="ms").strftime("%Y%m%d")
         return f"{start}_{end}"
 
     @staticmethod
@@ -99,13 +99,15 @@ class StrategyPlotter:
             daily_from_levels = higher_base.copy()
             daily_from_levels["level_high"] = daily_from_levels["high"].rolling(window=lookback).max().shift(1)
             daily_from_levels["level_low"] = daily_from_levels["low"].rolling(window=lookback).min().shift(1)
-            daily_from_levels["date"] = pd.to_datetime(daily_from_levels["datetime"]).dt.normalize()
+            daily_from_levels["day_bucket"] = (daily_from_levels["timestamp"] // 86_400_000).astype("int64")
             daily_from_levels = (
                 daily_from_levels.dropna(subset=["level_high", "level_low"])
-                .sort_values("datetime")
-                .drop_duplicates(subset=["date"], keep="last")[["date", "level_high", "level_low"]]
+                .sort_values("timestamp")
+                .drop_duplicates(subset=["day_bucket"], keep="last")[["day_bucket", "level_high", "level_low"]]
                 .reset_index(drop=True)
             )
+            daily_from_levels["date"] = pd.to_datetime(daily_from_levels["day_bucket"] * 86_400_000, unit="ms")
+            daily_from_levels = daily_from_levels[["date", "level_high", "level_low"]]
         if not daily_from_levels.empty:
             return daily_from_levels
 
@@ -113,12 +115,14 @@ class StrategyPlotter:
             return pd.DataFrame(columns=["date", "level_high", "level_low"])
 
         daily_from_annotated = annotated.copy()
-        daily_from_annotated["date"] = pd.to_datetime(daily_from_annotated["datetime"]).dt.normalize()
-        return (
-            daily_from_annotated.sort_values("datetime")
-            .drop_duplicates(subset=["date"], keep="last")[["date", "level_high", "level_low"]]
+        daily_from_annotated["day_bucket"] = (daily_from_annotated["timestamp"] // 86_400_000).astype("int64")
+        daily_from_annotated = (
+            daily_from_annotated.sort_values("timestamp")
+            .drop_duplicates(subset=["day_bucket"], keep="last")[["day_bucket", "level_high", "level_low"]]
             .reset_index(drop=True)
         )
+        daily_from_annotated["date"] = pd.to_datetime(daily_from_annotated["day_bucket"] * 86_400_000, unit="ms")
+        return daily_from_annotated[["date", "level_high", "level_low"]]
 
     def plot_daily_levels(
         self,
@@ -140,9 +144,10 @@ class StrategyPlotter:
             gridspec_kw={"height_ratios": [3, 2]},
         )
 
-        ax_top.plot(annotated["datetime"], annotated["close"], label="15m close", color="black", linewidth=1.0)
-        ax_top.plot(annotated["datetime"], annotated["level_high"], label="1d level_high", color="green", linewidth=1.2)
-        ax_top.plot(annotated["datetime"], annotated["level_low"], label="1d level_low", color="red", linewidth=1.2)
+        plot_time = pd.to_datetime(annotated["timestamp"], unit="ms")
+        ax_top.plot(plot_time, annotated["close"], label="15m close", color="black", linewidth=1.0)
+        ax_top.plot(plot_time, annotated["level_high"], label="1d level_high", color="green", linewidth=1.2)
+        ax_top.plot(plot_time, annotated["level_low"], label="1d level_low", color="red", linewidth=1.2)
         ax_top.set_title(f"{symbol}: 15m candles with 1d levels")
         ax_top.grid(alpha=0.3)
         ax_top.legend(loc="upper left")
@@ -192,7 +197,8 @@ class StrategyPlotter:
         saved_paths: list[Path] = []
         for span in symbol_spans:
             fig, ax = plt.subplots(1, 1, figsize=(14, 6))
-            ax.plot(annotated["datetime"], annotated["close"], color="black", linewidth=1.0, label="15m close")
+            plot_time = pd.to_datetime(annotated["timestamp"], unit="ms")
+            ax.plot(plot_time, annotated["close"], color="black", linewidth=1.0, label="15m close")
             ax.axhline(span.level_price, color="royalblue", linestyle="--", linewidth=1.2, label="daily level")
 
             x_start = mdates.date2num(span.retest_start_time.to_pydatetime())


### PR DESCRIPTION
### Motivation
- Stop normalizing/altering exchange time fields and operate on raw millisecond `timestamp` values to preserve original exchange semantics and avoid TZ/mapping issues.
- Keep conversions to Python `datetime` only at model/plot boundaries where real datetime objects are required.

### Description
- Switched data preparation to validate/sort by raw numeric `timestamp` instead of creating `datetime` columns in `vectorbt_runner/data_preparer.py` and `strategy/breakout/breakout_strategy.py`.
- Updated breakout strategy MTF pipeline to use `timestamp` for `merge_asof`, volume windows, level start times, and annotated outputs, and to convert to `datetime` only when constructing `Candle`, `Level` formation times, `TradeSignal` entry times and `RetestPlotSpan` times.
- Changed `PendingBreakout.level_start_time` type from `pd.Timestamp` to `int` (ms) to keep internal state in exchange timestamp format in `strategy/breakout/pending_breakout.py`.
- Reworked daily aggregation and plotting to bucket by `day_bucket = timestamp // 86_400_000` and build plot axes from `timestamp` milliseconds in `data/liquidity/daily_volume_ranker.py` and `vectorbt_runner/strategy_plotter.py`.

### Testing
- Compiled affected packages with `python -m compileall strategy data vectorbt_runner` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991ef21f8cc8320bdeccf478274376e)