### PR TITLE
Add TradeSignal.formation_timestamp_ms and set it in breakout flow

### DIFF
--- a/domain/models/trade_signal.py
+++ b/domain/models/trade_signal.py
@@ -10,6 +10,7 @@ from domain.value_objects.price import Price
 
 @dataclass(frozen=True, slots=True)
 class TradeSignal:
+    formation_timestamp_ms: int
     entry_price: Price
     entry_timestamp_ms: int
     stop_loss: Price
@@ -20,6 +21,14 @@ class TradeSignal:
 
     # region Приватные
     def __post_init__(self) -> None:
+        if self.formation_timestamp_ms is None:
+            msg = "Trade signal formation_timestamp_ms is required."
+            raise ValueError(msg)
+
+        if self.formation_timestamp_ms < 0:
+            msg = "Trade signal formation_timestamp_ms must be >= 0."
+            raise ValueError(msg)
+
         if self.entry_timestamp_ms is None:
             msg = "Trade signal entry_timestamp_ms is required."
             raise ValueError(msg)

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -411,6 +411,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             _log_invalid_signal(reason="invalid SHORT levels invariant")
             return None
         return TradeSignal(
+            formation_timestamp_ms=pending_retest.breakout.level_start_time,
             entry_price=Price(entry_price),
             entry_timestamp_ms=int(entry_row["timestamp"]),
             stop_loss=Price(float(stop)),


### PR DESCRIPTION
### Motivation
- Backtest plotting and diagnostics accessed `active_trade_signal.formation_timestamp_ms` but `TradeSignal` did not define this attribute, causing an `AttributeError` during plot-from-results/backtest flows.
- The breakout flow already carries a level formation timestamp via `pending_retest.breakout.level_start_time`, so the signal should include that timestamp for plotting and diagnostics.

### Description
- Added `formation_timestamp_ms: int` to the `TradeSignal` dataclass (`domain/models/trade_signal.py`).
- Added validation in `TradeSignal.__post_init__` to require `formation_timestamp_ms` and ensure it is `>= 0`.
- Populated `formation_timestamp_ms` when creating `TradeSignal` instances in the breakout strategy using `pending_retest.breakout.level_start_time` (`strategy/breakout/breakout_strategy.py`).

### Testing
- Compiled the modified modules with `python -m compileall domain/models/trade_signal.py strategy/breakout/breakout_strategy.py`, which completed successfully.
- Verified the changes by inspecting the updated source locations where `formation_timestamp_ms` is referenced and passed, and no runtime compilation errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69977fd53a348320a4388a49ad31edaa)