### PR TITLE
Fix invalid BREAKOUT_EXTREME stop-loss invariants in breakout signals

### DIFF
--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -323,6 +323,11 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             retest_high=pending_retest.retest_high,
             zone_ratio=pending_retest.retest_zone_ratio,
         )
+        stop = self._normalize_stop_for_entry(
+            stop=stop,
+            entry_price=entry_price,
+            side=pending_retest.breakout.side,
+        )
         risk = self._risk_from_entry(entry_price=entry_price, stop=stop, side=pending_retest.breakout.side)
         tp1, tp2 = self._targets_from_entry(
             entry_price=entry_price,
@@ -400,8 +405,18 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                     resolved_zone_ratio = params.resolve_retest_zone_ratio(0.0)
             return level * (1 - resolved_zone_ratio) if side == PositionSide.LONG else level * (1 + resolved_zone_ratio)
         if params.sl_mode.value == "BREAKOUT_EXTREME":
-            return breakout_extreme
+            if side == PositionSide.LONG:
+                return min(breakout_extreme, retest_low)
+            return max(breakout_extreme, retest_high)
         return retest_low if side == PositionSide.LONG else retest_high
+
+    @staticmethod
+    def _normalize_stop_for_entry(*, stop: float, entry_price: float, side: PositionSide) -> float:
+        """Гарантирует, что stop-loss находится по защитную сторону от цены входа."""
+        min_distance = max(entry_price * STRATEGY_RISK_FLOOR, STRATEGY_PRICE_EPSILON)
+        if side == PositionSide.LONG:
+            return min(stop, entry_price - min_distance)
+        return max(stop, entry_price + min_distance)
 
     @staticmethod
     def _risk_from_entry(*, entry_price: float, stop: float, side: PositionSide) -> float:


### PR DESCRIPTION
## Summary
- fix root cause of repeated `signal skipped: invalid ... levels invariant` for `sl_mode=BREAKOUT_EXTREME`
- for BREAKOUT_EXTREME stops, anchor stop to the safer side of both breakout and retest extremes:
  - LONG: `min(breakout_extreme, retest_low)`
  - SHORT: `max(breakout_extreme, retest_high)`
- add stop normalization relative to entry to guarantee protective placement with minimum distance based on risk floor

## Why
Backtest logs showed many skipped signals where stop-loss was on the wrong side of entry (or equal), especially for SHORT entries after retest. This happened because stop calculation in BREAKOUT_EXTREME used only breakout candle extreme, which can become non-protective by the actual entry candle.

## Impact
- eliminates invalid stop/entry geometry at signal construction
- reduces noisy skipped-signal logs caused by non-protective stops
- keeps risk/TP calculations consistent by ensuring positive protective distance

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69960dcc418c8320938357fc141de8dc)