### PR TITLE
Align bee_bite profiles to spec and make time units explicit

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -884,12 +884,12 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
         config.strategy.bee_bite_cooldown_bars = (
             int(getattr(args, "bee_bite_cooldown_bars", None))
             if getattr(args, "bee_bite_cooldown_bars", None) is not None
-            else profile_runtime.cooldown_bars
+            else profile_runtime.cooldown_hours
         )
         config.strategy.bee_bite_max_age_range = (
             int(getattr(args, "bee_bite_max_age_range", None))
             if getattr(args, "bee_bite_max_age_range", None) is not None
-            else profile_runtime.max_age_range
+            else profile_runtime.max_age_range_hours
         )
         validate_bee_bite_runtime(
             profile_id=config.strategy.bee_bite_profile,

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -175,8 +175,8 @@ def load_config(env_path: str | Path = ".env") -> AppConfig:
             os.getenv("BEE_BITE_RETEST_MODE"),
             default=bee_bite_runtime.retest_mode,
         ),
-        bee_bite_cooldown_bars=int(os.getenv("BEE_BITE_COOLDOWN_BARS", str(bee_bite_runtime.cooldown_bars))),
-        bee_bite_max_age_range=int(os.getenv("BEE_BITE_MAX_AGE_RANGE", str(bee_bite_runtime.max_age_range))),
+        bee_bite_cooldown_bars=int(os.getenv("BEE_BITE_COOLDOWN_BARS", str(bee_bite_runtime.cooldown_hours))),
+        bee_bite_max_age_range=int(os.getenv("BEE_BITE_MAX_AGE_RANGE", str(bee_bite_runtime.max_age_range_hours))),
     )
 
     simulation_config = SimulationConfig(

--- a/strategy/bee_bite/config.py
+++ b/strategy/bee_bite/config.py
@@ -73,11 +73,11 @@ class BeeBiteProfileRuntime:
     retest_mode: BeeBiteRetestMode
     top_n_min: int
     top_n_max: int
-    cooldown_bars: int
+    cooldown_hours: int
     min_depth_threshold: float
     micro_offset: float
     reclaim_limit: int
-    max_age_range: int
+    max_age_range_hours: int
 
 
 BEE_BITE_PROFILE_RUNTIME: dict[BeeBiteProfileId, BeeBiteProfileRuntime] = {
@@ -86,33 +86,33 @@ BEE_BITE_PROFILE_RUNTIME: dict[BeeBiteProfileId, BeeBiteProfileRuntime] = {
         retest_mode="confirmation",
         top_n_min=5,
         top_n_max=50,
-        cooldown_bars=8,
-        min_depth_threshold=0.3,
-        micro_offset=0.2,
-        reclaim_limit=6,
-        max_age_range=24,
+        cooldown_hours=8,
+        min_depth_threshold=0.15,
+        micro_offset=0.15,
+        reclaim_limit=5,
+        max_age_range_hours=12,
     ),
     "B": BeeBiteProfileRuntime(
         reclaim_mode="balanced",
         retest_mode="confirmation",
         top_n_min=10,
         top_n_max=80,
-        cooldown_bars=6,
-        min_depth_threshold=0.25,
-        micro_offset=0.15,
-        reclaim_limit=4,
-        max_age_range=20,
+        cooldown_hours=6,
+        min_depth_threshold=0.12,
+        micro_offset=0.10,
+        reclaim_limit=6,
+        max_age_range_hours=8,
     ),
     "C": BeeBiteProfileRuntime(
         reclaim_mode="aggressive",
         retest_mode="immediate",
         top_n_min=20,
         top_n_max=120,
-        cooldown_bars=4,
-        min_depth_threshold=0.2,
-        micro_offset=0.1,
-        reclaim_limit=3,
-        max_age_range=16,
+        cooldown_hours=4,
+        min_depth_threshold=0.10,
+        micro_offset=0.05,
+        reclaim_limit=8,
+        max_age_range_hours=6,
     ),
 }
 
@@ -131,7 +131,7 @@ BEE_BITE_PROFILE_BASELINES: dict[BeeBiteProfileId, BeeBiteParams] = {
         bite_min_depth_threshold=BEE_BITE_PROFILE_RUNTIME["A"].min_depth_threshold,
         bite_micro_offset=BEE_BITE_PROFILE_RUNTIME["A"].micro_offset,
         bite_reclaim_limit=BEE_BITE_PROFILE_RUNTIME["A"].reclaim_limit,
-        bite_max_age_range=BEE_BITE_PROFILE_RUNTIME["A"].max_age_range,
+        bite_max_age_range=BEE_BITE_PROFILE_RUNTIME["A"].max_age_range_hours,
         symbol="",
         bite_profile_id="A",
         bite_grid_mode="baseline",
@@ -149,7 +149,7 @@ BEE_BITE_PROFILE_BASELINES: dict[BeeBiteProfileId, BeeBiteParams] = {
         bite_min_depth_threshold=BEE_BITE_PROFILE_RUNTIME["B"].min_depth_threshold,
         bite_micro_offset=BEE_BITE_PROFILE_RUNTIME["B"].micro_offset,
         bite_reclaim_limit=BEE_BITE_PROFILE_RUNTIME["B"].reclaim_limit,
-        bite_max_age_range=BEE_BITE_PROFILE_RUNTIME["B"].max_age_range,
+        bite_max_age_range=BEE_BITE_PROFILE_RUNTIME["B"].max_age_range_hours,
         symbol="",
         bite_profile_id="B",
         bite_grid_mode="baseline",
@@ -167,7 +167,7 @@ BEE_BITE_PROFILE_BASELINES: dict[BeeBiteProfileId, BeeBiteParams] = {
         bite_min_depth_threshold=BEE_BITE_PROFILE_RUNTIME["C"].min_depth_threshold,
         bite_micro_offset=BEE_BITE_PROFILE_RUNTIME["C"].micro_offset,
         bite_reclaim_limit=BEE_BITE_PROFILE_RUNTIME["C"].reclaim_limit,
-        bite_max_age_range=BEE_BITE_PROFILE_RUNTIME["C"].max_age_range,
+        bite_max_age_range=BEE_BITE_PROFILE_RUNTIME["C"].max_age_range_hours,
         symbol="",
         bite_profile_id="C",
         bite_grid_mode="baseline",
@@ -316,10 +316,10 @@ def validate_bee_bite_runtime(
         supported = ", ".join(allowed_retest)
         raise ValueError(f"профиль {profile_id} поддерживает retest_mode только из [{supported}]")
 
-    if cooldown_bars != runtime.cooldown_bars:
-        raise ValueError(f"профиль {profile_id} требует cooldown_bars={runtime.cooldown_bars}")
-    if max_age_range != runtime.max_age_range:
-        raise ValueError(f"профиль {profile_id} требует max_age_range={runtime.max_age_range}")
+    if cooldown_bars != runtime.cooldown_hours:
+        raise ValueError(f"профиль {profile_id} требует cooldown_bars={runtime.cooldown_hours}")
+    if max_age_range != runtime.max_age_range_hours:
+        raise ValueError(f"профиль {profile_id} требует max_age_range={runtime.max_age_range_hours}")
 
     if top_n is None:
         return

--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -72,12 +72,12 @@ class BeeBiteEngine:
     }
     FIXED_RANGE_WINDOW: int | None = None
     PROFILE_STABILITY_THRESHOLD: dict[str, float] = {
-        "A": 0.8,
-        "B": 1.0,
-        "C": 1.2,
+        "A": 0.20,
+        "B": 0.25,
+        "C": 0.30,
     }
     PROFILE_TIME_EXIT_HOURS_NO_TP1: dict[str, int] = {
-        "A": 10,
+        "A": 12,
         "B": 8,
         "C": 6,
     }
@@ -218,7 +218,8 @@ class BeeBiteEngine:
             if state == BeeBiteState.RANGE_LOCKED and setup is not None:
                 range_started_idx = setup.retest_idx if setup.retest_idx is not None else i
                 elapsed_in_range = i - range_started_idx
-                if elapsed_in_range > params.bite_max_age_range:
+                max_age_range_candles = self._hours_to_candles(params.bite_max_age_range, params.entry_timeframe)
+                if elapsed_in_range > max_age_range_candles:
                     setup = None
                     state = BeeBiteState.IDLE
                     diagnostics["states"].append(state.value)


### PR DESCRIPTION
### Motivation
- Bring BeeBite profile runtime values in line with the new A/B/C specification and eliminate ambiguity between hours and bars for time-based settings.
- Ensure baseline parameter generation and CLI/config defaults cannot silently overwrite profile runtime defaults.

### Description
- Updated `BEE_BITE_PROFILE_RUNTIME` to use explicit hour fields and new values: `cooldown_hours` and `max_age_range_hours`, and set profile A/B/C fields to the requested spec for `min_depth_threshold`, `micro_offset`, `reclaim_limit`, `max_age_range_hours`, and `cooldown_hours` (`strategy/bee_bite/config.py`).
- Changed baseline params to read `bite_max_age_range` from `BEE_BITE_PROFILE_RUNTIME[...].max_age_range_hours` so baseline/default grids follow the runtime spec (`strategy/bee_bite/config.py`).
- Adjusted runtime validation to compare received `cooldown_bars`/`max_age_range` values against the renamed runtime hour fields to prevent accidental drift (`strategy/bee_bite/config.py`).
- Synced CLI and config loader to use the renamed runtime fields as defaults (`cli/commands.py`, `config/__init__.py`).
- Updated engine constants: `PROFILE_STABILITY_THRESHOLD` set to A/B/C = `0.20/0.25/0.30`, and `PROFILE_TIME_EXIT_HOURS_NO_TP1` set to A/B/C = `12/8/6` (`strategy/bee_bite/engine.py`).
- Replaced direct comparison against `params.bite_max_age_range` in the FSM with an explicit conversion from hours to candles via `_hours_to_candles(params.bite_max_age_range, params.entry_timeframe)` to remove hours-vs-bars ambiguity (`strategy/bee_bite/engine.py`).

### Testing
- Ran `python -m compileall strategy/bee_bite config cli` to ensure the affected modules compile successfully, and compilation completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a16c74aa08320baa384b5863ac41f)