### PR TITLE
Add strategy selection and factory-based backtest strategy wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ python launcher.py --mode analyze-cache --symbols BTC/USDT ETH/USDT
 python launcher.py --mode analyze-cache --top-n 50
 python launcher.py --mode analyze-cache --top-n 50 --plot true
 python launcher.py --mode analyze-cache --symbols BTC/USDT ETH/USDT --plot-from-results --results-input ./cache/results/backtest_results.csv
+python launcher.py --mode analyze-cache --top-n 50 --strategy breakout
+python launcher.py --mode analyze-cache --top-n 50 --strategy bee_bite
+python launcher.py --mode analyze-cache --symbols BTC/USDT --strategy bee_bite --plot-from-results --results-input ./cache/results/backtest_results.csv
 python launcher.py --mode make-report --input ./results/backtest_results.csv --output ./results/report.json
 python launcher.py --mode check-quality --symbols BTC/USDT ETH/USDT --output ./results/quality_report.json
 python launcher.py --mode plot-daily-levels --symbols BTC/USDT ETH/USDT --levels-tf 1d --entry-tf 15m --output-dir ./results/charts --limit 300
@@ -243,6 +246,26 @@ python launcher.py --mode clear-cache
 python launcher.py --config run_config.json
 ```
 
+
+
+### Выбор стратегии (`breakout` / `bee_bite`)
+
+По умолчанию используется `breakout`. Можно задать через `.env`:
+
+```env
+STRATEGY_ID=bee_bite
+```
+
+Или переопределить на конкретный запуск через CLI (имеет приоритет над `.env`):
+
+```bash
+python main.py run-backtest --strategy breakout
+python main.py run-backtest --strategy bee_bite
+```
+
+`--plot-from-results` автоматически читает нужные колонки под выбранную стратегию:
+- `breakout` — поля `lookback`, `volume_mult`, ...
+- `bee_bite` — поля `bite_lookback`, `bite_volume_mult`, ...
 
 ### Фиксация конца периода загрузки (повторяемые прогоны)
 

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -60,6 +60,7 @@ from domain.models.reporting.quality_symbol_stats import QualitySymbolStats
 from domain.models.reporting.trade_results_distribution import TradeResultsDistribution
 from strategy.breakout.breakout_strategy import BreakoutStrategy
 from strategy.breakout.config import PARAMETER_GRID_SIZE, TARGET_PARAMETER_COMBINATIONS, BreakoutParams
+from strategy.factory import build_breakout_strategy, build_strategy
 from utils.logger import get_logger
 from utils.retry import RetryExhaustedError
 from utils.symbols import normalize_symbol
@@ -123,31 +124,46 @@ def _coerce_trade_plot_span(value: object) -> TradePlotSpan | None:
         return None
 
 
+def _resolve_strategy_id(config: AppConfig, args: argparse.Namespace) -> str:
+    strategy_override = getattr(args, "strategy", None)
+    if strategy_override is not None:
+        return str(strategy_override).strip().lower()
+    return config.strategy.strategy_id
+
+
 def _build_breakout_params_from_row(
     row: pd.Series,
     *,
     symbol: str,
     levels_timeframe: Timeframe,
     entry_timeframe: Timeframe,
+    strategy_id: str,
 ) -> BreakoutParams:
+    if strategy_id == "breakout":
+        prefix = ""
+    elif strategy_id == "bee_bite":
+        prefix = "bite_"
+    else:
+        raise ValueError(f"Неподдерживаемый strategy_id: {strategy_id}")
+
     return BreakoutParams(
-        lookback=int(row["lookback"]),
-        volume_mult=float(row["volume_mult"]),
-        retest_window_hours=int(row["retest_window_hours"]),
-        retest_zone=float(row["retest_zone"]),
-        min_rr=float(row["min_rr"]),
-        sl_mode=SLMode(str(row["sl_mode"])),
-        tp2_mult=float(row["tp2_mult"]),
-        min_body_ratio=float(row["min_body_ratio"]),
-        min_move_atr=float(row["min_move_atr"]),
-        max_retest_depth=float(row["max_retest_depth"]),
-        confirmation_bars=int(row["confirmation_bars"]),
-        entry_trigger=EntryTrigger(str(row["entry_trigger"])),
+        lookback=int(row[f"{prefix}lookback"]),
+        volume_mult=float(row[f"{prefix}volume_mult"]),
+        retest_window_hours=int(row[f"{prefix}retest_window_hours"]),
+        retest_zone=float(row[f"{prefix}retest_zone"]),
+        min_rr=float(row[f"{prefix}min_rr"]),
+        sl_mode=SLMode(str(row[f"{prefix}sl_mode"])),
+        tp2_mult=float(row[f"{prefix}tp2_mult"]),
+        min_body_ratio=float(row[f"{prefix}min_body_ratio"]),
+        min_move_atr=float(row[f"{prefix}min_move_atr"]),
+        max_retest_depth=float(row[f"{prefix}max_retest_depth"]),
+        confirmation_bars=int(row[f"{prefix}confirmation_bars"]),
+        entry_trigger=EntryTrigger(str(row[f"{prefix}entry_trigger"])),
         symbol=symbol,
         retest_zone_atr=(
             None
-            if pd.isna(row.get("retest_zone_atr"))
-            else float(row["retest_zone_atr"])
+            if pd.isna(row.get(f"{prefix}retest_zone_atr"))
+            else float(row[f"{prefix}retest_zone_atr"])
         ),
         levels_timeframe=levels_timeframe,
         entry_timeframe=entry_timeframe,
@@ -166,6 +182,7 @@ def _plot_trade_setups_for_symbols(
     levels_timeframe: Timeframe,
     entry_timeframe: Timeframe,
     log_prefix: str,
+    strategy_id: str,
 ) -> None:
     output_dir = Path(getattr(args, "output_dir", None) or (config.backtest.results_dir / "trade_plots"))
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -180,6 +197,7 @@ def _plot_trade_setups_for_symbols(
             symbol=symbol,
             levels_timeframe=levels_timeframe,
             entry_timeframe=entry_timeframe,
+            strategy_id=strategy_id,
         )
         strategy.generate_events_multi_tf(mtf_frames=mtf_frames, params=cfg)
         diagnostics = strategy.consume_last_generation_diagnostics()
@@ -222,6 +240,7 @@ def _load_plot_params_row_from_results(
     args: argparse.Namespace,
     *,
     logger: Logger,
+    strategy_id: str,
 ) -> pd.Series | None:
     csv_path = Path(getattr(args, "results_input", None) or getattr(args, "input", None) or (
         config.backtest.results_dir / config.backtest.results_file_name
@@ -235,20 +254,40 @@ def _load_plot_params_row_from_results(
         logger.error("plot-from-results: файл результатов пустой: %s", csv_path)
         return None
 
-    required_columns = [
-        "lookback",
-        "volume_mult",
-        "retest_window_hours",
-        "retest_zone",
-        "min_rr",
-        "sl_mode",
-        "tp2_mult",
-        "min_body_ratio",
-        "min_move_atr",
-        "max_retest_depth",
-        "confirmation_bars",
-        "entry_trigger",
-    ]
+    required_columns_by_strategy = {
+        "breakout": [
+            "lookback",
+            "volume_mult",
+            "retest_window_hours",
+            "retest_zone",
+            "min_rr",
+            "sl_mode",
+            "tp2_mult",
+            "min_body_ratio",
+            "min_move_atr",
+            "max_retest_depth",
+            "confirmation_bars",
+            "entry_trigger",
+        ],
+        "bee_bite": [
+            "bite_lookback",
+            "bite_volume_mult",
+            "bite_retest_window_hours",
+            "bite_retest_zone",
+            "bite_min_rr",
+            "bite_sl_mode",
+            "bite_tp2_mult",
+            "bite_min_body_ratio",
+            "bite_min_move_atr",
+            "bite_max_retest_depth",
+            "bite_confirmation_bars",
+            "bite_entry_trigger",
+        ],
+    }
+    required_columns = required_columns_by_strategy.get(strategy_id)
+    if required_columns is None:
+        logger.error("plot-from-results: неподдерживаемая стратегия %s", strategy_id)
+        return None
     missing_columns = [column for column in required_columns if column not in frame.columns]
     if missing_columns:
         logger.error("plot-from-results: отсутствуют обязательные колонки: %s", ", ".join(missing_columns))
@@ -762,6 +801,8 @@ def _update_cache_inner(config: AppConfig, args: argparse.Namespace) -> int:
 
 def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
     logger = get_logger("run-backtest", level=config.backtest.log_level, logs_dir=config.backtest.logs_dir)
+    strategy_id = _resolve_strategy_id(config, args)
+    config.strategy.strategy_id = strategy_id
     levels_timeframe = _resolve_timeframe(
         getattr(args, "levels_tf", None),
         fallback=config.strategy.levels_timeframe,
@@ -919,11 +960,8 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
         logger.info("запуск-бектеста: не удалось подготовить данные")
         return 0
 
-    strategy = BreakoutStrategy(
-        commission_rate=config.simulation.commission_rate,
-        slippage=config.simulation.slippage,
-        logger=logger,
-    )
+    strategy = build_strategy(config, logger)
+    breakout_strategy = build_breakout_strategy(config, logger)
     runner = BacktestRunner(
         config.backtest.results_dir,
         config.backtest.results_file_name,
@@ -946,20 +984,21 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
         )
     plot_from_results = _to_bool_flag(getattr(args, "plot_from_results", None), default=False)
     if plot_from_results:
-        best_row = _load_plot_params_row_from_results(config, args, logger=logger)
+        best_row = _load_plot_params_row_from_results(config, args, logger=logger, strategy_id=strategy_id)
         if best_row is None:
             return 1
         _plot_trade_setups_for_symbols(
             config=config,
             args=args,
             logger=logger,
-            strategy=strategy,
+            strategy=breakout_strategy,
             preparer=preparer,
             symbol_frames=symbol_frames,
             params_row=best_row,
             levels_timeframe=levels_timeframe,
             entry_timeframe=entry_timeframe,
             log_prefix="plot-from-results",
+            strategy_id=strategy_id,
         )
         return 0
 
@@ -970,13 +1009,13 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
         entry_timeframe=entry_timeframe,
     )
     summary = runner.build_summary(results)
-    if PARAMETER_GRID_SIZE != TARGET_PARAMETER_COMBINATIONS:
+    if strategy_id == "breakout" and PARAMETER_GRID_SIZE != TARGET_PARAMETER_COMBINATIONS:
         logger.warning(
             "запуск-бэктеста: расчетная мощность сетки=%s отличается от целевой=%s (ожидается 5832)",
             PARAMETER_GRID_SIZE,
             TARGET_PARAMETER_COMBINATIONS,
         )
-    if len(results) != TARGET_PARAMETER_COMBINATIONS:
+    if strategy_id == "breakout" and len(results) != TARGET_PARAMETER_COMBINATIONS:
         logger.warning(
             "запуск-бэктеста: фактическое число комбинаций=%s отличается от целевого=%s (ожидается 5832)",
             len(results),
@@ -1019,13 +1058,14 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
             config=config,
             args=args,
             logger=logger,
-            strategy=strategy,
+            strategy=breakout_strategy,
             preparer=preparer,
             symbol_frames=symbol_frames,
             params_row=best_row,
             levels_timeframe=levels_timeframe,
             entry_timeframe=entry_timeframe,
             log_prefix="запуск-бэктеста: plot=true",
+            strategy_id=strategy_id,
         )
     return 0
 
@@ -1416,11 +1456,10 @@ def _plot_daily_levels_inner(config: AppConfig, args: argparse.Namespace) -> int
         logger.info("plot-daily-levels: нет символов для построения")
         return 0
 
-    strategy = BreakoutStrategy(
-        commission_rate=config.simulation.commission_rate,
-        slippage=config.simulation.slippage,
-        logger=logger,
-    )
+    strategy = build_strategy(config, logger)
+    if not isinstance(strategy, BreakoutStrategy):
+        logger.error("plot-daily-levels поддерживает только breakout")
+        return 1
     base_params = strategy.build_parameter_grid()[0]
     plotter = StrategyPlotter(data_preparer=preparer, strategy=strategy)
 
@@ -1569,11 +1608,10 @@ def _plot_retests_inner(config: AppConfig, args: argparse.Namespace) -> int:
         logger.info("plot-retests: нет символов для построения")
         return 0
 
-    strategy = BreakoutStrategy(
-        commission_rate=config.simulation.commission_rate,
-        slippage=config.simulation.slippage,
-        logger=logger,
-    )
+    strategy = build_strategy(config, logger)
+    if not isinstance(strategy, BreakoutStrategy):
+        logger.error("plot-retests поддерживает только breakout")
+        return 1
     base_params = strategy.build_parameter_grid()[0]
     plotter = StrategyPlotter(data_preparer=preparer, strategy=strategy)
 

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -81,6 +81,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Таймфрейм входов (например 15m). Приоритетнее ENTRY_TIMEFRAME из env",
     )
+    run_bt.add_argument(
+        "--strategy",
+        choices=["breakout", "bee_bite"],
+        default=None,
+        help="Идентификатор стратегии. Приоритетнее STRATEGY_ID из env",
+    )
     run_bt.add_argument("--plot", default=False, help="Строить графики сделок (true/false)")
     run_bt.add_argument(
         "--plot-from-results",

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -37,6 +37,8 @@ __all__ = [
     "load_config",
 ]
 
+SUPPORTED_STRATEGY_IDS = {"breakout", "bee_bite"}
+
 
 # region Приватные
 
@@ -73,6 +75,14 @@ def _parse_bool(value: str | None, *, default: bool = False) -> bool:
     if normalized in {"0", "false", "no", "n", "off"}:
         return False
     raise ValueError(f"Invalid boolean value: {value}")
+
+
+def _parse_strategy_id(value: str | None, *, default: str = "breakout") -> str:
+    strategy_id = (value or default).strip().lower()
+    if strategy_id not in SUPPORTED_STRATEGY_IDS:
+        supported = ", ".join(sorted(SUPPORTED_STRATEGY_IDS))
+        raise ValueError(f"Invalid STRATEGY_ID: {strategy_id}. Supported values: {supported}")
+    return strategy_id
 
 
 def _parse_anchor_timestamp_ms(value: str | None, *, env_name: str) -> int | None:
@@ -143,6 +153,7 @@ def load_config(env_path: str | Path = ".env") -> AppConfig:
     )
 
     strategy_config = StrategyConfig(
+        strategy_id=_parse_strategy_id(os.getenv("STRATEGY_ID")),
         levels_timeframe=strategy_levels_timeframe,
         entry_timeframe=strategy_entry_timeframe,
     )

--- a/config/strategy_config.py
+++ b/config/strategy_config.py
@@ -9,5 +9,6 @@ from domain.enums.timeframe import Timeframe
 
 @dataclass(slots=True)
 class StrategyConfig:
+    strategy_id: str = "breakout"
     levels_timeframe: Timeframe = Timeframe.D1
     entry_timeframe: Timeframe = Timeframe.M15

--- a/strategy/bee_bite/__init__.py
+++ b/strategy/bee_bite/__init__.py
@@ -1,0 +1,4 @@
+from strategy.bee_bite.bee_bite_strategy import BeeBiteStrategy
+from strategy.bee_bite.config import BeeBiteParams
+
+__all__ = ["BeeBiteStrategy", "BeeBiteParams"]

--- a/strategy/bee_bite/bee_bite_strategy.py
+++ b/strategy/bee_bite/bee_bite_strategy.py
@@ -1,0 +1,99 @@
+"""Адаптер стратегии bee_bite поверх breakout-ядра."""
+
+from __future__ import annotations
+
+from strategy.base_strategy import BaseStrategy
+from strategy.bee_bite.config import BeeBiteParams
+from strategy.breakout.breakout_strategy import BreakoutStrategy
+from strategy.breakout.config import BreakoutParams
+from vectorbt_runner.mtf_frames import SymbolMtfFrames
+
+
+class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
+    """bee_bite использует breakout-логику с собственными именами параметров."""
+
+    def __init__(self, breakout: BreakoutStrategy) -> None:
+        self._breakout = breakout
+
+    def _to_breakout_params(self, params: BeeBiteParams) -> BreakoutParams:
+        return BreakoutParams(
+            lookback=params.bite_lookback,
+            volume_mult=params.bite_volume_mult,
+            retest_window_hours=params.bite_retest_window_hours,
+            retest_zone=params.bite_retest_zone,
+            min_rr=params.bite_min_rr,
+            sl_mode=params.bite_sl_mode,
+            tp2_mult=params.bite_tp2_mult,
+            min_body_ratio=params.bite_min_body_ratio,
+            min_move_atr=params.bite_min_move_atr,
+            max_retest_depth=params.bite_max_retest_depth,
+            confirmation_bars=params.bite_confirmation_bars,
+            entry_trigger=params.bite_entry_trigger,
+            symbol=params.symbol,
+            retest_zone_atr=params.bite_retest_zone_atr,
+            levels_timeframe=params.levels_timeframe,
+            entry_timeframe=params.entry_timeframe,
+        )
+
+    @staticmethod
+    def _from_breakout_params(params: BreakoutParams) -> BeeBiteParams:
+        return BeeBiteParams(
+            bite_lookback=params.lookback,
+            bite_volume_mult=params.volume_mult,
+            bite_retest_window_hours=params.retest_window_hours,
+            bite_retest_zone=params.retest_zone,
+            bite_min_rr=params.min_rr,
+            bite_sl_mode=params.sl_mode,
+            bite_tp2_mult=params.tp2_mult,
+            bite_min_body_ratio=params.min_body_ratio,
+            bite_min_move_atr=params.min_move_atr,
+            bite_max_retest_depth=params.max_retest_depth,
+            bite_confirmation_bars=params.confirmation_bars,
+            bite_entry_trigger=params.entry_trigger,
+            symbol=params.symbol,
+            bite_retest_zone_atr=params.retest_zone_atr,
+            levels_timeframe=params.levels_timeframe,
+            entry_timeframe=params.entry_timeframe,
+        )
+
+    def validate_config(self, params: BeeBiteParams) -> None:
+        self._breakout.validate_config(self._to_breakout_params(params))
+
+    def prepare_data(self, data):
+        return self._breakout.prepare_data(data)
+
+    def generate_events(self, data, params: BeeBiteParams):
+        return self._breakout.generate_events(data, self._to_breakout_params(params))
+
+    def generate_events_multi_tf(self, *, mtf_frames: SymbolMtfFrames, params: BeeBiteParams):
+        return self._breakout.generate_events_multi_tf(mtf_frames=mtf_frames, params=self._to_breakout_params(params))
+
+    def build_parameter_grid(self) -> list[BeeBiteParams]:
+        return [self._from_breakout_params(params) for params in self._breakout.build_parameter_grid()]
+
+    def params_to_row(self, params: BeeBiteParams) -> dict[str, int | float | str | None]:
+        return {
+            "bite_lookback": params.bite_lookback,
+            "bite_volume_mult": params.bite_volume_mult,
+            "bite_retest_window_hours": params.bite_retest_window_hours,
+            "bite_retest_zone": params.bite_retest_zone,
+            "bite_min_rr": params.bite_min_rr,
+            "bite_retest_zone_atr": params.bite_retest_zone_atr,
+            "bite_sl_mode": params.bite_sl_mode.value,
+            "bite_tp2_mult": params.bite_tp2_mult,
+            "bite_min_body_ratio": params.bite_min_body_ratio,
+            "bite_min_move_atr": params.bite_min_move_atr,
+            "bite_max_retest_depth": params.bite_max_retest_depth,
+            "bite_confirmation_bars": params.bite_confirmation_bars,
+            "bite_entry_trigger": params.bite_entry_trigger.value,
+        }
+
+    def prepare_symbol_context(self, *, symbol: str, mtf_frames: SymbolMtfFrames, params: BeeBiteParams):
+        return self._breakout.prepare_symbol_context(
+            symbol=symbol,
+            mtf_frames=mtf_frames,
+            params=self._to_breakout_params(params),
+        )
+
+    def consume_last_generation_diagnostics(self) -> dict[str, object]:
+        return self._breakout.consume_last_generation_diagnostics()

--- a/strategy/bee_bite/config.py
+++ b/strategy/bee_bite/config.py
@@ -1,0 +1,29 @@
+"""Конфиг и параметры стратегии bee_bite."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from domain.enums.entry_trigger import EntryTrigger
+from domain.enums.sl_mode import SLMode
+from domain.enums.timeframe import Timeframe
+
+
+@dataclass(frozen=True, slots=True)
+class BeeBiteParams:
+    bite_lookback: int
+    bite_volume_mult: float
+    bite_retest_window_hours: int
+    bite_retest_zone: float
+    bite_min_rr: float
+    bite_sl_mode: SLMode
+    bite_tp2_mult: float
+    bite_min_body_ratio: float
+    bite_min_move_atr: float
+    bite_max_retest_depth: float
+    bite_confirmation_bars: int
+    bite_entry_trigger: EntryTrigger
+    symbol: str
+    bite_retest_zone_atr: float | None = None
+    levels_timeframe: Timeframe = Timeframe.D1
+    entry_timeframe: Timeframe = Timeframe.M15

--- a/strategy/factory.py
+++ b/strategy/factory.py
@@ -1,0 +1,27 @@
+"""Фабрика построения стратегий."""
+
+from __future__ import annotations
+
+from logging import Logger
+
+from config import AppConfig
+from strategy.base_strategy import BaseStrategy
+from strategy.bee_bite import BeeBiteStrategy
+from strategy.breakout.breakout_strategy import BreakoutStrategy
+
+
+def build_breakout_strategy(config: AppConfig, logger: Logger) -> BreakoutStrategy:
+    return BreakoutStrategy(
+        commission_rate=config.simulation.commission_rate,
+        slippage=config.simulation.slippage,
+        logger=logger,
+    )
+
+
+def build_strategy(config: AppConfig, logger: Logger) -> BaseStrategy[object]:
+    breakout = build_breakout_strategy(config, logger)
+    if config.strategy.strategy_id == "breakout":
+        return breakout
+    if config.strategy.strategy_id == "bee_bite":
+        return BeeBiteStrategy(breakout)
+    raise ValueError(f"Неподдерживаемый strategy_id: {config.strategy.strategy_id}")


### PR DESCRIPTION
### Motivation
- Support running different strategy variants from the same codebase by introducing a strategy identifier and a factory to build the appropriate strategy instance.
- Enable per-run override of the strategy selection via CLI while keeping a project-wide default in `.env`.
- Allow `plot-from-results` and plotting flows to use strategy-specific parameter columns (existing breakout columns vs `bite_*` for bee_bite).

### Description
- Added `strategy_id: str` to `StrategyConfig` with default `"breakout"` and implemented parsing of `STRATEGY_ID` from env in `load_config` with validation (`"breakout"`, `"bee_bite"`).
- Introduced `strategy/factory.py` with `build_strategy(config, logger)` returning `BaseStrategy` and `build_breakout_strategy(config, logger)` for breakout-specific plotting code.
- Implemented `bee_bite` adapter under `strategy/bee_bite/` that maps `bite_*` params to `BreakoutParams` and exposes its own `BeeBiteParams` and `BeeBiteStrategy` (adapter over `BreakoutStrategy`).
- Replaced direct `BreakoutStrategy(...)` construction in `cli/commands.py` with factory usage, added resolution of strategy id from CLI (`--strategy`) or config, and branched `plot-from-results`/plot flows to accept strategy-specific CSV columns (no prefix for `breakout`, `bite_` prefix for `bee_bite`).
- Added CLI override `--strategy` to `run-backtest` in `cli/parser.py` and updated `README.md` with usage examples for `.env` and CLI strategy selection and notes about required CSV columns for `--plot-from-results`.

### Testing
- Ran `python -m compileall config cli strategy` to verify modules compile; compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999e9a7ac588320bc15c508009f9b2a)