### PR TITLE
Add Bee Bite profiles, controlled expanded grid, validation and CLI/runtime integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,17 @@ python main.py run-backtest --strategy bee_bite
 - `breakout` — поля `lookback`, `volume_mult`, ...
 - `bee_bite` — поля `bite_lookback`, `bite_volume_mult`, ...
 
+Для `bee_bite` доступны профиль и режим сетки:
+- `--bee-bite-profile {A,B,C}` — фиксированный baseline-профиль;
+- `--bee-bite-grid {baseline,expanded}` — baseline (узкий) или controlled-grid (широкий) вокруг baseline.
+
+Переменные окружения для `bee_bite`:
+
+```env
+BEE_BITE_PROFILE=A
+BEE_BITE_GRID_MODE=baseline
+```
+
 ### Фиксация конца периода загрузки (повторяемые прогоны)
 
 Можно зафиксировать «текущий момент» для `fetch-data` и `update-cache`, чтобы получать повторяемые выборки:
@@ -315,3 +326,17 @@ python main.py clear-cache
 ## Параметры breakout-стратегии
 
 По умолчанию грид `retest_window_hours` для перебора параметров: `12, 24, 36, 48` (в часах).
+
+## Сценарии запуска Bee Bite
+
+Узкий baseline (один валидный профиль):
+
+```bash
+python main.py run-backtest --strategy bee_bite --bee-bite-profile A --bee-bite-grid baseline --top-n 50
+```
+
+Широкая controlled-сетка вокруг профиля:
+
+```bash
+python main.py run-backtest --strategy bee_bite --bee-bite-profile A --bee-bite-grid expanded --top-n 100
+```

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -59,6 +59,7 @@ from domain.models.reporting.quality_summary import QualitySummary
 from domain.models.reporting.quality_symbol_stats import QualitySymbolStats
 from domain.models.reporting.trade_results_distribution import TradeResultsDistribution
 from domain.models.reporting.symbol_fetch_result import SymbolFetchResult
+from strategy.bee_bite import parse_bee_bite_grid_mode, parse_bee_bite_profile_id, validate_bee_bite_runtime
 from strategy.breakout.breakout_strategy import BreakoutStrategy
 from strategy.breakout.config import PARAMETER_GRID_SIZE, TARGET_PARAMETER_COMBINATIONS, BreakoutParams
 from strategy.factory import build_breakout_strategy, build_strategy
@@ -857,6 +858,21 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
     logger = get_logger("run-backtest", level=config.backtest.log_level, logs_dir=config.backtest.logs_dir)
     strategy_id = _resolve_strategy_id(config, args)
     config.strategy.strategy_id = strategy_id
+
+    if strategy_id == "bee_bite":
+        config.strategy.bee_bite_profile = parse_bee_bite_profile_id(
+            getattr(args, "bee_bite_profile", None),
+            default=config.strategy.bee_bite_profile,
+        )
+        config.strategy.bee_bite_grid_mode = parse_bee_bite_grid_mode(
+            getattr(args, "bee_bite_grid", None),
+            default=config.strategy.bee_bite_grid_mode,
+        )
+        validate_bee_bite_runtime(
+            profile_id=config.strategy.bee_bite_profile,
+            grid_mode=config.strategy.bee_bite_grid_mode,
+            top_n=getattr(args, "top_n", None),
+        )
     levels_timeframe = _resolve_timeframe(
         getattr(args, "levels_tf", None),
         fallback=config.strategy.levels_timeframe,

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -87,6 +87,18 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Идентификатор стратегии. Приоритетнее STRATEGY_ID из env",
     )
+    run_bt.add_argument(
+        "--bee-bite-profile",
+        choices=["A", "B", "C"],
+        default=None,
+        help="Профиль bee_bite (A/B/C). Используется как baseline.",
+    )
+    run_bt.add_argument(
+        "--bee-bite-grid",
+        choices=["baseline", "expanded"],
+        default=None,
+        help="Режим сетки bee_bite: baseline (узкий) или expanded (широкий).",
+    )
     run_bt.add_argument("--plot", default=False, help="Строить графики сделок (true/false)")
     run_bt.add_argument(
         "--plot-from-results",

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -27,6 +27,7 @@ from constants import (
     DEFAULT_LIQUIDITY_SKIP_ERROR_RATIO_THRESHOLD,
 )
 from domain.enums.timeframe import Timeframe
+from strategy.bee_bite.config import parse_bee_bite_grid_mode, parse_bee_bite_profile_id
 
 __all__ = [
     "AppConfig",
@@ -156,6 +157,8 @@ def load_config(env_path: str | Path = ".env") -> AppConfig:
         strategy_id=_parse_strategy_id(os.getenv("STRATEGY_ID")),
         levels_timeframe=strategy_levels_timeframe,
         entry_timeframe=strategy_entry_timeframe,
+        bee_bite_profile=parse_bee_bite_profile_id(os.getenv("BEE_BITE_PROFILE")),
+        bee_bite_grid_mode=parse_bee_bite_grid_mode(os.getenv("BEE_BITE_GRID_MODE")),
     )
 
     simulation_config = SimulationConfig(

--- a/config/strategy_config.py
+++ b/config/strategy_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from domain.enums.timeframe import Timeframe
+from strategy.bee_bite.config import BeeBiteGridMode, BeeBiteProfileId
 
 
 @dataclass(slots=True)
@@ -12,3 +13,5 @@ class StrategyConfig:
     strategy_id: str = "breakout"
     levels_timeframe: Timeframe = Timeframe.D1
     entry_timeframe: Timeframe = Timeframe.M15
+    bee_bite_profile: BeeBiteProfileId = "A"
+    bee_bite_grid_mode: BeeBiteGridMode = "baseline"

--- a/strategy/bee_bite/__init__.py
+++ b/strategy/bee_bite/__init__.py
@@ -1,4 +1,23 @@
 from strategy.bee_bite.bee_bite_strategy import BeeBiteStrategy
-from strategy.bee_bite.config import BeeBiteParams
+from strategy.bee_bite.config import (
+    BEE_BITE_GRID_MODES,
+    BEE_BITE_PROFILE_IDS,
+    BeeBiteGridMode,
+    BeeBiteParams,
+    BeeBiteProfileId,
+    parse_bee_bite_grid_mode,
+    parse_bee_bite_profile_id,
+    validate_bee_bite_runtime,
+)
 
-__all__ = ["BeeBiteStrategy", "BeeBiteParams"]
+__all__ = [
+    "BeeBiteStrategy",
+    "BeeBiteParams",
+    "BeeBiteProfileId",
+    "BeeBiteGridMode",
+    "BEE_BITE_PROFILE_IDS",
+    "BEE_BITE_GRID_MODES",
+    "parse_bee_bite_profile_id",
+    "parse_bee_bite_grid_mode",
+    "validate_bee_bite_runtime",
+]

--- a/strategy/bee_bite/bee_bite_strategy.py
+++ b/strategy/bee_bite/bee_bite_strategy.py
@@ -3,7 +3,13 @@
 from __future__ import annotations
 
 from strategy.base_strategy import BaseStrategy
-from strategy.bee_bite.config import BeeBiteParams
+from strategy.bee_bite.config import (
+    BeeBiteGridMode,
+    BeeBiteParams,
+    BeeBiteProfileId,
+    build_bee_bite_grid,
+    validate_bee_bite_params,
+)
 from strategy.breakout.breakout_strategy import BreakoutStrategy
 from strategy.breakout.config import BreakoutParams
 from vectorbt_runner.mtf_frames import SymbolMtfFrames
@@ -12,8 +18,16 @@ from vectorbt_runner.mtf_frames import SymbolMtfFrames
 class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
     """bee_bite использует breakout-логику с собственными именами параметров."""
 
-    def __init__(self, breakout: BreakoutStrategy) -> None:
+    def __init__(
+        self,
+        breakout: BreakoutStrategy,
+        *,
+        profile_id: BeeBiteProfileId,
+        grid_mode: BeeBiteGridMode,
+    ) -> None:
         self._breakout = breakout
+        self._profile_id = profile_id
+        self._grid_mode = grid_mode
 
     def _to_breakout_params(self, params: BeeBiteParams) -> BreakoutParams:
         return BreakoutParams(
@@ -33,10 +47,10 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
             retest_zone_atr=params.bite_retest_zone_atr,
             levels_timeframe=params.levels_timeframe,
             entry_timeframe=params.entry_timeframe,
-            bite_r_trade=params.r_trade,
-            bite_portfolio_risk_limit=params.portfolio_risk_limit,
-            bite_min_stop_atr_ratio=params.min_stop_atr_ratio,
-            bite_t_max_in_trade=params.t_max_in_trade,
+            r_trade=params.bite_r_trade,
+            portfolio_risk_limit=params.bite_portfolio_risk_limit,
+            min_stop_atr_ratio=params.bite_min_stop_atr_ratio,
+            t_max_in_trade=params.bite_t_max_in_trade,
         )
 
     @staticmethod
@@ -65,6 +79,7 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
         )
 
     def validate_config(self, params: BeeBiteParams) -> None:
+        validate_bee_bite_params(params)
         self._breakout.validate_config(self._to_breakout_params(params))
 
     def prepare_data(self, data):
@@ -76,7 +91,6 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
     def generate_events_multi_tf(self, *, mtf_frames: SymbolMtfFrames, params: BeeBiteParams):
         return self._breakout.generate_events_multi_tf(mtf_frames=mtf_frames, params=self._to_breakout_params(params))
 
-
     def generate_events_portfolio(self, *, symbol_frames: dict[str, SymbolMtfFrames], params: BeeBiteParams):
         return self._breakout.generate_events_portfolio(
             symbol_frames=symbol_frames,
@@ -84,10 +98,12 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
         )
 
     def build_parameter_grid(self) -> list[BeeBiteParams]:
-        return [self._from_breakout_params(params) for params in self._breakout.build_parameter_grid()]
+        return build_bee_bite_grid(profile_id=self._profile_id, grid_mode=self._grid_mode)
 
     def params_to_row(self, params: BeeBiteParams) -> dict[str, int | float | str | None]:
         return {
+            "bite_profile_id": params.bite_profile_id,
+            "bite_grid_mode": params.bite_grid_mode,
             "bite_lookback": params.bite_lookback,
             "bite_volume_mult": params.bite_volume_mult,
             "bite_retest_window_hours": params.bite_retest_window_hours,

--- a/strategy/bee_bite/config.py
+++ b/strategy/bee_bite/config.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from itertools import product
+from typing import Literal
 
 from domain.enums.entry_trigger import EntryTrigger
 from domain.enums.sl_mode import SLMode
 from domain.enums.timeframe import Timeframe
+
+BeeBiteProfileId = Literal["A", "B", "C"]
+BeeBiteGridMode = Literal["baseline", "expanded"]
+
+BEE_BITE_PROFILE_IDS: tuple[BeeBiteProfileId, ...] = ("A", "B", "C")
+BEE_BITE_GRID_MODES: tuple[BeeBiteGridMode, ...] = ("baseline", "expanded")
 
 
 @dataclass(frozen=True, slots=True)
@@ -31,3 +39,209 @@ class BeeBiteParams:
     bite_portfolio_risk_limit: float = 3.0
     bite_min_stop_atr_ratio: float = 0.3
     bite_t_max_in_trade: int | None = None
+    bite_profile_id: BeeBiteProfileId = "A"
+    bite_grid_mode: BeeBiteGridMode = "baseline"
+
+
+BEE_BITE_PROFILE_BASELINES: dict[BeeBiteProfileId, BeeBiteParams] = {
+    "A": BeeBiteParams(
+        bite_lookback=13,
+        bite_volume_mult=1.5,
+        bite_retest_window_hours=24,
+        bite_retest_zone=0.002,
+        bite_retest_zone_atr=1.0,
+        bite_min_rr=3.0,
+        bite_sl_mode=SLMode.RETEST_EXTREME,
+        bite_tp2_mult=2.0,
+        bite_min_body_ratio=0.4,
+        bite_min_move_atr=0.5,
+        bite_max_retest_depth=1.0,
+        bite_confirmation_bars=2,
+        bite_entry_trigger=EntryTrigger.PRICE_CONFIRMATION,
+        symbol="",
+        bite_profile_id="A",
+        bite_grid_mode="baseline",
+    ),
+    "B": BeeBiteParams(
+        bite_lookback=21,
+        bite_volume_mult=2.0,
+        bite_retest_window_hours=36,
+        bite_retest_zone=0.002,
+        bite_retest_zone_atr=1.25,
+        bite_min_rr=3.5,
+        bite_sl_mode=SLMode.BREAKOUT_EXTREME,
+        bite_tp2_mult=2.5,
+        bite_min_body_ratio=0.4,
+        bite_min_move_atr=0.5,
+        bite_max_retest_depth=1.0,
+        bite_confirmation_bars=2,
+        bite_entry_trigger=EntryTrigger.PRICE_CONFIRMATION,
+        symbol="",
+        bite_profile_id="B",
+        bite_grid_mode="baseline",
+    ),
+    "C": BeeBiteParams(
+        bite_lookback=8,
+        bite_volume_mult=1.2,
+        bite_retest_window_hours=12,
+        bite_retest_zone=0.002,
+        bite_retest_zone_atr=0.75,
+        bite_min_rr=2.5,
+        bite_sl_mode=SLMode.LEVEL,
+        bite_tp2_mult=1.5,
+        bite_min_body_ratio=0.4,
+        bite_min_move_atr=0.5,
+        bite_max_retest_depth=1.0,
+        bite_confirmation_bars=1,
+        bite_entry_trigger=EntryTrigger.IMMEDIATE,
+        symbol="",
+        bite_profile_id="C",
+        bite_grid_mode="baseline",
+    ),
+}
+
+BEE_BITE_EXTENDED_GRID_OFFSETS: dict[str, tuple[int | float | EntryTrigger | SLMode, ...]] = {
+    "bite_lookback": (-5, 0, 5),
+    "bite_volume_mult": (-0.3, 0.0, 0.3),
+    "bite_retest_window_hours": (-12, 0, 12),
+    "bite_retest_zone_atr": (-0.25, 0.0, 0.25),
+    "bite_min_rr": (-0.5, 0.0, 0.5),
+    "bite_sl_mode": (SLMode.RETEST_EXTREME, SLMode.LEVEL, SLMode.BREAKOUT_EXTREME),
+    "bite_tp2_mult": (-0.5, 0.0, 0.5),
+    "bite_confirmation_bars": (-1, 0, 1),
+    "bite_entry_trigger": (EntryTrigger.IMMEDIATE, EntryTrigger.PRICE_CONFIRMATION),
+}
+
+
+def parse_bee_bite_profile_id(raw_value: str | None, *, default: BeeBiteProfileId = "A") -> BeeBiteProfileId:
+    profile = (raw_value or default).strip().upper()
+    if profile not in BEE_BITE_PROFILE_IDS:
+        supported = ", ".join(BEE_BITE_PROFILE_IDS)
+        raise ValueError(f"Invalid BEE_BITE_PROFILE: {profile}. Supported values: {supported}")
+    return profile  # type: ignore[return-value]
+
+
+def parse_bee_bite_grid_mode(raw_value: str | None, *, default: BeeBiteGridMode = "baseline") -> BeeBiteGridMode:
+    grid_mode = (raw_value or default).strip().lower()
+    if grid_mode not in BEE_BITE_GRID_MODES:
+        supported = ", ".join(BEE_BITE_GRID_MODES)
+        raise ValueError(f"Invalid BEE_BITE_GRID_MODE: {grid_mode}. Supported values: {supported}")
+    return grid_mode  # type: ignore[return-value]
+
+
+def build_bee_bite_grid(*, profile_id: BeeBiteProfileId, grid_mode: BeeBiteGridMode) -> list[BeeBiteParams]:
+    baseline = BEE_BITE_PROFILE_BASELINES[profile_id]
+    if grid_mode == "baseline":
+        return [baseline]
+
+    lookbacks = _numeric_candidates(baseline.bite_lookback, BEE_BITE_EXTENDED_GRID_OFFSETS["bite_lookback"])
+    volume_mult = _numeric_candidates(baseline.bite_volume_mult, BEE_BITE_EXTENDED_GRID_OFFSETS["bite_volume_mult"])
+    retest_windows = _numeric_candidates(
+        baseline.bite_retest_window_hours,
+        BEE_BITE_EXTENDED_GRID_OFFSETS["bite_retest_window_hours"],
+    )
+    retest_zone_atr = _numeric_candidates(
+        baseline.bite_retest_zone_atr,
+        BEE_BITE_EXTENDED_GRID_OFFSETS["bite_retest_zone_atr"],
+    )
+    min_rr = _numeric_candidates(baseline.bite_min_rr, BEE_BITE_EXTENDED_GRID_OFFSETS["bite_min_rr"])
+    tp2_mult = _numeric_candidates(baseline.bite_tp2_mult, BEE_BITE_EXTENDED_GRID_OFFSETS["bite_tp2_mult"])
+    confirmation_bars = _numeric_candidates(
+        baseline.bite_confirmation_bars,
+        BEE_BITE_EXTENDED_GRID_OFFSETS["bite_confirmation_bars"],
+    )
+    sl_modes = tuple(BEE_BITE_EXTENDED_GRID_OFFSETS["bite_sl_mode"])
+    entry_triggers = tuple(BEE_BITE_EXTENDED_GRID_OFFSETS["bite_entry_trigger"])
+
+    combinations: list[BeeBiteParams] = []
+    for lb, vm, rw, rza, rr, sl_mode, tp2, confirm_bars, trigger in product(
+        lookbacks,
+        volume_mult,
+        retest_windows,
+        retest_zone_atr,
+        min_rr,
+        sl_modes,
+        tp2_mult,
+        confirmation_bars,
+        entry_triggers,
+    ):
+        params = replace(
+            baseline,
+            bite_lookback=int(lb),
+            bite_volume_mult=float(vm),
+            bite_retest_window_hours=int(rw),
+            bite_retest_zone_atr=None if rza is None else float(rza),
+            bite_min_rr=float(rr),
+            bite_sl_mode=sl_mode,
+            bite_tp2_mult=float(tp2),
+            bite_confirmation_bars=int(confirm_bars),
+            bite_entry_trigger=trigger,
+            bite_grid_mode="expanded",
+        )
+        try:
+            validate_bee_bite_params(params)
+        except ValueError:
+            continue
+        combinations.append(params)
+
+    return combinations
+
+
+def validate_bee_bite_runtime(*, profile_id: BeeBiteProfileId, grid_mode: BeeBiteGridMode, top_n: int | None) -> None:
+    if profile_id not in BEE_BITE_PROFILE_IDS:
+        raise ValueError(f"Неподдерживаемый профиль bee_bite: {profile_id}")
+    if grid_mode not in BEE_BITE_GRID_MODES:
+        raise ValueError(f"Неподдерживаемый режим сетки bee_bite: {grid_mode}")
+
+    if top_n is None:
+        return
+
+    if top_n < 1 or top_n > 500:
+        raise ValueError("для bee_bite параметр --top-n должен быть в диапазоне [1, 500]")
+    if grid_mode == "expanded" and top_n < 20:
+        raise ValueError("для bee_bite в режиме expanded параметр --top-n должен быть >= 20")
+
+
+def validate_bee_bite_params(params: BeeBiteParams) -> None:
+    if params.bite_lookback < 5 or params.bite_lookback > 120:
+        raise ValueError("параметр bite_lookback должен быть в диапазоне [5, 120]")
+    if params.bite_volume_mult <= 0.0 or params.bite_volume_mult > 5.0:
+        raise ValueError("параметр bite_volume_mult должен быть в диапазоне (0, 5]")
+    if params.bite_retest_window_hours < 4 or params.bite_retest_window_hours > 96:
+        raise ValueError("параметр bite_retest_window_hours должен быть в диапазоне [4, 96]")
+    if params.bite_retest_zone < 0.0 or params.bite_retest_zone > 0.02:
+        raise ValueError("параметр bite_retest_zone должен быть в диапазоне [0.0, 0.02]")
+    if params.bite_retest_zone_atr is not None and (params.bite_retest_zone_atr < 0.2 or params.bite_retest_zone_atr > 3.0):
+        raise ValueError("параметр bite_retest_zone_atr должен быть в диапазоне [0.2, 3.0]")
+    if params.bite_min_rr <= 1.0 or params.bite_min_rr > 8.0:
+        raise ValueError("параметр bite_min_rr должен быть в диапазоне (1.0, 8.0]")
+    if params.bite_tp2_mult <= 1.0 or params.bite_tp2_mult > 4.0:
+        raise ValueError("параметр bite_tp2_mult должен быть в диапазоне (1.0, 4.0]")
+    if params.bite_confirmation_bars < 1 or params.bite_confirmation_bars > 6:
+        raise ValueError("параметр bite_confirmation_bars должен быть в диапазоне [1, 6]")
+
+    # Правило совместимости reclaim/retest:
+    # reclaim = подтверждение закрытием (PRICE_CONFIRMATION), retest = immediate вход на касании.
+    if params.bite_entry_trigger == EntryTrigger.PRICE_CONFIRMATION and params.bite_confirmation_bars < 2:
+        raise ValueError("режим reclaim (PRICE_CONFIRMATION) требует bite_confirmation_bars >= 2")
+    if params.bite_entry_trigger == EntryTrigger.IMMEDIATE and params.bite_confirmation_bars != 1:
+        raise ValueError("режим retest (IMMEDIATE) требует bite_confirmation_bars == 1")
+
+
+def _numeric_candidates(
+    baseline_value: int | float | None,
+    offsets: tuple[int | float | EntryTrigger | SLMode, ...],
+) -> tuple[int | float | None, ...]:
+    if baseline_value is None:
+        return (None,)
+
+    values: set[int | float] = set()
+    for offset in offsets:
+        if isinstance(offset, (EntryTrigger, SLMode)):
+            continue
+        candidate = baseline_value + offset
+        if isinstance(baseline_value, int):
+            values.add(int(candidate))
+        else:
+            values.add(round(float(candidate), 4))
+    return tuple(sorted(values))

--- a/strategy/factory.py
+++ b/strategy/factory.py
@@ -23,5 +23,9 @@ def build_strategy(config: AppConfig, logger: Logger) -> BaseStrategy[object]:
     if config.strategy.strategy_id == "breakout":
         return breakout
     if config.strategy.strategy_id == "bee_bite":
-        return BeeBiteStrategy(breakout)
+        return BeeBiteStrategy(
+            breakout,
+            profile_id=config.strategy.bee_bite_profile,
+            grid_mode=config.strategy.bee_bite_grid_mode,
+        )
     raise ValueError(f"Неподдерживаемый strategy_id: {config.strategy.strategy_id}")


### PR DESCRIPTION
### Motivation
- Provide deterministic, auditable Bee Bite baselines (A/B/C) and a controlled expansion mode for wider parameter sweeps. 
- Separate the concepts of a validated `profile` (single baseline) and a `grid` (controlled expansion around that baseline) to avoid mixing baseline correctness with brute-force grids. 
- Enforce runtime and parameter validation to prevent pathological runs (invalid bounds, incompatible reclaim/retest settings, and unsuitable `--top-n` for wide grids). 

### Description
- Added a new Bee Bite config module `strategy/bee_bite/config.py` that defines fixed baseline profiles `A/B/C`, parsing helpers (`parse_bee_bite_profile_id`, `parse_bee_bite_grid_mode`), an `expanded` controlled grid builder `build_bee_bite_grid`, and parameter/runtime validators (`validate_bee_bite_params`, `validate_bee_bite_runtime`).
- Split parameter types: `profile` = validated baseline `BeeBiteParams`, `grid` = controlled expansion via offsets; added type aliases `BeeBiteProfileId` and `BeeBiteGridMode` and constants `BEE_BITE_PROFILE_IDS` / `BEE_BITE_GRID_MODES`.
- Integrated profile/grid into runtime: `StrategyConfig` gained `bee_bite_profile` and `bee_bite_grid_mode`, env vars `BEE_BITE_PROFILE` / `BEE_BITE_GRID_MODE` are supported, and new CLI flags `--bee-bite-profile` / `--bee-bite-grid` were added to `run-backtest` with runtime validation in `cli/commands.py`.
- Updated `BeeBiteStrategy` to accept `profile_id` and `grid_mode`, to produce parameter grid via `build_bee_bite_grid`, and to serialize grid metadata into results (added `bite_profile_id` and `bite_grid_mode` columns); also fixed the risk-field mapping into `BreakoutParams` (`r_trade`, `portfolio_risk_limit`, `min_stop_atr_ratio`, `t_max_in_trade`).

### Testing
- Compiled affected modules with `python -m compileall strategy/bee_bite config cli strategy/factory.py`, which succeeded. 
- Attempted to exercise CLI help with `python main.py run-backtest --help`, but the import failed in this environment due to a missing runtime dependency (`pandas`), so end-to-end runtime verification was not performed. 
- Basic sanity checks (module imports / grid builder logic) are included in the code and will run when the full runtime dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999f083f944832081acaf7fce8f5680)