### PR TITLE
Remove datetime normalization and use raw unix-ms timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,19 +234,19 @@ python launcher.py --config run_config.json
 Можно зафиксировать «текущий момент» для `fetch-data` и `update-cache`, чтобы получать повторяемые выборки:
 
 ```env
-FETCH_ANCHOR_DATETIME=2025-01-31T23:59:59
+FETCH_ANCHOR_TIMESTAMP_MS=1738367999000
 ```
 
-Тогда параметр `--days` будет отсчитываться назад именно от `FETCH_ANCHOR_DATETIME`, а не от реального `now`.
+Тогда параметр `--days` будет отсчитываться назад именно от `FETCH_ANCHOR_TIMESTAMP_MS`, а не от текущего времени.
 
 Дополнительно можно переопределить это значение через CLI (приоритет выше env):
 
 ```bash
-python main.py fetch-data --top-n 100 --days 30 --end-datetime 2025-01-31T23:59:59
-python main.py update-cache --top-n 100 --days 7 --end-datetime 2025-01-31T23:59:59
+python main.py fetch-data --top-n 100 --days 30 --end-timestamp-ms 1738367999000
+python main.py update-cache --top-n 100 --days 7 --end-timestamp-ms 1738367999000
 ```
 
-Поддерживается ISO-формат даты/времени (`YYYY-MM-DD` или `YYYY-MM-DDTHH:MM:SS`).
+Используется только unix timestamp в миллисекундах (ms) без преобразований и таймзон.
 
 ## Базовые CLI-команды (старый способ)
 

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -8,7 +8,7 @@ import json
 import shutil
 from collections import Counter
 from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta
+import time
 from logging import Logger
 from pathlib import Path
 from typing import Callable
@@ -276,43 +276,20 @@ def _resolve_symbols(
     return [futures_symbol_map[symbol] for symbol in liquid_symbols]
 
 
-def _parse_iso_datetime(
-        value: str,
-        *,
-        argument_name: str,
-) -> datetime:
-    raw_value = value.strip()
-    try:
-        parsed = datetime.fromisoformat(raw_value)
-    except ValueError as error:
-        raise ValueError(
-            f"Некорректный формат {argument_name}: {value}. "
-            f"Ожидается ISO дата/дата-время, например 2025-01-31 или 2025-01-31T23:59:59"
-        ) from error
+def _resolve_fetch_anchor_timestamp_ms(config: AppConfig, end_timestamp_ms_raw: int | None) -> int:
+    if end_timestamp_ms_raw is not None:
+        return int(end_timestamp_ms_raw)
 
-    return parsed
+    if config.fetch.anchor_timestamp_ms is not None:
+        return int(config.fetch.anchor_timestamp_ms)
+
+    return int(time.time() * 1000)
 
 
-def _resolve_fetch_anchor_datetime(config: AppConfig, end_datetime_raw: datetime | str | None) -> datetime:
-    if isinstance(end_datetime_raw, datetime):
-        return end_datetime_raw
-
-    if isinstance(end_datetime_raw, str):
-        return _parse_iso_datetime(
-            end_datetime_raw,
-            argument_name="--end-datetime",
-        )
-
-    if config.fetch.anchor_datetime is not None:
-        return config.fetch.anchor_datetime
-
-    return datetime.now()
-
-
-def _fetch_period(config: AppConfig, days: int, end_datetime_raw: datetime | str | None = None) -> tuple[datetime, datetime]:
-    local_end = _resolve_fetch_anchor_datetime(config, end_datetime_raw)
-    local_start = local_end - timedelta(days=days)
-    return local_start, local_end
+def _fetch_period(config: AppConfig, days: int, end_timestamp_ms_raw: int | None = None) -> tuple[int, int]:
+    end_timestamp_ms = _resolve_fetch_anchor_timestamp_ms(config, end_timestamp_ms_raw)
+    start_timestamp_ms = end_timestamp_ms - (days * 86_400_000)
+    return start_timestamp_ms, end_timestamp_ms
 
 
 @dataclass(frozen=True, slots=True)
@@ -432,12 +409,12 @@ def _fetch_data_inner(config: AppConfig, args: argparse.Namespace) -> int:
         logger.info("загрузка-данных: не найдено символов для загрузки")
         return 0
 
-    start_time, end_time = _fetch_period(config, args.days, getattr(args, "end_datetime", None))
+    start_timestamp_ms, end_timestamp_ms = _fetch_period(config, args.days, getattr(args, "end_timestamp_ms", None))
     failed_symbols: set[str] = set()
     fetch_summaries: dict[Timeframe, FetchSummary] = {}
     for timeframe in config.fetch.timeframes:
         logger.info("загрузка-данных: сбор кэша для TF=%s", timeframe.value)
-        result = fetcher.fetch_all(symbols=symbols, timeframe=timeframe, start_time=start_time, end_time=end_time)
+        result = fetcher.fetch_all(symbols=symbols, timeframe=timeframe, start_timestamp_ms=start_timestamp_ms, end_timestamp_ms=end_timestamp_ms)
         fetch_summaries[timeframe] = _log_fetch_summary(
             f"fetch-data[{timeframe.value}]",
             logger,
@@ -520,11 +497,11 @@ def _update_cache_inner(config: AppConfig, args: argparse.Namespace) -> int:
         logger.info("обновление-кэша: не найдено символов для обновления")
         return 0
 
-    start_time, end_time = _fetch_period(config, args.days, getattr(args, "end_datetime", None))
+    start_timestamp_ms, end_timestamp_ms = _fetch_period(config, args.days, getattr(args, "end_timestamp_ms", None))
     failed_symbols: set[str] = set()
     for timeframe in config.fetch.timeframes:
         logger.info("обновление-кэша: сбор кэша для TF=%s", timeframe.value)
-        result = fetcher.fetch_all(symbols=symbols, timeframe=timeframe, start_time=start_time, end_time=end_time)
+        result = fetcher.fetch_all(symbols=symbols, timeframe=timeframe, start_timestamp_ms=start_timestamp_ms, end_timestamp_ms=end_timestamp_ms)
         _log_fetch_summary(f"update-cache[{timeframe.value}]", logger, len(symbols), result.failed_symbols_count)
         failed_symbols.update(
             symbol

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -22,7 +22,7 @@ def build_parser() -> argparse.ArgumentParser:
     fetch.add_argument("--top-n", type=int, default=None)
     fetch.add_argument("--days", type=int, default=DEFAULT_FETCH_DAYS)
     fetch.add_argument("--min-volume-usd", type=float, default=DEFAULT_MIN_VOLUME_USD)
-    fetch.add_argument("--end-datetime", default=None, help="Якорная дата/время окончания периода в ISO формате")
+    fetch.add_argument("--end-timestamp-ms", type=int, default=None, help="Якорный timestamp окончания периода (unix ms)")
     fetch.add_argument(
         "--ignore-coingecko",
         action="store_true",
@@ -34,7 +34,7 @@ def build_parser() -> argparse.ArgumentParser:
     update.add_argument("--top-n", type=int, default=None)
     update.add_argument("--days", type=int, default=DEFAULT_UPDATE_DAYS)
     update.add_argument("--min-volume-usd", type=float, default=DEFAULT_MIN_VOLUME_USD)
-    update.add_argument("--end-datetime", default=None, help="Якорная дата/время окончания периода в ISO формате")
+    update.add_argument("--end-timestamp-ms", type=int, default=None, help="Якорный timestamp окончания периода (unix ms)")
     update.add_argument(
         "--ignore-coingecko",
         action="store_true",

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-from datetime import datetime
 from pathlib import Path
 
 from config.app_config import AppConfig
@@ -76,7 +75,7 @@ def _parse_bool(value: str | None, *, default: bool = False) -> bool:
     raise ValueError(f"Invalid boolean value: {value}")
 
 
-def _parse_anchor_datetime(value: str | None, *, env_name: str) -> datetime | None:
+def _parse_anchor_timestamp_ms(value: str | None, *, env_name: str) -> int | None:
     if value is None:
         return None
 
@@ -85,12 +84,14 @@ def _parse_anchor_datetime(value: str | None, *, env_name: str) -> datetime | No
         return None
 
     try:
-        parsed = datetime.fromisoformat(raw_value)
+        parsed = int(raw_value)
     except ValueError as error:
         raise ValueError(
-            f"Invalid {env_name}: {value}. Expected ISO date/datetime, for example "
-            f"2025-01-31 or 2025-01-31T23:59:59"
+            f"Invalid {env_name}: {value}. Expected unix timestamp in milliseconds, for example 1735689599000"
         ) from error
+
+    if parsed < 0:
+        raise ValueError(f"Invalid {env_name}: {value}. Timestamp must be non-negative.")
 
     return parsed
 
@@ -126,9 +127,9 @@ def load_config(env_path: str | Path = ".env") -> AppConfig:
             )
         ),
         ignore_coingecko=_parse_bool(os.getenv("IGNORE_COINGECKO"), default=False),
-        anchor_datetime=_parse_anchor_datetime(
-            os.getenv("FETCH_ANCHOR_DATETIME"),
-            env_name="FETCH_ANCHOR_DATETIME",
+        anchor_timestamp_ms=_parse_anchor_timestamp_ms(
+            os.getenv("FETCH_ANCHOR_TIMESTAMP_MS"),
+            env_name="FETCH_ANCHOR_TIMESTAMP_MS",
         ),
     )
 

--- a/config/fetch_config.py
+++ b/config/fetch_config.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 
 from constants import (
     DEFAULT_COINGECKO_MIN_REQUEST_INTERVAL_SECONDS,
@@ -26,7 +25,7 @@ class FetchConfig:
     coingecko_volume_batch_size: int = DEFAULT_COINGECKO_VOLUME_BATCH_SIZE
     liquidity_skip_error_ratio_threshold: float = DEFAULT_LIQUIDITY_SKIP_ERROR_RATIO_THRESHOLD
     ignore_coingecko: bool = True
-    anchor_datetime: datetime | None = None
+    anchor_timestamp_ms: int | None = None
 
     def __post_init__(self) -> None:
         if not self.timeframes:

--- a/data/fetchers/market_data_fetcher.py
+++ b/data/fetchers/market_data_fetcher.py
@@ -1,7 +1,6 @@
 """Модуль проекта."""
 from __future__ import annotations
 
-from datetime import datetime
 from pathlib import Path
 
 from constants import (
@@ -94,8 +93,8 @@ class MarketDataFetcher:
         self,
         symbols: list[str],
         timeframe: Timeframe,
-        start_time: datetime,
-        end_time: datetime,
+        start_timestamp_ms: int,
+        end_timestamp_ms: int,
     ) -> FetchAllResult:
         """Загружает полный набор рыночных метрик."""
         self._logger.info(f"Загрузка старт: {len(symbols)} символов, TF={timeframe.value}")
@@ -103,14 +102,14 @@ class MarketDataFetcher:
         ohlcv_result = self._ohlcv_fetcher.fetch_many(
             symbols,
             timeframe,
-            start_time,
-            end_time,
+            start_timestamp_ms,
+            end_timestamp_ms,
         )
         oi_result = self._oi_fetcher.fetch_many(
             symbols,
             timeframe,
-            start_time,
-            end_time,
+            start_timestamp_ms,
+            end_timestamp_ms,
         )
 
         market_caps = self.fetch_market_caps(symbols)

--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 from pathlib import Path
 
 from constants import (
@@ -45,10 +44,10 @@ class OhlcvFetcher:
         self._gap_detector = GapDetector()
         self._validator = DataValidator()
 
-    def fetch_symbol(self, symbol: str, timeframe: Timeframe, start_time: datetime, end_time: datetime) -> int:
+    def fetch_symbol(self, symbol: str, timeframe: Timeframe, start_timestamp_ms: int, end_timestamp_ms: int) -> int:
         """Загружает OHLCV-данные для одного символа."""
-        start_timestamp_ms = int(start_time.timestamp() * 1000)
-        end_timestamp_ms = int(end_time.timestamp() * 1000)
+        start_timestamp_ms = int(start_timestamp_ms)
+        end_timestamp_ms = int(end_timestamp_ms)
         next_start_ms = start_timestamp_ms
         watermark_column = "close"
         last_timestamp_ms = self._storage.get_last_timestamp_for_column(symbol, timeframe, watermark_column)
@@ -88,14 +87,14 @@ class OhlcvFetcher:
         self,
         symbols: list[str],
         timeframe: Timeframe,
-        start_time: datetime,
-        end_time: datetime,
+        start_timestamp_ms: int,
+        end_timestamp_ms: int,
     ) -> dict[str, SymbolFetchResult]:
         """Последовательно загружает OHLCV для набора символов."""
         results: dict[str, SymbolFetchResult] = {}
         for index, symbol in enumerate(symbols):
             try:
-                added_rows = self.fetch_symbol(symbol, timeframe, start_time, end_time)
+                added_rows = self.fetch_symbol(symbol, timeframe, start_timestamp_ms, end_timestamp_ms)
                 results[symbol] = SymbolFetchResult.ok(added_rows)
             except Exception as exc:
                 if isinstance(exc, ParquetCacheValidationError) or "parquet cache validation failed" in str(exc).lower():

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 from pathlib import Path
 
 from constants import (
@@ -43,10 +42,10 @@ class OiFetcher:
         self._deduplicator = Deduplicator()
         self._validator = DataValidator()
 
-    def fetch_symbol(self, symbol: str, timeframe: Timeframe, start_time: datetime, end_time: datetime) -> int:
+    def fetch_symbol(self, symbol: str, timeframe: Timeframe, start_timestamp_ms: int, end_timestamp_ms: int) -> int:
         """Загружает историю open interest для одного символа."""
-        start_timestamp_ms = int(start_time.timestamp() * 1000)
-        end_timestamp_ms = int(end_time.timestamp() * 1000)
+        start_timestamp_ms = int(start_timestamp_ms)
+        end_timestamp_ms = int(end_timestamp_ms)
         next_start_ms = start_timestamp_ms
         watermark_column = "open_interest"
         last_timestamp_ms = self._storage.get_last_timestamp_for_column(symbol, timeframe, watermark_column)
@@ -96,14 +95,14 @@ class OiFetcher:
         self,
         symbols: list[str],
         timeframe: Timeframe,
-        start_time: datetime,
-        end_time: datetime,
+        start_timestamp_ms: int,
+        end_timestamp_ms: int,
     ) -> dict[str, SymbolFetchResult]:
         """Последовательно загружает open interest для набора символов."""
         results: dict[str, SymbolFetchResult] = {}
         for index, symbol in enumerate(symbols):
             try:
-                added_rows = self.fetch_symbol(symbol, timeframe, start_time, end_time)
+                added_rows = self.fetch_symbol(symbol, timeframe, start_timestamp_ms, end_timestamp_ms)
                 results[symbol] = SymbolFetchResult.ok(added_rows)
             except Exception as exc:
                 if isinstance(exc, ParquetCacheValidationError) or "parquet cache validation failed" in str(exc).lower():

--- a/launcher.py
+++ b/launcher.py
@@ -70,7 +70,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--top-n", type=int, default=None, help="Количество топ монет для fetch/update")
     parser.add_argument("--min-volume-usd", type=float, default=None, help="Минимальный суточный объем в USD")
     parser.add_argument("--days", type=int, default=30, help="Число дней для fetch/update")
-    parser.add_argument("--end-datetime", default=None, help="Якорная дата/время окончания периода в ISO формате")
+    parser.add_argument("--end-timestamp-ms", type=int, default=None, help="Якорный timestamp окончания периода (unix ms)")
     parser.add_argument(
         "--ignore-coingecko",
         action="store_true",
@@ -96,7 +96,7 @@ def _task_namespace(task: dict[str, Any], cli_args: argparse.Namespace) -> argpa
         ),
         min_volume_usd=task.get("min_volume_usd", cli_args.min_volume_usd),
         days=int(task.get("days", cli_args.days)),
-        end_datetime=task.get("end_datetime", cli_args.end_datetime),
+        end_timestamp_ms=task.get("end_timestamp_ms", cli_args.end_timestamp_ms),
         symbols=task.get("symbols", cli_args.symbols),
         levels_tf=task.get("levels_tf", cli_args.levels_tf),
         entry_tf=task.get("entry_tf", cli_args.entry_tf),


### PR DESCRIPTION
### Motivation
- Eliminate ISO/datetime parsing and timezone conversions for fetch boundaries so the system treats timestamps exactly as received from exchanges (no normalization or mapping between time systems).

### Description
- Replace `FetchConfig.anchor_datetime` and env `FETCH_ANCHOR_DATETIME` with `anchor_timestamp_ms` and env `FETCH_ANCHOR_TIMESTAMP_MS`, parsing as integer milliseconds and validating non-negative values.
- Switch CLI args from `--end-datetime` to `--end-timestamp-ms` and update `launcher`/task namespace to propagate `end_timestamp_ms` instead of ISO datetimes.
- Change orchestration to compute fetch windows in milliseconds via `_fetch_period`/`_resolve_fetch_anchor_timestamp_ms` and propagate `start_timestamp_ms`/`end_timestamp_ms` through `cli.commands` and `MarketDataFetcher`.
- Update fetchers to accept and propagate raw millisecond timestamps end-to-end by changing `OhlcvFetcher`/`OiFetcher` signatures and removing `datetime -> timestamp` conversions inside them; update `MarketDataFetcher` accordingly.
- Update `README.md` examples and documentation to reflect unix-ms timestamp usage and to state that no timezone/ISO conversions are performed.

### Testing
- Ran `python -m compileall cli config data launcher.py` to ensure modules compile successfully and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991f3d83008832089cb13c5f66cb18b)