### PR TITLE
Обновить формулы SL/TP для bee_bite и унифицировать порядок выхода

### DIFF
--- a/simulation/exit_manager.py
+++ b/simulation/exit_manager.py
@@ -58,8 +58,8 @@ class ExitManager:
         breakeven_price: Callable[[float, PositionSide], float],
         update_stop: Callable[[float], None],
     ) -> tuple[float | None, bool]:
-        if candle.low.value <= position.stop_loss.value:
-            return position.stop_loss.value, position.sl_moved_to_be
+        if not position.tp1_done and candle.low.value <= position.stop_loss.value:
+            return position.stop_loss.value, False
 
         if not position.tp1_done and candle.high.value >= position.take_profit_1.value:
             tp1_ratio = position.tp1_close_ratio if position.tp1_close_ratio is not None else self.config.tp1_close_ratio
@@ -68,22 +68,20 @@ class ExitManager:
             position.tp1_done = True
             position.sl_moved_to_be = True
             if self.config.bee_bite_mode:
-                be_plus = position.entry_price.value * (1 + 0.001)
-                update_stop(be_plus)
+                update_stop(position.entry_price.value * 1.001)
                 position.highest_close_since_tp1 = candle.close.value
             else:
                 be = breakeven_price(position.entry_price.value, PositionSide.LONG)
-                be_plus = be * (1 + self.config.be_plus_offset_ratio)
-                update_stop(be_plus)
-            if candle.low.value <= position.stop_loss.value:
-                return position.stop_loss.value, True
+                update_stop(be * (1 + self.config.be_plus_offset_ratio))
+
+        if not position.tp1_done:
+            return None, False
 
         self._maybe_update_trailing_stop(candle=candle, position=position, side=PositionSide.LONG, update_stop=update_stop)
-
-        if candle.low.value <= position.stop_loss.value:
-            return position.stop_loss.value, True
         if candle.high.value >= position.take_profit_2.value:
             return position.take_profit_2.value, False
+        if candle.low.value <= position.stop_loss.value:
+            return position.stop_loss.value, True
         return None, False
 
     def _process_short(
@@ -95,8 +93,8 @@ class ExitManager:
         breakeven_price: Callable[[float, PositionSide], float],
         update_stop: Callable[[float], None],
     ) -> tuple[float | None, bool]:
-        if candle.high.value >= position.stop_loss.value:
-            return position.stop_loss.value, position.sl_moved_to_be
+        if not position.tp1_done and candle.high.value >= position.stop_loss.value:
+            return position.stop_loss.value, False
 
         if not position.tp1_done and candle.low.value <= position.take_profit_1.value:
             tp1_ratio = position.tp1_close_ratio if position.tp1_close_ratio is not None else self.config.tp1_close_ratio
@@ -105,22 +103,20 @@ class ExitManager:
             position.tp1_done = True
             position.sl_moved_to_be = True
             if self.config.bee_bite_mode:
-                be_plus = position.entry_price.value * (1 - 0.001)
-                update_stop(be_plus)
+                update_stop(position.entry_price.value * 0.999)
                 position.lowest_close_since_tp1 = candle.close.value
             else:
                 be = breakeven_price(position.entry_price.value, PositionSide.SHORT)
-                be_plus = be * (1 - self.config.be_plus_offset_ratio)
-                update_stop(be_plus)
-            if candle.high.value >= position.stop_loss.value:
-                return position.stop_loss.value, True
+                update_stop(be * (1 - self.config.be_plus_offset_ratio))
+
+        if not position.tp1_done:
+            return None, False
 
         self._maybe_update_trailing_stop(candle=candle, position=position, side=PositionSide.SHORT, update_stop=update_stop)
-
-        if candle.high.value >= position.stop_loss.value:
-            return position.stop_loss.value, True
         if candle.low.value <= position.take_profit_2.value:
             return position.take_profit_2.value, False
+        if candle.high.value >= position.stop_loss.value:
+            return position.stop_loss.value, True
         return None, False
 
     def _maybe_update_trailing_stop(

--- a/simulation/portfolio_state_engine.py
+++ b/simulation/portfolio_state_engine.py
@@ -620,15 +620,14 @@ class PortfolioStateEngine:
         atr_bg = float(state.atr_bg if state.atr_bg is not None else max(abs(resistance - support) * 0.25, entry * 0.001))
         high_pump = float(state.high_pump if state.high_pump is not None else max(entry, resistance))
 
+        buffer = max(0.1 * atr_bg, 0.001 * entry)
         if side == PositionSide.LONG:
             lowest_break = float(state.lowest_break if state.lowest_break is not None else support)
-            stop = min(lowest_break, support - 0.1 * atr_bg)
-            tp1_floor = max(resistance, entry + 0.5 * atr_bg)
+            stop = lowest_break - buffer
             low_before_pump = None
         else:
             lowest_break = float(state.lowest_break if state.lowest_break is not None else resistance)
-            stop = max(lowest_break, resistance + 0.1 * atr_bg)
-            tp1_floor = min(support, entry - 0.5 * atr_bg)
+            stop = lowest_break + buffer
             low_before_pump = high_pump if high_pump < entry else entry - atr_bg
 
         plan = build_bee_bite_trade_plan(
@@ -636,14 +635,15 @@ class PortfolioStateEngine:
             entry_price=entry,
             atr_bg=atr_bg,
             stop_loss=stop,
+            support=support,
+            resistance=resistance,
             high_pump=high_pump,
             low_before_pump=low_before_pump,
-            be_offset_ratio=0.001,
         )
         if plan is None or plan.stop_distance < (0.3 * atr_bg):
             return None
 
-        tp1 = max(plan.tp1, tp1_floor) if side == PositionSide.LONG else min(plan.tp1, tp1_floor)
+        tp1 = plan.tp1
         tp2 = plan.tp2
 
         signal = TradeSignal(
@@ -652,14 +652,14 @@ class PortfolioStateEngine:
             entry_price=Price(entry),
             entry_timestamp_ms=int(row["timestamp"]),
             formation_timestamp_ms=int(row["timestamp"]),
-            stop_loss=Price(stop),
+            stop_loss=Price(plan.stop_loss),
             take_profit_1=Price(tp1),
             take_profit_2=Price(tp2),
             breakout_timestamp_ms=int(row["timestamp"]),
             retest_timestamp_ms=int(row["timestamp"]),
             atr_bg=atr_bg,
             high_pump=high_pump,
-            tp1_close_ratio=resolve_profile_tp1_share(self.config.bee_bite_profile_id, 0.5),
+            tp1_close_ratio=resolve_profile_tp1_share(self.config.bee_bite_profile_id),
         )
         return signal
 

--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -349,17 +349,26 @@ class BeeBiteEngine:
         if setup.range_low is None or setup.range_high is None:
             return None, entry_idx
 
-        stop = min(setup.range_low, setup.level_price) if setup.side == PositionSide.LONG else max(setup.range_high, setup.level_price)
+        buffer = max(0.1 * setup.atr_bg, 0.001 * entry_price)
+        if setup.side == PositionSide.LONG:
+            if setup.lowest_break is None:
+                return None, entry_idx
+            stop = float(setup.lowest_break) - buffer
+        else:
+            if setup.lowest_break is None:
+                return None, entry_idx
+            stop = float(setup.lowest_break) + buffer
         trade_plan = build_bee_bite_trade_plan(
             side=setup.side,
             entry_price=entry_price,
             atr_bg=setup.atr_bg,
             stop_loss=stop,
+            support=float(setup.range_low),
+            resistance=float(setup.range_high),
             high_pump=setup.high_pump,
             low_before_pump=setup.low_before_pump,
-            be_offset_ratio=params.bite_tp1_stop_buffer_pct,
         )
-        if trade_plan is None:
+        if trade_plan is None or trade_plan.stop_distance < (0.3 * setup.atr_bg):
             return None, entry_idx
         risk = max(trade_plan.stop_distance, entry_price * 0.0001)
         stop = trade_plan.stop_loss
@@ -370,8 +379,7 @@ class BeeBiteEngine:
             return None, entry_idx
 
         position_size = params.bite_r_trade / risk
-        tp1_share = min(max(params.bite_tp1_share, 0.05), 0.95)
-        tp1_share = resolve_profile_tp1_share(params.bite_profile_id, tp1_share)
+        tp1_share = resolve_profile_tp1_share(params.bite_profile_id)
         remainder_share = 1.0 - tp1_share
 
         trailing_mode = trade_plan.trailing_mode

--- a/strategy/bee_bite/trade_plan.py
+++ b/strategy/bee_bite/trade_plan.py
@@ -24,8 +24,8 @@ class BeeBiteTradePlan:
     be_stop: float
 
 
-def resolve_profile_tp1_share(profile_id: str | None, fallback: float = 0.5) -> float:
-    raw = PROFILE_TP1_SHARE.get((profile_id or "").upper(), fallback)
+def resolve_profile_tp1_share(profile_id: str | None) -> float:
+    raw = PROFILE_TP1_SHARE.get((profile_id or "").upper(), PROFILE_TP1_SHARE["C"])
     return min(max(raw, 0.05), 0.95)
 
 
@@ -35,10 +35,10 @@ def build_bee_bite_trade_plan(
     entry_price: float,
     atr_bg: float,
     stop_loss: float,
+    support: float,
+    resistance: float,
     high_pump: float | None,
     low_before_pump: float | None,
-    be_offset_ratio: float,
-    trailing_tp2_atr_multiplier: float = 10.0,
 ) -> BeeBiteTradePlan | None:
     if atr_bg <= 0:
         return None
@@ -50,16 +50,17 @@ def build_bee_bite_trade_plan(
     if stop_distance <= 0:
         return None
 
+    mid = (support + resistance) / 2.0
     if side == PositionSide.LONG:
-        tp1 = entry_price + stop_distance
+        tp1 = mid if mid > entry_price else resistance
         fixed_tp2 = high_pump if high_pump is not None and (high_pump - entry_price) >= atr_bg else None
-        trailing_tp2 = entry_price + trailing_tp2_atr_multiplier * atr_bg
-        be_stop = entry_price * (1 + be_offset_ratio)
+        trailing_tp2 = entry_price + atr_bg
+        be_stop = entry_price * 1.001
     else:
-        tp1 = entry_price - stop_distance
+        tp1 = mid if mid < entry_price else support
         fixed_tp2 = low_before_pump if low_before_pump is not None and (entry_price - low_before_pump) >= atr_bg else None
-        trailing_tp2 = entry_price - trailing_tp2_atr_multiplier * atr_bg
-        be_stop = entry_price * (1 - be_offset_ratio)
+        trailing_tp2 = entry_price - atr_bg
+        be_stop = entry_price * 0.999
 
     trailing_mode = fixed_tp2 is None
     tp2 = trailing_tp2 if trailing_mode else fixed_tp2


### PR DESCRIPTION
### Motivation
- Привести расчёт уровней сделки bee_bite к новым правилам стопа/тейк-профайла и поведению TP/BE/TP2 для единообразного симулятора. 
- Устранить неоднозначности в порядке срабатывания TP/SL/BE в симуляторе и использовать профильные доли TP1 (A/B/C = 70/60/50%).

### Description
- В `strategy/bee_bite/trade_plan.py` пересчитан план сделки: TP1 теперь выбирается как `mid = (support + resistance)/2` если `mid` выгоднее для входа, иначе край уровня; TP2 — фиксированный только при движении до экстремума пампа >= `1.0 * ATR_bg`, иначе trailing на `±1.0 * ATR_bg`; BE после TP1 зафиксирован на `entry * 1.001` (long) / `entry * 0.999` (short); TP1 доля берётся строго по профилю A/B/C = 0.7/0.6/0.5. (файл: `strategy/bee_bite/trade_plan.py`).
- В `strategy/bee_bite/engine.py` изменена логика вычисления SL до вызова плана: `buffer = max(0.1 * ATR_bg, 0.001 * entry)` и стоп привязан к `lowest_break - buffer` (для long) / `+ buffer` (для short); теперь план отбраковывается если `stop_distance < 0.3 * ATR_bg`. Также передаём `support`/`resistance` в `build_bee_bite_trade_plan` и используем профильную долю TP1 (файл: `strategy/bee_bite/engine.py`).
- В `simulation/portfolio_state_engine.py` синхронизировал формулы: те же buffer/stop, передача `support`/`resistance` в план, использование `plan.stop_loss` и `plan.tp1/ tp2` в сигнале, и проверка `plan.stop_distance >= 0.3 * ATR_bg`. TP1 close ratio в сигнале теперь определяется функцией профиля (файл: `simulation/portfolio_state_engine.py`).
- В `simulation/exit_manager.py` упорядочил и упростил порядок обработки выходов, чтобы избежать двусмысленной логики: до TP1 — приоритизация SL (если TP1 не закрыт), затем обработка TP1; после TP1 — переход стопа в BE (`entry ± 0.1%` при bee_bite_mode), обновление trailing, затем TP2 приоритет над SL, и финальная проверка SL; это даёт детерминированный порядок исполнения TP/SL/BE (файл: `simulation/exit_manager.py`).

### Testing
- Скомпилированы изменённые модули командой `python -m compileall strategy/bee_bite simulation` без ошибок.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a17946ffc8320948b481d54fb699f)