### PR TITLE
Add timestamp order validation to TradeSignal, Position and TradeResult models

### DIFF
--- a/domain/models/position.py
+++ b/domain/models/position.py
@@ -38,4 +38,32 @@ class Position:
         if self.retest_timestamp_ms is not None and self.retest_timestamp_ms < 0:
             msg = "Position retest_timestamp_ms must be >= 0."
             raise ValueError(msg)
+
+        if (
+            self.breakout_timestamp_ms is not None
+            and self.retest_timestamp_ms is not None
+            and self.breakout_timestamp_ms > self.retest_timestamp_ms
+        ):
+            msg = (
+                "Position invalid timestamp order: breakout_timestamp_ms must be <= "
+                f"retest_timestamp_ms, got breakout_timestamp_ms={self.breakout_timestamp_ms}, "
+                f"retest_timestamp_ms={self.retest_timestamp_ms}."
+            )
+            raise ValueError(msg)
+
+        if self.breakout_timestamp_ms is not None and self.breakout_timestamp_ms > self.entry_timestamp_ms:
+            msg = (
+                "Position invalid timestamp order: breakout_timestamp_ms must be <= "
+                f"entry_timestamp_ms, got breakout_timestamp_ms={self.breakout_timestamp_ms}, "
+                f"entry_timestamp_ms={self.entry_timestamp_ms}."
+            )
+            raise ValueError(msg)
+
+        if self.retest_timestamp_ms is not None and self.retest_timestamp_ms > self.entry_timestamp_ms:
+            msg = (
+                "Position invalid timestamp order: retest_timestamp_ms must be <= "
+                f"entry_timestamp_ms, got retest_timestamp_ms={self.retest_timestamp_ms}, "
+                f"entry_timestamp_ms={self.entry_timestamp_ms}."
+            )
+            raise ValueError(msg)
     # endregion Приватные

--- a/domain/models/trade_result.py
+++ b/domain/models/trade_result.py
@@ -38,4 +38,48 @@ class TradeResult:
         if self.retest_timestamp_ms is not None and self.retest_timestamp_ms < 0:
             msg = "Trade result retest_timestamp_ms must be >= 0."
             raise ValueError(msg)
+
+        if (
+            self.breakout_timestamp_ms is not None
+            and self.retest_timestamp_ms is not None
+            and self.breakout_timestamp_ms > self.retest_timestamp_ms
+        ):
+            msg = (
+                "Trade result invalid timestamp order: breakout_timestamp_ms must be <= "
+                f"retest_timestamp_ms, got breakout_timestamp_ms={self.breakout_timestamp_ms}, "
+                f"retest_timestamp_ms={self.retest_timestamp_ms}."
+            )
+            raise ValueError(msg)
+
+        if self.breakout_timestamp_ms is not None and self.breakout_timestamp_ms > self.entry_timestamp_ms:
+            msg = (
+                "Trade result invalid timestamp order: breakout_timestamp_ms must be <= "
+                f"entry_timestamp_ms, got breakout_timestamp_ms={self.breakout_timestamp_ms}, "
+                f"entry_timestamp_ms={self.entry_timestamp_ms}."
+            )
+            raise ValueError(msg)
+
+        if self.retest_timestamp_ms is not None and self.retest_timestamp_ms > self.entry_timestamp_ms:
+            msg = (
+                "Trade result invalid timestamp order: retest_timestamp_ms must be <= "
+                f"entry_timestamp_ms, got retest_timestamp_ms={self.retest_timestamp_ms}, "
+                f"entry_timestamp_ms={self.entry_timestamp_ms}."
+            )
+            raise ValueError(msg)
+
+        if self.breakout_timestamp_ms is not None and self.breakout_timestamp_ms > self.exit_timestamp_ms:
+            msg = (
+                "Trade result invalid timestamp order: breakout_timestamp_ms must be <= "
+                f"exit_timestamp_ms, got breakout_timestamp_ms={self.breakout_timestamp_ms}, "
+                f"exit_timestamp_ms={self.exit_timestamp_ms}."
+            )
+            raise ValueError(msg)
+
+        if self.retest_timestamp_ms is not None and self.retest_timestamp_ms > self.exit_timestamp_ms:
+            msg = (
+                "Trade result invalid timestamp order: retest_timestamp_ms must be <= "
+                f"exit_timestamp_ms, got retest_timestamp_ms={self.retest_timestamp_ms}, "
+                f"exit_timestamp_ms={self.exit_timestamp_ms}."
+            )
+            raise ValueError(msg)
     # endregion Приватные

--- a/domain/models/trade_signal.py
+++ b/domain/models/trade_signal.py
@@ -43,6 +43,42 @@ class TradeSignal:
             msg = "Trade signal retest_timestamp_ms must be >= 0."
             raise ValueError(msg)
 
+        if (
+            self.breakout_timestamp_ms is not None
+            and self.retest_timestamp_ms is not None
+            and self.breakout_timestamp_ms > self.retest_timestamp_ms
+        ):
+            msg = (
+                "Trade signal invalid timestamp order: breakout_timestamp_ms must be <= "
+                f"retest_timestamp_ms, got breakout_timestamp_ms={self.breakout_timestamp_ms}, "
+                f"retest_timestamp_ms={self.retest_timestamp_ms}."
+            )
+            raise ValueError(msg)
+
+        if self.breakout_timestamp_ms is not None and self.breakout_timestamp_ms > self.entry_timestamp_ms:
+            msg = (
+                "Trade signal invalid timestamp order: breakout_timestamp_ms must be <= "
+                f"entry_timestamp_ms, got breakout_timestamp_ms={self.breakout_timestamp_ms}, "
+                f"entry_timestamp_ms={self.entry_timestamp_ms}."
+            )
+            raise ValueError(msg)
+
+        if self.retest_timestamp_ms is not None and self.retest_timestamp_ms > self.entry_timestamp_ms:
+            msg = (
+                "Trade signal invalid timestamp order: retest_timestamp_ms must be <= "
+                f"entry_timestamp_ms, got retest_timestamp_ms={self.retest_timestamp_ms}, "
+                f"entry_timestamp_ms={self.entry_timestamp_ms}."
+            )
+            raise ValueError(msg)
+
+        if self.breakout_timestamp_ms is not None and self.formation_timestamp_ms > self.breakout_timestamp_ms:
+            msg = (
+                "Trade signal invalid timestamp order: formation_timestamp_ms must be <= "
+                f"breakout_timestamp_ms, got formation_timestamp_ms={self.formation_timestamp_ms}, "
+                f"breakout_timestamp_ms={self.breakout_timestamp_ms}."
+            )
+            raise ValueError(msg)
+
         if not self.symbol:
             msg = "Trade signal symbol is required."
             raise ValueError(msg)


### PR DESCRIPTION
### Motivation
- Защитить доменные модели от неконсистентных временных меток и упростить отладку при неверном порядке событий.
- Ввести явные проверки порядка таймстампов для сигналов, позиций и результатов сделок, чтобы ошибки выявлялись на момент создания объектов. 

### Description
- В `TradeSignal.__post_init__` добавлены проверки: `breakout_timestamp_ms <= retest_timestamp_ms` (если оба заданы), `breakout_timestamp_ms <= entry_timestamp_ms`, `retest_timestamp_ms <= entry_timestamp_ms` и `formation_timestamp_ms <= breakout_timestamp_ms`, с подробными сообщениями об ошибках, включающими фактические значения. 
- В `Position.__post_init__` добавлены аналогичные проверки порядка для `breakout_timestamp_ms`, `retest_timestamp_ms` и `entry_timestamp_ms` с информативными текстами ошибок. 
- В `TradeResult.__post_init__` добавлены проверки `breakout_timestamp_ms <= retest_timestamp_ms` (если оба заданы), `breakout_timestamp_ms <= entry_timestamp_ms`, `retest_timestamp_ms <= entry_timestamp_ms` и защитные проверки `breakout_timestamp_ms <= exit_timestamp_ms` и `retest_timestamp_ms <= exit_timestamp_ms`, все с явными сообщениями об ошибке и значениями полей. 
- Все сообщения об ошибках сформулированы так, чтобы сразу было видно, какое правило нарушено и какие значения пришли. 

### Testing
- Запущена компиляция модулей командой `python -m compileall domain/models/trade_signal.py domain/models/position.py domain/models/trade_result.py`, которая завершилась успешно. 
- Нет добавленных unit-тестов; изменения проверялись статической компиляцией и синтаксическим контролем.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c775961883209c9b6d55e6910529)