### PR TITLE
Separate entry marker from breakout event in strategy plotter

### DIFF
--- a/vectorbt_runner/strategy_plotter.py
+++ b/vectorbt_runner/strategy_plotter.py
@@ -619,7 +619,7 @@ class StrategyPlotter:
                 text_color="#eff6ff",
             )
 
-            ax_top.scatter([entry_time], [span.entry_price], color=self.TV_ENTRY, marker="^", s=80, zorder=5, label="Breakout")
+            ax_top.scatter([entry_time], [span.entry_price], color=self.TV_ENTRY, marker="^", s=80, zorder=5, label="Entry")
             ax_top.scatter([exit_time], [span.exit_price], color="#a855f7", marker="X", s=80, zorder=5)
 
             if retest_span_for_plot is not None:


### PR DESCRIPTION
### Motivation
- Avoid mixing the entry marker with the breakout event in trade plots so that the breakout is only shown when there is a real `RetestPlotSpan.breakout_timestamp_ms`/`breakout_price`, and the legend can show distinct `Breakout event`, `Entry`, and `Return` items.

### Description
- Changed the entry scatter label in `vectorbt_runner/strategy_plotter.py` from `"Breakout"` to `"Entry"`, while leaving the breakout visualization intact and labeled as `"Breakout event"` when `retest_span_for_plot.breakout_timestamp_ms` (and `breakout_price`/`level_price` fallback) is present.

### Testing
- Ran `python -m py_compile vectorbt_runner/strategy_plotter.py` and `rg -n "Breakout|breakout" vectorbt_runner/strategy_plotter.py`, both succeeded and confirmed the label change and remaining breakout-specific occurrences.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c14c1b488320b40c605b17e06ac8)