### PR TITLE
Fix static type-check warnings in exchange/data/vectorbt modules

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -768,7 +768,8 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
             invalid_volume_symbols += 1
             continue
 
-        volume_series = cast(pd.Series, pd.to_numeric(levels_frame["volume"], errors="coerce").dropna())
+        volume_numeric = pd.Series(pd.to_numeric(levels_frame["volume"], errors="coerce"), index=levels_frame.index)
+        volume_series = volume_numeric.dropna()
         if volume_series.empty:
             logger.debug(
                 "запуск-бэктеста: символ %s исключён из pre-rank, причина=нет валидного volume на levels_tf=%s",
@@ -1122,7 +1123,7 @@ def _collect_oi_quality_issues(frame: pd.DataFrame) -> list[dict[str, str]]:
             }
         ]
 
-    oi: pd.Series = pd.to_numeric(frame["open_interest"], errors="coerce")
+    oi = pd.Series(pd.to_numeric(frame["open_interest"], errors="coerce"), index=frame.index)
     issues: list[dict[str, str]] = []
 
     if oi.isna().any():

--- a/data/clients/coingecko_client.py
+++ b/data/clients/coingecko_client.py
@@ -223,7 +223,11 @@ class CoinGeckoClient(MarketDataClient):
 
     @staticmethod
     def _parse_expires_at_to_epoch_ms(value: object) -> int | None:
-        if value is None or pd.isna(value):
+        if value is None:
+            return None
+        if isinstance(value, (pd.Series, pd.DataFrame)):
+            return None
+        if pd.isna(value):
             return None
 
         if isinstance(value, (int, float)):

--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -81,13 +81,14 @@ class CcxtFuturesClient(ExchangeClient):
                 defaultType=CCXT_MARKET_TYPE_SWAP,
                 fetchCurrencies=False,
             )
-            return ccxt.binanceusdm(cast(Any, params))
+            return cast(CcxtFuturesApi, ccxt.binanceusdm(cast(Any, params)))
         if exchange == Exchange.BYBIT:
             params["options"] = CcxtClientOptions(defaultType=CCXT_MARKET_TYPE_SWAP)
-            return ccxt.bybit(cast(Any, params))
+            return cast(CcxtFuturesApi, ccxt.bybit(cast(Any, params)))
         if exchange == Exchange.OKX:
             params["options"] = CcxtClientOptions(defaultType=CCXT_MARKET_TYPE_SWAP)
-            return ccxt.okx(cast(Any, params))
+            return cast(CcxtFuturesApi, ccxt.okx(cast(Any, params)))
+        raise ValueError(f"Unsupported exchange for CCXT futures client: {exchange}")
 
     def _retry_exchange_call(
         self,
@@ -199,6 +200,8 @@ class CcxtFuturesClient(ExchangeClient):
             return symbols
 
         def _safe_float(value: object) -> float:
+            if not isinstance(value, (int, float, str, bytes)):
+                return 0.0
             try:
                 parsed = float(value)
             except (TypeError, ValueError):

--- a/data/liquidity/daily_volume_ranker.py
+++ b/data/liquidity/daily_volume_ranker.py
@@ -24,7 +24,7 @@ class DailyVolumeRanker:
         return (
             isinstance(value, Integral)
             and not isinstance(value, bool)
-            and cls._UNIX_MS_MIN <= value <= cls._UNIX_MS_MAX
+            and cls._UNIX_MS_MIN <= int(value) <= cls._UNIX_MS_MAX
         )
 
     def __init__(self, cache_dir: Path) -> None:

--- a/data/quality/data_validator.py
+++ b/data/quality/data_validator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from numbers import Integral
-from typing import cast
 
 import pandas as pd
 
@@ -29,7 +28,7 @@ class DataValidator:
             return (
                 isinstance(value, Integral)
                 and not isinstance(value, bool)
-                and cls._UNIX_MS_MIN <= value <= cls._UNIX_MS_MAX
+                and cls._UNIX_MS_MIN <= int(value) <= cls._UNIX_MS_MAX
             )
 
         return series.map(_is_unix_ms)
@@ -83,7 +82,7 @@ class DataValidator:
             return issues
 
         numeric_columns: dict[str, pd.Series] = {
-            col: cast(pd.Series, pd.to_numeric(normalized[col], errors="coerce"))
+            col: pd.Series(pd.to_numeric(normalized[col], errors="coerce"), index=normalized.index)
             for col in ("open", "high", "low", "close", "volume", "open_interest")
             if col in normalized.columns
         }

--- a/data/quality/gap_detector.py
+++ b/data/quality/gap_detector.py
@@ -18,7 +18,7 @@ class GapDetector:
         return (
             isinstance(value, Integral)
             and not isinstance(value, bool)
-            and cls._UNIX_MS_MIN <= value <= cls._UNIX_MS_MAX
+            and cls._UNIX_MS_MIN <= int(value) <= cls._UNIX_MS_MAX
         )
 
     @staticmethod

--- a/utils/retry.py
+++ b/utils/retry.py
@@ -82,3 +82,9 @@ def run_with_retry(
                 sleep_seconds += random.uniform(0.0, jitter_seconds)
             if sleep_seconds > 0:
                 time.sleep(sleep_seconds)
+
+    raise RetryExhaustedError(
+        operation=operation,
+        attempts=attempts,
+        reason="повторы завершились без результата",
+    )

--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -125,7 +125,7 @@ class BacktestRunner:
         normalized_trades: list[TradeResult] = trades
         for trade in normalized_trades:
             pnl_value = trade.pnl
-            pnl_percent += trade.pnl_percent.value
+            pnl_percent += float(trade.pnl_percent.value)
             if pnl_value > 0:
                 profits += pnl_value
                 wins += 1

--- a/vectorbt_runner/data_preparer.py
+++ b/vectorbt_runner/data_preparer.py
@@ -135,15 +135,15 @@ class DataPreparer:
             pnl_percent = trade["pnl_percent"]
             pnl = trade["pnl"]
 
-            entries.loc[entry_time] = True
-            exits.loc[exit_time] = True
-            close.loc[entry_time] = running_price
+            entries.at[entry_time] = True
+            exits.at[exit_time] = True
+            close.at[entry_time] = running_price
 
             running_price *= SIMULATION_UNIT_INCREMENT + (pnl_percent / SIMULATION_PNL_PERCENT_DIVISOR)
-            close.loc[exit_time] = running_price
+            close.at[exit_time] = running_price
 
             cumulative_pnl += pnl
-            equity_curve.loc[exit_time] = cumulative_pnl
+            equity_curve.at[exit_time] = cumulative_pnl
 
         close = close.ffill()
         equity_curve = equity_curve.replace(SIMULATION_ZERO_VALUE, pd.NA).ffill().fillna(SIMULATION_ZERO_VALUE)

--- a/vectorbt_runner/strategy_plotter.py
+++ b/vectorbt_runner/strategy_plotter.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
+import matplotlib.ticker as mticker
 import pandas as pd
 import numpy as np
 from matplotlib.patches import Rectangle
@@ -90,7 +91,8 @@ class StrategyPlotter:
     @staticmethod
     def _prepare_plot_frame(frame: pd.DataFrame) -> pd.DataFrame:
         plot_frame = frame.copy()
-        plot_frame["plot_time"] = pd.to_datetime(plot_frame["timestamp"], unit="ms", utc=True).dt.tz_localize(None)
+        plot_dt = pd.to_datetime(plot_frame["timestamp"], unit="ms", utc=True)
+        plot_frame["plot_time"] = pd.DatetimeIndex(plot_dt).tz_localize(None)
         return plot_frame
 
     @staticmethod
@@ -177,7 +179,7 @@ class StrategyPlotter:
         formatter.show_offset = False
         ax.xaxis.set_major_locator(locator)
         ax.xaxis.set_major_formatter(formatter)
-        ax.xaxis.set_minor_locator(mdates.NullLocator())
+        ax.xaxis.set_minor_locator(mticker.NullLocator())
 
     @staticmethod
     def _add_trade_rr_markup(ax: plt.Axes, *, entry_time: pd.Timestamp, zone_end: pd.Timestamp, entry_price: float, stop_loss: float, take_profit_1: float, take_profit_2: float) -> None:
@@ -397,7 +399,7 @@ class StrategyPlotter:
                 linestyle="--",
                 linewidth=1.2,
             )
-            level_start_time = pd.to_datetime(span.level_start_timestamp_ms, unit="ms")
+            level_start_time = mdates.date2num(pd.to_datetime(span.level_start_timestamp_ms, unit="ms"))
             ax.axvline(
                 x=level_start_time,
                 color=self.TV_LEVEL_START,
@@ -427,8 +429,8 @@ class StrategyPlotter:
                 marker_price = span.confirmation_price if span.confirmation_price is not None else span.level_price
                 marker = "^" if span.side.name == "LONG" else "v"
                 ax.axvspan(
-                    confirmation_time - pd.to_timedelta(20, unit="m"),
-                    confirmation_time + pd.to_timedelta(20, unit="m"),
+                    mdates.date2num(confirmation_time - pd.to_timedelta(20, unit="m")),
+                    mdates.date2num(confirmation_time + pd.to_timedelta(20, unit="m")),
                     color="#a855f7",
                     alpha=0.12,
                     zorder=1,
@@ -501,7 +503,7 @@ class StrategyPlotter:
             self._apply_dark_theme(ax_bottom)
             self._plot_candles(ax_top, trade_window)
 
-            level_start_time = pd.to_datetime(span.level_start_timestamp_ms, unit="ms")
+            level_start_time = mdates.date2num(pd.to_datetime(span.level_start_timestamp_ms, unit="ms"))
             entry_time = pd.to_datetime(span.entry_timestamp_ms, unit="ms")
             exit_time = pd.to_datetime(span.exit_timestamp_ms, unit="ms")
             entry_label = pd.to_datetime(span.entry_timestamp_ms, unit="ms", utc=True).strftime("%Y%m%d_%H%M")
@@ -581,8 +583,8 @@ class StrategyPlotter:
                 confirmation_time = pd.to_datetime(confirmation_span.confirmation_timestamp_ms, unit="ms")
                 confirmation_price = confirmation_span.confirmation_price if confirmation_span.confirmation_price is not None else span.entry_price
                 ax_top.axvspan(
-                    confirmation_time - pd.to_timedelta(20, unit="m"),
-                    confirmation_time + pd.to_timedelta(20, unit="m"),
+                    mdates.date2num(confirmation_time - pd.to_timedelta(20, unit="m")),
+                    mdates.date2num(confirmation_time + pd.to_timedelta(20, unit="m")),
                     color="#a855f7",
                     alpha=0.12,
                     zorder=1,


### PR DESCRIPTION
## Summary
- fixed inconsistent return paths in `CcxtFuturesClient._build_client` and `run_with_retry`
- tightened ccxt/client numeric conversion code paths to avoid unsafe `object -> float` conversions
- replaced fragile pandas casts with explicit `pd.Series(...)` normalization in data validation and CLI OI/volume checks
- adjusted timestamp/Integral guards to use explicit integer comparison
- resolved plotting/data-preparer typing mismatches by using pandas-safe index assignment and matplotlib-compatible x-axis values
- switched minor locator import to `matplotlib.ticker.NullLocator` and normalized datetime conversion used in plotting

## Validation
- `python -m compileall -q cli/commands.py data/clients/coingecko_client.py data/exchanges/ccxt_futures_client.py data/liquidity/daily_volume_ranker.py data/quality/data_validator.py data/quality/gap_detector.py utils/retry.py vectorbt_runner/backtest_runner.py vectorbt_runner/data_preparer.py vectorbt_runner/strategy_plotter.py`

## Notes
- no tests were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998b86c14e08320b94683f6ad58f138)