### PR TITLE
Align LEVEL stop-loss zone calculation with retest zone ratio

### DIFF
--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -321,6 +321,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             breakout_extreme=pending_retest.breakout.breakout_extreme,
             retest_low=pending_retest.retest_low,
             retest_high=pending_retest.retest_high,
+            zone_ratio=pending_retest.retest_zone_ratio,
         )
         risk = self._risk_from_entry(entry_price=entry_price, stop=stop, side=pending_retest.breakout.side)
         tp1, tp2 = self._targets_from_entry(
@@ -380,9 +381,24 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         breakout_extreme: float,
         retest_low: float,
         retest_high: float,
+        natr: float | None = None,
+        zone_ratio: float | None = None,
     ) -> float:
+        """Рассчитывает SL; для режима LEVEL использует ту же зону, что и ретест.
+
+        Приоритет зоны: явный ``zone_ratio`` -> ``resolve_retest_zone_ratio(natr)`` ->
+        фиксированный ``retest_zone`` (когда ``retest_zone_atr is None``).
+        """
         if params.sl_mode.value == "LEVEL":
-            return level * (1 - params.retest_zone) if side == PositionSide.LONG else level * (1 + params.retest_zone)
+            resolved_zone_ratio = zone_ratio
+            if resolved_zone_ratio is None:
+                if natr is not None:
+                    resolved_zone_ratio = params.resolve_retest_zone_ratio(natr)
+                elif params.retest_zone_atr is None:
+                    resolved_zone_ratio = max(params.retest_zone, 0.0)
+                else:
+                    resolved_zone_ratio = params.resolve_retest_zone_ratio(0.0)
+            return level * (1 - resolved_zone_ratio) if side == PositionSide.LONG else level * (1 + resolved_zone_ratio)
         if params.sl_mode.value == "BREAKOUT_EXTREME":
             return breakout_extreme
         return retest_low if side == PositionSide.LONG else retest_high
@@ -789,6 +805,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             retest_end_idx=None,
                             retest_low=float(row["low"]),
                             retest_high=float(row["high"]),
+                            retest_zone_ratio=params.resolve_retest_zone_ratio(max(float(row.get("natr", 0.0)), 0.0)),
                             confirmation_end_idx=idx + max(1, int(params.confirmation_bars)),
                             volume_before=volume_check["v_before"],
                             volume_after=volume_check["v_after"],

--- a/strategy/breakout/config.py
+++ b/strategy/breakout/config.py
@@ -48,7 +48,11 @@ class BreakoutParams:
     entry_timeframe: Timeframe = Timeframe.M15
 
     def resolve_retest_zone_ratio(self, natr: float) -> float:
-        """Возвращает долю зоны ретеста с учётом настроек."""
+        """Возвращает долю зоны ретеста/SL в режиме LEVEL по единому правилу.
+
+        Если задан ``retest_zone_atr``, зона считается динамически: ``retest_zone_atr * natr``.
+        Иначе используется фиксированная ``retest_zone`` для обратной совместимости.
+        """
         if self.retest_zone_atr is None:
             return max(self.retest_zone, 0.0)
         return max(self.retest_zone_atr * max(natr, 0.0), 0.0)

--- a/strategy/breakout/pending_retest.py
+++ b/strategy/breakout/pending_retest.py
@@ -15,6 +15,7 @@ class PendingRetest:
     retest_end_idx: int | None
     retest_low: float
     retest_high: float
+    retest_zone_ratio: float
     confirmation_end_idx: int
     volume_before: float
     volume_after: float


### PR DESCRIPTION
### Motivation

- Синхронизировать правило расчёта SL в режиме `LEVEL` с зоной, используемой при определении ретеста, чтобы одна и та же зона применялась при валидации ретеста и при вычислении стоп-лосса.

### Description

- Добавлено поле `retest_zone_ratio` в `PendingRetest` для фиксации рассчитанной на момент ретеста доли зоны и её дальнейшего использования.
- При создании `PendingRetest` теперь сохраняется `retest_zone_ratio = params.resolve_retest_zone_ratio(max(float(row.get("natr", 0.0)), 0.0))` для текущей свечи ретеста.
- В `_build_signal_from_retest(...)` передаётся `zone_ratio=pending_retest.retest_zone_ratio` в вызов `_resolve_stop_loss(...)`, чтобы SL использовал ту же зону, что и `_is_retest_candle`.
- Расширен `_resolve_stop_loss(...)` дополнительными аргументами `natr` и `zone_ratio` и реализовано правило приоритета зоны: явный `zone_ratio` → `params.resolve_retest_zone_ratio(natr)` → фиксированный `retest_zone` (для обратной совместимости, когда `retest_zone_atr is None`).
- Обновлён докстринг `BreakoutParams.resolve_retest_zone_ratio` и докстринг `_resolve_stop_loss` для фиксации единого правила вычисления зоны (динамическая ATR-зона при `retest_zone_atr`, иначе фиксированная `retest_zone`).

### Testing

- Выполнена проверка синтаксиса компиляцией модулей: `python -m py_compile strategy/breakout/breakout_strategy.py strategy/breakout/config.py strategy/breakout/pending_retest.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995a019113c83209920b1244d11a53d)