### PR TITLE
Fix cold-start symbol bootstrap to use exchange volume

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -172,9 +172,24 @@ def _resolve_symbols(
         min_cache_ready_symbols = min(top_n, len(exchange_symbols_normalized))
         is_cold_start = len(symbols_with_volume) < min_cache_ready_symbols
         if is_cold_start:
-            bootstrap_symbols = exchange_symbols_normalized[:top_n]
+            try:
+                bootstrap_symbols = [
+                    normalize_symbol(symbol)
+                    for symbol in exchange_client.get_futures_symbols_by_quote_volume()[:top_n]
+                    if normalize_symbol(symbol) in futures_symbol_map
+                ]
+                bootstrap_mode = "bootstrap-exchange-volume"
+            except Exception as exc:
+                logger.warning(
+                    "подбор-символов: bootstrap по объёму биржи недоступен (%s), fallback на алфавит",
+                    exc,
+                )
+                bootstrap_symbols = exchange_symbols_normalized[:top_n]
+                bootstrap_mode = "bootstrap-alphabetical-fallback"
+
             logger.info(
-                "подбор-символов: кэш пуст, выполняется bootstrap без фильтра ликвидности (режим=bootstrap mode)"
+                "подбор-символов: кэш пуст, выполняется bootstrap без фильтра ликвидности (режим=%s)",
+                bootstrap_mode,
             )
             logger.info(
                 "подбор-символов: CoinGecko отключен, всего на бирже=%s → в кэше с объёмом=%s (порог готовности=%s) → после bootstrap top_n=%s",

--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+from math import isfinite
 from typing import Any, Callable, cast
 
 import pandas as pd
@@ -181,6 +182,48 @@ class CcxtFuturesClient(ExchangeClient):
                 symbols.append(symbol)
 
         return sorted(set(symbols))
+
+    def get_futures_symbols_by_quote_volume(self) -> list[str]:
+        """Возвращает фьючерсные символы, отсортированные по 24ч quote volume (убывание)."""
+        symbols = self.get_futures_symbols()
+        if not symbols:
+            return []
+
+        tickers_payload = self._retry_exchange_startup_call(
+            operation="ccxt_fetch_tickers",
+            endpoint="fetch_tickers",
+            call=self._client.fetch_tickers,
+            args=(symbols,),
+        )
+        if not isinstance(tickers_payload, dict):
+            return symbols
+
+        def _safe_float(value: object) -> float:
+            try:
+                parsed = float(value)
+            except (TypeError, ValueError):
+                return 0.0
+            return parsed if isfinite(parsed) and parsed > 0 else 0.0
+
+        volumes_by_symbol: dict[str, float] = {}
+        for symbol in symbols:
+            ticker = tickers_payload.get(symbol)
+            if not isinstance(ticker, dict):
+                volumes_by_symbol[symbol] = 0.0
+                continue
+
+            quote_volume = _safe_float(ticker.get("quoteVolume"))
+            if quote_volume == 0.0:
+                base_volume = _safe_float(ticker.get("baseVolume"))
+                last_price = _safe_float(ticker.get("last"))
+                quote_volume = base_volume * last_price
+            volumes_by_symbol[symbol] = quote_volume
+
+        return sorted(
+            symbols,
+            key=lambda symbol: (volumes_by_symbol.get(symbol, 0.0), symbol),
+            reverse=True,
+        )
 
     def fetch_ohlcv(
         self,

--- a/data/exchanges/ccxt_types.py
+++ b/data/exchanges/ccxt_types.py
@@ -21,6 +21,10 @@ class CcxtFuturesApi(Protocol):
         """Описывает загрузку свечей через API биржи."""
         ...
 
+    def fetch_tickers(self, symbols: list[str] | None = None) -> dict[str, dict[str, object]]:
+        """Описывает загрузку тикеров через API биржи."""
+        ...
+
 
 @runtime_checkable
 class CcxtOpenInterestApi(Protocol):


### PR DESCRIPTION
## Summary
- changed `ignore_coingecko` cold-start selection to bootstrap symbols by exchange 24h quote volume instead of alphabetical order
- added `CcxtFuturesClient.get_futures_symbols_by_quote_volume()` with safe parsing and fallback using `baseVolume * last`
- extended `CcxtFuturesApi` protocol with `fetch_tickers` to keep typing consistent
- kept alphabetical fallback only when ticker bootstrap is unavailable, with explicit warning log

## Why
When cache is empty, bootstrap previously used the first `top_n` symbols alphabetically, which populated cache with non-representative markets and caused later liquidity ranking to be biased.

## Validation
- `python -m compileall cli/commands.py data/exchanges/ccxt_futures_client.py data/exchanges/ccxt_types.py`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699357ef7c44832098c7497f50df7934)