### PR TITLE
Preserve breakout/retest timestamps across trade lifecycle

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -86,6 +86,43 @@ def _to_bool_flag(value: object, *, default: bool = False) -> bool:
     return default
 
 
+def _coerce_trade_plot_span(value: object) -> TradePlotSpan | None:
+    if isinstance(value, TradePlotSpan):
+        return value
+    if not isinstance(value, dict):
+        return None
+    try:
+        return TradePlotSpan(
+            symbol=str(value["symbol"]),
+            side=PositionSide(str(value["side"])),
+            level_start_timestamp_ms=int(value["level_start_timestamp_ms"]),
+            entry_timestamp_ms=int(value["entry_timestamp_ms"]),
+            exit_timestamp_ms=int(value["exit_timestamp_ms"]),
+            entry_price=float(value["entry_price"]),
+            exit_price=float(value["exit_price"]),
+            stop_loss=float(value["stop_loss"]),
+            take_profit_1=float(value["take_profit_1"]),
+            take_profit_2=float(value["take_profit_2"]),
+            result_type=str(value["result_type"]),
+            level_high=float(value["level_high"]),
+            level_low=float(value["level_low"]),
+            resistance_touch_timestamps_ms=tuple(int(ts) for ts in value.get("resistance_touch_timestamps_ms", ())),
+            support_touch_timestamps_ms=tuple(int(ts) for ts in value.get("support_touch_timestamps_ms", ())),
+            breakout_timestamp_ms=(
+                int(value["breakout_timestamp_ms"])
+                if value.get("breakout_timestamp_ms") is not None
+                else None
+            ),
+            retest_timestamp_ms=(
+                int(value["retest_timestamp_ms"])
+                if value.get("retest_timestamp_ms") is not None
+                else None
+            ),
+        )
+    except (TypeError, ValueError, KeyError):
+        return None
+
+
 def _build_breakout_params_from_row(
     row: pd.Series,
     *,
@@ -149,7 +186,9 @@ def _plot_trade_setups_for_symbols(
         raw_spans_obj = diagnostics.get("trade_plot_spans", [])
         raw_spans = raw_spans_obj if isinstance(raw_spans_obj, list) else []
         trade_spans: list[TradePlotSpan] = [
-            span for span in raw_spans if isinstance(span, TradePlotSpan)
+            span
+            for span in (_coerce_trade_plot_span(raw_span) for raw_span in raw_spans)
+            if span is not None
         ]
         raw_retest_spans_obj = diagnostics.get("retest_plot_spans", [])
         raw_retest_spans = raw_retest_spans_obj if isinstance(raw_retest_spans_obj, list) else []

--- a/domain/models/position.py
+++ b/domain/models/position.py
@@ -16,6 +16,8 @@ class Position:
     stop_loss: Price
     take_profit_1: Price
     take_profit_2: Price
+    breakout_timestamp_ms: int | None = None
+    retest_timestamp_ms: int | None = None
     tp1_done: bool = False
     sl_moved_to_be: bool = False
 
@@ -27,5 +29,13 @@ class Position:
 
         if self.size.value <= 0:
             msg = "Position size must be positive."
+            raise ValueError(msg)
+
+        if self.breakout_timestamp_ms is not None and self.breakout_timestamp_ms < 0:
+            msg = "Position breakout_timestamp_ms must be >= 0."
+            raise ValueError(msg)
+
+        if self.retest_timestamp_ms is not None and self.retest_timestamp_ms < 0:
+            msg = "Position retest_timestamp_ms must be >= 0."
             raise ValueError(msg)
     # endregion Приватные

--- a/domain/models/trade_plot_span.py
+++ b/domain/models/trade_plot_span.py
@@ -24,3 +24,5 @@ class TradePlotSpan:
     level_low: float
     resistance_touch_timestamps_ms: tuple[int, ...] = field(default_factory=tuple)
     support_touch_timestamps_ms: tuple[int, ...] = field(default_factory=tuple)
+    breakout_timestamp_ms: int | None = None
+    retest_timestamp_ms: int | None = None

--- a/domain/models/trade_result.py
+++ b/domain/models/trade_result.py
@@ -18,6 +18,8 @@ class TradeResult:
     result_type: TradeResultType
     pnl: float
     pnl_percent: Percentage
+    breakout_timestamp_ms: int | None = None
+    retest_timestamp_ms: int | None = None
 
     # region Приватные
     def __post_init__(self) -> None:
@@ -27,5 +29,13 @@ class TradeResult:
 
         if self.exit_timestamp_ms < self.entry_timestamp_ms:
             msg = "Trade result exit_timestamp_ms cannot be earlier than entry_timestamp_ms."
+            raise ValueError(msg)
+
+        if self.breakout_timestamp_ms is not None and self.breakout_timestamp_ms < 0:
+            msg = "Trade result breakout_timestamp_ms must be >= 0."
+            raise ValueError(msg)
+
+        if self.retest_timestamp_ms is not None and self.retest_timestamp_ms < 0:
+            msg = "Trade result retest_timestamp_ms must be >= 0."
             raise ValueError(msg)
     # endregion Приватные

--- a/domain/models/trade_signal.py
+++ b/domain/models/trade_signal.py
@@ -18,6 +18,8 @@ class TradeSignal:
     take_profit_2: Price
     position_side: PositionSide
     symbol: str
+    breakout_timestamp_ms: int | None = None
+    retest_timestamp_ms: int | None = None
 
     # region Приватные
     def __post_init__(self) -> None:
@@ -31,6 +33,14 @@ class TradeSignal:
 
         if self.entry_timestamp_ms is None:
             msg = "Trade signal entry_timestamp_ms is required."
+            raise ValueError(msg)
+
+        if self.breakout_timestamp_ms is not None and self.breakout_timestamp_ms < 0:
+            msg = "Trade signal breakout_timestamp_ms must be >= 0."
+            raise ValueError(msg)
+
+        if self.retest_timestamp_ms is not None and self.retest_timestamp_ms < 0:
+            msg = "Trade signal retest_timestamp_ms must be >= 0."
             raise ValueError(msg)
 
         if not self.symbol:

--- a/simulation/position_simulator.py
+++ b/simulation/position_simulator.py
@@ -48,6 +48,8 @@ class StatefulPositionSimulator(PositionSimulator):
             stop_loss=signal.stop_loss,
             take_profit_1=signal.take_profit_1,
             take_profit_2=signal.take_profit_2,
+            breakout_timestamp_ms=signal.breakout_timestamp_ms,
+            retest_timestamp_ms=signal.retest_timestamp_ms,
         )
         self._realized_pnl = -fill.commission
         self._closed_size = 0.0

--- a/simulation/trade_classifier.py
+++ b/simulation/trade_classifier.py
@@ -44,4 +44,6 @@ class TradeClassifier:
             result_type=result_type,
             pnl=pnl,
             pnl_percent=Percentage(pnl_percent_value),
+            breakout_timestamp_ms=position.breakout_timestamp_ms,
+            retest_timestamp_ms=position.retest_timestamp_ms,
         )

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -454,6 +454,16 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         if side == PositionSide.SHORT and not (stop > entry_price > tp1):
             _log_invalid_signal(reason="invalid SHORT levels invariant")
             return None
+        breakout_timestamp_ms = (
+            int(annotated.iloc[breakout_idx]["timestamp"])
+            if 0 <= breakout_idx < len(annotated)
+            else None
+        )
+        retest_timestamp_ms = (
+            int(annotated.iloc[retest_idx]["timestamp"])
+            if 0 <= retest_idx < len(annotated)
+            else None
+        )
         return TradeSignal(
             formation_timestamp_ms=pending_retest.breakout.level_start_time,
             entry_price=Price(entry_price),
@@ -463,6 +473,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             take_profit_2=Price(float(tp2)),
             position_side=side,
             symbol=params.symbol,
+            breakout_timestamp_ms=breakout_timestamp_ms,
+            retest_timestamp_ms=retest_timestamp_ms,
         )
 
     @staticmethod
@@ -878,6 +890,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                                         if active_trade_level_context is not None
                                         else ()
                                     ),
+                                    breakout_timestamp_ms=active_trade_signal.breakout_timestamp_ms,
+                                    retest_timestamp_ms=active_trade_signal.retest_timestamp_ms,
                                 )
                             )
                     active_trade_signal = None
@@ -1334,6 +1348,8 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                                 if active_trade_level_context is not None
                                 else ()
                             ),
+                            breakout_timestamp_ms=active_trade_signal.breakout_timestamp_ms,
+                            retest_timestamp_ms=active_trade_signal.retest_timestamp_ms,
                         )
                     )
             active_trade_signal = None

--- a/vectorbt_runner/strategy_plotter.py
+++ b/vectorbt_runner/strategy_plotter.py
@@ -531,6 +531,16 @@ class StrategyPlotter:
                     nearest_retest_distance = distance
 
             retest_span_for_plot = confirmation_span if confirmation_span is not None else nearest_retest_span
+            breakout_time_from_trade = (
+                pd.to_datetime(span.breakout_timestamp_ms, unit="ms")
+                if span.breakout_timestamp_ms is not None
+                else None
+            )
+            retest_time_from_trade = (
+                pd.to_datetime(span.retest_timestamp_ms, unit="ms")
+                if span.retest_timestamp_ms is not None
+                else None
+            )
 
             zone_end = self._resolve_entry_zone_end(
                 trade_window,
@@ -663,6 +673,25 @@ class StrategyPlotter:
                             label="Breakout event",
                         )
 
+            if retest_span_for_plot is None and breakout_time_from_trade is not None:
+                ax_top.axvline(
+                    x=breakout_time_from_trade,
+                    color="#eab308",
+                    linestyle="--",
+                    linewidth=1.1,
+                    alpha=0.75,
+                    label="Breakout (trade)",
+                )
+            if retest_span_for_plot is None and retest_time_from_trade is not None:
+                ax_top.axvline(
+                    x=retest_time_from_trade,
+                    color="#a855f7",
+                    linestyle=":",
+                    linewidth=1.1,
+                    alpha=0.75,
+                    label="Retest (trade)",
+                )
+
             continuation_marker = "^" if span.side.name == "LONG" else "v"
             if confirmation_span is not None and confirmation_span.confirmation_timestamp_ms is not None:
                 confirmation_time = pd.to_datetime(confirmation_span.confirmation_timestamp_ms, unit="ms")
@@ -782,8 +811,18 @@ class StrategyPlotter:
                         zorder=6,
                     )
             title_suffix = " • Continuation confirmation" if confirmation_span is not None and confirmation_span.confirmation_timestamp_ms is not None else ""
+            breakout_label = (
+                pd.to_datetime(span.breakout_timestamp_ms, unit="ms", utc=True).strftime("%Y%m%d_%H%M")
+                if span.breakout_timestamp_ms is not None
+                else "n/a"
+            )
+            retest_label = (
+                pd.to_datetime(span.retest_timestamp_ms, unit="ms", utc=True).strftime("%Y%m%d_%H%M")
+                if span.retest_timestamp_ms is not None
+                else "n/a"
+            )
             ax_top.set_title(
-                f"{symbol} • {params.entry_timeframe.value} trade {span.side.value}: result={span.result_type}{title_suffix}",
+                f"{symbol} • {params.entry_timeframe.value} trade {span.side.value}: result={span.result_type} • B={breakout_label} • R={retest_label}{title_suffix}",
                 color="#f8fafc",
                 fontweight="bold",
             )


### PR DESCRIPTION
### Motivation
- Keep breakout and retest timestamps available for debugging and verification by propagating them from retest detection through signal → position → result and into plotting diagnostics.
- Ensure old artifacts remain readable by handling missing fields gracefully.

### Description
- Added optional `breakout_timestamp_ms` and `retest_timestamp_ms` to `TradeSignal` with non-negative validation and set them in `_build_signal_from_retest` using `pending_retest` indices.
- Propagated timestamps through execution: extended `Position` and `TradeResult` with the two optional fields and forwarded values in `StatefulPositionSimulator` and `TradeClassifier` so timestamps survive position opening/closing.
- Extended `TradePlotSpan` to include the new timestamps and populated them when appending diagnostics in `BreakoutStrategy` for both normal and forced closes.
- Made CLI diagnostics loading migration-safe by adding `_coerce_trade_plot_span` which accepts dicts or dataclass-like payloads and defaults missing new fields to `None`.
- Enhanced `StrategyPlotter` to use trade-span timestamps as a fallback overlay (vertical lines) and added breakout/retest labels to plot titles to aid visual verification when retest diagnostics are missing.

### Testing
- Compiled affected modules with `python -m compileall domain simulation strategy cli vectorbt_runner` and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c4d671b483209af74b0fdf3a0c1d)