### PR TITLE
Add explicit pd.Series typing for numeric columns

### DIFF
--- a/data/quality/data_validator.py
+++ b/data/quality/data_validator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from numbers import Integral
+from typing import cast
 
 import pandas as pd
 
@@ -81,8 +82,8 @@ class DataValidator:
             )
             return issues
 
-        numeric_columns = {
-            col: pd.to_numeric(normalized[col], errors="coerce")
+        numeric_columns: dict[str, pd.Series] = {
+            col: cast(pd.Series, pd.to_numeric(normalized[col], errors="coerce"))
             for col in ("open", "high", "low", "close", "volume", "open_interest")
             if col in normalized.columns
         }
@@ -119,10 +120,10 @@ class DataValidator:
                     add_issue(int(pos), issue_type, DataQualitySeverity.ERROR, f"Negative {col} value")
 
         if {"high", "low", "close"}.issubset(numeric_columns):
-            spread = (numeric_columns["high"] - numeric_columns["low"]).abs()
-            base = numeric_columns["close"].abs().replace(0, pd.NA)
-            ratio = spread / base
-            suspicious_mask = ratio.gt(SPREAD_TO_CLOSE_WARNING_THRESHOLD) & ratio.notna()
+            spread: pd.Series = (numeric_columns["high"] - numeric_columns["low"]).abs()
+            base: pd.Series = numeric_columns["close"].abs().replace(0, pd.NA)
+            ratio: pd.Series = spread / base
+            suspicious_mask: pd.Series = ratio.gt(SPREAD_TO_CLOSE_WARNING_THRESHOLD) & ratio.notna()
             for pos in normalized.index[suspicious_mask]:
                 threshold_pct = int(SPREAD_TO_CLOSE_WARNING_THRESHOLD * 100)
                 add_issue(


### PR DESCRIPTION
### Motivation
- Ensure static inspectors and type checkers recognize numeric column values as `pd.Series` to avoid false-positive type errors when calling Series methods like `.lt()`, `.notna()`, `.abs()` and `.eq()`.
- Keep existing numeric conversion and spread/base logic unchanged while making intermediate values explicitly typed for clarity and safety.

### Description
- Added `from typing import cast` import to enable explicit casts of `pd.to_numeric(...)` results.
- Annotated `numeric_columns` as `dict[str, pd.Series]` and wrapped `pd.to_numeric(...)` with `cast(pd.Series, ...)` to ensure the values are treated as `pd.Series`.
- Kept the existing `spread` / `base` formulas but added explicit `pd.Series` annotations for `spread`, `base`, `ratio`, and `suspicious_mask` so chained Series operations are correctly recognized.
- Did not change the runtime logic or the formulas used to compute spread, ratio, or masks.

### Testing
- Compiled the module with `python -m compileall data/quality/data_validator.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996da7d1a888320a89feeba6c62f8c3)