### PR TITLE
Add active-level touch timestamps and plot touch markers

### DIFF
--- a/domain/models/trade_plot_span.py
+++ b/domain/models/trade_plot_span.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from domain.enums.position_side import PositionSide
 
@@ -20,3 +20,7 @@ class TradePlotSpan:
     take_profit_1: float
     take_profit_2: float
     result_type: str
+    level_high: float
+    level_low: float
+    resistance_touch_timestamps_ms: tuple[int, ...] = field(default_factory=tuple)
+    support_touch_timestamps_ms: tuple[int, ...] = field(default_factory=tuple)

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -559,10 +559,12 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                     "resistance_min_bars_between_touches",
                     "resistance_max_penetration_atr",
                     "resistance_max_penetration_pct",
+                    "resistance_touch_timestamps_ms",
                     "support_touch_count",
                     "support_min_bars_between_touches",
                     "support_max_penetration_atr",
                     "support_max_penetration_pct",
+                    "support_touch_timestamps_ms",
                 ],
             )
 
@@ -660,10 +662,12 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             "resistance_min_bars_between_touches",
             "resistance_max_penetration_atr",
             "resistance_max_penetration_pct",
+            "resistance_touch_timestamps_ms",
             "support_touch_count",
             "support_min_bars_between_touches",
             "support_max_penetration_atr",
             "support_max_penetration_pct",
+            "support_touch_timestamps_ms",
         ]
         higher_level_rows = list(higher_levels[higher_level_columns].itertuples(index=False, name=None))
         if (
@@ -710,10 +714,12 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         active_resistance_min_touch_gap: int = 0
         active_resistance_max_penetration_atr: float = 0.0
         active_resistance_max_penetration_pct: float = 0.0
+        active_resistance_touch_timestamps_ms: tuple[int, ...] = ()
         active_support_touch_count: int = 0
         active_support_min_touch_gap: int = 0
         active_support_max_penetration_atr: float = 0.0
         active_support_max_penetration_pct: float = 0.0
+        active_support_touch_timestamps_ms: tuple[int, ...] = ()
 
         for idx, row_values in enumerate(annotated_rows):
             row_timestamp = int(row_values[0])
@@ -746,10 +752,12 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                 active_resistance_min_touch_gap = int(level_row[8])
                 active_resistance_max_penetration_atr = float(level_row[9])
                 active_resistance_max_penetration_pct = float(level_row[10])
-                active_support_touch_count = int(level_row[11])
-                active_support_min_touch_gap = int(level_row[12])
-                active_support_max_penetration_atr = float(level_row[13])
-                active_support_max_penetration_pct = float(level_row[14])
+                active_resistance_touch_timestamps_ms = tuple(int(value) for value in level_row[11])
+                active_support_touch_count = int(level_row[12])
+                active_support_min_touch_gap = int(level_row[13])
+                active_support_max_penetration_atr = float(level_row[14])
+                active_support_max_penetration_pct = float(level_row[15])
+                active_support_touch_timestamps_ms = tuple(int(value) for value in level_row[16])
                 diagnostics["last_level_metrics"] = {
                     "touch_count": active_touch_count,
                     "reaction_strength": active_reaction_strength,
@@ -758,10 +766,12 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                     "resistance_min_bars_between_touches": active_resistance_min_touch_gap,
                     "resistance_max_penetration_atr": active_resistance_max_penetration_atr,
                     "resistance_max_penetration_pct": active_resistance_max_penetration_pct,
+                    "resistance_touch_timestamps_ms": list(active_resistance_touch_timestamps_ms),
                     "support_touch_count": active_support_touch_count,
                     "support_min_bars_between_touches": active_support_min_touch_gap,
                     "support_max_penetration_atr": active_support_max_penetration_atr,
                     "support_max_penetration_pct": active_support_max_penetration_pct,
+                    "support_touch_timestamps_ms": list(active_support_touch_timestamps_ms),
                 }
                 level_idx += 1
 
@@ -795,6 +805,10 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                                     take_profit_1=active_trade_signal.take_profit_1.value,
                                     take_profit_2=active_trade_signal.take_profit_2.value,
                                     result_type=result.result_type.value,
+                                    level_high=active_level_high if active_level_high is not None else 0.0,
+                                    level_low=active_level_low if active_level_low is not None else 0.0,
+                                    resistance_touch_timestamps_ms=active_resistance_touch_timestamps_ms,
+                                    support_touch_timestamps_ms=active_support_touch_timestamps_ms,
                                 )
                             )
                     active_trade_signal = None
@@ -1176,6 +1190,10 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             take_profit_1=active_trade_signal.take_profit_1.value,
                             take_profit_2=active_trade_signal.take_profit_2.value,
                             result_type=forced_result.result_type.value,
+                            level_high=active_level_high if active_level_high is not None else 0.0,
+                            level_low=active_level_low if active_level_low is not None else 0.0,
+                            resistance_touch_timestamps_ms=active_resistance_touch_timestamps_ms,
+                            support_touch_timestamps_ms=active_support_touch_timestamps_ms,
                         )
                     )
             active_trade_signal = None

--- a/strategy/breakout/indicators/level_detector.py
+++ b/strategy/breakout/indicators/level_detector.py
@@ -36,7 +36,7 @@ class LevelDetector:
         level: float,
         atr: float,
         is_resistance: bool,
-    ) -> tuple[int, float, float, int, float, float]:
+    ) -> tuple[int, float, float, int, float, float, list[int]]:
         atr_safe = max(float(atr), 1e-12)
         tolerance = self._config.tolerance_atr_mult * atr_safe
 
@@ -96,6 +96,7 @@ class LevelDetector:
             min_bars_between_touches,
             max_penetration_atr,
             max_penetration_pct,
+            touches,
         )
 
     def detect(self, *, higher_base: pd.DataFrame, lookback: int) -> pd.DataFrame:
@@ -114,10 +115,12 @@ class LevelDetector:
                     "resistance_min_bars_between_touches",
                     "resistance_max_penetration_atr",
                     "resistance_max_penetration_pct",
+                    "resistance_touch_timestamps_ms",
                     "support_touch_count",
                     "support_min_bars_between_touches",
                     "support_max_penetration_atr",
                     "support_max_penetration_pct",
+                    "support_touch_timestamps_ms",
                 ],
             )
 
@@ -148,10 +151,12 @@ class LevelDetector:
         resistance_min_bars_between_touches_values: list[float] = []
         resistance_max_penetration_atr_values: list[float] = []
         resistance_max_penetration_pct_values: list[float] = []
+        resistance_touch_timestamps_values: list[list[int]] = []
         support_touch_counts: list[float] = []
         support_min_bars_between_touches_values: list[float] = []
         support_max_penetration_atr_values: list[float] = []
         support_max_penetration_pct_values: list[float] = []
+        support_touch_timestamps_values: list[list[int]] = []
 
         for idx in range(len(frame)):
             candidate_high = frame.at[idx, "level_high"]
@@ -165,13 +170,16 @@ class LevelDetector:
                 resistance_min_bars_between_touches_values.append(np.nan)
                 resistance_max_penetration_atr_values.append(np.nan)
                 resistance_max_penetration_pct_values.append(np.nan)
+                resistance_touch_timestamps_values.append([])
                 support_touch_counts.append(np.nan)
                 support_min_bars_between_touches_values.append(np.nan)
                 support_max_penetration_atr_values.append(np.nan)
                 support_max_penetration_pct_values.append(np.nan)
+                support_touch_timestamps_values.append([])
                 continue
 
             window_slice = slice(idx - lookback, idx)
+            window_timestamps = frame["timestamp"].iloc[window_slice].to_numpy(dtype="int64", copy=False)
             (
                 high_touch_count,
                 high_reaction,
@@ -179,6 +187,7 @@ class LevelDetector:
                 high_min_bars_between_touches,
                 high_max_penetration_atr,
                 high_max_penetration_pct,
+                high_touch_indices,
             ) = self._score_level(
                 highs=highs[window_slice],
                 lows=lows[window_slice],
@@ -193,6 +202,7 @@ class LevelDetector:
                 low_min_bars_between_touches,
                 low_max_penetration_atr,
                 low_max_penetration_pct,
+                low_touch_indices,
             ) = self._score_level(
                 highs=highs[window_slice],
                 lows=lows[window_slice],
@@ -216,10 +226,12 @@ class LevelDetector:
             resistance_min_bars_between_touches_values.append(float(high_min_bars_between_touches))
             resistance_max_penetration_atr_values.append(float(high_max_penetration_atr))
             resistance_max_penetration_pct_values.append(float(high_max_penetration_pct))
+            resistance_touch_timestamps_values.append([int(window_timestamps[touch_idx]) for touch_idx in high_touch_indices])
             support_touch_counts.append(float(low_touch_count))
             support_min_bars_between_touches_values.append(float(low_min_bars_between_touches))
             support_max_penetration_atr_values.append(float(low_max_penetration_atr))
             support_max_penetration_pct_values.append(float(low_max_penetration_pct))
+            support_touch_timestamps_values.append([int(window_timestamps[touch_idx]) for touch_idx in low_touch_indices])
 
         frame["touch_count"] = touch_counts
         frame["reaction_strength"] = reaction_strengths
@@ -228,10 +240,12 @@ class LevelDetector:
         frame["resistance_min_bars_between_touches"] = resistance_min_bars_between_touches_values
         frame["resistance_max_penetration_atr"] = resistance_max_penetration_atr_values
         frame["resistance_max_penetration_pct"] = resistance_max_penetration_pct_values
+        frame["resistance_touch_timestamps_ms"] = resistance_touch_timestamps_values
         frame["support_touch_count"] = support_touch_counts
         frame["support_min_bars_between_touches"] = support_min_bars_between_touches_values
         frame["support_max_penetration_atr"] = support_max_penetration_atr_values
         frame["support_max_penetration_pct"] = support_max_penetration_pct_values
+        frame["support_touch_timestamps_ms"] = support_touch_timestamps_values
 
         frame = frame.dropna(
             subset=[
@@ -263,9 +277,11 @@ class LevelDetector:
                 "resistance_min_bars_between_touches",
                 "resistance_max_penetration_atr",
                 "resistance_max_penetration_pct",
+                "resistance_touch_timestamps_ms",
                 "support_touch_count",
                 "support_min_bars_between_touches",
                 "support_max_penetration_atr",
                 "support_max_penetration_pct",
+                "support_touch_timestamps_ms",
             ]
         ].reset_index(drop=True)

--- a/vectorbt_runner/strategy_plotter.py
+++ b/vectorbt_runner/strategy_plotter.py
@@ -579,6 +579,37 @@ class StrategyPlotter:
                         alpha=0.8,
                     )
 
+                trade_touch_window_start = max(int(higher_window["timestamp"].min()), span.entry_timestamp_ms)
+                trade_touch_window_end = min(int(higher_window["timestamp"].max()), span.exit_timestamp_ms)
+                resistance_touch_times = [
+                    pd.to_datetime(timestamp_ms, unit="ms")
+                    for timestamp_ms in span.resistance_touch_timestamps_ms
+                    if trade_touch_window_start <= int(timestamp_ms) <= trade_touch_window_end
+                ]
+                support_touch_times = [
+                    pd.to_datetime(timestamp_ms, unit="ms")
+                    for timestamp_ms in span.support_touch_timestamps_ms
+                    if trade_touch_window_start <= int(timestamp_ms) <= trade_touch_window_end
+                ]
+                if resistance_touch_times:
+                    ax_bottom.scatter(
+                        resistance_touch_times,
+                        [span.level_high] * len(resistance_touch_times),
+                        color=self.TV_ENTRY,
+                        marker="v",
+                        s=48,
+                        zorder=6,
+                    )
+                if support_touch_times:
+                    ax_bottom.scatter(
+                        support_touch_times,
+                        [span.level_low] * len(support_touch_times),
+                        color="#f59e0b",
+                        marker="^",
+                        s=48,
+                        zorder=6,
+                    )
+
             self._add_styled_legend(
                 ax_top,
                 [
@@ -601,6 +632,8 @@ class StrategyPlotter:
                     Line2D([0], [0], color=self.TV_LEVEL_START, linestyle=self.TV_LEVEL_START_LINESTYLE, linewidth=2, label="Level start"),
                     Line2D([0], [0], color=self.TV_ENTRY, linestyle="--", linewidth=2, label="Higher TF level high"),
                     Line2D([0], [0], color="#f59e0b", linestyle="--", linewidth=2, label="Higher TF level low"),
+                    Line2D([0], [0], marker="v", color=self.TV_ENTRY, linestyle="None", markersize=8, label="Level touch (resistance)"),
+                    Line2D([0], [0], marker="^", color="#f59e0b", linestyle="None", markersize=8, label="Level touch (support)"),
                 ],
             )
             ax_top.set_title(


### PR DESCRIPTION
### Motivation

- Make level detection provide concrete timestamps of resistance/support touches so they can be visualized and analyzed.
- Surface these touch timestamps through the strategy diagnostics and plot spans so plotter can render precise touch markers on higher-TF level lines.
- Keep trade plots readable by drawing only touches relevant to the active level inside the trade window and by adding legend entries for touch markers.

### Description

- `strategy/breakout/indicators/level_detector.py`: extended `_score_level` to return touch indices and added serializable `resistance_touch_timestamps_ms` and `support_touch_timestamps_ms` columns to returned `higher_levels` (lists of `int` timestamps derived from window indices). 
- `strategy/breakout/breakout_strategy.py`: updated `higher_level_columns` handling to expect the new timestamp fields, preserved active-level touch timestamps in local `active_*_touch_timestamps_ms` variables, included them into `last_level_metrics` diagnostics, and propagated them into `TradePlotSpan` instances along with `level_high`/`level_low`.
- `domain/models/trade_plot_span.py`: extended `TradePlotSpan` dataclass with `level_high`, `level_low`, `resistance_touch_timestamps_ms`, and `support_touch_timestamps_ms` fields so plotter receives the touch metadata directly from diagnostics.
- `vectorbt_runner/strategy_plotter.py`: added rendering of touch markers on the higher-TF (bottom) chart using different markers for resistance (`v`) and support (`^`), filtered markers to the current trade window (entry→exit inside the shown higher-window) to avoid clutter, and extended the bottom-chart legend with `Level touch` entries for both types.

### Testing

- Ran compilation check with `python -m compileall strategy/breakout/indicators/level_detector.py strategy/breakout/breakout_strategy.py domain/models/trade_plot_span.py vectorbt_runner/strategy_plotter.py`, and all files compiled successfully. 
- Verified the modified modules load without syntax errors by importing/compiling the changed files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69977badbb448320a5cf24e4f0d4aee7)