### PR TITLE
Remove datetime-based human formatter from utils

### DIFF
--- a/utils/formatters.py
+++ b/utils/formatters.py
@@ -1,16 +1,3 @@
-"""Вспомогательные функции форматирования даты и времени."""
+"""Вспомогательные форматтеры без timezone и без datetime-нормализаций."""
 
 from __future__ import annotations
-
-from datetime import UTC, datetime
-
-
-def format_datetime_human(timestamp_ms: int) -> str:
-    """Форматирует unix timestamp в миллисекундах в человекочитаемый UTC вид."""
-    if not isinstance(timestamp_ms, int):
-        msg = "Timestamp must be int in unix milliseconds."
-        raise TypeError(msg)
-    if timestamp_ms < 0:
-        msg = "Timestamp must be non-negative."
-        raise ValueError(msg)
-    return datetime.fromtimestamp(timestamp_ms / 1000, tz=UTC).strftime("%d.%m.%Y %H:%M:%S")


### PR DESCRIPTION
### Motivation
- Убрать неиспользуемую функцию, удалить зависимость от `datetime`/`UTC` и явно закрепить принцип работы форматтеров без timezone и без datetime-нормализаций.

### Description
- Удалён `format_datetime_human` из `utils/formatters.py`, удалён импорт `from datetime import UTC, datetime`, и обновлён docstring модуля на `"Вспомогательные форматтеры без timezone и без datetime-нормализаций."`.

### Testing
- Подтверждена отсутствие вызовов и импортов функции с помощью `rg "format_datetime_human" -n` и проверки по месту с `rg "format_datetime_human|utils\\.formatters|from utils import formatters" -n`, оба поиска не вернули результатов.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699207784ba483208a60f88db5bd02f7)