### PR TITLE
Use exchange timestamps as-is (remove timestamp/datetime normalization)

### DIFF
--- a/data/storage/parquet_storage.py
+++ b/data/storage/parquet_storage.py
@@ -45,9 +45,7 @@ class ParquetStorage:
             raise ValueError("data must contain 'timestamp' column")
 
         prepared = data.copy()
-        prepared["timestamp"] = pd.to_numeric(prepared["timestamp"], errors="coerce")
         prepared = prepared.loc[prepared["timestamp"].notna()].copy()
-        prepared["timestamp"] = prepared["timestamp"].astype("int64")
         return prepared
 
     def _validate_written_cache(
@@ -76,8 +74,8 @@ class ParquetStorage:
                 f"symbol={symbol}, timeframe={timeframe.value}, path={path}, missing_column=timestamp"
             )
 
-        incoming_ts = set(pd.to_numeric(incoming["timestamp"], errors="coerce").dropna().astype("int64").tolist())
-        written_ts = set(pd.to_numeric(written["timestamp"], errors="coerce").dropna().astype("int64").tolist())
+        incoming_ts = set(incoming["timestamp"].dropna().tolist())
+        written_ts = set(written["timestamp"].dropna().tolist())
         missing = incoming_ts - written_ts
         if missing:
             raise ParquetCacheValidationError(
@@ -100,7 +98,7 @@ class ParquetStorage:
         if data.empty or "timestamp" not in data.columns:
             return None
 
-        timestamps = pd.to_numeric(data["timestamp"], errors="coerce").dropna()
+        timestamps = data["timestamp"].dropna()
         if timestamps.empty:
             return None
         return int(timestamps.max())
@@ -120,7 +118,7 @@ class ParquetStorage:
         if not valid_rows.any():
             return None
 
-        timestamps = pd.to_numeric(data.loc[valid_rows, "timestamp"], errors="coerce").dropna()
+        timestamps = data.loc[valid_rows, "timestamp"].dropna()
         if timestamps.empty:
             return None
         return int(timestamps.max())

--- a/vectorbt_runner/data_preparer.py
+++ b/vectorbt_runner/data_preparer.py
@@ -66,9 +66,7 @@ class DataPreparer:
 
         prepared = frame.copy()
         prepared["symbol"] = symbol
-        prepared["timestamp"] = pd.to_numeric(prepared["timestamp"], errors="coerce")
         prepared = prepared.dropna(subset=["timestamp"])
-        prepared["timestamp"] = prepared["timestamp"].astype("int64")
 
         numeric_cols = [col for col in DATA_PREPARER_NUMERIC_COLUMNS if col in prepared.columns]
         for col in numeric_cols:


### PR DESCRIPTION
### Motivation
- Упростить поток данных так, чтобы временные метки использовались «как пришли» от биржи без принудительной нормализации или приведения типов. 
- Исключить неявные преобразования/потенциальные ошибки при приведении `timestamp` к числовому типу и к `int64`.

### Description
- Убрана принудительная конверсия `timestamp` через `pd.to_numeric(..., errors="coerce")` и приведение к `int64` в `data/storage/parquet_storage.py`, оставлено только отбрасывание `null`-значений. 
- Сравнение/проверка наборов timestamp в валидации кэша теперь выполняется по исходным значениям без промежуточной нормализации в `data/storage/parquet_storage.py`. 
- Удалена привязка `timestamp` к числовому типу в подготовке данных для vectorbt в `vectorbt_runner/data_preparer.py`, теперь сохраняется исходный формат меток времени из кэша/биржи. 
- Изменения минимальны и фокусируются только на удалении шагов нормализации, логика объединения/сохранения осталась прежней.

### Testing
- Скомпилированы изменённые файлы командой `python -m compileall data/storage/parquet_storage.py vectorbt_runner/data_preparer.py` и проверка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991f2055df08320a4278ae7c2a94688)