### PR TITLE
Use raw open_interest for quality checks and remove alignment terminology

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -21,9 +21,9 @@ from constants import (
     DEFAULT_REPORT_OUTPUT_FILE,
     OI_STALE_MIN_OBSERVATIONS,
     OI_STALE_RATIO_THRESHOLD,
-    QUALITY_OI_ALIGNMENT_LEADING_GAPS_ISSUE,
-    QUALITY_OI_ALIGNMENT_MISSING_VALUES_ISSUE,
-    QUALITY_OI_ALIGNMENT_STALE_SERIES_ISSUE,
+    QUALITY_OI_LEADING_GAPS_ISSUE,
+    QUALITY_OI_MISSING_VALUES_ISSUE,
+    QUALITY_OI_STALE_SERIES_ISSUE,
     QUALITY_OI_MISSING_COLUMN_ISSUE,
     QUALITY_SEVERITY_CRITICAL,
     QUALITY_SEVERITY_ERROR,
@@ -688,7 +688,7 @@ def _make_report_inner(config: AppConfig, args: argparse.Namespace) -> int:
     return 0
 
 
-def _collect_oi_alignment_issues(frame: pd.DataFrame) -> list[dict[str, str]]:
+def _collect_oi_quality_issues(frame: pd.DataFrame) -> list[dict[str, str]]:
     if "open_interest" not in frame.columns:
         return [
             {
@@ -704,9 +704,9 @@ def _collect_oi_alignment_issues(frame: pd.DataFrame) -> list[dict[str, str]]:
     if oi.isna().any():
         issues.append(
             {
-                "issue_type": QUALITY_OI_ALIGNMENT_MISSING_VALUES_ISSUE,
+                "issue_type": QUALITY_OI_MISSING_VALUES_ISSUE,
                 "severity": QUALITY_SEVERITY_WARNING,
-                "description": "Есть пропуски open_interest после выравнивания",
+                "description": "Есть сырые пропуски open_interest",
             }
         )
 
@@ -717,28 +717,27 @@ def _collect_oi_alignment_issues(frame: pd.DataFrame) -> list[dict[str, str]]:
             if leading_missing > 0:
                 issues.append(
                     {
-                        "issue_type": QUALITY_OI_ALIGNMENT_LEADING_GAPS_ISSUE,
+                        "issue_type": QUALITY_OI_LEADING_GAPS_ISSUE,
                         "severity": QUALITY_SEVERITY_WARNING,
                         "description": "Обнаружены пропуски open_interest в начале ряда",
                     }
                 )
 
-        aligned_oi = oi.ffill()
-        aligned_valid_mask = aligned_oi.notna()
-        comparison_mask = aligned_valid_mask & aligned_valid_mask.shift(1, fill_value=False)
+        valid_mask = oi.notna()
+        comparison_mask = valid_mask & valid_mask.shift(1, fill_value=False)
         compared_observations = int(comparison_mask.sum())
 
         if compared_observations >= OI_STALE_MIN_OBSERVATIONS:
-            stale_ratio = (aligned_oi.diff().eq(0) & comparison_mask).sum() / compared_observations
+            stale_ratio = (oi.diff().eq(0) & comparison_mask).sum() / compared_observations
         else:
             stale_ratio = 0.0
 
         if stale_ratio > OI_STALE_RATIO_THRESHOLD:
             issues.append(
                 {
-                    "issue_type": QUALITY_OI_ALIGNMENT_STALE_SERIES_ISSUE,
+                    "issue_type": QUALITY_OI_STALE_SERIES_ISSUE,
                     "severity": QUALITY_SEVERITY_ERROR,
-                    "description": "open_interest почти не меняется, вероятна рассинхронизация",
+                    "description": "open_interest почти не меняется на сырых данных",
                 }
             )
 
@@ -758,12 +757,12 @@ def _build_quality_recommendations(summary: QualitySummary, symbols: dict[str, Q
 
     oi_problem_types = {
         QUALITY_OI_MISSING_COLUMN_ISSUE,
-        QUALITY_OI_ALIGNMENT_MISSING_VALUES_ISSUE,
-        QUALITY_OI_ALIGNMENT_LEADING_GAPS_ISSUE,
-        QUALITY_OI_ALIGNMENT_STALE_SERIES_ISSUE,
+        QUALITY_OI_MISSING_VALUES_ISSUE,
+        QUALITY_OI_LEADING_GAPS_ISSUE,
+        QUALITY_OI_STALE_SERIES_ISSUE,
     }
     if any(problem in oi_problem_types for problem in summary.by_issue_type):
-        recommendations.append("Ресинхронизация OI: перезапустите загрузку OI с выравниванием относительно OHLCV")
+        recommendations.append("Проверка OI-источника: перезапустите загрузку OI и проверьте сырые пропуски/аномалии")
 
     if summary.issues_total > 0 or summary.gaps_total > 0:
         recommendations.append("Повторная валидация: после исправлений выполните check-quality повторно")
@@ -820,19 +819,19 @@ def _check_quality_inner(config: AppConfig, args: argparse.Namespace) -> int:
 
         issues = validator.validate(symbol, config.fetch.timeframe, frame)
         gaps = gap_detector.detect_gaps(frame, config.fetch.timeframe)
-        oi_alignment_issues = _collect_oi_alignment_issues(frame)
+        oi_quality_issues = _collect_oi_quality_issues(frame)
 
         all_issue_types = [issue.issue_type for issue in issues]
         all_severities = [issue.severity.value for issue in issues]
-        all_issue_types.extend(item["issue_type"] for item in oi_alignment_issues)
-        all_severities.extend(item["severity"] for item in oi_alignment_issues)
+        all_issue_types.extend(item["issue_type"] for item in oi_quality_issues)
+        all_severities.extend(item["severity"] for item in oi_quality_issues)
 
         symbol_issue_counter = Counter(all_issue_types)
         symbol_severity_counter = Counter(all_severities)
         issues_by_type.update(symbol_issue_counter)
         issues_by_severity.update(symbol_severity_counter)
 
-        symbol_total_issues = len(issues) + len(oi_alignment_issues)
+        symbol_total_issues = len(issues) + len(oi_quality_issues)
         total_issues += symbol_total_issues
         total_gaps += len(gaps)
 
@@ -845,7 +844,7 @@ def _check_quality_inner(config: AppConfig, args: argparse.Namespace) -> int:
 
         logger.info(
             f"проверка-качества: {symbol} проблемы={symbol_total_issues} пропуски={len(gaps)} "
-            f"проблемы_выравнивания_oi={len(oi_alignment_issues)}"
+            f"проблемы_oi={len(oi_quality_issues)}"
         )
 
     summary = QualitySummary(

--- a/constants.py
+++ b/constants.py
@@ -129,9 +129,9 @@ REPORT_TRADES_COUNT_FILTER = 30
 REPORT_PROFIT_FACTOR_FILTER = 1.0
 REPORT_PROFITABLE_PF_THRESHOLD = 1.0
 QUALITY_OI_MISSING_COLUMN_ISSUE = "oi_missing_column"
-QUALITY_OI_ALIGNMENT_MISSING_VALUES_ISSUE = "oi_alignment_missing_values"
-QUALITY_OI_ALIGNMENT_LEADING_GAPS_ISSUE = "oi_alignment_leading_gaps"
-QUALITY_OI_ALIGNMENT_STALE_SERIES_ISSUE = "oi_alignment_stale_series"
+QUALITY_OI_MISSING_VALUES_ISSUE = "oi_missing_values"
+QUALITY_OI_LEADING_GAPS_ISSUE = "oi_leading_gaps"
+QUALITY_OI_STALE_SERIES_ISSUE = "oi_stale_series"
 QUALITY_SEVERITY_ERROR = "ERROR"
 QUALITY_SEVERITY_WARNING = "WARNING"
 QUALITY_SEVERITY_CRITICAL = "CRITICAL"
@@ -166,7 +166,7 @@ SIMULATION_PARQUET_FILE_NAME = "data.parquet"
 # Пороги качества данных
 SPREAD_TO_CLOSE_WARNING_THRESHOLD = 0.3
 OI_STALE_RATIO_THRESHOLD = 0.98
-# Минимальное число выровненных сравнений ОИ, при котором оценка доли застоя имеет смысл.
+# Минимальное число последовательных сравнений ОИ, при котором оценка доли застоя имеет смысл.
 OI_STALE_MIN_OBSERVATIONS = 3
 
 # Пороги симуляции


### PR DESCRIPTION
### Motivation

- Avoid masking real gaps/anomalies by forward-filling OI when evaluating data quality and report raw missing/stale observations. 
- Remove the misleading `alignment` terminology and make issue names/messages reflect checks on raw `open_interest` values.

### Description

- Renamed OI issue constants in `constants.py` from `QUALITY_OI_ALIGNMENT_*` to `QUALITY_OI_MISSING_VALUES_ISSUE`, `QUALITY_OI_LEADING_GAPS_ISSUE`, and `QUALITY_OI_STALE_SERIES_ISSUE`, and clarified the related comment for `OI_STALE_MIN_OBSERVATIONS`.
- Replaced `_collect_oi_alignment_issues` with `_collect_oi_quality_issues` in `cli/commands.py` and updated all call sites in the `check-quality` flow (local variable renames and log text updates).
- Removed forward-fill logic (`.ffill()`) and instead compute leading gaps, missing values and stale-series checks directly on raw `open_interest` using a `valid_mask` and neighbor comparisons; stale ratio is now computed from `oi.diff()` constrained by consecutive valid-observation mask.
- Updated issue descriptions and recommendation text to reference raw OI gaps/anomalies instead of alignment/resynchronization wording.

### Testing

- Ran `python -m py_compile cli/commands.py constants.py` to validate syntax, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699209afb51c8320aa30301a27c129d5)