### PR TITLE
Fail-safe построение сигналов ретеста пробоя и отдельный лог исключений

### DIFF
--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -279,9 +279,11 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         entry_idx: int,
         pending_retest: PendingRetest,
         params: BreakoutParams,
-    ) -> TradeSignal | None:
+    ) -> TradeSignal:
         if entry_idx >= len(annotated):
-            return None
+            raise ValueError(
+                f"entry_idx {entry_idx} out of range for annotated length {len(annotated)}"
+            )
         entry_row = annotated.iloc[entry_idx]
         entry_price = float(entry_row["open"])
         stop = self._resolve_stop_loss(
@@ -304,33 +306,24 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         breakout_idx = pending_retest.breakout.breakout_idx
         retest_idx = pending_retest.retest_idx
 
-        def _log_invalid_signal(reason: str) -> None:
-            self._logger.info(
-                "signal skipped: %s symbol=%s side=%s sl_mode=%s entry=%.8f stop=%.8f tp1=%.8f tp2=%.8f breakout_idx=%s retest_idx=%s",
-                reason,
-                params.symbol,
-                side.value,
-                params.sl_mode.value,
-                entry_price,
-                stop,
-                tp1,
-                tp2,
-                breakout_idx,
-                retest_idx,
+        def _raise_invalid_signal(reason: str) -> None:
+            raise ValueError(
+                "invalid signal levels: "
+                f"{reason}; symbol={params.symbol}; side={side.value}; sl_mode={params.sl_mode.value}; "
+                f"entry={entry_price:.8f}; stop={stop:.8f}; tp1={tp1:.8f}; tp2={tp2:.8f}; "
+                f"breakout_idx={breakout_idx}; retest_idx={retest_idx}; entry_idx={entry_idx}"
             )
 
         if side == PositionSide.SHORT:
             if tp1 < 0:
-                _log_invalid_signal(reason="negative tp1")
-                return None
+                _raise_invalid_signal(reason="negative tp1")
             if tp2 < 0:
                 tp2 = tp1
         if side == PositionSide.LONG and not (stop < entry_price < tp1):
-            _log_invalid_signal(reason="invalid LONG levels invariant")
-            return None
+            _raise_invalid_signal(reason="invalid LONG levels invariant")
         if side == PositionSide.SHORT and not (stop > entry_price > tp1):
-            _log_invalid_signal(reason="invalid SHORT levels invariant")
-            return None
+            _raise_invalid_signal(reason="invalid SHORT levels invariant")
+
         return TradeSignal(
             entry_price=Price(entry_price),
             entry_timestamp_ms=int(entry_row["timestamp"]),
@@ -503,6 +496,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             "signal_not_filled_end_of_data": 0,
             "breakout_pending_end_of_data": 0,
             "retest_pending_end_of_data": 0,
+            "signal_invalid_levels": 0,
+            "signal_build_unexpected_exceptions": 0,
             "trades_generated": 0,
             "retest_plot_spans": [],
         }
@@ -532,6 +527,41 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         active_level_high: float | None = None
         active_level_low: float | None = None
         active_level_start_time: int | None = None
+
+        def _safe_build_signal_from_retest(*, entry_idx: int, pending_retest_value: PendingRetest) -> TradeSignal | None:
+            try:
+                return self._build_signal_from_retest(
+                    annotated=annotated,
+                    entry_idx=entry_idx,
+                    pending_retest=pending_retest_value,
+                    params=params,
+                )
+            except ValueError as exc:
+                diagnostics["signal_invalid_levels"] += 1
+                self._logger.exception(
+                    "signal_invalid_levels symbol=%s side=%s entry_trigger=%s entry_idx=%s retest_idx=%s breakout_idx=%s error=%s",
+                    params.symbol,
+                    pending_retest_value.breakout.side.value,
+                    params.entry_trigger.value,
+                    entry_idx,
+                    pending_retest_value.retest_idx,
+                    pending_retest_value.breakout.breakout_idx,
+                    exc,
+                )
+                return None
+            except Exception as exc:  # pragma: no cover
+                diagnostics["signal_build_unexpected_exceptions"] += 1
+                self._logger.exception(
+                    "signal_build_unexpected_exception symbol=%s side=%s entry_trigger=%s entry_idx=%s retest_idx=%s breakout_idx=%s error=%s",
+                    params.symbol,
+                    pending_retest_value.breakout.side.value,
+                    params.entry_trigger.value,
+                    entry_idx,
+                    pending_retest_value.retest_idx,
+                    pending_retest_value.breakout.breakout_idx,
+                    exc,
+                )
+                return None
 
         for idx in range(len(annotated)):
             row = annotated.iloc[idx]
@@ -589,11 +619,9 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                         pending_retest.retest_idx,
                         pending_retest.breakout.breakout_idx,
                     )
-                    pending_signal = self._build_signal_from_retest(
-                        annotated=annotated,
+                    pending_signal = _safe_build_signal_from_retest(
                         entry_idx=entry_idx,
-                        pending_retest=pending_retest,
-                        params=params,
+                        pending_retest_value=pending_retest,
                     )
                     pending_retest = None
                     continue
@@ -647,11 +675,9 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                         pending_retest.retest_idx,
                         pending_retest.breakout.breakout_idx,
                     )
-                    pending_signal = self._build_signal_from_retest(
-                        annotated=annotated,
+                    pending_signal = _safe_build_signal_from_retest(
                         entry_idx=entry_idx,
-                        pending_retest=pending_retest,
-                        params=params,
+                        pending_retest_value=pending_retest,
                     )
                     pending_retest = None
                     continue
@@ -879,6 +905,16 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
 
         diagnostics["trades_generated"] = len(trades)
         diagnostics["retest_plot_spans"] = retest_plot_spans
+        exception_log_path = getattr(self._logger, "exception_log_path", None)
+        diagnostics["exception_log_path"] = exception_log_path
+        self._logger.info(
+            "generation_summary symbol=%s trades_generated=%s signal_invalid_levels=%s signal_build_unexpected_exceptions=%s exception_log_path=%s",
+            params.symbol,
+            diagnostics["trades_generated"],
+            diagnostics["signal_invalid_levels"],
+            diagnostics["signal_build_unexpected_exceptions"],
+            exception_log_path,
+        )
         self._last_generation_diagnostics = diagnostics
         return trades
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -39,6 +39,13 @@ class _ColorFormatter(logging.Formatter):
         return f"{color}{message}{self.RESET}"
 
 
+class _ExceptionOnlyFilter(logging.Filter):
+    """Пропускает только записи с исключениями и traceback."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return bool(record.exc_info)
+
+
 _NAMED_LOG_LEVELS: Final[dict[str, int]] = {
     "CRITICAL": logging.CRITICAL,
     "ERROR": logging.ERROR,
@@ -66,6 +73,7 @@ def get_logger(
     resolved_logs_dir = Path(logs_dir)
     resolved_logs_dir.mkdir(parents=True, exist_ok=True)
     file_path = resolved_logs_dir / f"{name}.log"
+    exception_file_path = resolved_logs_dir / f"{name}.exceptions.log"
 
     if not logger.handlers:
         stream_handler = logging.StreamHandler()
@@ -81,9 +89,40 @@ def get_logger(
         )
         file_handler.setLevel(resolved_level)
         file_handler.setFormatter(logging.Formatter(LOGGER_MESSAGE_FORMAT, datefmt=LOGGER_DATE_FORMAT))
+        file_handler.set_name("default_file")
         logger.addHandler(file_handler)
+
+        exception_file_handler = RotatingFileHandler(
+            exception_file_path,
+            maxBytes=LOGGER_FILE_MAX_BYTES,
+            backupCount=LOGGER_FILE_BACKUP_COUNT,
+            encoding=LOGGER_FILE_ENCODING,
+        )
+        exception_file_handler.setLevel(logging.ERROR)
+        exception_file_handler.setFormatter(logging.Formatter(LOGGER_MESSAGE_FORMAT, datefmt=LOGGER_DATE_FORMAT))
+        exception_file_handler.addFilter(_ExceptionOnlyFilter())
+        exception_file_handler.set_name("exceptions_file")
+        logger.addHandler(exception_file_handler)
     else:
         for handler in logger.handlers:
-            handler.setLevel(resolved_level)
+            if handler.get_name() == "exceptions_file":
+                handler.setLevel(logging.ERROR)
+            else:
+                handler.setLevel(resolved_level)
+        has_exception_handler = any(handler.get_name() == "exceptions_file" for handler in logger.handlers)
+        if not has_exception_handler:
+            exception_file_handler = RotatingFileHandler(
+                exception_file_path,
+                maxBytes=LOGGER_FILE_MAX_BYTES,
+                backupCount=LOGGER_FILE_BACKUP_COUNT,
+                encoding=LOGGER_FILE_ENCODING,
+            )
+            exception_file_handler.setLevel(logging.ERROR)
+            exception_file_handler.setFormatter(logging.Formatter(LOGGER_MESSAGE_FORMAT, datefmt=LOGGER_DATE_FORMAT))
+            exception_file_handler.addFilter(_ExceptionOnlyFilter())
+            exception_file_handler.set_name("exceptions_file")
+            logger.addHandler(exception_file_handler)
+
+    setattr(logger, "exception_log_path", str(exception_file_path))
 
     return logger


### PR DESCRIPTION
### Motivation

- Обеспечить отказоустойчивое поведение при построении сигналов из ретеста в ветках `IMMEDIATE` и `CONFIRMATION`, чтобы единичные невалидные кейсы не прерывали весь бэктест. 
- Сделать явную предвалидацию уровней сигнала и централизованную обработку ошибок с учётом диагностик. 
- Сохранить стек-трейсы исключений в отдельный файл для последующего анализа и добавить сводку по исключениям в итоговый лог генерации.

### Description

- `/_build_signal_from_retest` теперь выполняет строгую предвалидацию и при невалидных условиях выбрасывает `ValueError` с подробным контекстом (включая `entry_idx` и уровни). 
- В `generate_events_multi_tf` добавлен локальный обёрточный метод `_safe_build_signal_from_retest`, который вызывает `self._build_signal_from_retest`, ловит `ValueError` и любые неожиданные `Exception`, увеличивает соответствующие счётчики диагностики и логирует полные стеки через `logger.exception`, затем возвращает `None` вместо проброса. 
- В `diagnostics` добавлены поля `signal_invalid_levels`, `signal_build_unexpected_exceptions` и `exception_log_path`, и в конце работы `generate_events_multi_tf` выводится итоговая строка с этими счётчиками и путём к файлу исключений. 
- В `utils/logger.py` добавлен `RotatingFileHandler` для отдельного файла `'<name>.exceptions.log'` с фильтром `_ExceptionOnlyFilter` (пропускает записи с `exc_info`) и атрибут `logger.exception_log_path` с путём к файлу для включения в diagnostics.

### Testing

- Выполнена проверочная компиляция модифицированных модулей: `python -m compileall strategy/breakout/breakout_strategy.py utils/logger.py` и компиляция прошла успешно. 
- Локальная статическая проверка целостности кода (импорт/compile) не выявила синтаксических ошибок.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994baa307f883208d89da2650d3e397)