### PR TITLE
Add `level_start_timestamp_ms` to plot spans and draw unified Level start marker

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -1248,6 +1248,7 @@ def _load_retest_spans_artifact(path: Path, logger: Logger) -> list[RetestPlotSp
                 RetestPlotSpan(
                     symbol=str(item["symbol"]),
                     side=PositionSide(str(item["side"])),
+                    level_start_timestamp_ms=int(item.get("level_start_timestamp_ms", item.get("level_start_time", item.get("retest_start_timestamp_ms", item["retest_start_time"])))),
                     level_price=float(item["level_price"]),
                     retest_low=float(item["retest_low"]),
                     retest_high=float(item["retest_high"]),

--- a/domain/models/retest_plot_span.py
+++ b/domain/models/retest_plot_span.py
@@ -13,10 +13,10 @@ class RetestPlotSpan:
 
     symbol: str
     side: PositionSide
+    level_start_timestamp_ms: int
     level_price: float
     retest_low: float
     retest_high: float
     retest_start_timestamp_ms: int
     retest_end_timestamp_ms: int
     status: str
-

--- a/domain/models/trade_plot_span.py
+++ b/domain/models/trade_plot_span.py
@@ -11,6 +11,7 @@ from domain.enums.position_side import PositionSide
 class TradePlotSpan:
     symbol: str
     side: PositionSide
+    level_start_timestamp_ms: int
     entry_timestamp_ms: int
     exit_timestamp_ms: int
     entry_price: float
@@ -19,4 +20,3 @@ class TradePlotSpan:
     take_profit_1: float
     take_profit_2: float
     result_type: str
-

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -786,6 +786,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                                 TradePlotSpan(
                                     symbol=params.symbol,
                                     side=active_trade_signal.position_side,
+                                    level_start_timestamp_ms=active_trade_signal.formation_timestamp_ms,
                                     entry_timestamp_ms=active_trade_signal.entry_timestamp_ms,
                                     exit_timestamp_ms=result.exit_timestamp_ms,
                                     entry_price=active_trade_signal.entry_price.value,
@@ -810,6 +811,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                         RetestPlotSpan(
                             symbol=params.symbol,
                             side=pending_retest.breakout.side,
+                            level_start_timestamp_ms=pending_retest.breakout.level_start_time,
                             level_price=pending_retest.breakout.level.price.value,
                             retest_low=pending_retest.retest_low,
                             retest_high=pending_retest.retest_high,
@@ -844,6 +846,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                         RetestPlotSpan(
                             symbol=params.symbol,
                             side=pending_retest.breakout.side,
+                            level_start_timestamp_ms=pending_retest.breakout.level_start_time,
                             level_price=pending_retest.breakout.level.price.value,
                             retest_low=pending_retest.retest_low,
                             retest_high=pending_retest.retest_high,
@@ -868,6 +871,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                         RetestPlotSpan(
                             symbol=params.symbol,
                             side=pending_retest.breakout.side,
+                            level_start_timestamp_ms=pending_retest.breakout.level_start_time,
                             level_price=pending_retest.breakout.level.price.value,
                             retest_low=pending_retest.retest_low,
                             retest_high=pending_retest.retest_high,
@@ -901,6 +905,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                         RetestPlotSpan(
                             symbol=params.symbol,
                             side=pending_retest.breakout.side,
+                            level_start_timestamp_ms=pending_retest.breakout.level_start_time,
                             level_price=pending_retest.breakout.level.price.value,
                             retest_low=pending_retest.retest_low,
                             retest_high=pending_retest.retest_high,
@@ -982,6 +987,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             RetestPlotSpan(
                                 symbol=params.symbol,
                                 side=pending_breakout.side,
+                                level_start_timestamp_ms=pending_breakout.level_start_time,
                                 level_price=pending_breakout.level.price.value,
                                 retest_low=float(row["low"]),
                                 retest_high=float(row["high"]),
@@ -1009,6 +1015,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             RetestPlotSpan(
                                 symbol=params.symbol,
                                 side=pending_breakout.side,
+                                level_start_timestamp_ms=pending_breakout.level_start_time,
                                 level_price=pending_breakout.level.price.value,
                                 retest_low=float(row["low"]),
                                 retest_high=float(row["high"]),
@@ -1138,6 +1145,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                 RetestPlotSpan(
                     symbol=params.symbol,
                     side=pending_retest.breakout.side,
+                    level_start_timestamp_ms=pending_retest.breakout.level_start_time,
                     level_price=pending_retest.breakout.level.price.value,
                     retest_low=pending_retest.retest_low,
                     retest_high=pending_retest.retest_high,
@@ -1159,6 +1167,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                         TradePlotSpan(
                             symbol=params.symbol,
                             side=active_trade_signal.position_side,
+                            level_start_timestamp_ms=active_trade_signal.formation_timestamp_ms,
                             entry_timestamp_ms=active_trade_signal.entry_timestamp_ms,
                             exit_timestamp_ms=forced_result.exit_timestamp_ms,
                             entry_price=active_trade_signal.entry_price.value,

--- a/vectorbt_runner/strategy_plotter.py
+++ b/vectorbt_runner/strategy_plotter.py
@@ -31,6 +31,8 @@ class StrategyPlotter:
     TV_BULL = "#089981"
     TV_BEAR = "#f23645"
     TV_ENTRY = "#4ea4dc"
+    TV_LEVEL_START = "#94a3b8"
+    TV_LEVEL_START_LINESTYLE = "-."
 
     def __init__(self, data_preparer: DataPreparer, strategy: BreakoutStrategy) -> None:
         self._data_preparer = data_preparer
@@ -378,6 +380,14 @@ class StrategyPlotter:
                 linestyle="--",
                 linewidth=1.2,
             )
+            level_start_time = pd.to_datetime(span.level_start_timestamp_ms, unit="ms")
+            ax.axvline(
+                x=level_start_time,
+                color=self.TV_LEVEL_START,
+                linestyle=self.TV_LEVEL_START_LINESTYLE,
+                linewidth=1.3,
+                alpha=0.9,
+            )
 
             x_start = pd.to_datetime(span.retest_start_timestamp_ms, unit="ms")
             x_end = pd.to_datetime(span.retest_end_timestamp_ms, unit="ms")
@@ -400,6 +410,7 @@ class StrategyPlotter:
                     Line2D([0], [0], color="#22c55e", linewidth=6, label="Bull candle"),
                     Line2D([0], [0], color="#ef4444", linewidth=6, label="Bear candle"),
                     Line2D([0], [0], color="#38bdf8", linestyle="--", linewidth=2, label="Daily level"),
+                    Line2D([0], [0], color=self.TV_LEVEL_START, linestyle=self.TV_LEVEL_START_LINESTYLE, linewidth=2, label="Level start"),
                     Line2D([0], [0], color="#f59e0b", linewidth=6, alpha=0.6, label=f"Retest ({span.status})"),
                 ],
             )
@@ -468,6 +479,7 @@ class StrategyPlotter:
             self._apply_dark_theme(ax_bottom)
             self._plot_candles(ax_top, trade_window)
 
+            level_start_time = pd.to_datetime(span.level_start_timestamp_ms, unit="ms")
             entry_time = pd.to_datetime(span.entry_timestamp_ms, unit="ms")
             exit_time = pd.to_datetime(span.exit_timestamp_ms, unit="ms")
             entry_label = pd.to_datetime(span.entry_timestamp_ms, unit="ms", utc=True).strftime("%Y%m%d_%H%M")
@@ -482,6 +494,13 @@ class StrategyPlotter:
             zone_end = entry_time + pd.to_timedelta(entry_bar_width_days, unit="D")
 
             ax_top.hlines(span.entry_price, entry_time, zone_end, color=self.TV_ENTRY, linestyle="-", linewidth=1.8)
+            ax_top.axvline(
+                x=level_start_time,
+                color=self.TV_LEVEL_START,
+                linestyle=self.TV_LEVEL_START_LINESTYLE,
+                linewidth=1.3,
+                alpha=0.9,
+            )
 
             price_range = float(trade_window["high"].max() - trade_window["low"].min())
             vertical_padding = max(price_range * 0.005, 1e-9)
@@ -530,6 +549,13 @@ class StrategyPlotter:
                 if higher_window.empty:
                     higher_window = higher_tf_frame
                 self._plot_candles(ax_bottom, higher_window)
+                ax_bottom.axvline(
+                    x=level_start_time,
+                    color=self.TV_LEVEL_START,
+                    linestyle=self.TV_LEVEL_START_LINESTYLE,
+                    linewidth=1.3,
+                    alpha=0.9,
+                )
 
                 level_slice = higher_tf_levels[
                     (higher_tf_levels["timestamp"] >= higher_window["timestamp"].min())
@@ -562,6 +588,7 @@ class StrategyPlotter:
                     Line2D([0], [0], color="#a6324a", linewidth=6, alpha=0.6, label="SL zone"),
                     Line2D([0], [0], color="#21875e", linewidth=6, alpha=0.6, label="TP1 zone"),
                     Line2D([0], [0], color="#0f6d54", linewidth=6, alpha=0.6, label="TP2 zone"),
+                    Line2D([0], [0], color=self.TV_LEVEL_START, linestyle=self.TV_LEVEL_START_LINESTYLE, linewidth=2, label="Level start"),
                     Line2D([0], [0], marker="^", color=self.TV_ENTRY, linestyle="None", markersize=9, label="Entry candle"),
                     Line2D([0], [0], marker="X", color="#a855f7", linestyle="None", markersize=9, label="Exit candle"),
                 ],
@@ -571,6 +598,7 @@ class StrategyPlotter:
                 [
                     Line2D([0], [0], color=self.TV_BULL, linewidth=6, label="Bull candle"),
                     Line2D([0], [0], color=self.TV_BEAR, linewidth=6, label="Bear candle"),
+                    Line2D([0], [0], color=self.TV_LEVEL_START, linestyle=self.TV_LEVEL_START_LINESTYLE, linewidth=2, label="Level start"),
                     Line2D([0], [0], color=self.TV_ENTRY, linestyle="--", linewidth=2, label="Higher TF level high"),
                     Line2D([0], [0], color="#f59e0b", linestyle="--", linewidth=2, label="Higher TF level low"),
                 ],


### PR DESCRIPTION
### Motivation
- Сделать на графиках ретестов и сделок видимым момент формирования уровня для лучшей дифференциации событий. 
- Передать timestamp старта уровня из логики стратегии в объекты визуализации для корректной отрисовки маркера. 
- Сохранить обратную совместимость при чтении старых JSON-артефактов ретестов.

### Description
- Добавлено поле `level_start_timestamp_ms: int` в `RetestPlotSpan` и `TradePlotSpan` (модели в `domain/models`).
- При создании всех `RetestPlotSpan` и `TradePlotSpan` в `strategy/breakout/breakout_strategy.py` прокинут `level_start_timestamp_ms` из соответствующего `pending_breakout`/`active_trade_signal` (`formation_timestamp_ms` / `level_start_time`).
- В `vectorbt_runner/strategy_plotter.py` добавлены `TV_LEVEL_START` и `TV_LEVEL_START_LINESTYLE`, и в `plot_retests` и `plot_trade_setups` отрисован вертикальный маркер `axvline` по `level_start_timestamp_ms` с единым цветом/стилем и добавлен пункт легенды `Level start` в обеих режимах. 
- В CLI-лоадере ретест-артефактов (`cli/commands.py`) добавлен fallback при чтении `level_start_timestamp_ms` из старых ключей (`level_start_time`, `retest_start_timestamp_ms`, `retest_start_time`) для обратной совместимости.

### Testing
- Запущена проверка синтаксиса через `ast.parse` на изменённых файлах и она вернула `ok` (успех). 
- Запущена компиляция Python модулей `python -m py_compile` для изменённых файлов и она завершилась без ошибок (успех).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69977a95dde8832099dbcc6f7b93a501)