### PR TITLE
Add analyze-cache trade plots and --plot flag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ CACHE_DIR=./cache
 ```
 
 Для `analyze-cache` отбор по `--top-n` выполняется по среднему объёму свечей (`volume`) на `levels_tf` (старший ТФ).
+Чтобы сразу строить графики сделок с точкой входа, TP1, TP2, SL и финалом сделки, добавь `--plot true` (изображения сохраняются в `cache/results/trade_plots`, можно переопределить через `--output-dir`).
 Приоритеты такие:
 - если одновременно переданы `--symbols` и `--top-n`, ранжирование выполняется только внутри списка `--symbols`;
 - если `--symbols` не переданы, ранжирование по `--top-n` выполняется по всем символам из кэша.
@@ -193,6 +194,7 @@ python launcher.py --mode update-cache --top-n 100 --days 7
 python launcher.py --mode update-cache --top-n 100 --days 7 --ignore-coingecko
 python launcher.py --mode analyze-cache --symbols BTC/USDT ETH/USDT
 python launcher.py --mode analyze-cache --top-n 50
+python launcher.py --mode analyze-cache --top-n 50 --plot true
 python launcher.py --mode make-report --input ./results/backtest_results.csv --output ./results/report.json
 python launcher.py --mode check-quality --symbols BTC/USDT ETH/USDT --output ./results/quality_report.json
 python launcher.py --mode plot-daily-levels --symbols BTC/USDT ETH/USDT --levels-tf 1d --entry-tf 15m --output-dir ./results/charts --limit 300
@@ -211,7 +213,7 @@ python launcher.py --mode clear-cache
   "tasks": [
     { "mode": "fetch-cache", "top_n": 100, "days": 30, "ignore_coingecko": true },
     { "mode": "update-cache", "top_n": 100, "days": 7, "ignore_coingecko": false },
-    { "mode": "analyze-cache", "symbols": ["BTC/USDT", "ETH/USDT"] },
+    { "mode": "analyze-cache", "symbols": ["BTC/USDT", "ETH/USDT"], "plot": true },
     { "mode": "make-report", "output": "./results/report.json" },
     { "mode": "check-quality", "output": "./results/quality_report.json" },
     {

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -44,9 +44,12 @@ from data.quality.data_validator import DataValidator
 from data.quality.gap_detector import GapDetector
 from data.storage.parquet_storage import ParquetStorage
 from domain.enums.exchange import Exchange
+from domain.enums.entry_trigger import EntryTrigger
 from domain.enums.position_side import PositionSide
+from domain.enums.sl_mode import SLMode
 from domain.enums.timeframe import Timeframe
 from domain.models.retest_plot_span import RetestPlotSpan
+from domain.models.trade_plot_span import TradePlotSpan
 from domain.models.reporting.backtest_report import BacktestReport
 from domain.models.reporting.backtest_summary import BacktestSummary
 from domain.models.reporting.optimal_parameter_ranges import OptimalParameterRanges
@@ -65,6 +68,52 @@ from vectorbt_runner import BacktestRunner, DataPreparer, SymbolMtfFrames, Strat
 # region Приватные
 
 _PROGRESS_LOG_EVERY = 100
+
+
+def _to_bool_flag(value: object, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "y", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "n", "off"}:
+        return False
+    return default
+
+
+def _build_breakout_params_from_row(
+    row: pd.Series,
+    *,
+    symbol: str,
+    levels_timeframe: Timeframe,
+    entry_timeframe: Timeframe,
+) -> BreakoutParams:
+    return BreakoutParams(
+        lookback=int(row["lookback"]),
+        volume_mult=float(row["volume_mult"]),
+        retest_window_hours=int(row["retest_window_hours"]),
+        retest_zone=float(row["retest_zone"]),
+        min_rr=float(row["min_rr"]),
+        sl_mode=SLMode(str(row["sl_mode"])),
+        tp2_mult=float(row["tp2_mult"]),
+        min_body_ratio=float(row["min_body_ratio"]),
+        min_move_atr=float(row["min_move_atr"]),
+        max_retest_depth=float(row["max_retest_depth"]),
+        confirmation_bars=int(row["confirmation_bars"]),
+        entry_trigger=EntryTrigger(str(row["entry_trigger"])),
+        symbol=symbol,
+        retest_zone_atr=(
+            None
+            if pd.isna(row.get("retest_zone_atr"))
+            else float(row["retest_zone_atr"])
+        ),
+        levels_timeframe=levels_timeframe,
+        entry_timeframe=entry_timeframe,
+    )
 
 def _run_with_logging(command_name: str, config: AppConfig, body: Callable[[], int]) -> int:
     logger = get_logger(
@@ -753,6 +802,50 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
             levels_timeframe.value,
             entry_timeframe.value,
         )
+
+    should_plot = _to_bool_flag(getattr(args, "plot", None), default=False)
+    if should_plot:
+        if results.empty:
+            logger.warning("запуск-бэктеста: plot=true, но результаты пустые")
+            return 0
+
+        best_row = results.iloc[0]
+        output_dir = Path(getattr(args, "output_dir", None) or (config.backtest.results_dir / "trade_plots"))
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        plotter = StrategyPlotter(data_preparer=preparer, strategy=strategy)
+        plotted_images = 0
+        symbols_with_plots = 0
+
+        for symbol, mtf_frames in symbol_frames.items():
+            cfg = _build_breakout_params_from_row(
+                best_row,
+                symbol=symbol,
+                levels_timeframe=levels_timeframe,
+                entry_timeframe=entry_timeframe,
+            )
+            strategy.generate_events_multi_tf(mtf_frames=mtf_frames, params=cfg)
+            diagnostics = strategy.consume_last_generation_diagnostics()
+            raw_spans = diagnostics.get("trade_plot_spans", [])
+            trade_spans = [span for span in raw_spans if isinstance(span, TradePlotSpan)]
+            saved_paths = plotter.plot_trade_setups(
+                symbol=symbol,
+                params=cfg,
+                output_dir=output_dir,
+                trade_spans=trade_spans,
+            )
+            if saved_paths:
+                symbols_with_plots += 1
+                plotted_images += len(saved_paths)
+
+        logger.info(
+            "запуск-бэктеста: plot=true, построены графики сделок symbols=%s images=%s output_dir=%s",
+            symbols_with_plots,
+            plotted_images,
+            output_dir,
+        )
+        if plotted_images == 0:
+            logger.warning("запуск-бэктеста: plot=true, но не найдено сделок для визуализации")
     return 0
 
 

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -81,6 +81,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Таймфрейм входов (например 15m). Приоритетнее ENTRY_TIMEFRAME из env",
     )
+    run_bt.add_argument("--plot", default=False, help="Строить графики сделок (true/false)")
 
     report = subparsers.add_parser("make-report", help="Сформировать JSON-отчет по результатам бектеста")
     report.add_argument("--input", default=None, help="Путь к CSV с результатами")

--- a/domain/models/__init__.py
+++ b/domain/models/__init__.py
@@ -8,6 +8,7 @@ from domain.models.position import Position
 from domain.models.retest_event import RetestEvent
 from domain.models.retest_plot_span import RetestPlotSpan
 from domain.models.symbol_info import SymbolInfo
+from domain.models.trade_plot_span import TradePlotSpan
 from domain.models.trade_result import TradeResult
 from domain.models.trade_signal import TradeSignal
 
@@ -20,6 +21,7 @@ __all__ = [
     "RetestEvent",
     "RetestPlotSpan",
     "SymbolInfo",
+    "TradePlotSpan",
     "TradeResult",
     "TradeSignal",
 ]

--- a/domain/models/trade_plot_span.py
+++ b/domain/models/trade_plot_span.py
@@ -1,0 +1,22 @@
+"""Модель данных для визуализации завершенной сделки."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from domain.enums.position_side import PositionSide
+
+
+@dataclass(frozen=True, slots=True)
+class TradePlotSpan:
+    symbol: str
+    side: PositionSide
+    entry_timestamp_ms: int
+    exit_timestamp_ms: int
+    entry_price: float
+    exit_price: float
+    stop_loss: float
+    take_profit_1: float
+    take_profit_2: float
+    result_type: str
+

--- a/launcher.py
+++ b/launcher.py
@@ -84,6 +84,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--limit", type=int, default=None, help="Ограничение числа свечей/событий для plot-режимов")
     parser.add_argument("--input", default=None, help="Входной CSV для отчета")
     parser.add_argument("--output", default=None, help="Выходной путь JSON/CSV")
+    parser.add_argument("--plot", default=None, help="Строить графики сделок (true/false) для analyze-cache")
     return parser
 
 
@@ -108,6 +109,11 @@ def _task_namespace(task: dict[str, Any], cli_args: argparse.Namespace) -> argpa
         ),
         input=task.get("input", cli_args.input),
         output=task.get("output", cli_args.output),
+        plot=(
+            _to_bool(task.get("plot"), fallback=cli_args.plot)
+            if "plot" in task
+            else _to_bool(cli_args.plot, fallback=False)
+        ),
         ignore_coingecko=(
             _to_bool(task.get("ignore_coingecko"), fallback=cli_args.ignore_coingecko)
             if "ignore_coingecko" in task

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -26,6 +26,7 @@ from domain.enums.timeframe import Timeframe
 from domain.models.candle import Candle
 from domain.models.level import Level
 from domain.models.retest_plot_span import RetestPlotSpan
+from domain.models.trade_plot_span import TradePlotSpan
 from domain.models.trade_result import TradeResult
 from domain.models.trade_signal import TradeSignal
 from domain.value_objects.price import Price
@@ -612,6 +613,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             "retest_pending_end_of_data": 0,
             "trades_generated": 0,
             "retest_plot_spans": [],
+            "trade_plot_spans": [],
             "level_score_summary": {},
         }
         diagnostics["context"] = {
@@ -683,6 +685,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         pending_breakout: PendingBreakout | None = None
         pending_retest: PendingRetest | None = None
         active_sim: StatefulPositionSimulator | None = None
+        active_trade_signal: TradeSignal | None = None
         retest_window_candles = max(1, self._hours_to_candles(params.retest_window_hours, params.entry_timeframe))
         level_idx = 0
         active_level_high: float | None = None
@@ -765,12 +768,31 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                     trade_classifier=TradeClassifier(),
                 )
                 active_sim.register_signal(pending_signal, size=STRATEGY_POSITION_SIZE)
+                active_trade_signal = pending_signal
                 pending_signal = None
 
             if active_sim is not None:
                 result = active_sim.process_candle(candle)
                 if result is not None:
                     trades.append(result)
+                    if active_trade_signal is not None:
+                        diagnostics_trade_spans = diagnostics.get("trade_plot_spans")
+                        if isinstance(diagnostics_trade_spans, list):
+                            diagnostics_trade_spans.append(
+                                TradePlotSpan(
+                                    symbol=params.symbol,
+                                    side=active_trade_signal.position_side,
+                                    entry_timestamp_ms=active_trade_signal.entry_timestamp_ms,
+                                    exit_timestamp_ms=result.exit_timestamp_ms,
+                                    entry_price=active_trade_signal.entry_price.value,
+                                    exit_price=result.exit_price.value,
+                                    stop_loss=active_trade_signal.stop_loss.value,
+                                    take_profit_1=active_trade_signal.take_profit_1.value,
+                                    take_profit_2=active_trade_signal.take_profit_2.value,
+                                    result_type=result.result_type.value,
+                                )
+                            )
+                    active_trade_signal = None
 
             active_position = active_sim is not None and active_sim.position is not None
             if active_position or pending_signal is not None:
@@ -1124,7 +1146,26 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         if active_sim is not None and active_sim.position is not None:
             final_row = annotated_rows[-1]
             final_timestamp_ms = int(final_row[0])
-            trades.append(active_sim.close_position(price=float(final_row[4]), exit_timestamp_ms=final_timestamp_ms))
+            forced_result = active_sim.close_position(price=float(final_row[4]), exit_timestamp_ms=final_timestamp_ms)
+            trades.append(forced_result)
+            if active_trade_signal is not None:
+                diagnostics_trade_spans = diagnostics.get("trade_plot_spans")
+                if isinstance(diagnostics_trade_spans, list):
+                    diagnostics_trade_spans.append(
+                        TradePlotSpan(
+                            symbol=params.symbol,
+                            side=active_trade_signal.position_side,
+                            entry_timestamp_ms=active_trade_signal.entry_timestamp_ms,
+                            exit_timestamp_ms=forced_result.exit_timestamp_ms,
+                            entry_price=active_trade_signal.entry_price.value,
+                            exit_price=forced_result.exit_price.value,
+                            stop_loss=active_trade_signal.stop_loss.value,
+                            take_profit_1=active_trade_signal.take_profit_1.value,
+                            take_profit_2=active_trade_signal.take_profit_2.value,
+                            result_type=forced_result.result_type.value,
+                        )
+                    )
+            active_trade_signal = None
 
         diagnostics["trades_generated"] = len(trades)
         diagnostics["retest_plot_spans"] = retest_plot_spans

--- a/vectorbt_runner/strategy_plotter.py
+++ b/vectorbt_runner/strategy_plotter.py
@@ -11,6 +11,7 @@ from matplotlib.patches import Rectangle
 
 from domain.enums.timeframe import Timeframe
 from domain.models.retest_plot_span import RetestPlotSpan
+from domain.models.trade_plot_span import TradePlotSpan
 from strategy.breakout.breakout_strategy import BreakoutStrategy
 from strategy.breakout.config import BreakoutParams
 from vectorbt_runner.data_preparer import DataPreparer
@@ -179,6 +180,22 @@ class StrategyPlotter:
         plt.close(fig)
         return output_path
 
+
+    @staticmethod
+    def _select_trade_window(
+        annotated: pd.DataFrame,
+        *,
+        entry_timestamp_ms: int,
+        exit_timestamp_ms: int,
+        padding_bars: int = 40,
+    ) -> pd.DataFrame:
+        if annotated.empty:
+            return annotated
+        timestamps = annotated["timestamp"].to_numpy(dtype="int64", copy=False)
+        start_idx = max(int(timestamps.searchsorted(entry_timestamp_ms, side="left")) - padding_bars, 0)
+        end_idx = min(int(timestamps.searchsorted(exit_timestamp_ms, side="right")) + padding_bars, len(annotated))
+        return annotated.iloc[start_idx:end_idx].reset_index(drop=True)
+
     def plot_retests(
         self,
         *,
@@ -226,6 +243,62 @@ class StrategyPlotter:
 
             timestamp = span.retest_start_timestamp_ms
             output_path = symbol_dir / f"retest_{timestamp}_{span.side.value}_{span.status}.png"
+            fig.tight_layout()
+            fig.savefig(output_path, dpi=150)
+            plt.close(fig)
+            saved_paths.append(output_path)
+
+        return saved_paths
+
+
+    def plot_trade_setups(
+        self,
+        *,
+        symbol: str,
+        params: BreakoutParams,
+        output_dir: Path | str,
+        trade_spans: list[TradePlotSpan],
+    ) -> list[Path]:
+        """Строит отдельные графики сделок с точками входа/выхода и уровнями TP/SL."""
+        annotated = self._load_annotated(symbol=symbol, params=params)
+        if annotated.empty:
+            return []
+
+        symbol_trades = [span for span in trade_spans if span.symbol == symbol]
+        if not symbol_trades:
+            return []
+
+        symbol_dir = self._resolve_symbol_output_dir(output_dir=output_dir, symbol=symbol)
+        saved_paths: list[Path] = []
+
+        for span in symbol_trades:
+            trade_window = self._select_trade_window(
+                annotated,
+                entry_timestamp_ms=span.entry_timestamp_ms,
+                exit_timestamp_ms=span.exit_timestamp_ms,
+            )
+            if trade_window.empty:
+                continue
+
+            fig, ax = plt.subplots(1, 1, figsize=(14, 6))
+            plot_time = trade_window["timestamp"]
+            ax.plot(plot_time, trade_window["close"], color="black", linewidth=1.0, label="15m close")
+
+            ax.axhline(span.entry_price, color="royalblue", linestyle="-", linewidth=1.2, label="entry")
+            ax.axhline(span.stop_loss, color="red", linestyle="--", linewidth=1.2, label="stop_loss")
+            ax.axhline(span.take_profit_1, color="green", linestyle="--", linewidth=1.2, label="tp1")
+            ax.axhline(span.take_profit_2, color="darkgreen", linestyle="--", linewidth=1.2, label="tp2")
+
+            ax.scatter([span.entry_timestamp_ms], [span.entry_price], color="blue", marker="^", s=70, label="entry point")
+            ax.scatter([span.exit_timestamp_ms], [span.exit_price], color="purple", marker="X", s=70, label="exit point")
+
+            ax.grid(alpha=0.3)
+            ax.legend(loc="upper left")
+            ax.set_title(f"{symbol} trade {span.side.value}: result={span.result_type}")
+            ax.xaxis.set_major_formatter(self._timestamp_formatter("%Y-%m-%d %H:%M"))
+            fig.autofmt_xdate(rotation=30)
+
+            output_path = symbol_dir / f"trade_{span.entry_timestamp_ms}_{span.side.value}_{span.result_type}.png"
             fig.tight_layout()
             fig.savefig(output_path, dpi=150)
             plt.close(fig)


### PR DESCRIPTION
## Summary
- Added `--plot` support for `analyze-cache` in `launcher.py` and task JSON execution, plus `run-backtest` parser support in `cli/parser.py`.
- Extended backtest flow in `cli/commands.py` to optionally generate trade charts after analysis (`plot=true`) using best parameter set.
- Added a new `TradePlotSpan` model and wired diagnostics generation in `BreakoutStrategy` so each finished trade carries entry/SL/TP1/TP2/exit/result info for visualization.
- Extended `StrategyPlotter` with `plot_trade_setups(...)` to render per-trade images including entry point, TP1, TP2, SL, and final exit.
- Updated README examples/documentation for `--mode analyze-cache --plot true` and JSON config usage.

## Validation
- `python -m py_compile launcher.py cli/commands.py cli/parser.py strategy/breakout/breakout_strategy.py vectorbt_runner/strategy_plotter.py domain/models/trade_plot_span.py domain/models/__init__.py`

## Notes
- Trade plots are saved to `cache/results/trade_plots` by default (or custom `--output-dir`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69961771637083209e71aa167367dde5)