### PR TITLE
Switch breakout flow to integer millisecond timestamps

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -1008,8 +1008,8 @@ def _load_retest_spans_artifact(path: Path, logger: Logger) -> list[RetestPlotSp
                     level_price=float(item["level_price"]),
                     retest_low=float(item["retest_low"]),
                     retest_high=float(item["retest_high"]),
-                    retest_start_time=pd.Timestamp(item["retest_start_time"]),
-                    retest_end_time=pd.Timestamp(item["retest_end_time"]),
+                    retest_start_timestamp_ms=int(item.get("retest_start_timestamp_ms", item["retest_start_time"])),
+                    retest_end_timestamp_ms=int(item.get("retest_end_timestamp_ms", item["retest_end_time"])),
                     status=str(item["status"]),
                 )
             )

--- a/constants.py
+++ b/constants.py
@@ -81,7 +81,7 @@ LOG_MSG_TASK_COMPLETED = "%s завершено"
 DATA_PREPARER_NUMERIC_COLUMNS = ("open", "high", "low", "close", "volume", "open_interest")
 DATA_PREPARER_EMPTY_FLOAT_DTYPE = "float64"
 DATA_PREPARER_EMPTY_BOOL_DTYPE = "bool"
-DATA_PREPARER_TRADE_COLUMNS = ("entry_time", "exit_time", "pnl", "pnl_percent", "result_type")
+DATA_PREPARER_TRADE_COLUMNS = ("entry_timestamp_ms", "exit_timestamp_ms", "pnl", "pnl_percent", "result_type")
 SIMULATION_ZERO_VALUE = 0.0
 SIMULATION_UNIT_INCREMENT = 1.0
 

--- a/domain/abstract/position_simulator.py
+++ b/domain/abstract/position_simulator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from datetime import datetime
 
 from domain.models.candle import Candle
 from domain.models.position import Position
@@ -19,7 +18,7 @@ class PositionSimulator(ABC):
     def open_position(self, position: Position) -> None:
         """Метод."""
     @abstractmethod
-    def close_position(self, price: float, exit_time: datetime) -> TradeResult:
+    def close_position(self, price: float, exit_timestamp_ms: int) -> TradeResult:
         """Метод."""
     @abstractmethod
     def update_stop(self, new_stop: float) -> None:

--- a/domain/models/candle.py
+++ b/domain/models/candle.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 
 from domain.value_objects.price import Price
 from domain.value_objects.volume import Volume
@@ -11,7 +10,7 @@ from domain.value_objects.volume import Volume
 
 @dataclass(frozen=True, slots=True)
 class Candle:
-    timestamp: datetime
+    timestamp_ms: int
     open: Price
     high: Price
     low: Price
@@ -21,8 +20,8 @@ class Candle:
 
     # region Приватные
     def __post_init__(self) -> None:
-        if self.timestamp is None:
-            msg = "Candle timestamp is required."
+        if self.timestamp_ms is None:
+            msg = "Candle timestamp_ms is required."
             raise ValueError(msg)
 
         if self.high.value < self.low.value:

--- a/domain/models/level.py
+++ b/domain/models/level.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 
 from domain.enums.level_type import LevelType
 from domain.value_objects.price import Price
@@ -13,23 +12,16 @@ from domain.value_objects.price import Price
 class Level:
     price: Price
     level_type: LevelType
-    formation_time: datetime
+    formation_timestamp_ms: int
     lookback: int
     shadow_ratio: float
-    formation_timestamp: datetime | None = None
     volume_before: float | None = None
     volume_after: float | None = None
 
     # region Приватные
     def __post_init__(self) -> None:
-        if self.formation_time is None:
-            msg = "Level formation_time is required."
-            raise ValueError(msg)
-
-        if self.formation_timestamp is None:
-            object.__setattr__(self, "formation_timestamp", self.formation_time)
-        elif not isinstance(self.formation_timestamp, datetime):
-            msg = "Level formation_timestamp must be datetime."
+        if self.formation_timestamp_ms is None:
+            msg = "Level formation_timestamp_ms is required."
             raise ValueError(msg)
 
         if self.lookback <= 0:

--- a/domain/models/position.py
+++ b/domain/models/position.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 
 from domain.value_objects.price import Price
 from domain.value_objects.volume import Volume
@@ -12,7 +11,7 @@ from domain.value_objects.volume import Volume
 @dataclass(slots=True)
 class Position:
     entry_price: Price
-    entry_time: datetime
+    entry_timestamp_ms: int
     size: Volume
     stop_loss: Price
     take_profit_1: Price
@@ -22,8 +21,8 @@ class Position:
 
     # region Приватные
     def __post_init__(self) -> None:
-        if self.entry_time is None:
-            msg = "Position entry_time is required."
+        if self.entry_timestamp_ms is None:
+            msg = "Position entry_timestamp_ms is required."
             raise ValueError(msg)
 
         if self.size.value <= 0:

--- a/domain/models/retest_plot_span.py
+++ b/domain/models/retest_plot_span.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import pandas as pd
-
 from domain.enums.position_side import PositionSide
 
 
@@ -18,7 +16,7 @@ class RetestPlotSpan:
     level_price: float
     retest_low: float
     retest_high: float
-    retest_start_time: pd.Timestamp
-    retest_end_time: pd.Timestamp
+    retest_start_timestamp_ms: int
+    retest_end_timestamp_ms: int
     status: str
 

--- a/domain/models/trade_result.py
+++ b/domain/models/trade_result.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 
 from domain.enums.trade_result_type import TradeResultType
 from domain.value_objects.percentage import Percentage
@@ -14,19 +13,19 @@ from domain.value_objects.price import Price
 class TradeResult:
     entry_price: Price
     exit_price: Price
-    entry_time: datetime
-    exit_time: datetime
+    entry_timestamp_ms: int
+    exit_timestamp_ms: int
     result_type: TradeResultType
     pnl: float
     pnl_percent: Percentage
 
     # region Приватные
     def __post_init__(self) -> None:
-        if self.entry_time is None or self.exit_time is None:
-            msg = "Trade result entry/exit time is required."
+        if self.entry_timestamp_ms is None or self.exit_timestamp_ms is None:
+            msg = "Trade result entry/exit timestamp_ms is required."
             raise ValueError(msg)
 
-        if self.exit_time < self.entry_time:
-            msg = "Trade result exit_time cannot be earlier than entry_time."
+        if self.exit_timestamp_ms < self.entry_timestamp_ms:
+            msg = "Trade result exit_timestamp_ms cannot be earlier than entry_timestamp_ms."
             raise ValueError(msg)
     # endregion Приватные

--- a/domain/models/trade_signal.py
+++ b/domain/models/trade_signal.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 
 from domain.enums.position_side import PositionSide
 from domain.value_objects.price import Price
@@ -12,7 +11,7 @@ from domain.value_objects.price import Price
 @dataclass(frozen=True, slots=True)
 class TradeSignal:
     entry_price: Price
-    entry_time: datetime
+    entry_timestamp_ms: int
     stop_loss: Price
     take_profit_1: Price
     take_profit_2: Price
@@ -21,8 +20,8 @@ class TradeSignal:
 
     # region Приватные
     def __post_init__(self) -> None:
-        if self.entry_time is None:
-            msg = "Trade signal entry_time is required."
+        if self.entry_timestamp_ms is None:
+            msg = "Trade signal entry_timestamp_ms is required."
             raise ValueError(msg)
 
         if not self.symbol:

--- a/simulation/position_simulator.py
+++ b/simulation/position_simulator.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from datetime import datetime
 
 from constants import SIMULATION_PRICE_COMPARISON_EPSILON, TP1_CLOSE_RATIO
 from domain.abstract.position_simulator import PositionSimulator
@@ -44,7 +43,7 @@ class StatefulPositionSimulator(PositionSimulator):
         fill = self.order_processor.execute_entry(candle.open.value, self.side, self._pending_size)
         self.position = Position(
             entry_price=Price(fill.price),
-            entry_time=candle.timestamp,
+            entry_timestamp_ms=candle.timestamp_ms,
             size=Volume(self._pending_size),
             stop_loss=signal.stop_loss,
             take_profit_1=signal.take_profit_1,
@@ -130,7 +129,7 @@ class StatefulPositionSimulator(PositionSimulator):
         trade_result = self.trade_classifier.build_result(
             position=self.position,
             exit_price=self._last_exit_price,
-            exit_time=candle.timestamp,
+            exit_timestamp_ms=candle.timestamp_ms,
             result_type=result_type,
             pnl=self._realized_pnl,
         )
@@ -163,7 +162,7 @@ class StatefulPositionSimulator(PositionSimulator):
         self._closed_size = 0.0
         self._last_exit_price = position.entry_price.value
 
-    def close_position(self, price: float, exit_time: datetime) -> TradeResult:
+    def close_position(self, price: float, exit_timestamp_ms: int) -> TradeResult:
         """Закрывает остаток позиции по заданной цене и времени, затем возвращает классифицированный результат сделки."""
         if self.position is None:
             msg = "Нет активной позиции для закрытия."
@@ -182,7 +181,7 @@ class StatefulPositionSimulator(PositionSimulator):
         trade_result = self.trade_classifier.build_result(
             position=self.position,
             exit_price=self._last_exit_price,
-            exit_time=exit_time,
+            exit_timestamp_ms=exit_timestamp_ms,
             result_type=result_type,
             pnl=self._realized_pnl,
         )

--- a/simulation/trade_classifier.py
+++ b/simulation/trade_classifier.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 
 from domain.enums.trade_result_type import TradeResultType
 from domain.models.position import Position
@@ -30,7 +29,7 @@ class TradeClassifier:
             *,
         position: Position,
         exit_price: float,
-        exit_time: datetime,
+        exit_timestamp_ms: int,
         result_type: TradeResultType,
         pnl: float,
     ) -> TradeResult:
@@ -40,8 +39,8 @@ class TradeClassifier:
         return TradeResult(
             entry_price=position.entry_price,
             exit_price=Price(exit_price),
-            entry_time=position.entry_time,
-            exit_time=exit_time,
+            entry_timestamp_ms=position.entry_timestamp_ms,
+            exit_timestamp_ms=exit_timestamp_ms,
             result_type=result_type,
             pnl=pnl,
             pnl_percent=Percentage(pnl_percent_value),

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -81,7 +81,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
 
     def _to_candle(self, row: pd.Series) -> Candle:
         return Candle(
-            timestamp=pd.to_datetime(row["timestamp"], unit="ms").to_pydatetime(),
+            timestamp_ms=int(row["timestamp"]),
             open=Price(float(row["open"])),
             high=Price(float(row["high"])),
             low=Price(float(row["low"])),
@@ -170,12 +170,10 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         volume_before: float | None,
         volume_after: float | None = None,
     ) -> Level:
-        formation_dt = pd.to_datetime(row["level_start_time"], unit="ms").to_pydatetime()
         return Level(
             price=Price(price),
             level_type=LevelType.RESISTANCE if side == PositionSide.LONG else LevelType.SUPPORT,
-            formation_time=formation_dt,
-            formation_timestamp=formation_dt,
+            formation_timestamp_ms=int(row["level_start_time"]),
             lookback=lookback,
             shadow_ratio=0.0,
             volume_before=volume_before,
@@ -308,7 +306,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         )
         return TradeSignal(
             entry_price=Price(entry_price),
-            entry_time=pd.to_datetime(entry_row["timestamp"], unit="ms").to_pydatetime(),
+            entry_timestamp_ms=int(entry_row["timestamp"]),
             stop_loss=Price(float(stop)),
             take_profit_1=Price(float(tp1)),
             take_profit_2=Price(float(tp2)),
@@ -537,8 +535,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             level_price=pending_retest.breakout.level.price.value,
                             retest_low=pending_retest.retest_low,
                             retest_high=pending_retest.retest_high,
-                            retest_start_time=pd.to_datetime(annotated.iloc[pending_retest.retest_start_idx]["timestamp"], unit="ms"),
-                            retest_end_time=pd.to_datetime(annotated.iloc[pending_retest.retest_end_idx]["timestamp"], unit="ms"),
+                            retest_start_timestamp_ms=int(annotated.iloc[pending_retest.retest_start_idx]["timestamp"]),
+                            retest_end_timestamp_ms=int(annotated.iloc[pending_retest.retest_end_idx]["timestamp"]),
                             status="confirmed",
                         )
                     )
@@ -571,8 +569,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             level_price=pending_retest.breakout.level.price.value,
                             retest_low=pending_retest.retest_low,
                             retest_high=pending_retest.retest_high,
-                            retest_start_time=pd.to_datetime(annotated.iloc[pending_retest.retest_start_idx]["timestamp"], unit="ms"),
-                            retest_end_time=pd.to_datetime(annotated.iloc[pending_retest.retest_end_idx]["timestamp"], unit="ms"),
+                            retest_start_timestamp_ms=int(annotated.iloc[pending_retest.retest_start_idx]["timestamp"]),
+                            retest_end_timestamp_ms=int(annotated.iloc[pending_retest.retest_end_idx]["timestamp"]),
                             status="confirmation_expired",
                         )
                     )
@@ -595,8 +593,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             level_price=pending_retest.breakout.level.price.value,
                             retest_low=pending_retest.retest_low,
                             retest_high=pending_retest.retest_high,
-                            retest_start_time=pd.to_datetime(annotated.iloc[pending_retest.retest_start_idx]["timestamp"], unit="ms"),
-                            retest_end_time=pd.to_datetime(annotated.iloc[pending_retest.retest_end_idx]["timestamp"], unit="ms"),
+                            retest_start_timestamp_ms=int(annotated.iloc[pending_retest.retest_start_idx]["timestamp"]),
+                            retest_end_timestamp_ms=int(annotated.iloc[pending_retest.retest_end_idx]["timestamp"]),
                             status="confirmed",
                         )
                     )
@@ -628,8 +626,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             level_price=pending_retest.breakout.level.price.value,
                             retest_low=pending_retest.retest_low,
                             retest_high=pending_retest.retest_high,
-                            retest_start_time=pd.to_datetime(annotated.iloc[pending_retest.retest_start_idx]["timestamp"], unit="ms"),
-                            retest_end_time=pd.to_datetime(annotated.iloc[pending_retest.retest_end_idx]["timestamp"], unit="ms"),
+                            retest_start_timestamp_ms=int(annotated.iloc[pending_retest.retest_start_idx]["timestamp"]),
+                            retest_end_timestamp_ms=int(annotated.iloc[pending_retest.retest_end_idx]["timestamp"]),
                             status="confirmation_not_received",
                         )
                     )
@@ -707,8 +705,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                                 level_price=pending_breakout.level.price.value,
                                 retest_low=float(row["low"]),
                                 retest_high=float(row["high"]),
-                                retest_start_time=pd.to_datetime(row["timestamp"], unit="ms"),
-                                retest_end_time=pd.to_datetime(row["timestamp"], unit="ms"),
+                                retest_start_timestamp_ms=int(row["timestamp"]),
+                                retest_end_timestamp_ms=int(row["timestamp"]),
                                 status="rejected_by_volume",
                             )
                         )
@@ -734,8 +732,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                                 level_price=pending_breakout.level.price.value,
                                 retest_low=float(row["low"]),
                                 retest_high=float(row["high"]),
-                                retest_start_time=pd.to_datetime(row["timestamp"], unit="ms"),
-                                retest_end_time=pd.to_datetime(row["timestamp"], unit="ms"),
+                                retest_start_timestamp_ms=int(row["timestamp"]),
+                                retest_end_timestamp_ms=int(row["timestamp"]),
                                 status="rejected_by_extra_filters",
                             )
                         )
@@ -807,7 +805,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                 params.symbol,
                 params.levels_timeframe.value,
                 params.entry_timeframe.value,
-                pending_signal.entry_time.isoformat(),
+                str(pending_signal.entry_timestamp_ms),
                 pending_signal.entry_price.value,
             )
 
@@ -823,16 +821,16 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                     level_price=pending_retest.breakout.level.price.value,
                     retest_low=pending_retest.retest_low,
                     retest_high=pending_retest.retest_high,
-                    retest_start_time=pd.to_datetime(annotated.iloc[pending_retest.retest_start_idx]["timestamp"], unit="ms"),
-                    retest_end_time=pd.to_datetime(annotated.iloc[pending_retest.retest_end_idx]["timestamp"], unit="ms"),
+                    retest_start_timestamp_ms=int(annotated.iloc[pending_retest.retest_start_idx]["timestamp"]),
+                    retest_end_timestamp_ms=int(annotated.iloc[pending_retest.retest_end_idx]["timestamp"]),
                     status="pending_end_of_data",
                 )
             )
 
         if active_sim is not None and active_sim.position is not None:
             final_row = annotated.iloc[-1]
-            final_time = pd.to_datetime(final_row["timestamp"], unit="ms").to_pydatetime()
-            trades.append(active_sim.close_position(price=float(final_row["close"]), exit_time=final_time))
+            final_timestamp_ms = int(final_row["timestamp"])
+            trades.append(active_sim.close_position(price=float(final_row["close"]), exit_timestamp_ms=final_timestamp_ms))
 
         diagnostics["trades_generated"] = len(trades)
         diagnostics["retest_plot_spans"] = retest_plot_spans

--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -118,7 +118,7 @@ class BacktestRunner:
             )
             raise RuntimeError(msg)
 
-        sorted_trades = sorted(trades, key=lambda trade: (trade.exit_time, trade.entry_time))
+        sorted_trades = sorted(trades, key=lambda trade: (trade.exit_timestamp_ms, trade.entry_timestamp_ms))
         cumulative_pnl = BACKTEST_EMPTY_PNL_PERCENT
         peak_pnl = BACKTEST_EMPTY_PNL_PERCENT
         max_dd = BACKTEST_EMPTY_MAX_DD

--- a/vectorbt_runner/data_preparer.py
+++ b/vectorbt_runner/data_preparer.py
@@ -26,8 +26,8 @@ from vectorbt_runner.vectorbt_inputs import VectorbtInputs
 
 
 # region Приватные
-def _to_timestamp(value: object) -> pd.Timestamp:
-    return pd.Timestamp(value)
+def _to_timestamp(value: int) -> pd.Timestamp:
+    return pd.to_datetime(value, unit="ms")
 
 
 # endregion Приватные
@@ -100,11 +100,11 @@ class DataPreparer:
                 trades=trades_frame,
             )
 
-        trades_sorted = sorted(trades, key=lambda trade: (trade.entry_time, trade.exit_time))
+        trades_sorted = sorted(trades, key=lambda trade: (trade.entry_timestamp_ms, trade.exit_timestamp_ms))
         trade_rows = [
             {
-                "entry_time": _to_timestamp(trade.entry_time),
-                "exit_time": _to_timestamp(trade.exit_time),
+                "entry_timestamp_ms": int(trade.entry_timestamp_ms),
+                "exit_timestamp_ms": int(trade.exit_timestamp_ms),
                 "pnl": float(trade.pnl),
                 "pnl_percent": float(trade.pnl_percent.value),
                 "result_type": trade.result_type.value,
@@ -114,7 +114,7 @@ class DataPreparer:
         trades_frame = pd.DataFrame(trade_rows)
 
         timeline = pd.DatetimeIndex(
-            sorted(set(trades_frame["entry_time"].tolist() + trades_frame["exit_time"].tolist()))
+            sorted(set(trades_frame["entry_timestamp_ms"].map(_to_timestamp).tolist() + trades_frame["exit_timestamp_ms"].map(_to_timestamp).tolist()))
         )
         close = pd.Series(initial_price, index=timeline, dtype=DATA_PREPARER_EMPTY_FLOAT_DTYPE)
         entries = pd.Series(False, index=timeline, dtype=DATA_PREPARER_EMPTY_BOOL_DTYPE)
@@ -124,8 +124,8 @@ class DataPreparer:
         running_price = float(initial_price)
         cumulative_pnl = SIMULATION_ZERO_VALUE
         for trade in trade_rows:
-            entry_time = trade["entry_time"]
-            exit_time = trade["exit_time"]
+            entry_time = _to_timestamp(int(trade["entry_timestamp_ms"]))
+            exit_time = _to_timestamp(int(trade["exit_timestamp_ms"]))
             pnl_percent = trade["pnl_percent"]
             pnl = trade["pnl"]
 

--- a/vectorbt_runner/strategy_plotter.py
+++ b/vectorbt_runner/strategy_plotter.py
@@ -201,8 +201,8 @@ class StrategyPlotter:
             ax.plot(plot_time, annotated["close"], color="black", linewidth=1.0, label="15m close")
             ax.axhline(span.level_price, color="royalblue", linestyle="--", linewidth=1.2, label="daily level")
 
-            x_start = mdates.date2num(span.retest_start_time.to_pydatetime())
-            x_end = mdates.date2num(span.retest_end_time.to_pydatetime())
+            x_start = mdates.date2num(pd.to_datetime(span.retest_start_timestamp_ms, unit="ms").to_pydatetime())
+            x_end = mdates.date2num(pd.to_datetime(span.retest_end_timestamp_ms, unit="ms").to_pydatetime())
             rect = Rectangle(
                 (x_start, span.retest_low),
                 max(x_end - x_start, 1e-9),
@@ -217,11 +217,11 @@ class StrategyPlotter:
             ax.xaxis_date()
             ax.grid(alpha=0.3)
             ax.legend(loc="upper left")
-            ax.set_title(f"{symbol} retest {span.side.value} ({span.status}) @ {span.retest_start_time}")
+            ax.set_title(f"{symbol} retest {span.side.value} ({span.status}) @ {pd.to_datetime(span.retest_start_timestamp_ms, unit='ms')}")
             ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d %H:%M"))
             fig.autofmt_xdate()
 
-            timestamp = span.retest_start_time.strftime("%Y%m%d_%H%M%S")
+            timestamp = pd.to_datetime(span.retest_start_timestamp_ms, unit="ms").strftime("%Y%m%d_%H%M%S")
             output_path = symbol_dir / f"retest_{timestamp}_{span.side.value}_{span.status}.png"
             fig.tight_layout()
             fig.savefig(output_path, dpi=150)


### PR DESCRIPTION
### Motivation
- Убрать в стратегии пробоя постоянные преобразования `pd.to_datetime(..., unit="ms")` / `.to_pydatetime()` и работать с целыми миллисекундными метками времени для простоты, производительности и единообразия типов по всему стеку.
- Синхронизировать доменные и симуляционных моделей, чтобы стратегия не делала никаких преобразований в `datetime` и не хранила смешанные типы времени.

### Description
- Убран вызов `pd.to_datetime(..., unit="ms")`/`.to_pydatetime()` в `strategy/breakout/breakout_strategy.py` и теперь свечи/сигналы/уровни/ретесты передаются как `int` миллисекунд (`*_timestamp_ms`).
- Переведены доменные модели на millisecond timestamps: `Candle.timestamp_ms`, `Level.formation_timestamp_ms`, `TradeSignal.entry_timestamp_ms`, `Position.entry_timestamp_ms`, `TradeResult.entry_timestamp_ms`/`exit_timestamp_ms`, `RetestPlotSpan.retest_start_timestamp_ms`/`retest_end_timestamp_ms`.
- Обновлён симулятор и классификатор (`simulation/position_simulator.py`, `simulation/trade_classifier.py`) для работы с полями `*_timestamp_ms` при открытии/закрытии позиций и построении `TradeResult`.
- Адаптированы вспомогательные модули и визуализация: `vectorbt_runner/data_preparer.py` теперь формирует колонки `entry_timestamp_ms`/`exit_timestamp_ms`, `vectorbt_runner/backtest_runner.py` сортирует по `*_timestamp_ms`, `vectorbt_runner/strategy_plotter.py` и `cli/commands.py` конвертируют/поддерживают `retest_*_timestamp_ms` (CLI парсер имеет бекворт-совместимый fallback на старые поля).
- Обновлена константа колонок трейдов в `constants.py` на `("entry_timestamp_ms", "exit_timestamp_ms", "pnl", "pnl_percent", "result_type")`.

### Testing
- Выполнена проверка компиляции модулей командой `python -m compileall strategy domain simulation vectorbt_runner cli constants.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991f5d62a44832083730fcc72bed47e)