### PR TITLE
Sync bee_bite profiles and engine constants with A/B/C semantics

### DIFF
--- a/strategy/bee_bite/config.py
+++ b/strategy/bee_bite/config.py
@@ -26,14 +26,14 @@ class ScoreThreshold:
 
 
 BEE_BITE_PROFILE_SCORE_THRESHOLDS: dict[BeeBiteProfileId, ScoreThreshold] = {
-    "A": ScoreThreshold(min_score=3.0),
-    "B": ScoreThreshold(min_score=4.0),
+    "A": ScoreThreshold(min_score=4.0),
+    "B": ScoreThreshold(min_score=3.0),
     "C": ScoreThreshold(min_score=2.0),
 }
 
 BEE_BITE_PROFILE_TOP_N: dict[BeeBiteProfileId, int] = {
-    "A": 2,
-    "B": 1,
+    "A": 1,
+    "B": 2,
     "C": 3,
 }
 
@@ -84,8 +84,8 @@ BEE_BITE_PROFILE_RUNTIME: dict[BeeBiteProfileId, BeeBiteProfileRuntime] = {
     "A": BeeBiteProfileRuntime(
         reclaim_mode="strict",
         retest_mode="confirmation",
-        top_n_min=20,
-        top_n_max=120,
+        top_n_min=5,
+        top_n_max=50,
         cooldown_bars=8,
         min_depth_threshold=0.3,
         micro_offset=0.2,
@@ -106,8 +106,8 @@ BEE_BITE_PROFILE_RUNTIME: dict[BeeBiteProfileId, BeeBiteProfileRuntime] = {
     "C": BeeBiteProfileRuntime(
         reclaim_mode="aggressive",
         retest_mode="immediate",
-        top_n_min=5,
-        top_n_max=50,
+        top_n_min=20,
+        top_n_max=120,
         cooldown_bars=4,
         min_depth_threshold=0.2,
         micro_offset=0.1,
@@ -295,10 +295,26 @@ def validate_bee_bite_runtime(
         raise ValueError(f"Неподдерживаемый reclaim-режим bee_bite: {reclaim_mode}")
     if retest_mode not in BEE_BITE_RETEST_MODES:
         raise ValueError(f"Неподдерживаемый retest-режим bee_bite: {retest_mode}")
-    if reclaim_mode != runtime.reclaim_mode:
-        raise ValueError(f"профиль {profile_id} требует reclaim_mode={runtime.reclaim_mode}")
-    if retest_mode != runtime.retest_mode:
-        raise ValueError(f"профиль {profile_id} требует retest_mode={runtime.retest_mode}")
+    allowed_reclaim_by_profile: dict[BeeBiteProfileId, tuple[BeeBiteReclaimMode, ...]] = {
+        "A": ("strict",),
+        "B": ("strict", "balanced"),
+        "C": ("balanced", "aggressive"),
+    }
+    allowed_retest_by_profile: dict[BeeBiteProfileId, tuple[BeeBiteRetestMode, ...]] = {
+        "A": ("confirmation",),
+        "B": ("confirmation",),
+        "C": ("confirmation", "immediate"),
+    }
+
+    allowed_reclaim = allowed_reclaim_by_profile[profile_id]
+    if reclaim_mode not in allowed_reclaim:
+        supported = ", ".join(allowed_reclaim)
+        raise ValueError(f"профиль {profile_id} поддерживает reclaim_mode только из [{supported}]")
+
+    allowed_retest = allowed_retest_by_profile[profile_id]
+    if retest_mode not in allowed_retest:
+        supported = ", ".join(allowed_retest)
+        raise ValueError(f"профиль {profile_id} поддерживает retest_mode только из [{supported}]")
 
     if cooldown_bars != runtime.cooldown_bars:
         raise ValueError(f"профиль {profile_id} требует cooldown_bars={runtime.cooldown_bars}")

--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -57,14 +57,14 @@ class BeeBiteEngine:
     REQUIRED_COLUMNS = ["timestamp", "open", "high", "low", "close", "volume"]
     CONSERVATIVE_RETEST_LIMIT = 6
     IMPULSE_THRESHOLDS: dict[str, float] = {
-        "A": 2.0,
+        "A": 2.5,
         "B": 2.2,
-        "C": 2.5,
+        "C": 2.0,
     }
     PROFILE_RANGE_WINDOW: dict[str, int] = {
-        "A": 32,
+        "A": 48,
         "B": 40,
-        "C": 48,
+        "C": 32,
     }
     FIXED_RANGE_WINDOW: int | None = None
     PROFILE_STABILITY_THRESHOLD: dict[str, float] = {
@@ -73,12 +73,12 @@ class BeeBiteEngine:
         "C": 1.2,
     }
     PROFILE_TP1_SHARE: dict[str, float] = {
-        "A": 0.4,
+        "A": 0.6,
         "B": 0.5,
-        "C": 0.6,
+        "C": 0.4,
     }
     PROFILE_TIME_EXIT_HOURS_NO_TP1: dict[str, int] = {
-        "A": 12,
+        "A": 10,
         "B": 8,
         "C": 6,
     }


### PR DESCRIPTION
### Motivation
- Привести профильные константы и поведение стратегии `bee_bite` в соответствие со спецификацией профилей A/B/C (A = Conservative, B = Balanced, C = Aggressive). 
- Устранить конфликты в валидации runtime-параметров при допустимых сочетаниях режимов `reclaim`/`retest` для каждого профиля. 
- Подстроить поведение движка под ожидаемую семантику профилей (импульс, окно диапазона, доля TP1, тайминги).

### Description
- Обновлены профильные значения в `strategy/bee_bite/config.py`: переставлены `BEE_BITE_PROFILE_SCORE_THRESHOLDS` для `A`/`B`, изменён порядок значений в `BEE_BITE_PROFILE_TOP_N` (`A=1`, `B=2`, `C=3`), и скорректированы `top_n` диапазоны в `BEE_BITE_PROFILE_RUNTIME` так, чтобы `A` был более консервативен (`top_n_min=5, top_n_max=50`) а `C` — более агрессивен (`top_n_min=20, top_n_max=120`).
- Перенастроена функция `validate_bee_bite_runtime` в `strategy/bee_bite/config.py`: вместо жёсткого сравнения режимов `reclaim_mode`/`retest_mode` с единственным значением добавлены допустимые множества режимов по профилю и соответствующие сообщения об ошибке для недопустимых комбинаций.
- Синхронизированы профильные константы ядра в `strategy/bee_bite/engine.py`: `IMPULSE_THRESHOLDS` теперь `{"A": 2.5, "B": 2.2, "C": 2.0}`, `PROFILE_RANGE_WINDOW` теперь `{"A": 48, "B": 40, "C": 32}`, `PROFILE_TP1_SHARE` теперь `{"A": 0.6, "B": 0.5, "C": 0.4}`, и `PROFILE_TIME_EXIT_HOURS_NO_TP1` для `A` установлен в `10` часов.

### Testing
- Выполнена компиляция файлов `strategy/bee_bite/config.py` и `strategy/bee_bite/engine.py` с помощью `python -m compileall`, компиляция прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a119808108320b0a4d258aec28c93)