### PR TITLE
Использовать начало lookback-окна для поля level_start_time

### DIFF
--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -589,7 +589,10 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         return annotated[self.ANNOTATED_COLUMNS].copy()
 
     def prepare_higher_tf_levels(self, *, higher_base: pd.DataFrame, lookback: int) -> pd.DataFrame:
-        """Готовит уровни старшего ТФ без маппинга на младший ТФ."""
+        """Готовит уровни старшего ТФ без маппинга на младший ТФ.
+
+        Поле `level_start_time` — это левая граница lookback-окна, на котором рассчитан уровень.
+        """
         if len(higher_base) < lookback + STRATEGY_MIN_LOOKBACK_BUFFER:
             return pd.DataFrame(
                 columns=[
@@ -699,6 +702,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             "timestamp",
             "level_high",
             "level_low",
+            # Время начала окна формирования уровня (левая граница lookback-окна).
             "level_start_time",
             "touch_count",
             "reaction_strength",

--- a/strategy/breakout/indicators/level_detector.py
+++ b/strategy/breakout/indicators/level_detector.py
@@ -142,7 +142,7 @@ class LevelDetector:
 
         frame["level_high"] = frame["high"].rolling(window=lookback).max().shift(1)
         frame["level_low"] = frame["low"].rolling(window=lookback).min().shift(1)
-        frame["level_start_time"] = frame["timestamp"]
+        level_start_times: list[float] = []
 
         touch_counts: list[float] = []
         reaction_strengths: list[float] = []
@@ -163,6 +163,7 @@ class LevelDetector:
             candidate_low = frame.at[idx, "level_low"]
             atr_value = atr[idx]
             if pd.isna(candidate_high) or pd.isna(candidate_low) or pd.isna(atr_value) or idx < lookback:
+                level_start_times.append(np.nan)
                 touch_counts.append(np.nan)
                 reaction_strengths.append(np.nan)
                 level_scores.append(np.nan)
@@ -180,6 +181,7 @@ class LevelDetector:
 
             window_slice = slice(idx - lookback, idx)
             window_timestamps = frame["timestamp"].iloc[window_slice].to_numpy(dtype="int64", copy=False)
+            level_start_times.append(float(window_timestamps[0]))
             (
                 high_touch_count,
                 high_reaction,
@@ -233,6 +235,7 @@ class LevelDetector:
             support_max_penetration_pct_values.append(float(low_max_penetration_pct))
             support_touch_timestamps_values.append([int(window_timestamps[touch_idx]) for touch_idx in low_touch_indices])
 
+        frame["level_start_time"] = level_start_times
         frame["touch_count"] = touch_counts
         frame["reaction_strength"] = reaction_strengths
         frame["level_score"] = level_scores
@@ -251,6 +254,7 @@ class LevelDetector:
             subset=[
                 "level_high",
                 "level_low",
+                "level_start_time",
                 "touch_count",
                 "reaction_strength",
                 "level_score",


### PR DESCRIPTION
### Motivation
- Сделать `level_start_time` корректно отражающим время формирования уровня как начало окна, на котором рассчитывается уровень, а не текущий `timestamp` строки.
- Обеспечить корректную агрегацию объёма и построение ретестов при использовании `level_start_time` в поиске индексов и построении спанов.

### Description
- В `LevelDetector.detect` заменено заполнение `level_start_time`: для валидных строк (`idx >= lookback`) записывается timestamp левой границы окна `idx - lookback`, а для невалидных строк — `NaN`.
- Добавлено включение `level_start_time` в список обязательных полей при `dropna`, чтобы строки без валидного окна удалялись вместе с остальными неполными метриками.
- В `breakout_strategy.py` обновлён docstring и инлайн-комментарий у формирования higher-level rows, поясняющие, что `level_start_time` — это начало lookback-окна, и подтверждена совместимость downstream-использований (`_build_level`, `_average_volume_before`, `RetestPlotSpan`, `TradeSignal.formation_timestamp_ms`).

### Testing
- Скомпилированы изменённые модули командой `python -m compileall strategy/breakout/indicators/level_detector.py strategy/breakout/breakout_strategy.py` и компиляция прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c3f6944c8320ba75492b6ff5236b)