### PR TITLE
Use breakout candle close for retest breakout markers

### DIFF
--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -204,6 +204,17 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             "natr": natr,
         }
 
+    @staticmethod
+    def _resolve_breakout_event_price(
+        *,
+        annotated_rows: list[tuple[object, ...]],
+        breakout_idx: int,
+        level_price: float,
+    ) -> float:
+        if 0 <= breakout_idx < len(annotated_rows) and len(annotated_rows[breakout_idx]) > 4:
+            return float(annotated_rows[breakout_idx][4])
+        return level_price
+
 
     def _build_level(
         self,
@@ -873,6 +884,11 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                 continue
 
             if pending_retest is not None:
+                breakout_event_price = self._resolve_breakout_event_price(
+                    annotated_rows=annotated_rows,
+                    breakout_idx=pending_retest.breakout.breakout_idx,
+                    level_price=pending_retest.breakout.level.price.value,
+                )
                 if params.entry_trigger == EntryTrigger.IMMEDIATE:
                     entry_idx = pending_retest.retest_idx + 1
                     pending_retest.retest_end_idx = pending_retest.retest_idx
@@ -888,7 +904,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             retest_end_timestamp_ms=timestamps_by_idx[pending_retest.retest_end_idx],
                             status="confirmed",
                             breakout_timestamp_ms=timestamps_by_idx[pending_retest.breakout.breakout_idx],
-                            breakout_price=pending_retest.breakout.level.price.value,
+                            breakout_price=breakout_event_price,
                         )
                     )
                     self._logger.debug(
@@ -933,7 +949,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             retest_end_timestamp_ms=timestamps_by_idx[pending_retest.retest_end_idx],
                             status="confirmation_expired",
                             breakout_timestamp_ms=timestamps_by_idx[pending_retest.breakout.breakout_idx],
-                            breakout_price=pending_retest.breakout.level.price.value,
+                            breakout_price=breakout_event_price,
                         )
                     )
                     self._logger.debug(
@@ -960,7 +976,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             retest_end_timestamp_ms=timestamps_by_idx[pending_retest.retest_end_idx],
                             status="confirmed",
                             breakout_timestamp_ms=timestamps_by_idx[pending_retest.breakout.breakout_idx],
-                            breakout_price=pending_retest.breakout.level.price.value,
+                            breakout_price=breakout_event_price,
                             confirmation_timestamp_ms=int(row["timestamp"]),
                             confirmation_price=float(row["close"]),
                             confirmation_candle_low=float(row["low"]),
@@ -1008,7 +1024,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                             retest_end_timestamp_ms=timestamps_by_idx[pending_retest.retest_end_idx],
                             status="confirmation_not_received",
                             breakout_timestamp_ms=timestamps_by_idx[pending_retest.breakout.breakout_idx],
-                            breakout_price=pending_retest.breakout.level.price.value,
+                            breakout_price=breakout_event_price,
                         )
                     )
                     self._logger.debug(
@@ -1080,6 +1096,11 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                         continue
                     if not bool(volume_check["is_ok"]):
                         diagnostics["retest_rejected_by_volume"] += 1
+                        breakout_event_price = self._resolve_breakout_event_price(
+                            annotated_rows=annotated_rows,
+                            breakout_idx=pending_breakout.breakout_idx,
+                            level_price=pending_breakout.level.price.value,
+                        )
                         retest_plot_spans.append(
                             RetestPlotSpan(
                                 symbol=params.symbol,
@@ -1092,7 +1113,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                                 retest_end_timestamp_ms=int(row["timestamp"]),
                                 status="rejected_by_volume",
                                 breakout_timestamp_ms=timestamps_by_idx[pending_breakout.breakout_idx],
-                                breakout_price=pending_breakout.level.price.value,
+                                breakout_price=breakout_event_price,
                             )
                         )
                         self._logger.debug(
@@ -1110,6 +1131,11 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                         )
                     else:
                         diagnostics["retest_rejected_by_extra_filters"] += 1
+                        breakout_event_price = self._resolve_breakout_event_price(
+                            annotated_rows=annotated_rows,
+                            breakout_idx=pending_breakout.breakout_idx,
+                            level_price=pending_breakout.level.price.value,
+                        )
                         retest_plot_spans.append(
                             RetestPlotSpan(
                                 symbol=params.symbol,
@@ -1122,7 +1148,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                                 retest_end_timestamp_ms=int(row["timestamp"]),
                                 status="rejected_by_extra_filters",
                                 breakout_timestamp_ms=timestamps_by_idx[pending_breakout.breakout_idx],
-                                breakout_price=pending_breakout.level.price.value,
+                                breakout_price=breakout_event_price,
                             )
                         )
                         self._logger.debug(
@@ -1242,6 +1268,11 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         if pending_retest is not None:
             diagnostics["retest_pending_end_of_data"] += 1
             pending_retest.retest_end_idx = min(pending_retest.confirmation_end_idx, len(annotated) - 1)
+            breakout_event_price = self._resolve_breakout_event_price(
+                annotated_rows=annotated_rows,
+                breakout_idx=pending_retest.breakout.breakout_idx,
+                level_price=pending_retest.breakout.level.price.value,
+            )
             retest_plot_spans.append(
                 RetestPlotSpan(
                     symbol=params.symbol,
@@ -1254,7 +1285,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                     retest_end_timestamp_ms=timestamps_by_idx[pending_retest.retest_end_idx],
                     status="pending_end_of_data",
                     breakout_timestamp_ms=timestamps_by_idx[pending_retest.breakout.breakout_idx],
-                    breakout_price=pending_retest.breakout.level.price.value,
+                    breakout_price=breakout_event_price,
                 )
             )
 

--- a/vectorbt_runner/strategy_plotter.py
+++ b/vectorbt_runner/strategy_plotter.py
@@ -644,11 +644,7 @@ class StrategyPlotter:
                 )
                 if retest_span_for_plot.breakout_timestamp_ms is not None:
                     breakout_time = pd.to_datetime(retest_span_for_plot.breakout_timestamp_ms, unit="ms")
-                    breakout_price = (
-                        retest_span_for_plot.breakout_price
-                        if retest_span_for_plot.breakout_price is not None
-                        else retest_span_for_plot.level_price
-                    )
+                    breakout_price = retest_span_for_plot.breakout_price
                     ax_top.axvline(
                         x=breakout_time,
                         color="#eab308",
@@ -656,15 +652,16 @@ class StrategyPlotter:
                         linewidth=1.1,
                         alpha=0.75,
                     )
-                    ax_top.scatter(
-                        [breakout_time],
-                        [breakout_price],
-                        color="#eab308",
-                        marker="D",
-                        s=64,
-                        zorder=6,
-                        label="Breakout event",
-                    )
+                    if breakout_price is not None:
+                        ax_top.scatter(
+                            [breakout_time],
+                            [breakout_price],
+                            color="#eab308",
+                            marker="D",
+                            s=64,
+                            zorder=6,
+                            label="Breakout event",
+                        )
 
             continuation_marker = "^" if span.side.name == "LONG" else "v"
             if confirmation_span is not None and confirmation_span.confirmation_timestamp_ms is not None:


### PR DESCRIPTION
### Motivation
- Сделать `RetestPlotSpan.breakout_price` фактической ценой события пробоя (цена свечи пробоя), а не всегда уровнем, сохранив `level_price` для совместимости.
- Обеспечить, чтобы plotter использовал `breakout_price` только как цену маркера события и не подменял её уровнем.

### Description
- Добавлен вспомогательный метод `_resolve_breakout_event_price` в `BreakoutStrategy`, который берёт `close` свечи по `breakout_idx` с fallback на `level_price` при отсутствии данных. 
- Во всех местах формирования `RetestPlotSpan` для confirmed/expired/not_received/rejected/pending_end_of_data заменено присвоение `breakout_price` на рассчитанное значение события `breakout_event_price`, причём `level_price` оставлен без изменений. 
- В `vectorbt_runner/strategy_plotter.py` удалён fallback `breakout_price -> level_price` и теперь маркер отрисовывается только если `breakout_price` не `None`, оставляя вертикальную линию по времени независимо от наличия цены.

### Testing
- Запущена компиляция файлов: `python -m py_compile strategy/breakout/breakout_strategy.py vectorbt_runner/strategy_plotter.py`, проверка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c28f467483208d49b844c95f7be3)