### PR TITLE
Refine side-specific level metrics for breakout pending levels

### DIFF
--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -615,12 +615,16 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                     "touch_count",
                     "reaction_strength",
                     "level_score",
+                    "resistance_reaction_strength",
+                    "resistance_level_score",
                     "resistance_touch_count",
                     "resistance_min_bars_between_touches",
                     "resistance_max_penetration_atr",
                     "resistance_max_penetration_pct",
                     "resistance_touch_timestamps_ms",
                     "support_touch_count",
+                    "support_reaction_strength",
+                    "support_level_score",
                     "support_min_bars_between_touches",
                     "support_max_penetration_atr",
                     "support_max_penetration_pct",
@@ -719,12 +723,16 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             "touch_count",
             "reaction_strength",
             "level_score",
+            "resistance_reaction_strength",
+            "resistance_level_score",
             "resistance_touch_count",
             "resistance_min_bars_between_touches",
             "resistance_max_penetration_atr",
             "resistance_max_penetration_pct",
             "resistance_touch_timestamps_ms",
             "support_touch_count",
+            "support_reaction_strength",
+            "support_level_score",
             "support_min_bars_between_touches",
             "support_max_penetration_atr",
             "support_max_penetration_pct",
@@ -773,12 +781,16 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         active_touch_count: int = 0
         active_reaction_strength: float = 0.0
         active_level_score: float = 0.0
+        active_resistance_reaction_strength: float = 0.0
+        active_resistance_level_score: float = 0.0
         active_resistance_touch_count: int = 0
         active_resistance_min_touch_gap: int = 0
         active_resistance_max_penetration_atr: float = 0.0
         active_resistance_max_penetration_pct: float = 0.0
         active_resistance_touch_timestamps_ms: tuple[int, ...] = ()
         active_support_touch_count: int = 0
+        active_support_reaction_strength: float = 0.0
+        active_support_level_score: float = 0.0
         active_support_min_touch_gap: int = 0
         active_support_max_penetration_atr: float = 0.0
         active_support_max_penetration_pct: float = 0.0
@@ -811,30 +823,44 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                 active_touch_count = int(level_row[4])
                 active_reaction_strength = float(level_row[5])
                 active_level_score = float(level_row[6])
-                active_resistance_touch_count = int(level_row[7])
-                active_resistance_min_touch_gap = int(level_row[8])
-                active_resistance_max_penetration_atr = float(level_row[9])
-                active_resistance_max_penetration_pct = float(level_row[10])
-                active_resistance_touch_timestamps_ms = tuple(int(value) for value in level_row[11])
-                active_support_touch_count = int(level_row[12])
-                active_support_min_touch_gap = int(level_row[13])
-                active_support_max_penetration_atr = float(level_row[14])
-                active_support_max_penetration_pct = float(level_row[15])
-                active_support_touch_timestamps_ms = tuple(int(value) for value in level_row[16])
+                active_resistance_reaction_strength = float(level_row[7])
+                active_resistance_level_score = float(level_row[8])
+                active_resistance_touch_count = int(level_row[9])
+                active_resistance_min_touch_gap = int(level_row[10])
+                active_resistance_max_penetration_atr = float(level_row[11])
+                active_resistance_max_penetration_pct = float(level_row[12])
+                active_resistance_touch_timestamps_ms = tuple(int(value) for value in level_row[13])
+                active_support_touch_count = int(level_row[14])
+                active_support_reaction_strength = float(level_row[15])
+                active_support_level_score = float(level_row[16])
+                active_support_min_touch_gap = int(level_row[17])
+                active_support_max_penetration_atr = float(level_row[18])
+                active_support_max_penetration_pct = float(level_row[19])
+                active_support_touch_timestamps_ms = tuple(int(value) for value in level_row[20])
                 diagnostics["last_level_metrics"] = {
-                    "touch_count": active_touch_count,
-                    "reaction_strength": active_reaction_strength,
-                    "level_score": active_level_score,
-                    "resistance_touch_count": active_resistance_touch_count,
-                    "resistance_min_bars_between_touches": active_resistance_min_touch_gap,
-                    "resistance_max_penetration_atr": active_resistance_max_penetration_atr,
-                    "resistance_max_penetration_pct": active_resistance_max_penetration_pct,
-                    "resistance_touch_timestamps_ms": list(active_resistance_touch_timestamps_ms),
-                    "support_touch_count": active_support_touch_count,
-                    "support_min_bars_between_touches": active_support_min_touch_gap,
-                    "support_max_penetration_atr": active_support_max_penetration_atr,
-                    "support_max_penetration_pct": active_support_max_penetration_pct,
-                    "support_touch_timestamps_ms": list(active_support_touch_timestamps_ms),
+                    "aggregated": {
+                        "touch_count": active_touch_count,
+                        "reaction_strength": active_reaction_strength,
+                        "level_score": active_level_score,
+                    },
+                    "resistance": {
+                        "touch_count": active_resistance_touch_count,
+                        "reaction_strength": active_resistance_reaction_strength,
+                        "level_score": active_resistance_level_score,
+                        "min_bars_between_touches": active_resistance_min_touch_gap,
+                        "max_penetration_atr": active_resistance_max_penetration_atr,
+                        "max_penetration_pct": active_resistance_max_penetration_pct,
+                        "touch_timestamps_ms": list(active_resistance_touch_timestamps_ms),
+                    },
+                    "support": {
+                        "touch_count": active_support_touch_count,
+                        "reaction_strength": active_support_reaction_strength,
+                        "level_score": active_support_level_score,
+                        "min_bars_between_touches": active_support_min_touch_gap,
+                        "max_penetration_atr": active_support_max_penetration_atr,
+                        "max_penetration_pct": active_support_max_penetration_pct,
+                        "touch_timestamps_ms": list(active_support_touch_timestamps_ms),
+                    },
                 }
                 level_idx += 1
 
@@ -1230,9 +1256,9 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                                 breakout_idx=idx,
                                 level_start_time=active_level_start_time,
                             ),
-                            touch_count=active_touch_count,
-                            reaction_strength=active_reaction_strength,
-                            level_score=active_level_score,
+                            touch_count=active_resistance_touch_count,
+                            reaction_strength=active_resistance_reaction_strength,
+                            level_score=active_resistance_level_score,
                         ),
                         breakout_extreme=float(row["low"]),
                         side=PositionSide.LONG,
@@ -1257,9 +1283,9 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                                 breakout_idx=idx,
                                 level_start_time=active_level_start_time,
                             ),
-                            touch_count=active_touch_count,
-                            reaction_strength=active_reaction_strength,
-                            level_score=active_level_score,
+                            touch_count=active_support_touch_count,
+                            reaction_strength=active_support_reaction_strength,
+                            level_score=active_support_level_score,
                         ),
                         breakout_extreme=float(row["high"]),
                         side=PositionSide.SHORT,

--- a/strategy/breakout/indicators/level_detector.py
+++ b/strategy/breakout/indicators/level_detector.py
@@ -111,12 +111,16 @@ class LevelDetector:
                     "touch_count",
                     "reaction_strength",
                     "level_score",
+                    "resistance_reaction_strength",
+                    "resistance_level_score",
                     "resistance_touch_count",
                     "resistance_min_bars_between_touches",
                     "resistance_max_penetration_atr",
                     "resistance_max_penetration_pct",
                     "resistance_touch_timestamps_ms",
                     "support_touch_count",
+                    "support_reaction_strength",
+                    "support_level_score",
                     "support_min_bars_between_touches",
                     "support_max_penetration_atr",
                     "support_max_penetration_pct",
@@ -147,12 +151,16 @@ class LevelDetector:
         touch_counts: list[float] = []
         reaction_strengths: list[float] = []
         level_scores: list[float] = []
+        resistance_reaction_strengths: list[float] = []
+        resistance_level_scores: list[float] = []
         resistance_touch_counts: list[float] = []
         resistance_min_bars_between_touches_values: list[float] = []
         resistance_max_penetration_atr_values: list[float] = []
         resistance_max_penetration_pct_values: list[float] = []
         resistance_touch_timestamps_values: list[list[int]] = []
         support_touch_counts: list[float] = []
+        support_reaction_strengths: list[float] = []
+        support_level_scores: list[float] = []
         support_min_bars_between_touches_values: list[float] = []
         support_max_penetration_atr_values: list[float] = []
         support_max_penetration_pct_values: list[float] = []
@@ -167,12 +175,16 @@ class LevelDetector:
                 touch_counts.append(np.nan)
                 reaction_strengths.append(np.nan)
                 level_scores.append(np.nan)
+                resistance_reaction_strengths.append(np.nan)
+                resistance_level_scores.append(np.nan)
                 resistance_touch_counts.append(np.nan)
                 resistance_min_bars_between_touches_values.append(np.nan)
                 resistance_max_penetration_atr_values.append(np.nan)
                 resistance_max_penetration_pct_values.append(np.nan)
                 resistance_touch_timestamps_values.append([])
                 support_touch_counts.append(np.nan)
+                support_reaction_strengths.append(np.nan)
+                support_level_scores.append(np.nan)
                 support_min_bars_between_touches_values.append(np.nan)
                 support_max_penetration_atr_values.append(np.nan)
                 support_max_penetration_pct_values.append(np.nan)
@@ -224,12 +236,16 @@ class LevelDetector:
             touch_counts.append(merged_touch_count)
             reaction_strengths.append(merged_reaction)
             level_scores.append(merged_score)
+            resistance_reaction_strengths.append(float(high_reaction))
+            resistance_level_scores.append(float(high_score))
             resistance_touch_counts.append(float(high_touch_count))
             resistance_min_bars_between_touches_values.append(float(high_min_bars_between_touches))
             resistance_max_penetration_atr_values.append(float(high_max_penetration_atr))
             resistance_max_penetration_pct_values.append(float(high_max_penetration_pct))
             resistance_touch_timestamps_values.append([int(window_timestamps[touch_idx]) for touch_idx in high_touch_indices])
             support_touch_counts.append(float(low_touch_count))
+            support_reaction_strengths.append(float(low_reaction))
+            support_level_scores.append(float(low_score))
             support_min_bars_between_touches_values.append(float(low_min_bars_between_touches))
             support_max_penetration_atr_values.append(float(low_max_penetration_atr))
             support_max_penetration_pct_values.append(float(low_max_penetration_pct))
@@ -239,12 +255,16 @@ class LevelDetector:
         frame["touch_count"] = touch_counts
         frame["reaction_strength"] = reaction_strengths
         frame["level_score"] = level_scores
+        frame["resistance_reaction_strength"] = resistance_reaction_strengths
+        frame["resistance_level_score"] = resistance_level_scores
         frame["resistance_touch_count"] = resistance_touch_counts
         frame["resistance_min_bars_between_touches"] = resistance_min_bars_between_touches_values
         frame["resistance_max_penetration_atr"] = resistance_max_penetration_atr_values
         frame["resistance_max_penetration_pct"] = resistance_max_penetration_pct_values
         frame["resistance_touch_timestamps_ms"] = resistance_touch_timestamps_values
         frame["support_touch_count"] = support_touch_counts
+        frame["support_reaction_strength"] = support_reaction_strengths
+        frame["support_level_score"] = support_level_scores
         frame["support_min_bars_between_touches"] = support_min_bars_between_touches_values
         frame["support_max_penetration_atr"] = support_max_penetration_atr_values
         frame["support_max_penetration_pct"] = support_max_penetration_pct_values
@@ -258,11 +278,15 @@ class LevelDetector:
                 "touch_count",
                 "reaction_strength",
                 "level_score",
+                "resistance_reaction_strength",
+                "resistance_level_score",
                 "resistance_touch_count",
                 "resistance_min_bars_between_touches",
                 "resistance_max_penetration_atr",
                 "resistance_max_penetration_pct",
                 "support_touch_count",
+                "support_reaction_strength",
+                "support_level_score",
                 "support_min_bars_between_touches",
                 "support_max_penetration_atr",
                 "support_max_penetration_pct",
@@ -277,12 +301,16 @@ class LevelDetector:
                 "touch_count",
                 "reaction_strength",
                 "level_score",
+                "resistance_reaction_strength",
+                "resistance_level_score",
                 "resistance_touch_count",
                 "resistance_min_bars_between_touches",
                 "resistance_max_penetration_atr",
                 "resistance_max_penetration_pct",
                 "resistance_touch_timestamps_ms",
                 "support_touch_count",
+                "support_reaction_strength",
+                "support_level_score",
                 "support_min_bars_between_touches",
                 "support_max_penetration_atr",
                 "support_max_penetration_pct",


### PR DESCRIPTION
### Motivation
- Устранить неоднозначность между агрегированными и side-specific метриками уровней и передавать в `PendingBreakout` релевантные значения для LONG/SHORT.

### Description
- При создании `PendingBreakout` для LONG теперь в `Level` передаются `touch_count=active_resistance_touch_count` и resistance-specific `reaction_strength/level_score`, а для SHORT — `touch_count=active_support_touch_count` и support-specific `reaction_strength/level_score`.
- Расширен `LevelDetector.detect` выходными колонками `resistance_reaction_strength`, `resistance_level_score`, `support_reaction_strength` и `support_level_score` и добавлена их передача в итоговый фрейм.
- Актуализированы `higher_level_columns` и парсинг `higher_level_rows` в `BreakoutStrategy` для подхвата новых колонок и заполнения соответствующих `active_*` переменных.
- Рефакторинг `diagnostics["last_level_metrics"]` в явную структуру с секциями `aggregated`, `resistance` и `support` для однозначных логов.

### Testing
- Выполнена проверка синтаксиса компиляцией: `python -m py_compile strategy/breakout/breakout_strategy.py strategy/breakout/indicators/level_detector.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c6b97f5883208cc6f4aaa0ae2649)