### PR TITLE
Добавить состояния качества OI/taker и учитывать их только при статусе OK

### DIFF
--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -200,6 +200,10 @@ class CcxtFuturesClient(ExchangeClient):
         if not symbols:
             return []
 
+        QUALITY_STATE_OK = "ok"
+        QUALITY_STATE_LOW = "low_quality"
+        QUALITY_STATE_MISSING = "missing"
+
         tickers_payload = self._retry_exchange_startup_call(
             operation="ccxt_fetch_tickers",
             endpoint="fetch_tickers",
@@ -263,6 +267,15 @@ class CcxtFuturesClient(ExchangeClient):
                     return parsed
             return 0.0
 
+        def _resolve_quality_state(value: float, *, quote_volume: float, low_ratio_threshold: float) -> str:
+            if value <= 0.0:
+                return QUALITY_STATE_MISSING
+            if quote_volume <= 0.0:
+                return QUALITY_STATE_LOW
+            if (value / quote_volume) < low_ratio_threshold:
+                return QUALITY_STATE_LOW
+            return QUALITY_STATE_OK
+
         records: list[dict[str, object]] = []
         for symbol in symbols:
             ticker = tickers_payload.get(symbol) if isinstance(tickers_payload, dict) else None
@@ -277,6 +290,8 @@ class CcxtFuturesClient(ExchangeClient):
                         "no_oi": True,
                         "no_taker": True,
                         "questionable_sync": True,
+                        "oi_quality_state": QUALITY_STATE_MISSING,
+                        "taker_quality_state": QUALITY_STATE_MISSING,
                     },
                 })
                 continue
@@ -290,6 +305,22 @@ class CcxtFuturesClient(ExchangeClient):
             trade_count_24h = _extract_trade_count_24h(ticker)
             open_interest_24h = _extract_open_interest(ticker)
             taker_buy_volume_24h = _extract_taker_buy_volume(ticker)
+            oi_quality_state = _resolve_quality_state(
+                open_interest_24h,
+                quote_volume=quote_volume,
+                low_ratio_threshold=0.001,
+            )
+            taker_quality_state = _resolve_quality_state(
+                taker_buy_volume_24h,
+                quote_volume=quote_volume,
+                low_ratio_threshold=0.005,
+            )
+
+            liquidity_score = quote_volume if quote_volume > 0.0 else 0.0
+            if oi_quality_state == QUALITY_STATE_OK:
+                liquidity_score *= 1.05
+            if taker_quality_state == QUALITY_STATE_OK:
+                liquidity_score *= 1.05
 
             quality_metadata = {
                 "no_oi": open_interest_24h <= 0.0,
@@ -297,19 +328,29 @@ class CcxtFuturesClient(ExchangeClient):
                 "questionable_sync": quote_volume <= 0.0 or trade_count_24h <= 0,
                 "open_interest_24h": open_interest_24h,
                 "taker_buy_volume_24h": taker_buy_volume_24h,
+                "oi_quality_state": oi_quality_state,
+                "taker_quality_state": taker_quality_state,
             }
             quality_flags = [flag for flag in ("no_oi", "no_taker", "questionable_sync") if bool(quality_metadata[flag])]
+            if oi_quality_state == QUALITY_STATE_LOW:
+                quality_flags.append("oi_low_quality")
+            if taker_quality_state == QUALITY_STATE_LOW:
+                quality_flags.append("taker_low_quality")
 
             records.append({
                 "symbol": symbol,
                 "quote_volume": quote_volume,
                 "trade_count_24h": trade_count_24h,
-                "liquidity_score": quote_volume if quote_volume > 0.0 else 0.0,
+                "liquidity_score": liquidity_score,
                 "quality_flags": quality_flags,
                 "quality_metadata": quality_metadata,
             })
 
-        return sorted(records, key=lambda row: (float(row["quote_volume"]), str(row["symbol"])), reverse=True)
+        return sorted(
+            records,
+            key=lambda row: (float(row["liquidity_score"]), float(row["quote_volume"]), str(row["symbol"])),
+            reverse=True,
+        )
 
     def fetch_ohlcv(
         self,

--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -22,6 +22,7 @@ from data.exchanges.ccxt_types import CcxtClientOptions, CcxtFuturesApi, CcxtOpe
 from domain.abstract.exchange_client import ExchangeClient
 from domain.exceptions import ExchangeConnectivityError
 from domain.enums.exchange import Exchange
+from domain.enums.liquidity_quality_state import LiquidityQualityState
 from domain.enums.timeframe import Timeframe
 from utils.retry import RetryExhaustedError, run_with_retry
 
@@ -200,9 +201,6 @@ class CcxtFuturesClient(ExchangeClient):
         if not symbols:
             return []
 
-        QUALITY_STATE_OK = "ok"
-        QUALITY_STATE_LOW = "low_quality"
-        QUALITY_STATE_MISSING = "missing"
 
         tickers_payload = self._retry_exchange_startup_call(
             operation="ccxt_fetch_tickers",
@@ -267,14 +265,19 @@ class CcxtFuturesClient(ExchangeClient):
                     return parsed
             return 0.0
 
-        def _resolve_quality_state(value: float, *, quote_volume: float, low_ratio_threshold: float) -> str:
+        def _resolve_quality_state(
+            value: float,
+            *,
+            quote_volume: float,
+            low_ratio_threshold: float,
+        ) -> LiquidityQualityState:
             if value <= 0.0:
-                return QUALITY_STATE_MISSING
+                return LiquidityQualityState.MISSING
             if quote_volume <= 0.0:
-                return QUALITY_STATE_LOW
+                return LiquidityQualityState.LOW_QUALITY
             if (value / quote_volume) < low_ratio_threshold:
-                return QUALITY_STATE_LOW
-            return QUALITY_STATE_OK
+                return LiquidityQualityState.LOW_QUALITY
+            return LiquidityQualityState.OK
 
         records: list[dict[str, object]] = []
         for symbol in symbols:
@@ -290,8 +293,8 @@ class CcxtFuturesClient(ExchangeClient):
                         "no_oi": True,
                         "no_taker": True,
                         "questionable_sync": True,
-                        "oi_quality_state": QUALITY_STATE_MISSING,
-                        "taker_quality_state": QUALITY_STATE_MISSING,
+                        "oi_quality_state": LiquidityQualityState.MISSING.value,
+                        "taker_quality_state": LiquidityQualityState.MISSING.value,
                     },
                 })
                 continue
@@ -317,9 +320,9 @@ class CcxtFuturesClient(ExchangeClient):
             )
 
             liquidity_score = quote_volume if quote_volume > 0.0 else 0.0
-            if oi_quality_state == QUALITY_STATE_OK:
+            if oi_quality_state == LiquidityQualityState.OK:
                 liquidity_score *= 1.05
-            if taker_quality_state == QUALITY_STATE_OK:
+            if taker_quality_state == LiquidityQualityState.OK:
                 liquidity_score *= 1.05
 
             quality_metadata = {
@@ -328,13 +331,13 @@ class CcxtFuturesClient(ExchangeClient):
                 "questionable_sync": quote_volume <= 0.0 or trade_count_24h <= 0,
                 "open_interest_24h": open_interest_24h,
                 "taker_buy_volume_24h": taker_buy_volume_24h,
-                "oi_quality_state": oi_quality_state,
-                "taker_quality_state": taker_quality_state,
+                "oi_quality_state": oi_quality_state.value,
+                "taker_quality_state": taker_quality_state.value,
             }
             quality_flags = [flag for flag in ("no_oi", "no_taker", "questionable_sync") if bool(quality_metadata[flag])]
-            if oi_quality_state == QUALITY_STATE_LOW:
+            if oi_quality_state == LiquidityQualityState.LOW_QUALITY:
                 quality_flags.append("oi_low_quality")
-            if taker_quality_state == QUALITY_STATE_LOW:
+            if taker_quality_state == LiquidityQualityState.LOW_QUALITY:
                 quality_flags.append("taker_low_quality")
 
             records.append({

--- a/domain/enums/__init__.py
+++ b/domain/enums/__init__.py
@@ -4,6 +4,7 @@ from domain.enums.data_quality_severity import DataQualitySeverity
 from domain.enums.entry_trigger import EntryTrigger
 from domain.enums.exchange import Exchange
 from domain.enums.level_type import LevelType
+from domain.enums.liquidity_quality_state import LiquidityQualityState
 from domain.enums.order_type import OrderType
 from domain.enums.position_side import PositionSide
 from domain.enums.sl_mode import SLMode
@@ -15,6 +16,7 @@ __all__ = [
     "EntryTrigger",
     "Exchange",
     "LevelType",
+    "LiquidityQualityState",
     "OrderType",
     "PositionSide",
     "SLMode",

--- a/domain/enums/liquidity_quality_state.py
+++ b/domain/enums/liquidity_quality_state.py
@@ -1,0 +1,9 @@
+"""Модуль проекта."""
+
+from enum import Enum
+
+
+class LiquidityQualityState(str, Enum):
+    OK = "ok"
+    LOW_QUALITY = "low_quality"
+    MISSING = "missing"


### PR DESCRIPTION
### Motivation
- Включить в метрики ликвидности явные состояния качества для OI и taker (`ok`/`low_quality`/`missing`) чтобы корректнее учитывать их влияние на ранжирование символов.
- Избежать штрафов за отсутствующие или низкокачественные OI/taker-данные, применяя их влияние на scoring только при уверенном статусе `ok`.

### Description
- Добавлены поля `oi_quality_state` и `taker_quality_state` со значениями `ok`, `low_quality`, `missing` в возвращаемые записи метрик ликвидности (включая fallback для отсутствующих тикеров).
- Реализована функция `_resolve_quality_state` для определения состояния по отношению значения OI/taker к `quote_volume` с порогами для `low_quality`.
- Обновлён расчёт `liquidity_score`: базовый score — `quote_volume`, и OI/taker дают буст только когда их качество = `ok`, при `missing`/`low_quality` не налагается штраф.
- Добавлены флаги `oi_low_quality`/`taker_low_quality`, и сортировка результатов теперь приоритизирует `liquidity_score` затем `quote_volume`.

### Testing
- Запущена компиляция модуля командой `python -m compileall data/exchanges/ccxt_futures_client.py` и она завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999f843554083209ff1af9f5bce704b)