### PR TITLE
Add positive integer validation for fetch/update CLI params

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -302,6 +302,8 @@ def _resolve_fetch_anchor_timestamp_ms(config: AppConfig, end_timestamp_ms_raw: 
 
 
 def _fetch_period(config: AppConfig, days: int, end_timestamp_ms_raw: int | None = None) -> tuple[int, int]:
+    if days <= 0:
+        raise ValueError("--days must be > 0")
     end_timestamp_ms = _resolve_fetch_anchor_timestamp_ms(config, end_timestamp_ms_raw)
     start_timestamp_ms = end_timestamp_ms - (days * 86_400_000)
     return start_timestamp_ms, end_timestamp_ms
@@ -383,6 +385,14 @@ def _resolve_timeframe(value: str | None, *, fallback: Timeframe, argument_name:
 
 def _fetch_data_inner(config: AppConfig, args: argparse.Namespace) -> int:
     logger = get_logger("fetch-data", level=config.backtest.log_level, logs_dir=config.backtest.logs_dir)
+
+    if args.top_n is not None and args.top_n <= 0:
+        logger.error("fetch-data: --top-n must be > 0")
+        return 1
+    if args.days <= 0:
+        logger.error("fetch-data: --days must be > 0")
+        return 1
+
     fetcher, exchange_client, market_client = _build_fetch_stack(config)
     futures_symbols = exchange_client.get_futures_symbols()
     all_futures_count = len(futures_symbols)
@@ -495,6 +505,14 @@ def _fetch_data_inner(config: AppConfig, args: argparse.Namespace) -> int:
 
 def _update_cache_inner(config: AppConfig, args: argparse.Namespace) -> int:
     logger = get_logger("update-cache", level=config.backtest.log_level, logs_dir=config.backtest.logs_dir)
+
+    if args.top_n is not None and args.top_n <= 0:
+        logger.error("update-cache: --top-n must be > 0")
+        return 1
+    if args.days <= 0:
+        logger.error("update-cache: --days must be > 0")
+        return 1
+
     fetcher, exchange_client, market_client = _build_fetch_stack(config)
     futures_symbols = exchange_client.get_futures_symbols()
     all_futures_count = len(futures_symbols)

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -13,14 +13,35 @@ from constants import DEFAULT_FETCH_DAYS, DEFAULT_MIN_VOLUME_USD, DEFAULT_QUALIT
 Handler = Callable[[AppConfig, argparse.Namespace], int]
 
 
+def positive_int(value: str, argument_name: str = "value") -> int:
+    """Преобразует строку в положительное целое число."""
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"{argument_name} must be > 0") from exc
+
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"{argument_name} must be > 0")
+    return parsed
+
+
+def _positive_int_for(argument_name: str) -> Callable[[str], int]:
+    """Возвращает валидатор положительного целого для конкретного аргумента."""
+
+    def _validator(value: str) -> int:
+        return positive_int(value, argument_name=argument_name)
+
+    return _validator
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Собирает и возвращает парсер аргументов CLI."""
     parser = argparse.ArgumentParser(prog="mtf-trend")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     fetch = subparsers.add_parser("fetch-data", help="Загрузка данных с бирж и CoinGecko")
-    fetch.add_argument("--top-n", type=int, default=None)
-    fetch.add_argument("--days", type=int, default=DEFAULT_FETCH_DAYS)
+    fetch.add_argument("--top-n", type=_positive_int_for("--top-n"), default=None)
+    fetch.add_argument("--days", type=_positive_int_for("--days"), default=DEFAULT_FETCH_DAYS)
     fetch.add_argument("--min-volume-usd", type=float, default=DEFAULT_MIN_VOLUME_USD)
     fetch.add_argument("--end-timestamp-ms", type=int, default=None, help="Якорный timestamp окончания периода (unix ms)")
     fetch.add_argument(
@@ -31,8 +52,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     update = subparsers.add_parser("update-cache", help="Инкрементальное обновление кэша")
-    update.add_argument("--top-n", type=int, default=None)
-    update.add_argument("--days", type=int, default=DEFAULT_UPDATE_DAYS)
+    update.add_argument("--top-n", type=_positive_int_for("--top-n"), default=None)
+    update.add_argument("--days", type=_positive_int_for("--days"), default=DEFAULT_UPDATE_DAYS)
     update.add_argument("--min-volume-usd", type=float, default=DEFAULT_MIN_VOLUME_USD)
     update.add_argument("--end-timestamp-ms", type=int, default=None, help="Якорный timestamp окончания периода (unix ms)")
     update.add_argument(


### PR DESCRIPTION
### Motivation
- Ensure that CLI numeric parameters for data fetching are strictly positive to avoid invalid runtime behaviour and confusing errors. 
- Provide user-friendly error messages for common misuses of `--top-n` and `--days` so users immediately know the fix. 
- Add defensive checks at business-logic level to avoid relying solely on CLI parsing and to fail fast with clear logs.

### Description
- Added a reusable validator `positive_int` and helper `_positive_int_for` in `cli/parser.py` and applied it to `--top-n` and `--days` for the `fetch-data` and `update-cache` subcommands so argparse messages read e.g. `--top-n must be > 0`.
- Added early validation in `cli/commands.py` inside `_fetch_data_inner` and `_update_cache_inner` that logs an error and returns `1` when `top_n` or `days` are invalid.
- Added a guard in `_fetch_period` to raise `ValueError("--days must be > 0")` when `days <= 0` to centralize period validation.
- Confirmed that existing defaults (`DEFAULT_FETCH_DAYS = 60`, `DEFAULT_UPDATE_DAYS = 7`) in `constants.py` remain valid and compatible with the new checks.

### Testing
- Ran parser checks with `build_parser().parse_args(...)` to verify that invalid inputs for `--top-n` and `--days` cause argparse errors with the new messages and that defaults parse correctly; these checks succeeded.
- Executed direct function invocations to verify `_fetch_period` raises `ValueError` for `days <= 0` and that `_fetch_data_inner`/`_update_cache_inner` log errors and return `1` on invalid inputs; these checks succeeded.
- Committed the changes with message `Validate positive CLI values for fetch/update commands` and created the PR titled `Add positive integer validation for fetch/update CLI params`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994cdd474148320b10ee822ddce73bf)