### PR TITLE
Unify timestamp deduplication in BreakoutStrategy.prepare_data

### DIFF
--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -559,7 +559,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         prepared["timestamp"] = pd.to_numeric(prepared["timestamp"], errors="coerce")
         prepared = prepared.dropna(subset=["timestamp"])
         prepared["timestamp"] = prepared["timestamp"].astype("int64")
-        prepared = prepared.sort_values("timestamp").reset_index(drop=True)
+        prepared = prepared.sort_values("timestamp").drop_duplicates(subset=["timestamp"], keep="last").reset_index(drop=True)
 
         for col in ("open", "high", "low", "close", "volume"):
             prepared[col] = pd.to_numeric(prepared[col], errors="coerce")


### PR DESCRIPTION
### Motivation
- Обеспечить единообразную политику дедупликации временной оси в стратегии пробоя и привести поведение к стандарту `vectorbt_runner/data_preparer.py`, чтобы downstream-механизмы, завязанные на `idx -> timestamp`, работали с однозначным timeline.

### Description
- В `BreakoutStrategy.prepare_data()` добавлена явная дедупликация после сортировки: `drop_duplicates(subset=["timestamp"], keep="last")`, чтобы зафиксировать политику `keep="last"` и устранить дубли по `timestamp`.

### Testing
- Запущена проверка компиляции `python -m compileall strategy/breakout/breakout_strategy.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c9134f3c8320b9572045bb624b6b)