### PR TITLE
Centralize BeeBite trade planning and profile-based TP/exit behavior

### DIFF
--- a/simulation/portfolio_state_engine.py
+++ b/simulation/portfolio_state_engine.py
@@ -13,6 +13,7 @@ from domain.models.candle import Candle
 from domain.models.trade_result import TradeResult
 from domain.models.trade_signal import TradeSignal
 from domain.value_objects.price import Price
+from strategy.bee_bite.trade_plan import build_bee_bite_trade_plan, resolve_profile_tp1_share
 from simulation.exit_manager import ExitManager, ExitManagerConfig
 from simulation.order_processor import OrderProcessor
 from simulation.position_simulator import StatefulPositionSimulator
@@ -103,6 +104,13 @@ class PortfolioStateEngine:
             "A": 8,
             "B": 6,
             "C": 4,
+        }
+    )
+    PROFILE_TIME_EXIT_HOURS_NO_TP1: dict[str, int] = field(
+        default_factory=lambda: {
+            "A": 10,
+            "B": 8,
+            "C": 6,
         }
     )
 
@@ -543,6 +551,7 @@ class PortfolioStateEngine:
             self._reject_candidate(candidate.symbol)
             return
         size = self._risk_manager.calc_position_size(signal=candidate.signal)
+        sim.max_bars_in_trade = self._resolve_time_exit_bars()
         sim.register_signal(candidate.signal, size=size)
         state.state = PortfolioState.IN_TRADE
         state.age = 0
@@ -569,6 +578,12 @@ class PortfolioStateEngine:
         if profile in self.PROFILE_COOLDOWN_HOURS:
             return self._hours_to_15m_bars(self.PROFILE_COOLDOWN_HOURS[profile])
         return self.config.cooldown_bars
+
+    def _resolve_time_exit_bars(self) -> int | None:
+        profile = (self.config.bee_bite_profile_id or "").upper()
+        if profile in self.PROFILE_TIME_EXIT_HOURS_NO_TP1:
+            return self._hours_to_15m_bars(self.PROFILE_TIME_EXIT_HOURS_NO_TP1[profile])
+        return self.config.t_max_in_trade
 
     @staticmethod
     def _hours_to_15m_bars(hours: int) -> int:
@@ -608,17 +623,28 @@ class PortfolioStateEngine:
         if side == PositionSide.LONG:
             lowest_break = float(state.lowest_break if state.lowest_break is not None else support)
             stop = min(lowest_break, support - 0.1 * atr_bg)
-            if (entry - stop) < (0.3 * atr_bg):
-                return None
-            tp1 = max(resistance, entry + 0.5 * atr_bg)
-            tp2 = max(high_pump, tp1 + atr_bg)
+            tp1_floor = max(resistance, entry + 0.5 * atr_bg)
+            low_before_pump = None
         else:
             lowest_break = float(state.lowest_break if state.lowest_break is not None else resistance)
             stop = max(lowest_break, resistance + 0.1 * atr_bg)
-            if (stop - entry) < (0.3 * atr_bg):
-                return None
-            tp1 = min(support, entry - 0.5 * atr_bg)
-            tp2 = min(high_pump if high_pump < entry else entry - atr_bg, tp1 - atr_bg)
+            tp1_floor = min(support, entry - 0.5 * atr_bg)
+            low_before_pump = high_pump if high_pump < entry else entry - atr_bg
+
+        plan = build_bee_bite_trade_plan(
+            side=side,
+            entry_price=entry,
+            atr_bg=atr_bg,
+            stop_loss=stop,
+            high_pump=high_pump,
+            low_before_pump=low_before_pump,
+            be_offset_ratio=0.001,
+        )
+        if plan is None or plan.stop_distance < (0.3 * atr_bg):
+            return None
+
+        tp1 = max(plan.tp1, tp1_floor) if side == PositionSide.LONG else min(plan.tp1, tp1_floor)
+        tp2 = plan.tp2
 
         signal = TradeSignal(
             symbol=symbol,
@@ -633,17 +659,9 @@ class PortfolioStateEngine:
             retest_timestamp_ms=int(row["timestamp"]),
             atr_bg=atr_bg,
             high_pump=high_pump,
-            tp1_close_ratio=self._resolve_tp1_close_ratio(),
+            tp1_close_ratio=resolve_profile_tp1_share(self.config.bee_bite_profile_id, 0.5),
         )
         return signal
-
-    def _resolve_tp1_close_ratio(self) -> float:
-        profile = (self.config.bee_bite_profile_id or "").upper()
-        if profile == "B":
-            return 0.6
-        if profile == "C":
-            return 0.7
-        return 0.5
 
     @staticmethod
     def _to_candle(row: dict[str, float | None]) -> Candle:

--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -15,6 +15,7 @@ from domain.models.trade_result import TradeResult
 from domain.value_objects.percentage import Percentage
 from domain.value_objects.price import Price
 from strategy.bee_bite.config import BeeBiteParams
+from strategy.bee_bite.trade_plan import build_bee_bite_trade_plan, resolve_profile_tp1_share
 from strategy.breakout.indicators.level_detector import LevelDetector
 from vectorbt_runner.mtf_frames import SymbolMtfFrames
 
@@ -74,11 +75,6 @@ class BeeBiteEngine:
         "A": 0.8,
         "B": 1.0,
         "C": 1.2,
-    }
-    PROFILE_TP1_SHARE: dict[str, float] = {
-        "A": 0.6,
-        "B": 0.5,
-        "C": 0.4,
     }
     PROFILE_TIME_EXIT_HOURS_NO_TP1: dict[str, int] = {
         "A": 10,
@@ -352,14 +348,21 @@ class BeeBiteEngine:
         if setup.range_low is None or setup.range_high is None:
             return None, entry_idx
 
-        if setup.side == PositionSide.LONG:
-            stop = min(setup.range_low, setup.level_price)
-            risk = max(entry_price - stop, entry_price * 0.0001)
-            tp1 = entry_price + risk
-        else:
-            stop = max(setup.range_high, setup.level_price)
-            risk = max(stop - entry_price, entry_price * 0.0001)
-            tp1 = entry_price - risk
+        stop = min(setup.range_low, setup.level_price) if setup.side == PositionSide.LONG else max(setup.range_high, setup.level_price)
+        trade_plan = build_bee_bite_trade_plan(
+            side=setup.side,
+            entry_price=entry_price,
+            atr_bg=setup.atr_bg,
+            stop_loss=stop,
+            high_pump=setup.high_pump,
+            low_before_pump=setup.low_before_pump,
+            be_offset_ratio=params.bite_tp1_stop_buffer_pct,
+        )
+        if trade_plan is None:
+            return None, entry_idx
+        risk = max(trade_plan.stop_distance, entry_price * 0.0001)
+        stop = trade_plan.stop_loss
+        tp1 = trade_plan.tp1
 
         trade_risk = params.bite_r_trade
         if trade_risk > params.bite_portfolio_risk_limit:
@@ -367,20 +370,14 @@ class BeeBiteEngine:
 
         position_size = params.bite_r_trade / risk
         tp1_share = min(max(params.bite_tp1_share, 0.05), 0.95)
-        profile_tp1_share = self.PROFILE_TP1_SHARE.get(params.bite_profile_id, tp1_share)
-        tp1_share = min(max(profile_tp1_share, 0.05), 0.95)
+        tp1_share = resolve_profile_tp1_share(params.bite_profile_id, tp1_share)
         remainder_share = 1.0 - tp1_share
 
-        tp2_fixed = self._resolve_fixed_tp2(entry_price=entry_price, setup=setup)
-        trailing_mode = tp2_fixed is None
+        trailing_mode = trade_plan.trailing_mode
+        tp2_fixed = None if trailing_mode else trade_plan.tp2
         trailing_reference = entry_price
         tp1_hit = False
-
-        stop_after_tp1 = (
-            entry_price * (1 + params.bite_tp1_stop_buffer_pct)
-            if setup.side == PositionSide.LONG
-            else entry_price * (1 - params.bite_tp1_stop_buffer_pct)
-        )
+        stop_after_tp1 = trade_plan.be_stop
 
         time_exit_hours = self.PROFILE_TIME_EXIT_HOURS_NO_TP1.get(params.bite_profile_id, 8)
         time_exit_candles = max(1, self._hours_to_candles(time_exit_hours, params.entry_timeframe))
@@ -508,20 +505,6 @@ class BeeBiteEngine:
             retest_timestamp_ms=setup.retest_timestamp,
         )
         return trade, exit_idx
-
-    def _resolve_fixed_tp2(self, *, entry_price: float, setup: SetupContext) -> float | None:
-        if setup.atr_bg <= 0:
-            return None
-        if setup.side == PositionSide.LONG:
-            if setup.high_pump is None:
-                return None
-            distance = setup.high_pump - entry_price
-            return setup.high_pump if distance >= setup.atr_bg else None
-
-        if setup.low_before_pump is None:
-            return None
-        distance = entry_price - setup.low_before_pump
-        return setup.low_before_pump if distance >= setup.atr_bg else None
 
     @staticmethod
     def _body_ratio(row: object) -> float:

--- a/strategy/bee_bite/trade_plan.py
+++ b/strategy/bee_bite/trade_plan.py
@@ -1,0 +1,73 @@
+"""Централизованный расчёт уровней сделки bee_bite."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from domain.enums.position_side import PositionSide
+
+
+PROFILE_TP1_SHARE: dict[str, float] = {
+    "A": 0.7,  # Conservative
+    "B": 0.6,  # Balanced
+    "C": 0.5,  # Aggressive
+}
+
+
+@dataclass(frozen=True, slots=True)
+class BeeBiteTradePlan:
+    stop_loss: float
+    stop_distance: float
+    tp1: float
+    tp2: float
+    trailing_mode: bool
+    be_stop: float
+
+
+def resolve_profile_tp1_share(profile_id: str | None, fallback: float = 0.5) -> float:
+    raw = PROFILE_TP1_SHARE.get((profile_id or "").upper(), fallback)
+    return min(max(raw, 0.05), 0.95)
+
+
+def build_bee_bite_trade_plan(
+    *,
+    side: PositionSide,
+    entry_price: float,
+    atr_bg: float,
+    stop_loss: float,
+    high_pump: float | None,
+    low_before_pump: float | None,
+    be_offset_ratio: float,
+    trailing_tp2_atr_multiplier: float = 10.0,
+) -> BeeBiteTradePlan | None:
+    if atr_bg <= 0:
+        return None
+
+    if side == PositionSide.LONG:
+        stop_distance = entry_price - stop_loss
+    else:
+        stop_distance = stop_loss - entry_price
+    if stop_distance <= 0:
+        return None
+
+    if side == PositionSide.LONG:
+        tp1 = entry_price + stop_distance
+        fixed_tp2 = high_pump if high_pump is not None and (high_pump - entry_price) >= atr_bg else None
+        trailing_tp2 = entry_price + trailing_tp2_atr_multiplier * atr_bg
+        be_stop = entry_price * (1 + be_offset_ratio)
+    else:
+        tp1 = entry_price - stop_distance
+        fixed_tp2 = low_before_pump if low_before_pump is not None and (entry_price - low_before_pump) >= atr_bg else None
+        trailing_tp2 = entry_price - trailing_tp2_atr_multiplier * atr_bg
+        be_stop = entry_price * (1 - be_offset_ratio)
+
+    trailing_mode = fixed_tp2 is None
+    tp2 = trailing_tp2 if trailing_mode else fixed_tp2
+    return BeeBiteTradePlan(
+        stop_loss=stop_loss,
+        stop_distance=stop_distance,
+        tp1=tp1,
+        tp2=tp2,
+        trailing_mode=trailing_mode,
+        be_stop=be_stop,
+    )


### PR DESCRIPTION
### Motivation
- Централизовать расчёт уровней сделки (`sl`, `stop_distance`, `TP1`, `TP2`/trailing, `BE`-stop) чтобы устранить дублирование логики между симулятором и стратегией.
- Применить профильные доли TP1 (Conservative/Aggressive/Balanced) и единую политику ветвления TP2 (fixed vs trailing) по правилу расстояния до `high_pump` относительно `ATR_bg`.
- Обеспечить профильное поведение time-exit: закрытие по рынку при истечении лимита времени, если `TP1` не достигнут.

### Description
- Добавлен новый вспомогательный модуль `strategy/bee_bite/trade_plan.py` с функциями `build_bee_bite_trade_plan` и `resolve_profile_tp1_share`, который вычисляет `stop_loss`, `stop_distance`, `tp1`, `tp2` (fixed vs trailing), `be_stop` и содержит профильные доли TP1 (`A`=0.7, `B`=0.6, `C`=0.5).
- В `strategy/bee_bite/engine.py` заменена локальная логика расчёта уровней в `_simulate_trade` на вызов `build_bee_bite_trade_plan`, профильная доля TP1 берётся через `resolve_profile_tp1_share`, `stop_after_tp1`/BE-stop и режим TP2 теперь приходят из плана, а прежняя `_resolve_fixed_tp2` удалена.
- В `simulation/portfolio_state_engine.py` сигнал строится через тот же `build_bee_bite_trade_plan` и профильная `tp1_close_ratio` теперь резолвится через `resolve_profile_tp1_share`, а при активации кандидата установлено `sim.max_bars_in_trade` на профильный лимит времени для реализации time-exit.
- Добавлена профильная таблица `PROFILE_TIME_EXIT_HOURS_NO_TP1` и метод `_resolve_time_exit_bars` в портфельном движке для перевода профиля в число 15m-баров.

### Testing
- Выполнена автоматическая проверка компиляции командой `python -m compileall simulation/portfolio_state_engine.py strategy/bee_bite/engine.py strategy/bee_bite/trade_plan.py`, компиляция прошла успешно. 
- При реализации тесты не добавлялись (соблюдена инструкция не создавать тесты).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a152936f8832090bd18b72fec080e)