### PR TITLE
Harden timestamp validation without coercion

### DIFF
--- a/data/liquidity/daily_volume_ranker.py
+++ b/data/liquidity/daily_volume_ranker.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from numbers import Integral
+
 from logging import Logger
 from pathlib import Path
 
@@ -13,6 +15,17 @@ from vectorbt_runner.data_preparer import DataPreparer
 
 class DailyVolumeRanker:
     """Ранжирует символы по среднему дневному USD-объёму из кэша."""
+
+    _UNIX_MS_MIN = 1_000_000_000_000
+    _UNIX_MS_MAX = 9_999_999_999_999
+
+    @classmethod
+    def _is_unix_ms(cls, value: object) -> bool:
+        return (
+            isinstance(value, Integral)
+            and not isinstance(value, bool)
+            and cls._UNIX_MS_MIN <= value <= cls._UNIX_MS_MAX
+        )
 
     def __init__(self, cache_dir: Path) -> None:
         self._preparer = DataPreparer(cache_dir)
@@ -44,7 +57,6 @@ class DailyVolumeRanker:
                 continue
 
             prepared = frame.copy()
-            prepared["timestamp"] = pd.to_numeric(prepared["timestamp"], errors="coerce")
             prepared = prepared.dropna(subset=["timestamp", "close", "volume"])
             if prepared.empty:
                 logger.info(
@@ -53,7 +65,16 @@ class DailyVolumeRanker:
                 )
                 continue
 
-            prepared["timestamp"] = prepared["timestamp"].astype("int64")
+            invalid_timestamp_mask = ~prepared["timestamp"].map(self._is_unix_ms)
+            invalid_timestamp_count = int(invalid_timestamp_mask.sum())
+            if invalid_timestamp_count > 0:
+                logger.info(
+                    "ликвидность-кэш: символ=%s исключён: невалидный timestamp (%d строк), ожидаются целочисленные unix ms без преобразований",
+                    symbol,
+                    invalid_timestamp_count,
+                )
+                continue
+
             prepared["daily_volume_usd"] = prepared["close"] * prepared["volume"]
 
             daily_volume = prepared.sort_values("timestamp").dropna(subset=["daily_volume_usd"])["daily_volume_usd"]

--- a/data/quality/data_validator.py
+++ b/data/quality/data_validator.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from numbers import Integral
+
 import pandas as pd
 
 from constants import SPREAD_TO_CLOSE_WARNING_THRESHOLD
@@ -12,6 +14,25 @@ from domain.models.data_quality_issue import DataQualityIssue
 
 class DataValidator:
     """Класс."""
+
+    _UNIX_MS_MIN = 1_000_000_000_000
+    _UNIX_MS_MAX = 9_999_999_999_999
+
+    @classmethod
+    def _is_valid_unix_ms_series(cls, series: pd.Series) -> pd.Series:
+        non_null = series.dropna()
+        if non_null.empty:
+            return pd.Series(False, index=series.index)
+
+        def _is_unix_ms(value: object) -> bool:
+            return (
+                isinstance(value, Integral)
+                and not isinstance(value, bool)
+                and cls._UNIX_MS_MIN <= value <= cls._UNIX_MS_MAX
+            )
+
+        return series.map(_is_unix_ms)
+
     @staticmethod
     def validate(symbol: str, timeframe: Timeframe, data: pd.DataFrame) -> list[DataQualityIssue]:
         """Проверяет данные и собирает найденные проблемы."""
@@ -41,12 +62,22 @@ class DataValidator:
             )
             return issues
 
-        ts = pd.to_numeric(normalized["timestamp"], errors="coerce")
-        if ts.notna().sum() == 0:
+        ts = normalized["timestamp"]
+        valid_ts_mask = DataValidator._is_valid_unix_ms_series(ts)
+        if not valid_ts_mask.any():
             add_dataset_issue(
                 "invalid_timestamp_series",
                 DataQualitySeverity.ERROR,
-                "Колонка timestamp не распознана как числовая серия: данные нельзя валидировать по времени, дальнейшие проверки остановлены.",
+                "Колонка timestamp должна содержать целочисленные unix ms без преобразований: данные нельзя валидировать по времени, дальнейшие проверки остановлены.",
+            )
+            return issues
+
+        invalid_ts_count = int((~valid_ts_mask).sum())
+        if invalid_ts_count > 0:
+            add_dataset_issue(
+                "invalid_timestamp_values",
+                DataQualitySeverity.ERROR,
+                f"Обнаружены невалидные timestamp ({invalid_ts_count}): требуются целочисленные unix ms без преобразований.",
             )
             return issues
 
@@ -57,9 +88,7 @@ class DataValidator:
         }
 
         def add_issue(pos: int, issue_type: str, severity: DataQualitySeverity, description: str) -> None:
-            if pd.isna(ts.iloc[pos]):
-                return
-            tstamp = int(ts.iloc[pos])
+            tstamp = ts.iloc[pos]
             issues.append(
                 DataQualityIssue(
                     symbol=symbol,
@@ -111,7 +140,7 @@ class DataValidator:
 
         for col, series in numeric_columns.items():
             if series.notna().sum() == 0:
-                valid_ts_positions = normalized.index[ts.notna()]
+                valid_ts_positions = normalized.index[valid_ts_mask]
                 if len(valid_ts_positions) == 0:
                     continue
                 add_issue(

--- a/data/quality/gap_detector.py
+++ b/data/quality/gap_detector.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from numbers import Integral
+
 import pandas as pd
 
 from constants import MILLISECONDS_IN_SECOND, TIMEFRAME_TO_DELTA
@@ -15,14 +17,29 @@ _TIMEFRAME_TO_MS = {
 
 class GapDetector:
     """Класс."""
+
+    _UNIX_MS_MIN = 1_000_000_000_000
+    _UNIX_MS_MAX = 9_999_999_999_999
+
+    @classmethod
+    def _is_unix_ms(cls, value: object) -> bool:
+        return (
+            isinstance(value, Integral)
+            and not isinstance(value, bool)
+            and cls._UNIX_MS_MIN <= value <= cls._UNIX_MS_MAX
+        )
+
     @staticmethod
     def detect_gaps(data: pd.DataFrame, timeframe: Timeframe) -> list[int]:
         """Ищет пропуски во временном ряду свечей по исходным меткам времени биржи."""
         if data.empty or "timestamp" not in data.columns:
             return []
 
-        timestamps = pd.to_numeric(data["timestamp"], errors="coerce").dropna().astype("int64")
+        timestamps = data["timestamp"].dropna()
         if timestamps.empty:
+            return []
+
+        if not timestamps.map(GapDetector._is_unix_ms).all():
             return []
 
         ts = sorted(set(timestamps.tolist()))


### PR DESCRIPTION
### Motivation
- Убрать неявные преобразования `timestamp` через `pd.to_numeric`/`astype` и обеспечить явную строгую валидацию исходных меток времени как целочисленных unix ms.
- Сделать поведение единообразным: либо fail-fast при невалидных временных данных, либо явный skip с понятными логами, но без изменения значений времени.

### Description
- В `data/quality/data_validator.py` заменена коэрцированная конверсия `timestamp` на строгую проверку значений с помощью `_is_valid_unix_ms_series`, и при невалидной серии/значениях добавляются явные dataset issues и выполнение валидатора завершается (fail-fast). 
- В `data/quality/gap_detector.py` убрана цепочка `to_numeric().dropna().astype("int64")`; теперь используются исходные `timestamp`, и если встречаются не-целочисленные/не-unix-ms значения — обработка прекращается и возвращается пустой список (без преобразований). 
- В `data/liquidity/daily_volume_ranker.py` убраны `to_numeric` и `astype("int64")` для `timestamp`, добавлена проверка `_is_unix_ms`, и при наличии невалидных `timestamp` символ логируется и пропускается без изменения временных меток. 
- Во всех трёх модулях введён единый диапазон допустимых unix ms (`_UNIX_MS_MIN/_UNIX_MS_MAX`) и соответствующие сообщения логов/issue с подчёркиванием, что преобразований не происходит.

### Testing
- Выполнена компиляция изменённых модулей командой `python -m compileall data/quality/data_validator.py data/quality/gap_detector.py data/liquidity/daily_volume_ranker.py`, которая успешно завершилась.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69920e3e8764832082f9b1e07160b9ae)