### PR TITLE
Add breakout metadata and retest-zone plotting for trade setups

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -1436,6 +1436,16 @@ def _load_retest_spans_artifact(path: Path, logger: Logger) -> list[RetestPlotSp
                     retest_start_timestamp_ms=int(item.get("retest_start_timestamp_ms", item["retest_start_time"])),
                     retest_end_timestamp_ms=int(item.get("retest_end_timestamp_ms", item["retest_end_time"])),
                     status=str(item["status"]),
+                    breakout_timestamp_ms=(
+                        int(item["breakout_timestamp_ms"])
+                        if item.get("breakout_timestamp_ms") is not None
+                        else None
+                    ),
+                    breakout_price=(
+                        float(item["breakout_price"])
+                        if item.get("breakout_price") is not None
+                        else None
+                    ),
                     confirmation_timestamp_ms=(
                         int(item["confirmation_timestamp_ms"])
                         if item.get("confirmation_timestamp_ms") is not None

--- a/domain/models/retest_plot_span.py
+++ b/domain/models/retest_plot_span.py
@@ -20,6 +20,8 @@ class RetestPlotSpan:
     retest_start_timestamp_ms: int
     retest_end_timestamp_ms: int
     status: str
+    breakout_timestamp_ms: int | None = None
+    breakout_price: float | None = None
     confirmation_timestamp_ms: int | None = None
     confirmation_price: float | None = None
     confirmation_candle_low: float | None = None

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -833,6 +833,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             retest_start_timestamp_ms=timestamps_by_idx[pending_retest.retest_start_idx],
                             retest_end_timestamp_ms=timestamps_by_idx[pending_retest.retest_end_idx],
                             status="confirmed",
+                            breakout_timestamp_ms=timestamps_by_idx[pending_retest.breakout.breakout_idx],
+                            breakout_price=pending_retest.breakout.level.price.value,
                         )
                     )
                     self._logger.debug(
@@ -868,6 +870,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             retest_start_timestamp_ms=timestamps_by_idx[pending_retest.retest_start_idx],
                             retest_end_timestamp_ms=timestamps_by_idx[pending_retest.retest_end_idx],
                             status="confirmation_expired",
+                            breakout_timestamp_ms=timestamps_by_idx[pending_retest.breakout.breakout_idx],
+                            breakout_price=pending_retest.breakout.level.price.value,
                         )
                     )
                     self._logger.debug(
@@ -893,6 +897,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             retest_start_timestamp_ms=timestamps_by_idx[pending_retest.retest_start_idx],
                             retest_end_timestamp_ms=timestamps_by_idx[pending_retest.retest_end_idx],
                             status="confirmed",
+                            breakout_timestamp_ms=timestamps_by_idx[pending_retest.breakout.breakout_idx],
+                            breakout_price=pending_retest.breakout.level.price.value,
                             confirmation_timestamp_ms=int(row["timestamp"]),
                             confirmation_price=float(row["close"]),
                             confirmation_candle_low=float(row["low"]),
@@ -931,6 +937,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             retest_start_timestamp_ms=timestamps_by_idx[pending_retest.retest_start_idx],
                             retest_end_timestamp_ms=timestamps_by_idx[pending_retest.retest_end_idx],
                             status="confirmation_not_received",
+                            breakout_timestamp_ms=timestamps_by_idx[pending_retest.breakout.breakout_idx],
+                            breakout_price=pending_retest.breakout.level.price.value,
                         )
                     )
                     self._logger.debug(
@@ -1013,6 +1021,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                                 retest_start_timestamp_ms=int(row["timestamp"]),
                                 retest_end_timestamp_ms=int(row["timestamp"]),
                                 status="rejected_by_volume",
+                                breakout_timestamp_ms=timestamps_by_idx[pending_breakout.breakout_idx],
+                                breakout_price=pending_breakout.level.price.value,
                             )
                         )
                         self._logger.debug(
@@ -1041,6 +1051,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                                 retest_start_timestamp_ms=int(row["timestamp"]),
                                 retest_end_timestamp_ms=int(row["timestamp"]),
                                 status="rejected_by_extra_filters",
+                                breakout_timestamp_ms=timestamps_by_idx[pending_breakout.breakout_idx],
+                                breakout_price=pending_breakout.level.price.value,
                             )
                         )
                         self._logger.debug(
@@ -1171,6 +1183,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                     retest_start_timestamp_ms=timestamps_by_idx[pending_retest.retest_start_idx],
                     retest_end_timestamp_ms=timestamps_by_idx[pending_retest.retest_end_idx],
                     status="pending_end_of_data",
+                    breakout_timestamp_ms=timestamps_by_idx[pending_retest.breakout.breakout_idx],
+                    breakout_price=pending_retest.breakout.level.price.value,
                 )
             )
 

--- a/vectorbt_runner/strategy_plotter.py
+++ b/vectorbt_runner/strategy_plotter.py
@@ -517,15 +517,20 @@ class StrategyPlotter:
             exit_label = pd.to_datetime(span.exit_timestamp_ms, unit="ms", utc=True).strftime("%Y%m%d_%H%M")
 
             confirmation_span = None
+            nearest_retest_span = None
+            nearest_retest_distance = None
             for retest_span in symbol_retests:
                 if retest_span.side != span.side:
                     continue
-                if retest_span.confirmation_timestamp_ms is None:
-                    continue
-                if retest_span.confirmation_timestamp_ms > span.entry_timestamp_ms:
-                    continue
-                if confirmation_span is None or retest_span.confirmation_timestamp_ms > confirmation_span.confirmation_timestamp_ms:
-                    confirmation_span = retest_span
+                if retest_span.confirmation_timestamp_ms is not None and retest_span.confirmation_timestamp_ms <= span.entry_timestamp_ms:
+                    if confirmation_span is None or retest_span.confirmation_timestamp_ms > confirmation_span.confirmation_timestamp_ms:
+                        confirmation_span = retest_span
+                distance = abs(int(retest_span.retest_end_timestamp_ms) - int(span.entry_timestamp_ms))
+                if nearest_retest_distance is None or distance < nearest_retest_distance:
+                    nearest_retest_span = retest_span
+                    nearest_retest_distance = distance
+
+            retest_span_for_plot = confirmation_span if confirmation_span is not None else nearest_retest_span
 
             zone_end = self._resolve_entry_zone_end(
                 trade_window,
@@ -616,6 +621,50 @@ class StrategyPlotter:
 
             ax_top.scatter([entry_time], [span.entry_price], color=self.TV_ENTRY, marker="^", s=80, zorder=5, label="Breakout")
             ax_top.scatter([exit_time], [span.exit_price], color="#a855f7", marker="X", s=80, zorder=5)
+
+            if retest_span_for_plot is not None:
+                retest_start_time = pd.to_datetime(retest_span_for_plot.retest_start_timestamp_ms, unit="ms")
+                retest_end_time = pd.to_datetime(retest_span_for_plot.retest_end_timestamp_ms, unit="ms")
+                retest_rect_x0 = mdates.date2num(retest_start_time)
+                retest_rect_width = max(mdates.date2num(retest_end_time) - retest_rect_x0, 1e-9)
+                retest_rect_y0 = min(retest_span_for_plot.retest_low, retest_span_for_plot.retest_high)
+                retest_rect_height = max(abs(retest_span_for_plot.retest_high - retest_span_for_plot.retest_low), 1e-9)
+                ax_top.add_patch(
+                    Rectangle(
+                        (retest_rect_x0, retest_rect_y0),
+                        retest_rect_width,
+                        retest_rect_height,
+                        linewidth=1.1,
+                        edgecolor="#a855f7",
+                        facecolor="#a855f7",
+                        alpha=0.14,
+                        zorder=2,
+                        label="Retest zone",
+                    )
+                )
+                if retest_span_for_plot.breakout_timestamp_ms is not None:
+                    breakout_time = pd.to_datetime(retest_span_for_plot.breakout_timestamp_ms, unit="ms")
+                    breakout_price = (
+                        retest_span_for_plot.breakout_price
+                        if retest_span_for_plot.breakout_price is not None
+                        else retest_span_for_plot.level_price
+                    )
+                    ax_top.axvline(
+                        x=breakout_time,
+                        color="#eab308",
+                        linestyle="--",
+                        linewidth=1.1,
+                        alpha=0.75,
+                    )
+                    ax_top.scatter(
+                        [breakout_time],
+                        [breakout_price],
+                        color="#eab308",
+                        marker="D",
+                        s=64,
+                        zorder=6,
+                        label="Breakout event",
+                    )
 
             continuation_marker = "^" if span.side.name == "LONG" else "v"
             if confirmation_span is not None and confirmation_span.confirmation_timestamp_ms is not None:


### PR DESCRIPTION
### Motivation
- Enable visualization of the full path «from breakout to return» by attaching breakout event data to retest spans and drawing the retest zone on trade setup charts.
- Improve selection of which retest span to show on a trade plot by preferring a confirmation span and falling back to the nearest retest when no confirmation exists.

### Description
- Extend `RetestPlotSpan` with optional `breakout_timestamp_ms` and `breakout_price` fields to carry the breakout event metadata.
- Populate `breakout_timestamp_ms` and `breakout_price` in all `RetestPlotSpan` instances emitted by the breakout strategy when retests are recorded (confirmed, expired, not received, rejected, pending end-of-data) in `strategy/breakout/breakout_strategy.py`.
- Update `plot_trade_setups(...)` in `vectorbt_runner/strategy_plotter.py` to pick `confirmation_span` or fallback to the nearest retest and to draw a retest rectangle on `ax_top` using X=`retest_start_timestamp_ms → retest_end_timestamp_ms` and Y=`retest_low → retest_high`, and to draw a dedicated breakout marker (vertical line + marker) using `breakout_timestamp_ms`/`breakout_price`.
- Add parsing of the new `breakout_timestamp_ms` and `breakout_price` fields in the retest artifact loader in `cli/commands.py`.

### Testing
- Compiled updated modules with `python -m compileall /workspace/mtf-trend/domain/models/retest_plot_span.py /workspace/mtf-trend/strategy/breakout/breakout_strategy.py /workspace/mtf-trend/vectorbt_runner/strategy_plotter.py /workspace/mtf-trend/cli/commands.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998be66e79c832086847f065938d96a)