### PR TITLE
Use encoded symbol path segment for strategy plot output directories

### DIFF
--- a/vectorbt_runner/strategy_plotter.py
+++ b/vectorbt_runner/strategy_plotter.py
@@ -9,6 +9,7 @@ import pandas as pd
 from matplotlib.ticker import FuncFormatter
 from matplotlib.patches import Rectangle
 
+from data.storage.parquet_storage import ParquetStorage
 from domain.enums.timeframe import Timeframe
 from domain.models.retest_plot_span import RetestPlotSpan
 from domain.models.trade_plot_span import TradePlotSpan
@@ -27,7 +28,8 @@ class StrategyPlotter:
 
     @staticmethod
     def _resolve_symbol_output_dir(output_dir: Path | str, symbol: str) -> Path:
-        symbol_dir = Path(output_dir) / symbol
+        encoded_symbol = ParquetStorage.encode_symbol_for_path(symbol)
+        symbol_dir = Path(output_dir) / encoded_symbol
         symbol_dir.mkdir(parents=True, exist_ok=True)
         return symbol_dir
 


### PR DESCRIPTION
### Motivation
- Avoid creating unsafe filesystem paths from raw `symbol` values (e.g. `AAA/BBB:CCC`) by reusing the existing symbol encoding so symbols do not produce nested folders or illegal characters while preserving the original `symbol` for human-readable titles.

### Description
- Import `ParquetStorage` and update `StrategyPlotter._resolve_symbol_output_dir` to use `ParquetStorage.encode_symbol_for_path(symbol)` when building the output directory, keeping `symbol` unchanged for plot titles.

### Testing
- Verified encoding behavior with a small script reproducing `quote(..., safe='')` and confirmed `AAA/BBB:CCC` becomes `AAA%2FBBB%3ACCC` and results in a single path segment (succeeded); attempted to import and exercise `StrategyPlotter` but the import failed due to missing `pandas` in the environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69961ddecf00832080cd39bfc54e76a9)