### PR TITLE
Добавить taker_buy_volume и quality-метаданные ликвидности

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -58,6 +58,7 @@ from domain.models.reporting.quality_report import QualityReport
 from domain.models.reporting.quality_summary import QualitySummary
 from domain.models.reporting.quality_symbol_stats import QualitySymbolStats
 from domain.models.reporting.trade_results_distribution import TradeResultsDistribution
+from domain.models.reporting.symbol_fetch_result import SymbolFetchResult
 from strategy.breakout.breakout_strategy import BreakoutStrategy
 from strategy.breakout.config import PARAMETER_GRID_SIZE, TARGET_PARAMETER_COMBINATIONS, BreakoutParams
 from strategy.factory import build_breakout_strategy, build_strategy
@@ -382,8 +383,9 @@ def _resolve_symbols(
         cache_dir: Path,
         liquidity_timeframe: Timeframe,
         futures_symbols_raw: list[str] | None = None,
-) -> list[str]:
+) -> tuple[list[str], dict[str, dict[str, object]]]:
     futures_symbols_raw = futures_symbols_raw or exchange_client.get_futures_symbols()
+    liquidity_quality_by_symbol: dict[str, dict[str, object]] = {}
     futures_symbol_map = {
         normalize_symbol(symbol): symbol
         for symbol in futures_symbols_raw
@@ -412,11 +414,27 @@ def _resolve_symbols(
         is_cold_start = len(symbols_with_volume) < min_cache_ready_symbols
         if is_cold_start:
             try:
-                bootstrap_symbols = [
-                    normalize_symbol(symbol)
-                    for symbol in exchange_client.get_futures_symbols_by_quote_volume()[:top_n]
-                    if normalize_symbol(symbol) in futures_symbol_map
+                ranked_metrics = exchange_client.get_futures_symbols_with_liquidity_metrics()
+                ranked_filtered = [
+                    item
+                    for item in ranked_metrics
+                    if float(item.get("quote_volume", 0.0) or 0.0) >= 10_000_000.0
                 ]
+                bootstrap_symbols = [
+                    normalize_symbol(str(item["symbol"]))
+                    for item in ranked_filtered[:top_n]
+                    if normalize_symbol(str(item["symbol"])) in futures_symbol_map
+                ]
+                liquidity_quality_by_symbol.update({
+                    str(item["symbol"]): {
+                        "liquidity_score": float(item.get("liquidity_score", 0.0) or 0.0),
+                        "quote_volume": float(item.get("quote_volume", 0.0) or 0.0),
+                        "trade_count_24h": int(item.get("trade_count_24h", 0) or 0),
+                        "quality_flags": list(item.get("quality_flags", [])),
+                        "quality_metadata": dict(item.get("quality_metadata", {})),
+                    }
+                    for item in ranked_metrics
+                })
                 bootstrap_mode = "bootstrap-exchange-volume"
             except Exception as exc:
                 logger.warning(
@@ -437,7 +455,7 @@ def _resolve_symbols(
                 min_cache_ready_symbols,
                 len(bootstrap_symbols),
             )
-            return [futures_symbol_map[symbol] for symbol in bootstrap_symbols]
+            return [futures_symbol_map[symbol] for symbol in bootstrap_symbols], liquidity_quality_by_symbol
 
         liquid_symbols = [
             symbol
@@ -463,7 +481,7 @@ def _resolve_symbols(
             min_volume_usd,
             len(symbols_with_volume) - len(liquid_symbols),
         )
-        return [futures_symbol_map[symbol] for symbol in ranked_top_symbols]
+        return [futures_symbol_map[symbol] for symbol in ranked_top_symbols], liquidity_quality_by_symbol
 
     market_caps_by_symbol = market_client.get_market_caps(exchange_symbols_normalized)
     ranked_symbols = sorted(
@@ -527,7 +545,7 @@ def _resolve_symbols(
         excluded_by_liquidity,
         len(liquid_symbols),
     )
-    return [futures_symbol_map[symbol] for symbol in liquid_symbols]
+    return [futures_symbol_map[symbol] for symbol in liquid_symbols], liquidity_quality_by_symbol
 
 
 def _resolve_fetch_anchor_timestamp_ms(config: AppConfig, end_timestamp_ms_raw: int | None) -> int:
@@ -609,6 +627,28 @@ def _log_loaded_coins(logger: Logger, count: int, action: str) -> None:
     logger.info(template, count)
 
 
+def _attach_liquidity_quality_metadata(
+    results: dict[str, SymbolFetchResult],
+    liquidity_quality_by_symbol: dict[str, dict[str, object]],
+) -> dict[str, SymbolFetchResult]:
+    if not liquidity_quality_by_symbol:
+        return results
+
+    enriched: dict[str, SymbolFetchResult] = {}
+    for symbol, symbol_result in results.items():
+        metadata = liquidity_quality_by_symbol.get(symbol, {})
+        if not metadata:
+            enriched[symbol] = symbol_result
+            continue
+        enriched[symbol] = SymbolFetchResult(
+            success=symbol_result.success,
+            message=symbol_result.message,
+            added_rows=symbol_result.added_rows,
+            quality_metadata=dict(metadata),
+        )
+    return enriched
+
+
 def _resolve_timeframe(value: str | None, *, fallback: Timeframe, argument_name: str) -> Timeframe:
     if value is None:
         return fallback
@@ -639,7 +679,7 @@ def _fetch_data_inner(config: AppConfig, args: argparse.Namespace) -> int:
     ignore_coingecko = args.ignore_coingecko if args.ignore_coingecko is not None else config.fetch.ignore_coingecko
     market_client.set_skip_invalid_coin_id_filter(ignore_coingecko)
     top_n = args.top_n if args.top_n is not None else all_futures_count
-    symbols = _resolve_symbols(
+    symbols, liquidity_quality_by_symbol = _resolve_symbols(
         exchange_client,
         market_client,
         top_n=top_n,
@@ -658,6 +698,7 @@ def _fetch_data_inner(config: AppConfig, args: argparse.Namespace) -> int:
         "coingecko-disabled" if ignore_coingecko else "coingecko-enabled",
     )
     if not symbols:
+        liquidity_quality_by_symbol = {}
         logger.info("загрузка-данных: не найдено символов для загрузки")
         return 0
 
@@ -677,6 +718,13 @@ def _fetch_data_inner(config: AppConfig, args: argparse.Namespace) -> int:
             start_timestamp_ms=start_timestamp_ms,
             end_timestamp_ms=end_timestamp_ms,
         )
+        enriched_ohlcv = _attach_liquidity_quality_metadata(result.ohlcv, liquidity_quality_by_symbol)
+        result.ohlcv.clear()
+        result.ohlcv.update(enriched_ohlcv)
+        enriched_open_interest = _attach_liquidity_quality_metadata(result.open_interest, liquidity_quality_by_symbol)
+        result.open_interest.clear()
+        result.open_interest.update(enriched_open_interest)
+
         fetch_summaries[timeframe] = _log_fetch_summary(
             f"fetch-data[{timeframe.value}]",
             logger,
@@ -704,7 +752,7 @@ def _fetch_data_inner(config: AppConfig, args: argparse.Namespace) -> int:
             config.fetch.liquidity_skip_error_ratio_threshold,
         )
         if skip_reason is None:
-            followup_symbols = _resolve_symbols(
+            followup_symbols, liquidity_quality_by_symbol = _resolve_symbols(
                 exchange_client,
                 market_client,
                 top_n=top_n,
@@ -759,7 +807,7 @@ def _update_cache_inner(config: AppConfig, args: argparse.Namespace) -> int:
     ignore_coingecko = args.ignore_coingecko if args.ignore_coingecko is not None else config.fetch.ignore_coingecko
     market_client.set_skip_invalid_coin_id_filter(ignore_coingecko)
     top_n = args.top_n if args.top_n is not None else all_futures_count
-    symbols = _resolve_symbols(
+    symbols, liquidity_quality_by_symbol = _resolve_symbols(
         exchange_client,
         market_client,
         top_n=top_n,
@@ -785,6 +833,12 @@ def _update_cache_inner(config: AppConfig, args: argparse.Namespace) -> int:
     for timeframe in config.fetch.timeframes:
         logger.info("обновление-кэша: сбор кэша для TF=%s", timeframe.value)
         result = fetcher.fetch_all(symbols=symbols, timeframe=timeframe, start_timestamp_ms=start_timestamp_ms, end_timestamp_ms=end_timestamp_ms)
+        enriched_ohlcv = _attach_liquidity_quality_metadata(result.ohlcv, liquidity_quality_by_symbol)
+        result.ohlcv.clear()
+        result.ohlcv.update(enriched_ohlcv)
+        enriched_open_interest = _attach_liquidity_quality_metadata(result.open_interest, liquidity_quality_by_symbol)
+        result.open_interest.clear()
+        result.open_interest.update(enriched_open_interest)
         _log_fetch_summary(f"update-cache[{timeframe.value}]", logger, len(symbols), result.failed_symbols_count)
         failed_symbols.update(
             symbol

--- a/constants.py
+++ b/constants.py
@@ -38,7 +38,7 @@ TIMEFRAME_TO_DELTA = {
     Timeframe.W1: timedelta(weeks=1),
 }
 
-OHLCV_FRAME_COLUMNS = ("timestamp", "open", "high", "low", "close", "volume")
+OHLCV_FRAME_COLUMNS = ("timestamp", "open", "high", "low", "close", "volume", "taker_buy_volume")
 OPEN_INTEREST_FRAME_COLUMNS = ("timestamp", "open_interest")
 CCXT_MARKET_TYPE_SWAP = "swap"
 FUTURES_SETTLEMENT_QUOTE_ASSET = "USDT"
@@ -79,7 +79,7 @@ LOG_MSG_SKIP_UP_TO_DATE = "%s пропуск: %s уже актуален"
 LOG_MSG_TASK_COMPLETED = "%s завершено"
 
 # Константы подготовщика данных
-DATA_PREPARER_NUMERIC_COLUMNS = ("open", "high", "low", "close", "volume", "open_interest")
+DATA_PREPARER_NUMERIC_COLUMNS = ("open", "high", "low", "close", "volume", "open_interest", "taker_buy_volume")
 DATA_PREPARER_EMPTY_FLOAT_DTYPE = "float64"
 DATA_PREPARER_EMPTY_BOOL_DTYPE = "bool"
 DATA_PREPARER_TRADE_COLUMNS = ("entry_timestamp_ms", "exit_timestamp_ms", "pnl", "pnl_percent", "result_type")

--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -186,6 +186,16 @@ class CcxtFuturesClient(ExchangeClient):
 
     def get_futures_symbols_by_quote_volume(self) -> list[str]:
         """Возвращает фьючерсные символы, отсортированные по 24ч quote volume (убывание)."""
+        ranked = self.get_futures_symbols_with_liquidity_metrics()
+        min_quote_volume = 10_000_000.0
+        return [
+            str(item["symbol"])
+            for item in ranked
+            if float(item.get("quote_volume", 0.0) or 0.0) >= min_quote_volume
+        ]
+
+    def get_futures_symbols_with_liquidity_metrics(self) -> list[dict[str, object]]:
+        """Возвращает символы с 24ч метриками ликвидности и quality-флагами."""
         symbols = self.get_futures_symbols()
         if not symbols:
             return []
@@ -196,8 +206,6 @@ class CcxtFuturesClient(ExchangeClient):
             call=self._client.fetch_tickers,
             args=(symbols,),
         )
-        if not isinstance(tickers_payload, dict):
-            return symbols
 
         def _safe_float(value: object) -> float:
             if not isinstance(value, (int, float, str, bytes)):
@@ -208,11 +216,69 @@ class CcxtFuturesClient(ExchangeClient):
                 return 0.0
             return parsed if isfinite(parsed) and parsed > 0 else 0.0
 
-        volumes_by_symbol: dict[str, float] = {}
+        def _safe_int(value: object) -> int:
+            if not isinstance(value, (int, float, str, bytes)):
+                return 0
+            try:
+                parsed = int(float(value))
+            except (TypeError, ValueError):
+                return 0
+            return parsed if parsed > 0 else 0
+
+        def _extract_trade_count_24h(ticker: dict[str, object]) -> int:
+            info = ticker.get("info")
+            candidates = [ticker.get("count"), ticker.get("trades")]
+            if isinstance(info, dict):
+                candidates.extend([info.get("count"), info.get("tradeCount"), info.get("numberOfTrades")])
+            for candidate in candidates:
+                parsed = _safe_int(candidate)
+                if parsed > 0:
+                    return parsed
+            return 0
+
+        def _extract_open_interest(ticker: dict[str, object]) -> float:
+            info = ticker.get("info")
+            candidates = [ticker.get("openInterest")]
+            if isinstance(info, dict):
+                candidates.extend([info.get("openInterest"), info.get("openInterestValue")])
+            for candidate in candidates:
+                parsed = _safe_float(candidate)
+                if parsed > 0.0:
+                    return parsed
+            return 0.0
+
+        def _extract_taker_buy_volume(ticker: dict[str, object]) -> float:
+            info = ticker.get("info")
+            if not isinstance(info, dict):
+                return 0.0
+            candidates = [
+                info.get("takerBuyQuoteVolume"),
+                info.get("taker_buy_quote_volume"),
+                info.get("takerBuyVolume"),
+                info.get("taker_buy_volume"),
+            ]
+            for candidate in candidates:
+                parsed = _safe_float(candidate)
+                if parsed > 0.0:
+                    return parsed
+            return 0.0
+
+        records: list[dict[str, object]] = []
         for symbol in symbols:
-            ticker = tickers_payload.get(symbol)
+            ticker = tickers_payload.get(symbol) if isinstance(tickers_payload, dict) else None
             if not isinstance(ticker, dict):
-                volumes_by_symbol[symbol] = 0.0
+                records.append({
+                    "symbol": symbol,
+                    "quote_volume": 0.0,
+                    "trade_count_24h": 0,
+                    "liquidity_score": 0.0,
+                    "quality_flags": ["no_oi", "no_taker", "questionable_sync"],
+                    "quality_metadata": {
+                        "no_oi": True,
+                        "no_taker": True,
+                        "questionable_sync": True,
+                    },
+                })
                 continue
 
             quote_volume = _safe_float(ticker.get("quoteVolume"))
@@ -220,13 +286,30 @@ class CcxtFuturesClient(ExchangeClient):
                 base_volume = _safe_float(ticker.get("baseVolume"))
                 last_price = _safe_float(ticker.get("last"))
                 quote_volume = base_volume * last_price
-            volumes_by_symbol[symbol] = quote_volume
 
-        return sorted(
-            symbols,
-            key=lambda symbol: (volumes_by_symbol.get(symbol, 0.0), symbol),
-            reverse=True,
-        )
+            trade_count_24h = _extract_trade_count_24h(ticker)
+            open_interest_24h = _extract_open_interest(ticker)
+            taker_buy_volume_24h = _extract_taker_buy_volume(ticker)
+
+            quality_metadata = {
+                "no_oi": open_interest_24h <= 0.0,
+                "no_taker": taker_buy_volume_24h <= 0.0,
+                "questionable_sync": quote_volume <= 0.0 or trade_count_24h <= 0,
+                "open_interest_24h": open_interest_24h,
+                "taker_buy_volume_24h": taker_buy_volume_24h,
+            }
+            quality_flags = [flag for flag in ("no_oi", "no_taker", "questionable_sync") if bool(quality_metadata[flag])]
+
+            records.append({
+                "symbol": symbol,
+                "quote_volume": quote_volume,
+                "trade_count_24h": trade_count_24h,
+                "liquidity_score": quote_volume if quote_volume > 0.0 else 0.0,
+                "quality_flags": quality_flags,
+                "quality_metadata": quality_metadata,
+            })
+
+        return sorted(records, key=lambda row: (float(row["quote_volume"]), str(row["symbol"])), reverse=True)
 
     def fetch_ohlcv(
         self,
@@ -261,7 +344,13 @@ class CcxtFuturesClient(ExchangeClient):
                 break
             since = last_ts + 1
 
-        frame = pd.DataFrame(all_rows, columns=OHLCV_FRAME_COLUMNS)
+        normalized_rows = [
+            list(row[: len(OHLCV_FRAME_COLUMNS)])
+            if len(row) >= len(OHLCV_FRAME_COLUMNS)
+            else [*row, None]
+            for row in all_rows
+        ]
+        frame = pd.DataFrame(normalized_rows, columns=OHLCV_FRAME_COLUMNS)
         if frame.empty:
             return frame
 

--- a/data/quality/data_validator.py
+++ b/data/quality/data_validator.py
@@ -83,7 +83,7 @@ class DataValidator:
 
         numeric_columns: dict[str, pd.Series] = {
             col: pd.Series(pd.to_numeric(normalized[col], errors="coerce"), index=normalized.index)
-            for col in ("open", "high", "low", "close", "volume", "open_interest")
+            for col in ("open", "high", "low", "close", "volume", "open_interest", "taker_buy_volume")
             if col in normalized.columns
         }
 
@@ -110,6 +110,7 @@ class DataValidator:
         issue_type_by_column = {
             "volume": "negative_volume",
             "open_interest": "negative_open_interest",
+            "taker_buy_volume": "negative_taker_buy_volume",
         }
         for col, issue_type in issue_type_by_column.items():
             if col in numeric_columns:

--- a/domain/models/candle.py
+++ b/domain/models/candle.py
@@ -17,6 +17,7 @@ class Candle:
     close: Price
     volume: Volume
     open_interest: Volume
+    taker_buy_volume: Volume | None = None
 
     # region Приватные
     def __post_init__(self) -> None:

--- a/domain/models/reporting/symbol_fetch_result.py
+++ b/domain/models/reporting/symbol_fetch_result.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True, slots=True)
@@ -10,14 +10,15 @@ class SymbolFetchResult:
     success: bool
     message: str
     added_rows: int = 0
+    quality_metadata: dict[str, object] = field(default_factory=dict)
 
     @classmethod
     def ok(cls, added_rows: int) -> "SymbolFetchResult":
         """Создаёт успешный результат загрузки символа."""
-        return cls(success=True, message="ok", added_rows=added_rows)
+        return cls(success=True, message="ok", added_rows=added_rows, quality_metadata={})
 
     @classmethod
     def error(cls, message: str) -> "SymbolFetchResult":
         """Создаёт результат загрузки с ошибкой."""
-        return cls(success=False, message=message, added_rows=0)
+        return cls(success=False, message=message, added_rows=0, quality_metadata={})
 

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -54,6 +54,7 @@ class CandleRow(TypedDict):
     volume: float
     natr: float
     open_interest: NotRequired[float | int]
+    taker_buy_volume: NotRequired[float | int]
 
 
 @dataclass(frozen=True, slots=True)
@@ -198,6 +199,11 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             close=Price(float(row["close"])),
             volume=Volume(float(row["volume"])),
             open_interest=Volume(float(row.get("open_interest", STRATEGY_DEFAULT_OPEN_INTEREST))),
+            taker_buy_volume=(
+                Volume(float(row.get("taker_buy_volume")))
+                if row.get("taker_buy_volume") is not None and str(row.get("taker_buy_volume")).strip() != ""
+                else None
+            ),
         )
 
     @staticmethod


### PR DESCRIPTION
### Motivation
- Учесть taker-метрику в кэше/моделях свечи и подготовке данных для стратегий.
- Собрать дополнительные 24h метрики ликвидности (включая количество сделок) из payload тикеров и маркировать сомнительные случаи quality-флагами.
- Применить порог фильтра ликвидности `quote_volume >= 10_000_000` при bootstrap-отборе символов по биржевым тикерам.
- Сохранять per-symbol метаданные качества, чтобы можно было объяснить, почему score/ликвидность по символу обнулены или урезаны.

### Description
- Добавлено поле `taker_buy_volume` в `OHLCV_FRAME_COLUMNS` и `DATA_PREPARER_NUMERIC_COLUMNS` в `constants.py`.
- Расширена доменная модель свечи `Candle` с опциональным полем `taker_buy_volume`, и обновлён маппинг в `strategy/breakout/breakout_strategy.py` для чтения этого поля.
- В `data/exchanges/ccxt_futures_client.py` добавлен метод `get_futures_symbols_with_liquidity_metrics()` который извлекает из тикеров `quote_volume`, 24h `trade_count` (через `count`/`trades` и поля в `info` с fallback), `taker_buy_volume`, вычисляет `liquidity_score` и формирует `quality_flags` (`no_oi`, `no_taker`, `questionable_sync`) и `quality_metadata` для каждого символа; `get_futures_symbols_by_quote_volume()` теперь фильтрует по `quote_volume >= 10_000_000`.
- В `fetch_ohlcv` реализована нормализация строк пакета под обновлённую схему колонок (включая возможное отсутствие taker-колонки) для безопасного чтения в DataFrame.
- Добавлено поле `quality_metadata` в `SymbolFetchResult` и в `cli/commands.py` реализована логика проброса/пришивания этих metadata к результатам загрузки `ohlcv`/`open_interest` через `_attach_liquidity_quality_metadata` и изменение сигнатуры `_resolve_symbols` для возврата словаря качества по символу.
- В `data/quality/data_validator.py` добавлена поддержка `taker_buy_volume` в числовых проверках и проверке на отрицательные значения.

### Testing
- Выполнена компиляция модифицированных модулей с помощью `python -m compileall cli data domain strategy vectorbt_runner constants.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ebf967448320b149b4bee18b996d)