### PR TITLE
Handle missing open_interest when reading parquet cache

### DIFF
--- a/vectorbt_runner/data_preparer.py
+++ b/vectorbt_runner/data_preparer.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Iterable
 
 import pandas as pd
+from pyarrow import parquet as pq
 
 from constants import (
     DATA_PREPARER_EMPTY_BOOL_DTYPE,
@@ -59,7 +60,9 @@ class DataPreparer:
         if not path.exists():
             return pd.DataFrame()
 
-        required_columns_subset = list(self.INPUT_COLUMNS)
+        parquet_schema = pq.ParquetFile(path).schema
+        available_columns = set(parquet_schema.names)
+        required_columns_subset = [column for column in self.INPUT_COLUMNS if column in available_columns]
         frame = pd.read_parquet(path, columns=required_columns_subset)
         missing = [col for col in self.REQUIRED_COLUMNS if col not in frame.columns]
         if missing:


### PR DESCRIPTION
### Motivation
- Prevent backtest crashes when legacy parquet cache files contain only OHLCV and lack the optional `open_interest` column.

### Description
- Use `pyarrow.parquet.ParquetFile(path).schema` to inspect the parquet schema before reading the file.
- Filter `DataPreparer.INPUT_COLUMNS` to only request columns that actually exist in the parquet file and then call `pd.read_parquet(...)` with that subset.
- Keep required strategy columns (`timestamp`, `open`, `high`, `low`, `close`, `volume`) enforced while treating `open_interest` as optional.
- Changes are implemented in `vectorbt_runner/data_preparer.py` and add an import of `pyarrow.parquet`.

### Testing
- Ran `python -m compileall vectorbt_runner/data_preparer.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699626190d3c8320a035743871f27a74)