### PR TITLE
Gate diagnostics aggregation in BacktestRunner.run behind DEBUG logging

### DIFF
--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -345,6 +345,7 @@ class BacktestRunner:
         total = len(grid)
         symbols_count = len(symbol_frames)
         started_at = perf_counter()
+        collect_diagnostics = self._logger.isEnabledFor(logging.DEBUG)
 
         prepared_symbol_data: dict[str, dict[int, pd.DataFrame]] = {}
         higher_levels: dict[str, dict[int, pd.DataFrame]] = {}
@@ -394,15 +395,16 @@ class BacktestRunner:
                         higher_levels=higher_levels[symbol][params.lookback],
                         skip_validation=True,
                     )
-                    diagnostics_raw = strategy.consume_last_generation_diagnostics()
-                    diagnostics_counter = self._extract_diagnostic_counter(diagnostics_raw)
-                    rejection_diagnostics_total.update(diagnostics_counter)
-                    context = diagnostics_raw.get("context")
-                    context_symbol = symbol
-                    if isinstance(context, dict) and isinstance(context.get("symbol"), str):
-                        context_symbol = context["symbol"]
-                    key = (context_symbol, self._params_signature(cfg))
-                    rejection_diagnostics_by_key[key].update(diagnostics_counter)
+                    if collect_diagnostics:
+                        diagnostics_raw = strategy.consume_last_generation_diagnostics()
+                        diagnostics_counter = self._extract_diagnostic_counter(diagnostics_raw)
+                        rejection_diagnostics_total.update(diagnostics_counter)
+                        context = diagnostics_raw.get("context")
+                        context_symbol = symbol
+                        if isinstance(context, dict) and isinstance(context.get("symbol"), str):
+                            context_symbol = context["symbol"]
+                        key = (context_symbol, self._params_signature(cfg))
+                        rejection_diagnostics_by_key[key].update(diagnostics_counter)
                 else:
                     trades = cast("BaseStrategy[BreakoutParams]", strategy).generate_events_multi_tf(
                         mtf_frames=mtf_frames,
@@ -448,7 +450,7 @@ class BacktestRunner:
             total_trades,
             no_trades_share,
         )
-        if rejection_diagnostics_total:
+        if collect_diagnostics and rejection_diagnostics_total:
             diagnostic_parts = [
                 f"{name}={value}"
                 for name, value in rejection_diagnostics_total.most_common()
@@ -459,7 +461,8 @@ class BacktestRunner:
                 ", ".join(diagnostic_parts),
             )
 
-        self._log_zero_entry_with_retests(dict(rejection_diagnostics_by_key))
+        if collect_diagnostics:
+            self._log_zero_entry_with_retests(dict(rejection_diagnostics_by_key))
 
         self._save_results(results)
         return results


### PR DESCRIPTION
### Motivation
- Уменьшить накладные расходы и подавить диагностические логи/агрегацию, когда логгер не в режиме `DEBUG`, при этом не менять поведение генерации событий.

### Description
- Добавлен флаг `collect_diagnostics = self._logger.isEnabledFor(logging.DEBUG)` в `BacktestRunner.run` для определения необходимости сбора диагностики.
- Вызов `strategy.generate_events_multi_tf(...)` оставлен без изменений, а `consume_last_generation_diagnostics()`, преобразование в `Counter`, построение ключа `(symbol, params_signature)` и `Counter.update(...)` теперь выполняются только если `collect_diagnostics == True`.
- Логирование сводной диагностики и вызов `_log_zero_entry_with_retests(...)` в конце `run()` теперь выполняются только при `collect_diagnostics == True`.

### Testing
- Запущен локальный smoke-скрипт с `StubBreakoutStrategy` на уровне логирования `INFO`, и проверено, что сохранённый CSV и `results` содержат `5832` строк и колонки совпадают, при этом диагностика не собирается (`consume_calls=0`) — тест успешен.
- Запущен тот же smoke-скрипт на уровне `DEBUG`, и проверено, что `results` и CSV по-прежнему содержат `5832` строк и те же колонки, при этом диагностика собирается (`consume_calls=5832`) — тест успешен.
- Выводы показали, что формат/количество строк результатов не изменилось между режимами логирования, а отличаются только диагностические логи.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699586d36638832095ba42b65071b20b)