### PR TITLE
Add --top-n argument to run-backtest CLI and document ranking priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ CACHE_DIR=./cache
 ```
 
 Для `analyze-cache` отбор по `--top-n` выполняется по среднему объёму свечей (`volume`) на `levels_tf` (старший ТФ).
-Если одновременно переданы `--symbols` и `--top-n`, ранжируется только указанный поднабор символов.
+Приоритеты такие:
+- если одновременно переданы `--symbols` и `--top-n`, ранжирование выполняется только внутри списка `--symbols`;
+- если `--symbols` не переданы, ранжирование по `--top-n` выполняется по всем символам из кэша.
 
 Результат бектеста сохраняется в CSV (по умолчанию):
 
@@ -190,6 +192,7 @@ python launcher.py --mode fetch-cache --top-n 100 --days 30 --ignore-coingecko
 python launcher.py --mode update-cache --top-n 100 --days 7
 python launcher.py --mode update-cache --top-n 100 --days 7 --ignore-coingecko
 python launcher.py --mode analyze-cache --symbols BTC/USDT ETH/USDT
+python launcher.py --mode analyze-cache --top-n 50
 python launcher.py --mode make-report --input ./results/backtest_results.csv --output ./results/report.json
 python launcher.py --mode check-quality --symbols BTC/USDT ETH/USDT --output ./results/quality_report.json
 python launcher.py --mode plot-daily-levels --symbols BTC/USDT ETH/USDT --levels-tf 1d --entry-tf 15m --output-dir ./results/charts --limit 300
@@ -273,9 +276,12 @@ python main.py update-cache --top-n 100 --days 7 --ignore-coingecko
 # При --ignore-coingecko команда автоматически использует bootstrap mode (без фильтра ликвидности),
 # если кэш объёмов ещё не прогрет; после прогрева применяется cache-liquidity mode.
 python main.py run-backtest --top-n 50
+python main.py run-backtest --symbols BTC/USDT ETH/USDT --top-n 2
 python main.py make-report
 
 # Для run-backtest отбор по --top-n идёт по среднему объёму свечей (volume) на levels_tf.
+# Приоритеты: с --symbols ранжирование только внутри переданного списка,
+# без --symbols — по всем символам, найденным в кэше.
 python main.py check-quality
 python main.py clear-cache
 ```

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -66,6 +66,12 @@ def build_parser() -> argparse.ArgumentParser:
     run_bt = subparsers.add_parser("run-backtest", help="Запуск бектеста по данным в кэше")
     run_bt.add_argument("--symbols", nargs="*", default=None, help="Список символов, например BTC/USDT ETH/USDT")
     run_bt.add_argument(
+        "--top-n",
+        type=_positive_int_for("--top-n"),
+        default=None,
+        help="Количество символов для отбора по среднему объёму старшего ТФ",
+    )
+    run_bt.add_argument(
         "--levels-tf",
         default=None,
         help="Таймфрейм уровней (например 1d). Приоритетнее LEVELS_TIMEFRAME из env",


### PR DESCRIPTION
### Motivation
- Provide a CLI switch to limit symbols used by `run-backtest` by average volume on the higher timeframe.
- Make behavior and priority explicit in `README.md` so users understand how `--top-n` interacts with `--symbols` and launcher modes.

### Description
- Added `--top-n` to the `run-backtest` parser in `cli/parser.py` using the validator `_positive_int_for("--top-n")`, with `default=None` and help text about selection by average volume on the higher timeframe.
- Verified that `main.py` still passes raw `args` to handlers and `resolve_handler` maps `run-backtest` to `commands.run_backtest` so `args.top_n` is delivered unchanged to the command.
- Confirmed in `cli/commands.py` that `run-backtest` reads `top_n = getattr(args, "top_n", None)` and applies pre-ranking based on average `volume` from `levels_tf`.
- Updated `README.md` to include examples for `launcher.py --mode analyze-cache --top-n ...` and `main.py run-backtest --top-n ...` and to explicitly state ranking priorities when `--symbols` is or isn't provided.

### Testing
- Attempted a runtime validation by parsing `['run-backtest', '--top-n', '7']`, but the small script import failed with `ModuleNotFoundError: No module named 'pandas'` in the environment, so runtime execution could not be completed.
- Performed static inspections confirming the new argument in `cli/parser.py`, the handler mapping in `resolve_handler`, and `getattr(args, 'top_n', None)` usage in `_run_backtest_inner`; these inspections succeeded.
- Git operations (`git add`/`commit`/`show`) completed successfully and the change was committed.
- No automated unit tests were added or modified per project instruction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69960a36aab0832085445be60b2235d2)