### PR TITLE
Use source timeframe timestamps instead of synthetic day buckets

### DIFF
--- a/data/liquidity/daily_volume_ranker.py
+++ b/data/liquidity/daily_volume_ranker.py
@@ -54,10 +54,9 @@ class DailyVolumeRanker:
                 continue
 
             prepared["timestamp"] = prepared["timestamp"].astype("int64")
-            prepared["day_bucket"] = prepared["timestamp"] // 86_400_000
             prepared["daily_volume_usd"] = prepared["close"] * prepared["volume"]
 
-            daily_volume = prepared.groupby("day_bucket", as_index=True)["daily_volume_usd"].sum(min_count=1).dropna()
+            daily_volume = prepared.sort_values("timestamp").dropna(subset=["daily_volume_usd"])["daily_volume_usd"]
             if daily_volume.empty:
                 logger.info(
                     "ликвидность-кэш: символ=%s исключён: не удалось посчитать дневной USD-объём",
@@ -77,4 +76,3 @@ class DailyVolumeRanker:
             result[symbol] = avg_daily_volume_usd
 
         return result
-

--- a/vectorbt_runner/strategy_plotter.py
+++ b/vectorbt_runner/strategy_plotter.py
@@ -103,35 +103,29 @@ class StrategyPlotter:
         annotated: pd.DataFrame,
         lookback: int,
     ) -> pd.DataFrame:
-        daily_from_levels = pd.DataFrame(columns=["timestamp_ms", "level_high", "level_low"])
+        daily_from_levels = pd.DataFrame(columns=["timestamp", "level_high", "level_low"])
         if not higher_base.empty:
             daily_from_levels = higher_base.copy()
             daily_from_levels["level_high"] = daily_from_levels["high"].rolling(window=lookback).max().shift(1)
             daily_from_levels["level_low"] = daily_from_levels["low"].rolling(window=lookback).min().shift(1)
-            daily_from_levels["day_bucket"] = (daily_from_levels["timestamp"] // 86_400_000).astype("int64")
             daily_from_levels = (
                 daily_from_levels.dropna(subset=["level_high", "level_low"])
                 .sort_values("timestamp")
-                .drop_duplicates(subset=["day_bucket"], keep="last")[["day_bucket", "level_high", "level_low"]]
+                .drop_duplicates(subset=["timestamp"], keep="last")[["timestamp", "level_high", "level_low"]]
                 .reset_index(drop=True)
             )
-            daily_from_levels["timestamp_ms"] = daily_from_levels["day_bucket"] * 86_400_000
-            daily_from_levels = daily_from_levels[["timestamp_ms", "level_high", "level_low"]]
         if not daily_from_levels.empty:
             return daily_from_levels
 
         if annotated.empty:
-            return pd.DataFrame(columns=["timestamp_ms", "level_high", "level_low"])
+            return pd.DataFrame(columns=["timestamp", "level_high", "level_low"])
 
         daily_from_annotated = annotated.copy()
-        daily_from_annotated["day_bucket"] = (daily_from_annotated["timestamp"] // 86_400_000).astype("int64")
-        daily_from_annotated = (
+        return (
             daily_from_annotated.sort_values("timestamp")
-            .drop_duplicates(subset=["day_bucket"], keep="last")[["day_bucket", "level_high", "level_low"]]
+            .drop_duplicates(subset=["timestamp"], keep="last")[["timestamp", "level_high", "level_low"]]
             .reset_index(drop=True)
         )
-        daily_from_annotated["timestamp_ms"] = daily_from_annotated["day_bucket"] * 86_400_000
-        return daily_from_annotated[["timestamp_ms", "level_high", "level_low"]]
 
     def plot_daily_levels(
         self,
@@ -161,10 +155,10 @@ class StrategyPlotter:
         ax_top.grid(alpha=0.3)
         ax_top.legend(loc="upper left")
 
-        ax_bottom.plot(daily_levels["timestamp_ms"], daily_levels["level_high"], label="Daily level high", color="green")
-        ax_bottom.plot(daily_levels["timestamp_ms"], daily_levels["level_low"], label="Daily level low", color="red")
+        ax_bottom.plot(daily_levels["timestamp"], daily_levels["level_high"], label="Daily level high", color="green")
+        ax_bottom.plot(daily_levels["timestamp"], daily_levels["level_low"], label="Daily level low", color="red")
         ax_bottom.fill_between(
-            daily_levels["timestamp_ms"],
+            daily_levels["timestamp"],
             daily_levels["level_low"],
             daily_levels["level_high"],
             color="lightgray",


### PR DESCRIPTION
### Motivation
- Убрать синтетическое разбиение по суткам (`day_bucket = timestamp // 86_400_000`) и обратную реконструкцию (`timestamp_ms = day_bucket * 86_400_000`), чтобы расчёт дневных уровней и дневного объёма опирался только на реальные записи уже загруженного таймфрейма. 
- Это предотвратит восстановление «дней» из intraday `timestamp` и сохранит исходную временную ось для downstream-кода и визуализаций.

### Description
- В `StrategyPlotter._build_daily_levels_frame` удалено вычисление `day_bucket` и построение `timestamp_ms`, выходной фрейм теперь содержит `timestamp`, `level_high` и `level_low` с дедупликацией по реальному `timestamp` вместо синтетического бакета. 
- В `StrategyPlotter.plot_daily_levels` заменено использование `daily_levels["timestamp_ms"]` на `daily_levels["timestamp"]` для построения линий и `fill_between`. 
- В `DailyVolumeRanker.calculate_avg_daily_volume_usd` удалено формирование `day_bucket` и группировка по нему; вместо этого рассчитывается `daily_volume_usd = close * volume` по исходным строкам выбранного ТФ и берётся среднее по этих записей (после сортировки по `timestamp` и удаления `NaN`). 
- Выполнен коммит изменений с описанием, отражающим переход на использование исходных временных меток.

### Testing
- Запущена компиляция: `python -m compileall vectorbt_runner/strategy_plotter.py data/liquidity/daily_volume_ranker.py`, компиляция прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992091760688320bd4a2f5fff3d1841)