### PR TITLE
Refactor Bee Bite execution into shared risk and exit modules

### DIFF
--- a/simulation/__init__.py
+++ b/simulation/__init__.py
@@ -4,6 +4,20 @@ from simulation.models.fill import Fill
 from simulation.order_processor import OrderProcessor
 from simulation.position_simulator import StatefulPositionSimulator
 from simulation.portfolio_state_engine import PortfolioEngineConfig, PortfolioStateEngine, PortfolioState
+from simulation.risk_manager import RiskConfig, RiskManager
+from simulation.exit_manager import ExitManager, ExitManagerConfig
 from simulation.trade_classifier import TradeClassifier
 
-__all__ = ["Fill", "OrderProcessor", "StatefulPositionSimulator", "TradeClassifier", "PortfolioEngineConfig", "PortfolioStateEngine", "PortfolioState"]
+__all__ = [
+    "Fill",
+    "OrderProcessor",
+    "StatefulPositionSimulator",
+    "TradeClassifier",
+    "PortfolioEngineConfig",
+    "PortfolioStateEngine",
+    "PortfolioState",
+    "RiskConfig",
+    "RiskManager",
+    "ExitManager",
+    "ExitManagerConfig",
+]

--- a/simulation/exit_manager.py
+++ b/simulation/exit_manager.py
@@ -1,0 +1,131 @@
+"""Переиспользуемая механика TP1 -> BE+ -> TP2/trailing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from constants import TP1_CLOSE_RATIO
+from domain.enums.position_side import PositionSide
+from domain.models.candle import Candle
+from domain.models.position import Position
+
+
+@dataclass(frozen=True, slots=True)
+class ExitManagerConfig:
+    tp1_close_ratio: float = TP1_CLOSE_RATIO
+    be_plus_offset_ratio: float = 0.0
+    trailing_offset_ratio: float | None = None
+
+
+@dataclass(slots=True)
+class ExitManager:
+    config: ExitManagerConfig
+
+    def process(
+        self,
+        *,
+        candle: Candle,
+        position: Position,
+        side: PositionSide,
+        close_leg: Callable[[float, float], None],
+        breakeven_price: Callable[[float, PositionSide], float],
+        update_stop: Callable[[float], None],
+    ) -> tuple[float | None, bool]:
+        if side == PositionSide.LONG:
+            return self._process_long(
+                candle=candle,
+                position=position,
+                close_leg=close_leg,
+                breakeven_price=breakeven_price,
+                update_stop=update_stop,
+            )
+        return self._process_short(
+            candle=candle,
+            position=position,
+            close_leg=close_leg,
+            breakeven_price=breakeven_price,
+            update_stop=update_stop,
+        )
+
+    def _process_long(
+        self,
+        *,
+        candle: Candle,
+        position: Position,
+        close_leg: Callable[[float, float], None],
+        breakeven_price: Callable[[float, PositionSide], float],
+        update_stop: Callable[[float], None],
+    ) -> tuple[float | None, bool]:
+        if candle.low.value <= position.stop_loss.value:
+            return position.stop_loss.value, position.sl_moved_to_be
+
+        if not position.tp1_done and candle.high.value >= position.take_profit_1.value:
+            tp1_size = position.size.value * self.config.tp1_close_ratio
+            close_leg(tp1_size, position.take_profit_1.value)
+            position.tp1_done = True
+            position.sl_moved_to_be = True
+            be = breakeven_price(position.entry_price.value, PositionSide.LONG)
+            be_plus = be * (1 + self.config.be_plus_offset_ratio)
+            update_stop(be_plus)
+            if candle.low.value <= position.stop_loss.value:
+                return position.stop_loss.value, True
+
+        self._maybe_update_trailing_stop(candle=candle, position=position, side=PositionSide.LONG, update_stop=update_stop)
+
+        if candle.low.value <= position.stop_loss.value:
+            return position.stop_loss.value, True
+        if candle.high.value >= position.take_profit_2.value:
+            return position.take_profit_2.value, False
+        return None, False
+
+    def _process_short(
+        self,
+        *,
+        candle: Candle,
+        position: Position,
+        close_leg: Callable[[float, float], None],
+        breakeven_price: Callable[[float, PositionSide], float],
+        update_stop: Callable[[float], None],
+    ) -> tuple[float | None, bool]:
+        if candle.high.value >= position.stop_loss.value:
+            return position.stop_loss.value, position.sl_moved_to_be
+
+        if not position.tp1_done and candle.low.value <= position.take_profit_1.value:
+            tp1_size = position.size.value * self.config.tp1_close_ratio
+            close_leg(tp1_size, position.take_profit_1.value)
+            position.tp1_done = True
+            position.sl_moved_to_be = True
+            be = breakeven_price(position.entry_price.value, PositionSide.SHORT)
+            be_plus = be * (1 - self.config.be_plus_offset_ratio)
+            update_stop(be_plus)
+            if candle.high.value >= position.stop_loss.value:
+                return position.stop_loss.value, True
+
+        self._maybe_update_trailing_stop(candle=candle, position=position, side=PositionSide.SHORT, update_stop=update_stop)
+
+        if candle.high.value >= position.stop_loss.value:
+            return position.stop_loss.value, True
+        if candle.low.value <= position.take_profit_2.value:
+            return position.take_profit_2.value, False
+        return None, False
+
+    def _maybe_update_trailing_stop(
+        self,
+        *,
+        candle: Candle,
+        position: Position,
+        side: PositionSide,
+        update_stop: Callable[[float], None],
+    ) -> None:
+        trailing = self.config.trailing_offset_ratio
+        if trailing is None or not position.tp1_done:
+            return
+        if side == PositionSide.LONG:
+            candidate = candle.high.value * (1 - trailing)
+            if candidate > position.stop_loss.value:
+                update_stop(candidate)
+            return
+        candidate = candle.low.value * (1 + trailing)
+        if candidate < position.stop_loss.value:
+            update_stop(candidate)

--- a/simulation/portfolio_state_engine.py
+++ b/simulation/portfolio_state_engine.py
@@ -7,7 +7,6 @@ from enum import Enum
 
 import pandas as pd
 
-from constants import STRATEGY_POSITION_SIZE
 from domain.enums.position_side import PositionSide
 from domain.models.candle import Candle
 from domain.models.trade_result import TradeResult
@@ -16,6 +15,7 @@ from domain.value_objects.price import Price
 from simulation.order_processor import OrderProcessor
 from simulation.position_simulator import StatefulPositionSimulator
 from simulation.trade_classifier import TradeClassifier
+from simulation.risk_manager import RiskConfig, RiskManager
 
 
 class PortfolioState(str, Enum):
@@ -31,6 +31,10 @@ class PortfolioState(str, Enum):
 @dataclass(slots=True)
 class PortfolioEngineConfig:
     top_n: int = 1
+    r_trade: float = 1.0
+    portfolio_risk_limit: float = 3.0
+    min_stop_atr_ratio: float = 0.3
+    t_max_in_trade: int | None = None
     cooldown_bars: int = 8
     max_age_range: int = 24
     reclaim_limit: int = 3
@@ -73,11 +77,21 @@ class PortfolioStateEngine:
     slippage: float
     _states: dict[str, SymbolState] = field(default_factory=dict)
     _sims: dict[str, StatefulPositionSimulator] = field(default_factory=dict)
+    _risk_manager: RiskManager | None = None
 
     def run(self, symbol_frames: dict[str, pd.DataFrame]) -> list[TradeResult]:
         timeline = self._build_timeline(symbol_frames)
         if not timeline:
             return []
+
+        if self._risk_manager is None:
+            self._risk_manager = RiskManager(
+                RiskConfig(
+                    r_trade=self.config.r_trade,
+                    portfolio_risk_limit=self.config.portfolio_risk_limit,
+                    min_stop_atr_ratio=self.config.min_stop_atr_ratio,
+                )
+            )
 
         trades: list[TradeResult] = []
         for ts in timeline:
@@ -136,6 +150,7 @@ class PortfolioStateEngine:
             side=PositionSide.LONG,
             order_processor=OrderProcessor(commission_rate=self.commission_rate, slippage=self.slippage),
             trade_classifier=TradeClassifier(),
+            max_bars_in_trade=self.config.t_max_in_trade,
         )
 
     def _process_active_trade(
@@ -228,6 +243,9 @@ class PortfolioStateEngine:
 
             if state.reclaim_count >= self.config.reclaim_limit:
                 signal = self._build_signal(symbol=symbol, row=row, side=state.break_side)
+                if signal is None:
+                    self._reset_state(state)
+                    return None
                 state.signal = signal
                 state.state = PortfolioState.ENTRY_SIGNAL
                 state.age = 0
@@ -276,7 +294,17 @@ class PortfolioStateEngine:
         state = self._states[candidate.symbol]
         sim = self._sims[candidate.symbol]
         sim.side = candidate.side
-        sim.register_signal(candidate.signal, size=STRATEGY_POSITION_SIZE)
+        assert self._risk_manager is not None
+        active_positions = [
+            (other_sim.position, other_sim.side)
+            for other_sim in self._sims.values()
+            if other_sim.position is not None
+        ]
+        if not self._risk_manager.can_open_with_portfolio_limit(active_positions=active_positions, signal=candidate.signal):
+            self._reject_candidate(candidate.symbol)
+            return
+        size = self._risk_manager.calc_position_size(signal=candidate.signal)
+        sim.register_signal(candidate.signal, size=size)
         state.state = PortfolioState.IN_TRADE
         state.age = 0
 
@@ -303,7 +331,7 @@ class PortfolioStateEngine:
             state.signal = None
         return trades
 
-    def _build_signal(self, *, symbol: str, row: dict[str, float], side: PositionSide) -> TradeSignal:
+    def _build_signal(self, *, symbol: str, row: dict[str, float], side: PositionSide) -> TradeSignal | None:
         entry = row["close"]
         risk = max(entry * 0.005, 1e-8)
         if side == PositionSide.LONG:
@@ -314,7 +342,7 @@ class PortfolioStateEngine:
             stop = entry + risk
             tp1 = entry - risk
             tp2 = entry - risk * self.config.rr
-        return TradeSignal(
+        signal = TradeSignal(
             symbol=symbol,
             position_side=side,
             entry_price=Price(entry),
@@ -326,6 +354,7 @@ class PortfolioStateEngine:
             breakout_timestamp_ms=int(row["timestamp"]),
             retest_timestamp_ms=int(row["timestamp"]),
         )
+        return signal
 
     @staticmethod
     def _to_candle(row: dict[str, float]) -> Candle:

--- a/simulation/position_simulator.py
+++ b/simulation/position_simulator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from constants import SIMULATION_PRICE_COMPARISON_EPSILON, TP1_CLOSE_RATIO
 from domain.abstract.position_simulator import PositionSimulator
@@ -14,6 +14,7 @@ from domain.models.trade_result import TradeResult
 from domain.models.trade_signal import TradeSignal
 from domain.value_objects.price import Price
 from domain.value_objects.volume import Volume
+from simulation.exit_manager import ExitManager, ExitManagerConfig
 from simulation.order_processor import OrderProcessor
 from simulation.trade_classifier import TradeClassifier
 
@@ -25,6 +26,8 @@ class StatefulPositionSimulator(PositionSimulator):
     side: PositionSide
     order_processor: OrderProcessor
     trade_classifier: TradeClassifier
+    exit_manager: ExitManager = field(default_factory=lambda: ExitManager(config=ExitManagerConfig(tp1_close_ratio=TP1_CLOSE_RATIO)))
+    max_bars_in_trade: int | None = None
 
     position: Position | None = None
     _pending_signal: TradeSignal | None = None
@@ -32,6 +35,7 @@ class StatefulPositionSimulator(PositionSimulator):
     _realized_pnl: float = 0.0
     _closed_size: float = 0.0
     _last_exit_price: float = 0.0
+    _bars_in_trade: int = 0
 
     # region Приватные
 
@@ -54,54 +58,37 @@ class StatefulPositionSimulator(PositionSimulator):
         self._realized_pnl = -fill.commission
         self._closed_size = 0.0
         self._last_exit_price = fill.price
+        self._bars_in_trade = 0
         self._pending_signal = None
         self._pending_size = 0.0
 
     def _process_long(self, candle: Candle) -> TradeResult | None:
         assert self.position is not None
-
-        if candle.low.value <= self.position.stop_loss.value:
-            return self._finalize(candle, self.position.stop_loss.value, exit_at_be=self.position.sl_moved_to_be)
-
-        if not self.position.tp1_done and candle.high.value >= self.position.take_profit_1.value:
-            self._take_tp1()
-            if candle.low.value <= self.position.stop_loss.value:
-                return self._finalize(candle, self.position.stop_loss.value, exit_at_be=True)
-
-        if self.position.tp1_done and candle.low.value <= self.position.stop_loss.value:
-            return self._finalize(candle, self.position.stop_loss.value, exit_at_be=True)
-
-        if candle.high.value >= self.position.take_profit_2.value:
-            return self._finalize(candle, self.position.take_profit_2.value, exit_at_tp2=True)
-
+        target, exit_at_be = self.exit_manager.process(
+            candle=candle,
+            position=self.position,
+            side=self.side,
+            close_leg=lambda size, price: self._close_leg(size=size, target_price=price),
+            breakeven_price=self.order_processor.breakeven_price,
+            update_stop=lambda stop: self.update_stop(stop),
+        )
+        if target is not None:
+            return self._finalize(candle, target, exit_at_be=exit_at_be, exit_at_tp2=math.isclose(target, self.position.take_profit_2.value, abs_tol=SIMULATION_PRICE_COMPARISON_EPSILON))
         return None
 
     def _process_short(self, candle: Candle) -> TradeResult | None:
         assert self.position is not None
-
-        if candle.high.value >= self.position.stop_loss.value:
-            return self._finalize(candle, self.position.stop_loss.value, exit_at_be=self.position.sl_moved_to_be)
-
-        if not self.position.tp1_done and candle.low.value <= self.position.take_profit_1.value:
-            self._take_tp1()
-            if candle.high.value >= self.position.stop_loss.value:
-                return self._finalize(candle, self.position.stop_loss.value, exit_at_be=True)
-
-        if self.position.tp1_done and candle.high.value >= self.position.stop_loss.value:
-            return self._finalize(candle, self.position.stop_loss.value, exit_at_be=True)
-
-        if candle.low.value <= self.position.take_profit_2.value:
-            return self._finalize(candle, self.position.take_profit_2.value, exit_at_tp2=True)
-
+        target, exit_at_be = self.exit_manager.process(
+            candle=candle,
+            position=self.position,
+            side=self.side,
+            close_leg=lambda size, price: self._close_leg(size=size, target_price=price),
+            breakeven_price=self.order_processor.breakeven_price,
+            update_stop=lambda stop: self.update_stop(stop),
+        )
+        if target is not None:
+            return self._finalize(candle, target, exit_at_be=exit_at_be, exit_at_tp2=math.isclose(target, self.position.take_profit_2.value, abs_tol=SIMULATION_PRICE_COMPARISON_EPSILON))
         return None
-
-    def _take_tp1(self) -> None:
-        assert self.position is not None
-        tp1_size = self.position.size.value * TP1_CLOSE_RATIO
-        self._close_leg(size=tp1_size, target_price=self.position.take_profit_1.value)
-        self.position.tp1_done = True
-        self.position.sl_moved_to_be = True
-        self.position.stop_loss = Price(self.order_processor.breakeven_price(self.position.entry_price.value, self.side))
 
     def _close_leg(self, *, size: float, target_price: float) -> None:
         assert self.position is not None
@@ -136,6 +123,7 @@ class StatefulPositionSimulator(PositionSimulator):
             pnl=self._realized_pnl,
         )
         self.position = None
+        self._bars_in_trade = 0
         return trade_result
 
     # endregion Приватные
@@ -153,6 +141,10 @@ class StatefulPositionSimulator(PositionSimulator):
         if self.position is None:
             return None
 
+        self._bars_in_trade += 1
+        if self.max_bars_in_trade is not None and self._bars_in_trade >= self.max_bars_in_trade:
+            return self._finalize(candle, candle.close.value, exit_at_be=False, exit_at_tp2=False)
+
         if self.side == PositionSide.LONG:
             return self._process_long(candle)
         return self._process_short(candle)
@@ -163,6 +155,7 @@ class StatefulPositionSimulator(PositionSimulator):
         self._realized_pnl = 0.0
         self._closed_size = 0.0
         self._last_exit_price = position.entry_price.value
+        self._bars_in_trade = 0
 
     def close_position(self, price: float, exit_timestamp_ms: int) -> TradeResult:
         """Закрывает остаток позиции по заданной цене и времени, затем возвращает классифицированный результат сделки."""
@@ -188,6 +181,7 @@ class StatefulPositionSimulator(PositionSimulator):
             pnl=self._realized_pnl,
         )
         self.position = None
+        self._bars_in_trade = 0
         return trade_result
 
     def update_stop(self, new_stop: float) -> None:

--- a/simulation/risk_manager.py
+++ b/simulation/risk_manager.py
@@ -1,0 +1,62 @@
+"""Общий риск-менеджер: размер позиции, фильтры риска и лимит портфеля."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from constants import STRATEGY_PRICE_EPSILON
+from domain.enums.position_side import PositionSide
+from domain.models.position import Position
+from domain.models.trade_signal import TradeSignal
+
+
+@dataclass(frozen=True, slots=True)
+class RiskConfig:
+    r_trade: float
+    portfolio_risk_limit: float
+    min_stop_atr_ratio: float = 0.3
+
+
+@dataclass(slots=True)
+class RiskManager:
+    config: RiskConfig
+
+    @staticmethod
+    def per_unit_risk(*, entry_price: float, stop_loss: float, side: PositionSide) -> float:
+        if side == PositionSide.LONG:
+            return max(entry_price - stop_loss, STRATEGY_PRICE_EPSILON)
+        return max(stop_loss - entry_price, STRATEGY_PRICE_EPSILON)
+
+    def calc_position_size(self, *, signal: TradeSignal) -> float:
+        risk = self.per_unit_risk(
+            entry_price=signal.entry_price.value,
+            stop_loss=signal.stop_loss.value,
+            side=signal.position_side,
+        )
+        return self.config.r_trade / risk
+
+    def check_stop_distance_by_atr(self, *, signal: TradeSignal, atr_bg: float) -> bool:
+        if atr_bg <= 0:
+            return True
+        stop_distance = self.per_unit_risk(
+            entry_price=signal.entry_price.value,
+            stop_loss=signal.stop_loss.value,
+            side=signal.position_side,
+        )
+        return stop_distance >= self.config.min_stop_atr_ratio * atr_bg
+
+    def total_open_risk(self, positions: list[tuple[Position, PositionSide]]) -> float:
+        return sum(
+            self.per_unit_risk(
+                entry_price=position.entry_price.value,
+                stop_loss=position.stop_loss.value,
+                side=side,
+            )
+            * position.size.value
+            for position, side in positions
+        )
+
+    def can_open_with_portfolio_limit(self, *, active_positions: list[tuple[Position, PositionSide]], signal: TradeSignal) -> bool:
+        current_risk = self.total_open_risk(active_positions)
+        new_trade_risk = self.config.r_trade
+        return (current_risk + new_trade_risk) <= self.config.portfolio_risk_limit

--- a/strategy/bee_bite/bee_bite_strategy.py
+++ b/strategy/bee_bite/bee_bite_strategy.py
@@ -33,6 +33,10 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
             retest_zone_atr=params.bite_retest_zone_atr,
             levels_timeframe=params.levels_timeframe,
             entry_timeframe=params.entry_timeframe,
+            bite_r_trade=params.r_trade,
+            bite_portfolio_risk_limit=params.portfolio_risk_limit,
+            bite_min_stop_atr_ratio=params.min_stop_atr_ratio,
+            bite_t_max_in_trade=params.t_max_in_trade,
         )
 
     @staticmethod
@@ -54,6 +58,10 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
             bite_retest_zone_atr=params.retest_zone_atr,
             levels_timeframe=params.levels_timeframe,
             entry_timeframe=params.entry_timeframe,
+            bite_r_trade=params.r_trade,
+            bite_portfolio_risk_limit=params.portfolio_risk_limit,
+            bite_min_stop_atr_ratio=params.min_stop_atr_ratio,
+            bite_t_max_in_trade=params.t_max_in_trade,
         )
 
     def validate_config(self, params: BeeBiteParams) -> None:
@@ -93,6 +101,10 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
             "bite_max_retest_depth": params.bite_max_retest_depth,
             "bite_confirmation_bars": params.bite_confirmation_bars,
             "bite_entry_trigger": params.bite_entry_trigger.value,
+            "bite_r_trade": params.bite_r_trade,
+            "bite_portfolio_risk_limit": params.bite_portfolio_risk_limit,
+            "bite_min_stop_atr_ratio": params.bite_min_stop_atr_ratio,
+            "bite_t_max_in_trade": params.bite_t_max_in_trade,
         }
 
     def prepare_symbol_context(self, *, symbol: str, mtf_frames: SymbolMtfFrames, params: BeeBiteParams):

--- a/strategy/bee_bite/config.py
+++ b/strategy/bee_bite/config.py
@@ -27,3 +27,7 @@ class BeeBiteParams:
     bite_retest_zone_atr: float | None = None
     levels_timeframe: Timeframe = Timeframe.D1
     entry_timeframe: Timeframe = Timeframe.M15
+    bite_r_trade: float = 1.0
+    bite_portfolio_risk_limit: float = 3.0
+    bite_min_stop_atr_ratio: float = 0.3
+    bite_t_max_in_trade: int | None = None

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -18,7 +18,6 @@ from constants import (
     STRATEGY_MIN_RR,
     STRATEGY_MIN_TP2_MULT,
     STRATEGY_MIN_VOLUME_MULT,
-    STRATEGY_POSITION_SIZE,
     STRATEGY_REQUIRED_COLUMNS,
     STRATEGY_RISK_FLOOR, STRATEGY_PRICE_EPSILON,
 )
@@ -28,6 +27,7 @@ from domain.enums.position_side import PositionSide
 from domain.enums.timeframe import Timeframe
 from domain.models.candle import Candle
 from domain.models.level import Level
+from domain.models.position import Position
 from domain.models.retest_plot_span import RetestPlotSpan
 from domain.models.trade_plot_span import TradePlotSpan
 from domain.models.trade_result import TradeResult
@@ -38,6 +38,7 @@ from simulation.order_processor import OrderProcessor
 from simulation.position_simulator import StatefulPositionSimulator
 from simulation.trade_classifier import TradeClassifier
 from simulation.portfolio_state_engine import PortfolioEngineConfig, PortfolioStateEngine
+from simulation.risk_manager import RiskConfig, RiskManager
 from strategy.base_strategy import BaseStrategy
 from strategy.breakout.config import BREAKOUT_PARAMETER_GRID, BreakoutParams
 from strategy.breakout.indicators.level_detector import LevelDetector
@@ -492,6 +493,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         entry_idx: int,
         pending_retest: PendingRetest,
         params: BreakoutParams,
+        risk_manager: RiskManager,
     ) -> TradeSignal | None:
         if entry_idx >= len(annotated):
             return None
@@ -560,7 +562,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             if 0 <= retest_idx < len(annotated)
             else None
         )
-        return TradeSignal(
+        signal = TradeSignal(
             formation_timestamp_ms=pending_retest.breakout.level_start_time,
             entry_price=Price(entry_price),
             entry_timestamp_ms=int(entry_row["timestamp"]),
@@ -572,6 +574,11 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             breakout_timestamp_ms=breakout_timestamp_ms,
             retest_timestamp_ms=retest_timestamp_ms,
         )
+        atr_bg = max(float(entry_row.get("natr", 0.0)), 0.0) * max(entry_price, STRATEGY_PRICE_EPSILON)
+        if not risk_manager.check_stop_distance_by_atr(signal=signal, atr_bg=atr_bg):
+            _log_invalid_signal(reason="stop distance too close to ATR filter")
+            return None
+        return signal
 
     @staticmethod
     def _resolve_stop_loss(
@@ -761,7 +768,13 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             return []
 
         engine = PortfolioStateEngine(
-            config=PortfolioEngineConfig(top_n=1),
+            config=PortfolioEngineConfig(
+                top_n=1,
+                r_trade=params.r_trade,
+                portfolio_risk_limit=params.portfolio_risk_limit,
+                min_stop_atr_ratio=params.min_stop_atr_ratio,
+                t_max_in_trade=params.t_max_in_trade,
+            ),
             commission_rate=self._commission_rate,
             slippage=self._slippage,
         )
@@ -826,6 +839,14 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             "max_touch_penetration_atr": params.max_touch_penetration_atr,
             "max_touch_penetration_pct": params.max_touch_penetration_pct,
         }
+
+        risk_manager = RiskManager(
+            RiskConfig(
+                r_trade=params.r_trade,
+                portfolio_risk_limit=params.portfolio_risk_limit,
+                min_stop_atr_ratio=params.min_stop_atr_ratio,
+            )
+        )
         if annotated.empty:
             self._last_generation_diagnostics = diagnostics
             return []
@@ -989,8 +1010,17 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                     side=pending_signal.position_side,
                     order_processor=OrderProcessor(commission_rate=self._commission_rate, slippage=self._slippage),
                     trade_classifier=TradeClassifier(),
+                    max_bars_in_trade=params.t_max_in_trade,
                 )
-                active_sim.register_signal(pending_signal, size=STRATEGY_POSITION_SIZE)
+                active_positions: list[tuple[Position, PositionSide]] = []
+                if active_sim.position is not None:
+                    active_positions.append((active_sim.position, active_sim.side))
+                if not risk_manager.can_open_with_portfolio_limit(active_positions=active_positions, signal=pending_signal):
+                    pending_signal = None
+                    pending_signal_level_context = None
+                    continue
+                size = risk_manager.calc_position_size(signal=pending_signal)
+                active_sim.register_signal(pending_signal, size=size)
                 active_trade_signal = pending_signal
                 active_trade_level_context = pending_signal_level_context
                 pending_signal = None
@@ -1086,6 +1116,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                         entry_idx=entry_idx,
                         pending_retest=pending_retest,
                         params=params,
+                        risk_manager=risk_manager,
                     )
                     pending_signal_level_context = self._capture_trade_level_context(
                         side=pending_retest.breakout.side,
@@ -1162,6 +1193,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                         entry_idx=entry_idx,
                         pending_retest=pending_retest,
                         params=params,
+                        risk_manager=risk_manager,
                     )
                     pending_signal_level_context = self._capture_trade_level_context(
                         side=pending_retest.breakout.side,
@@ -1229,6 +1261,7 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
                         row=row,
                         breakout=pending_breakout,
                         params=params,
+                        risk_manager=risk_manager,
                     )
                     if volume_check["is_ok"] and extra_filters["is_ok"]:
                         pending_retest = PendingRetest(

--- a/strategy/breakout/config.py
+++ b/strategy/breakout/config.py
@@ -50,6 +50,10 @@ class BreakoutParams:
     max_touch_penetration_pct: float | None = None
     levels_timeframe: Timeframe = Timeframe.D1
     entry_timeframe: Timeframe = Timeframe.M15
+    r_trade: float = 1.0
+    portfolio_risk_limit: float = 3.0
+    min_stop_atr_ratio: float = 0.3
+    t_max_in_trade: int | None = None
 
     def resolve_retest_zone_ratio(self, natr: float) -> float:
         """Возвращает долю зоны ретеста/SL в режиме LEVEL по единому правилу.


### PR DESCRIPTION
### Motivation
- Централизовать логику расчёта размера позиции и проверок риска в переиспользуемом модуле, чтобы стратегия генерировала только сигналы/уровни, а исполнение и риск делегировались общему коду.
- Вынести повторяющуюся механику частичного выхода (TP1 -> BE+ -> TP2/trailing) в отдельный компонент для единообразного поведения симулятора.
- Добавить контроль минимальной дистанции `entry - sl >= 0.3 * ATR_bg` и лимит времени в сделке (`T_max_in_trade`) для защиты от слишком близких стопов и долгих удержаний.

### Description
- Добавлен общий риск-менеджер `simulation/risk_manager.py` с вычислением `per_unit_risk`, размером позиции от `R_trade` (`calc_position_size`), проверкой дистанции стопа относительно ATR (`check_stop_distance_by_atr`) и контролем суммарного риска портфеля (`can_open_with_portfolio_limit`).
- Добавлен `simulation/exit_manager.py`, инкапсулирующий логику частичного выхода на `TP1`, перевод стопа в `BE+`, опциональный trailing и финализацию на `TP2/SL` для обеих сторон позиции.
- `StatefulPositionSimulator` (в `simulation/position_simulator.py`) делегирует обработку жизненного цикла выхода в `ExitManager`, поддерживает `max_bars_in_trade` (time-stop) и сброс счётчика баров при открытии/закрытии позиций.
- Параметры стратегий расширены: в `BreakoutParams` и `BeeBiteParams` добавлены поля риска и исполнения (`r_trade`, `portfolio_risk_limit`, `min_stop_atr_ratio`, `t_max_in_trade`), и Bee Bite теперь прокидывает эти значения в breakout-ядро; `BreakoutStrategy` использует `RiskManager` для ATR-фильтра и расчёта размера позиции при портфельном исполнении.
- В `PortfolioStateEngine` заменено фиксированное `STRATEGY_POSITION_SIZE` на расчёт размера через `RiskManager`, добавлена проверка лимита портфеля перед регистрацией сигнала и передача `t_max_in_trade` в симулятор позиции.
- Обновлён `simulation` экспорт (`simulation/__init__.py`) для новых компонентов `RiskManager` и `ExitManager`.

### Testing
- Скомпилированы целевые пакеты командой `python -m compileall strategy simulation domain config`, компиляция прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ef07902c8320b5e1abc93b799367)