### PR TITLE
Adjust bee_bite FSM break/reclaim/retest handling

### DIFF
--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -43,10 +43,19 @@ class SetupContext:
     atr_pre: float = 0.0
     atr_bg: float = 0.0
     core_width: float = 0.0
+    break_idx: int | None = None
+    reclaim_idx: int | None = None
+    lowest_break: float | None = None
+    retest_touch_idx: int | None = None
 
 
 class BeeBiteEngine:
     REQUIRED_COLUMNS = ["timestamp", "open", "high", "low", "close", "volume"]
+    MIN_DEPTH_THRESHOLD = 0.25
+    MICRO_OFFSET = 0.15
+    DEFAULT_RECLAIM_LIMIT = 4
+    CONSERVATIVE_RECLAIM_LIMIT = 6
+    CONSERVATIVE_RETEST_LIMIT = 6
 
     def __init__(self) -> None:
         self._detector = LevelDetector()
@@ -153,6 +162,10 @@ class BeeBiteEngine:
                         setup.range_low, setup.range_high, setup.core_width, setup.atr_bg = range_setup
                         setup.retest_idx = i
                         setup.retest_timestamp = timestamp
+                        setup.break_idx = None
+                        setup.reclaim_idx = None
+                        setup.lowest_break = None
+                        setup.retest_touch_idx = None
                         state = BeeBiteState.RANGE_LOCKED
                         diagnostics["states"].append(state.value)
                     else:
@@ -161,22 +174,91 @@ class BeeBiteEngine:
                         diagnostics["states"].append(state.value)
 
             if state == BeeBiteState.RANGE_LOCKED and setup is not None:
-                state = BeeBiteState.BREAK_ACTIVE
-                diagnostics["states"].append(state.value)
+                boundary = setup.range_low if setup.side == PositionSide.LONG else setup.range_high
+                puncture_price = float(row.low) if setup.side == PositionSide.LONG else float(row.high)
+                puncture_detected = puncture_price < boundary if setup.side == PositionSide.LONG else puncture_price > boundary
+                if puncture_detected and setup.atr_bg > 0 and setup.core_width > 0:
+                    depth = abs(puncture_price - boundary)
+                    min_depth = self.MIN_DEPTH_THRESHOLD * setup.atr_bg
+                    max_depth = 0.5 * setup.core_width
+                    if min_depth <= depth <= max_depth:
+                        setup.break_idx = i
+                        setup.lowest_break = puncture_price
+                        setup.reclaim_idx = None
+                        setup.retest_touch_idx = None
+                        state = BeeBiteState.BREAK_ACTIVE
+                        diagnostics["states"].append(state.value)
 
-            if state == BeeBiteState.BREAK_ACTIVE and setup is not None and setup.retest_idx is not None:
-                if params.bite_entry_trigger == EntryTrigger.IMMEDIATE:
-                    state = BeeBiteState.ENTRY_SIGNAL
+            if state == BeeBiteState.BREAK_ACTIVE and setup is not None and setup.break_idx is not None:
+                boundary = setup.range_low if setup.side == PositionSide.LONG else setup.range_high
+                break_price = float(row.low) if setup.side == PositionSide.LONG else float(row.high)
+                if setup.lowest_break is None:
+                    setup.lowest_break = break_price
+                elif setup.side == PositionSide.LONG:
+                    setup.lowest_break = min(setup.lowest_break, break_price)
+                else:
+                    setup.lowest_break = max(setup.lowest_break, break_price)
+                reclaim_limit = (
+                    self.CONSERVATIVE_RECLAIM_LIMIT if params.bite_profile_id == "A" else self.DEFAULT_RECLAIM_LIMIT
+                )
+                elapsed_since_break = i - setup.break_idx
+                emergency_level = 0.7 * setup.core_width
+                emergency_break = (
+                    float(row.low) < (boundary - emergency_level)
+                    if setup.side == PositionSide.LONG
+                    else float(row.high) > (boundary + emergency_level)
+                )
+                if emergency_break or elapsed_since_break > reclaim_limit:
+                    setup = None
+                    state = BeeBiteState.IDLE
                     diagnostics["states"].append(state.value)
                 else:
-                    confirm_idx = setup.retest_idx + params.bite_confirmation_bars
-                    if i >= confirm_idx:
-                        ok = (setup.side == PositionSide.LONG and price_close > setup.level_price) or (
-                            setup.side == PositionSide.SHORT and price_close < setup.level_price
-                        )
-                        if ok:
+                    offset_threshold = self.MICRO_OFFSET * setup.atr_bg
+                    reclaim_ok = price_close > boundary if setup.side == PositionSide.LONG else price_close < boundary
+                    micro_ok = (
+                        price_close > (boundary + offset_threshold)
+                        if setup.side == PositionSide.LONG
+                        else price_close < (boundary - offset_threshold)
+                    )
+                    if setup.reclaim_idx is None and reclaim_ok and micro_ok:
+                        setup.reclaim_idx = i
+
+                    if setup.reclaim_idx is not None:
+                        if params.bite_profile_id == "A":
+                            retest_deadline = setup.reclaim_idx + self.CONSERVATIVE_RETEST_LIMIT
+                            touch_zone = (
+                                float(row.low) <= (boundary + offset_threshold)
+                                if setup.side == PositionSide.LONG
+                                else float(row.high) >= (boundary - offset_threshold)
+                            )
+                            if touch_zone:
+                                setup.retest_touch_idx = i
+                            confirm_close = (
+                                price_close > (boundary + offset_threshold)
+                                if setup.side == PositionSide.LONG
+                                else price_close < (boundary - offset_threshold)
+                            )
+                            if setup.retest_touch_idx is not None and i > setup.retest_touch_idx and confirm_close:
+                                state = BeeBiteState.ENTRY_SIGNAL
+                                diagnostics["states"].append(state.value)
+                            elif i > retest_deadline:
+                                setup = None
+                                state = BeeBiteState.IDLE
+                                diagnostics["states"].append(state.value)
+                        elif params.bite_entry_trigger == EntryTrigger.IMMEDIATE:
                             state = BeeBiteState.ENTRY_SIGNAL
                             diagnostics["states"].append(state.value)
+                        else:
+                            confirm_idx = setup.reclaim_idx + params.bite_confirmation_bars
+                            if i >= confirm_idx:
+                                confirm_close = (
+                                    price_close > (boundary + offset_threshold)
+                                    if setup.side == PositionSide.LONG
+                                    else price_close < (boundary - offset_threshold)
+                                )
+                                if confirm_close:
+                                    state = BeeBiteState.ENTRY_SIGNAL
+                                    diagnostics["states"].append(state.value)
 
             if state == BeeBiteState.ENTRY_SIGNAL and setup is not None and setup.retest_idx is not None:
                 trade, exit_idx = self._simulate_trade(rows=rows, entry_idx=i, setup=setup, params=params)


### PR DESCRIPTION
### Motivation

- Tighten and clarify how range punctures are detected and handled to avoid false break signals from tiny spikes. 
- Track break/reclaim lifecycle (including worst/lowest break) and provide profile-aware reclaim/retest behavior to support a conservative workflow.
- Prevent entries on deep invalidations by adding emergency reset conditions and a micro-offset filter for reclaim confirmations.

### Description

- Added new fields to `SetupContext`: `break_idx`, `reclaim_idx`, `lowest_break`, and `retest_touch_idx` to track the break/reclaim/retest lifecycle. 
- Introduced FSM constants `MIN_DEPTH_THRESHOLD`, `MICRO_OFFSET`, `DEFAULT_RECLAIM_LIMIT`, `CONSERVATIVE_RECLAIM_LIMIT`, and `CONSERVATIVE_RETEST_LIMIT` on `BeeBiteEngine`. 
- Changed `RANGE_LOCKED` -> `BREAK_ACTIVE` transition to require a real boundary puncture (`low < support` for long / symmetric for short) and a puncture depth constrained to `[MIN_DEPTH_THRESHOLD * ATR_bg, 0.5 * core_width]`. 
- Implemented `BREAK_ACTIVE` logic that maintains `lowest_break`, applies a profile-aware `ReclaimLimit` (conservative profile `A` uses a larger reclaim timeout), triggers an emergency reset when the break goes deeper than `0.7 * core_width`, and accepts reclaim only when the candle `close` crosses back through the boundary and passes a `MicroOffset * ATR_bg` filter. 
- For conservative profile (`A`) added a separate retest entry path (`RetestLimit = 6`) that requires a touch of the retest zone followed by a confirming close, with its own timeout and reset behavior.

### Testing

- Ran `python -m compileall strategy/bee_bite/engine.py` and the module compiled successfully. 
- No new unit tests were added or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a04e4ac1483208acc36a4bca1af8c)