### PR TITLE
Apply requested fallback rules for negative short TP levels

### DIFF
--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -15,7 +15,6 @@ from constants import (
     STRATEGY_MIN_TP2_MULT,
     STRATEGY_MIN_VOLUME_MULT,
     STRATEGY_POSITION_SIZE,
-    STRATEGY_PRICE_EPSILON,
     STRATEGY_REQUIRED_COLUMNS,
     STRATEGY_RISK_FLOOR,
 )
@@ -301,6 +300,20 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             tp2_mult=params.tp2_mult,
             side=pending_retest.breakout.side,
         )
+        if pending_retest.breakout.side == PositionSide.SHORT:
+            if tp1 < 0:
+                self._logger.info(
+                    "signal skipped: negative tp1 symbol=%s entry_price=%.8f risk=%.8f min_rr=%.8f tp1=%.8f tp2=%.8f",
+                    params.symbol,
+                    entry_price,
+                    risk,
+                    params.min_rr,
+                    tp1,
+                    tp2,
+                )
+                return None
+            if tp2 < 0:
+                tp2 = tp1
         return TradeSignal(
             entry_price=Price(entry_price),
             entry_timestamp_ms=int(entry_row["timestamp"]),


### PR DESCRIPTION
## Summary
Implemented the exact short TP handling rules requested:
- if TP1 is negative, skip the trade
- if TP1 is positive but TP2 is negative, set TP2 = TP1
- removed epsilon/zero-floor capping logic

## Changes
- file: `strategy/breakout/breakout_strategy.py`
- restored raw short target math in `_targets_from_entry`
- added short-side post-processing in `_build_signal_from_retest`:
  - logs and returns `None` when `tp1 < 0`
  - assigns `tp2 = tp1` when `tp2 < 0`
- removed now-unused `STRATEGY_PRICE_EPSILON` import from this module

## Notes
- no tests were added per instruction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699365f21a5c8320a511bf9904b61df9)