### PR TITLE
Refactor timeframe interval handling to use Timeframe.to_milliseconds()

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -818,7 +818,7 @@ def _check_quality_inner(config: AppConfig, args: argparse.Namespace) -> int:
             continue
 
         issues = validator.validate(symbol, config.fetch.timeframe, frame)
-        gaps = gap_detector.detect_gaps(frame, config.fetch.timeframe)
+        gaps = gap_detector.detect_gaps(frame, expected_step_ms=config.fetch.timeframe.to_milliseconds())
         oi_quality_issues = _collect_oi_quality_issues(frame)
 
         all_issue_types = [issue.issue_type for issue in issues]

--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -16,7 +16,6 @@ from constants import (
     MILLISECONDS_IN_SECOND,
     OHLCV_FRAME_COLUMNS,
     OPEN_INTEREST_FRAME_COLUMNS,
-    TIMEFRAME_TO_DELTA,
 )
 from data.exchanges.ccxt_types import CcxtClientOptions, CcxtFuturesApi, CcxtOpenInterestApi
 from domain.abstract.exchange_client import ExchangeClient
@@ -240,7 +239,7 @@ class CcxtFuturesClient(ExchangeClient):
 
         since = start_timestamp_ms
         ccxt_timeframe = timeframe.value
-        timeframe_ms = int(TIMEFRAME_TO_DELTA[timeframe].total_seconds() * MILLISECONDS_IN_SECOND)
+        timeframe_ms = timeframe.to_milliseconds()
         oi_limit = min(DEFAULT_FETCH_BATCH_SIZE, 500) if self.exchange == Exchange.BINANCE else DEFAULT_FETCH_BATCH_SIZE
 
         rows: list[dict[str, object]] = []

--- a/data/fetchers/ohlcv_fetcher.py
+++ b/data/fetchers/ohlcv_fetcher.py
@@ -9,7 +9,6 @@ from constants import (
     DEFAULT_LOG_LEVEL,
     DEFAULT_LOGS_DIR,
     LOG_MSG_SKIP_UP_TO_DATE,
-    TIMEFRAME_TO_DELTA,
 )
 from data.quality.data_validator import DataValidator
 from data.quality.deduplicator import Deduplicator
@@ -52,7 +51,7 @@ class OhlcvFetcher:
         watermark_column = "close"
         last_timestamp_ms = self._storage.get_last_timestamp_for_column(symbol, timeframe, watermark_column)
         if last_timestamp_ms is not None:
-            timeframe_ms = int(TIMEFRAME_TO_DELTA[timeframe].total_seconds() * 1000)
+            timeframe_ms = timeframe.to_milliseconds()
             next_start_ms = max(start_timestamp_ms, last_timestamp_ms + timeframe_ms)
 
         self._logger.info(
@@ -71,7 +70,7 @@ class OhlcvFetcher:
         data = self._exchange_client.fetch_ohlcv(symbol, timeframe, next_start_ms, end_timestamp_ms)
         data = self._deduplicator.deduplicate(data)
 
-        gaps = self._gap_detector.detect_gaps(data, timeframe)
+        gaps = self._gap_detector.detect_gaps(data, expected_step_ms=timeframe.to_milliseconds())
         if gaps:
             self._logger.info(f"OHLCV пропуски: {symbol} найдено {len(gaps)} пропусков")
 

--- a/data/fetchers/oi_fetcher.py
+++ b/data/fetchers/oi_fetcher.py
@@ -9,7 +9,6 @@ from constants import (
     DEFAULT_LOG_LEVEL,
     DEFAULT_LOGS_DIR,
     LOG_MSG_SKIP_UP_TO_DATE,
-    TIMEFRAME_TO_DELTA,
 )
 from data.quality.data_validator import DataValidator
 from data.quality.deduplicator import Deduplicator
@@ -50,7 +49,7 @@ class OiFetcher:
         watermark_column = "open_interest"
         last_timestamp_ms = self._storage.get_last_timestamp_for_column(symbol, timeframe, watermark_column)
         if last_timestamp_ms is not None:
-            timeframe_ms = int(TIMEFRAME_TO_DELTA[timeframe].total_seconds() * 1000)
+            timeframe_ms = timeframe.to_milliseconds()
             next_start_ms = max(start_timestamp_ms, last_timestamp_ms + timeframe_ms)
 
         self._logger.info(

--- a/data/quality/gap_detector.py
+++ b/data/quality/gap_detector.py
@@ -6,14 +6,6 @@ from numbers import Integral
 
 import pandas as pd
 
-from constants import MILLISECONDS_IN_SECOND, TIMEFRAME_TO_DELTA
-from domain.enums.timeframe import Timeframe
-
-_TIMEFRAME_TO_MS = {
-    timeframe: int(delta.total_seconds() * MILLISECONDS_IN_SECOND)
-    for timeframe, delta in TIMEFRAME_TO_DELTA.items()
-}
-
 
 class GapDetector:
     """Класс."""
@@ -30,7 +22,14 @@ class GapDetector:
         )
 
     @staticmethod
-    def detect_gaps(data: pd.DataFrame, timeframe: Timeframe) -> list[int]:
+    def _infer_step_ms(sorted_timestamps: list[int]) -> int | None:
+        diffs = [curr - prev for prev, curr in zip(sorted_timestamps, sorted_timestamps[1:]) if curr > prev]
+        if not diffs:
+            return None
+        return min(diffs)
+
+    @staticmethod
+    def detect_gaps(data: pd.DataFrame, expected_step_ms: int | None = None) -> list[int]:
         """Ищет пропуски во временном ряду свечей по исходным меткам времени биржи."""
         if data.empty or "timestamp" not in data.columns:
             return []
@@ -43,8 +42,8 @@ class GapDetector:
             return []
 
         ts = sorted(set(timestamps.tolist()))
-        step = _TIMEFRAME_TO_MS[timeframe]
-        if step <= 0:
+        step = expected_step_ms if expected_step_ms is not None else GapDetector._infer_step_ms(ts)
+        if step is None or step <= 0:
             return []
 
         missing: list[int] = []

--- a/domain/enums/timeframe.py
+++ b/domain/enums/timeframe.py
@@ -3,6 +3,16 @@
 from __future__ import annotations
 
 from enum import Enum
+import re
+
+
+_TIMEFRAME_PATTERN = re.compile(r"^(\d+)([mhdw])$")
+_SECONDS_PER_UNIT = {
+    "m": 60,
+    "h": 60 * 60,
+    "d": 24 * 60 * 60,
+    "w": 7 * 24 * 60 * 60,
+}
 
 
 class Timeframe(str, Enum):
@@ -14,3 +24,14 @@ class Timeframe(str, Enum):
     H4 = "4h"
     D1 = "1d"
     W1 = "1w"
+
+    def to_milliseconds(self) -> int:
+        """Возвращает длительность таймфрейма в миллисекундах."""
+        match = _TIMEFRAME_PATTERN.fullmatch(self.value)
+        if match is None:
+            raise ValueError(f"Неизвестный формат таймфрейма: {self.value}")
+
+        amount = int(match.group(1))
+        unit = match.group(2)
+        seconds = amount * _SECONDS_PER_UNIT[unit]
+        return seconds * 1000


### PR DESCRIPTION
### Motivation
- Убрать жёсткую зависимость от глобальной мапы `TIMEFRAME_TO_DELTA` и получать шаг таймфрейма напрямую из значения таймфрейма или из фактических данных ряда, чтобы сделать код менее хрупким и проще для расширения.
- Сделать детекцию пропусков в ряду более гибкой, позволяя явно передавать ожидаемый шаг или выводить его из реальных timestamp-диффов.

### Description
- Добавлен метод `Timeframe.to_milliseconds()` в `domain/enums/timeframe.py`, который парсит строковое значение таймфрейма и возвращает длину в миллисекундах.
- В `data/fetchers/ohlcv_fetcher.py` и `data/fetchers/oi_fetcher.py` заменён расчёт `timeframe_ms` через `TIMEFRAME_TO_DELTA` на `timeframe.to_milliseconds()`, и вызов `GapDetector.detect_gaps` теперь получает `expected_step_ms=timeframe.to_milliseconds()`.
- В `data/exchanges/ccxt_futures_client.py` расчёт `timeframe_ms` для батчинга OI также переведён на `timeframe.to_milliseconds()` и импорт `TIMEFRAME_TO_DELTA` убран из этих мест.
- `data/quality/gap_detector.py` переписан: убран `_TIMEFRAME_TO_MS`, добавлена возможность принять `expected_step_ms` параметром и функция `_infer_step_ms` для вывода шага из реальных timestamp-диффов при отсутствии ожидаемого шага.
- Обновлены места вызова детектора пропусков (CLI и фетчеры) для передачи ожидаемого шага явно через `timeframe.to_milliseconds()`.

### Testing
- Выполнена компиляция изменённых модулей через `python -m compileall domain/enums/timeframe.py data/fetchers/ohlcv_fetcher.py data/fetchers/oi_fetcher.py data/quality/gap_detector.py data/exchanges/ccxt_futures_client.py cli/commands.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992101b81ec8320a6068c97865c3ea9)