### PR TITLE
Rename breakout/retest event time fields to unix ms timestamps

### DIFF
--- a/domain/models/breakout_event.py
+++ b/domain/models/breakout_event.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 
 from domain.models.level import Level
 from domain.value_objects.price import Price
@@ -13,7 +12,7 @@ from domain.value_objects.volume import Volume
 @dataclass(frozen=True, slots=True)
 class BreakoutEvent:
     level: Level
-    breakout_time: datetime
+    breakout_timestamp_ms: int
     breakout_price: Price
     volume_before: Volume
     volume_after: Volume
@@ -21,8 +20,12 @@ class BreakoutEvent:
 
     # region Приватные
     def __post_init__(self) -> None:
-        if self.breakout_time is None:
-            msg = "Breakout time is required."
+        if not isinstance(self.breakout_timestamp_ms, int):
+            msg = "Breakout timestamp must be int in unix milliseconds."
+            raise TypeError(msg)
+
+        if self.breakout_timestamp_ms < 0:
+            msg = "Breakout timestamp must be non-negative."
             raise ValueError(msg)
 
         if self.volume_after.value == 0:

--- a/domain/models/retest_event.py
+++ b/domain/models/retest_event.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 
 from domain.models.breakout_event import BreakoutEvent
 from domain.value_objects.price import Price
@@ -13,18 +12,22 @@ from domain.value_objects.volume import Volume
 @dataclass(frozen=True, slots=True)
 class RetestEvent:
     breakout_event: BreakoutEvent
-    retest_time: datetime
+    retest_timestamp_ms: int
     retest_price: Price
     volume_retest: Volume
     oi_retest: Volume
 
     # region Приватные
     def __post_init__(self) -> None:
-        if self.retest_time is None:
-            msg = "Retest time is required."
+        if not isinstance(self.retest_timestamp_ms, int):
+            msg = "Retest timestamp must be int in unix milliseconds."
+            raise TypeError(msg)
+
+        if self.retest_timestamp_ms < 0:
+            msg = "Retest timestamp must be non-negative."
             raise ValueError(msg)
 
-        if self.retest_time < self.breakout_event.breakout_time:
-            msg = "Retest time cannot be earlier than breakout time."
+        if self.retest_timestamp_ms < self.breakout_event.breakout_timestamp_ms:
+            msg = "Retest timestamp cannot be earlier than breakout timestamp."
             raise ValueError(msg)
     # endregion Приватные

--- a/instruction.md
+++ b/instruction.md
@@ -173,11 +173,11 @@ SLIPPAGE=0.0005
 
 **`domain/models/breakout_event.py`:**
 
-- Датакласс BreakoutEvent: level, breakout_time, breakout_price, volume_before, volume_after, oi_value
+- Датакласс BreakoutEvent: level, breakout_timestamp_ms, breakout_price, volume_before, volume_after, oi_value
 
 **`domain/models/retest_event.py`:**
 
-- Датакласс RetestEvent: breakout_event, retest_time, retest_price, volume_retest, oi_retest
+- Датакласс RetestEvent: breakout_event, retest_timestamp_ms, retest_price, volume_retest, oi_retest
 
 **`domain/models/trade_signal.py`:**
 

--- a/utils/formatters.py
+++ b/utils/formatters.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 
-def format_datetime_human(value: datetime) -> str:
-    """Форматирует дату и время в человекочитаемый вид без таймзоны."""
-    return value.strftime("%d.%m.%Y %H:%M:%S")
+def format_datetime_human(timestamp_ms: int) -> str:
+    """Форматирует unix timestamp в миллисекундах в человекочитаемый UTC вид."""
+    if not isinstance(timestamp_ms, int):
+        msg = "Timestamp must be int in unix milliseconds."
+        raise TypeError(msg)
+    if timestamp_ms < 0:
+        msg = "Timestamp must be non-negative."
+        raise ValueError(msg)
+    return datetime.fromtimestamp(timestamp_ms / 1000, tz=UTC).strftime("%d.%m.%Y %H:%M:%S")


### PR DESCRIPTION
### Motivation
- Standardize event time representation to unix milliseconds (`int`) for simpler serialization and comparison across the codebase. 
- Enforce stricter runtime validation of timestamps (type and non-negativity) and ensure retest timestamps cannot precede breakout timestamps. 
- Update datetime formatting utility to accept the new `int` unix-ms convention.

### Description
- Replaced `BreakoutEvent.breakout_time` with `breakout_timestamp_ms: int` and added `__post_init__` checks to validate `int` type and non-negative value in `domain/models/breakout_event.py`. 
- Replaced `RetestEvent.retest_time` with `retest_timestamp_ms: int` and added `__post_init__` checks to validate `int` type, non-negative value, and `retest_timestamp_ms >= breakout_event.breakout_timestamp_ms` in `domain/models/retest_event.py`. 
- Rewrote `utils/formatters.format_datetime_human` to accept an `int` unix timestamp in milliseconds, validate it, and format to UTC human-readable string. 
- Updated documentation references in `instruction.md` to use the new field names and ran a project-wide search to remove occurrences of the old names.

### Testing
- Ran `python -m compileall domain/models utils/formatters.py` to ensure modules compile successfully, and it completed without errors. 
- Ran `rg -n "\bbreakout_time\b|\bretest_time\b" domain utils instruction.md` to verify no remaining occurrences of the old field names, and the search returned no results. 
- Ran project-wide searches for the new and old identifiers to confirm replacements and to check usages, and those checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992007a0bb083208729e5c67d40324e)