### PR TITLE
Unify bee_bite execution on portfolio pipeline

### DIFF
--- a/strategy/bee_bite/bee_bite_strategy.py
+++ b/strategy/bee_bite/bee_bite_strategy.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+import warnings
+
+import pandas as pd
+
+from domain.models.trade_result import TradeResult
+from simulation.portfolio_state_engine import PortfolioEngineConfig, PortfolioStateEngine
 from strategy.base_strategy import BaseStrategy
 from strategy.bee_bite.config import (
     BeeBiteGridMode,
     BeeBiteParams,
     BeeBiteProfileId,
     build_bee_bite_grid,
+    get_bee_bite_score_threshold,
+    get_bee_bite_top_n,
+    get_bee_bite_runtime,
     validate_bee_bite_params,
 )
 from strategy.bee_bite.engine import BeeBiteEngine
@@ -19,6 +28,7 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
         self._profile_id = profile_id
         self._grid_mode = grid_mode
         self._engine = BeeBiteEngine()
+        self._last_generation_diagnostics: dict[str, object] = {}
 
     def validate_config(self, params: BeeBiteParams) -> None:
         validate_bee_bite_params(params)
@@ -28,10 +38,89 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
         return self._engine.prepare_data(data)
 
     def generate_events(self, data, params: BeeBiteParams):
+        warnings.warn(
+            "BeeBiteStrategy.generate_events(...) deprecated: используйте generate_events_portfolio(...) "
+            "(или generate_events_multi_tf для совместимости с legacy-вызовами).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._engine.generate_events(data, params)
 
     def generate_events_multi_tf(self, *, mtf_frames: SymbolMtfFrames, params: BeeBiteParams):
+        warnings.warn(
+            "BeeBiteStrategy.generate_events_multi_tf(...) deprecated: основной путь для bee_bite — "
+            "generate_events_portfolio(...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._engine.generate_events_multi_tf(mtf_frames=mtf_frames, params=params)
+
+    def generate_events_portfolio(
+        self,
+        *,
+        symbol_frames: dict[str, SymbolMtfFrames],
+        params: BeeBiteParams,
+    ) -> list[TradeResult]:
+        entry_frames: dict[str, pd.DataFrame] = {}
+        for symbol, mtf in sorted(symbol_frames.items(), key=lambda item: item[0]):
+            frame = self._engine.prepare_data(mtf.entry_frame)
+            if frame.empty:
+                continue
+            columns = ["timestamp", "open", "high", "low", "close", "volume"]
+            optional_columns = [
+                "open_interest",
+                "taker_buy_volume",
+                "taker_buy_ratio",
+                "taker_ratio",
+                "avg_volume_range",
+                "avg_range_volume",
+                "range_volume_avg",
+                "oi_reclaim",
+                "oi_break_avg",
+                "range_volume_zscore",
+                "volume_range_zscore",
+                "zscore_range_volume",
+                "atr_bg",
+                "spread",
+                "bid_ask_spread",
+                "effective_spread",
+                "high_pump",
+                "lowest_break",
+                "support",
+                "resistance",
+            ]
+            columns.extend(column for column in optional_columns if column in frame.columns)
+            entry_frames[symbol] = frame[columns].copy()
+        if not entry_frames:
+            return []
+
+        profile_id = params.bite_profile_id
+        engine = PortfolioStateEngine(
+            config=PortfolioEngineConfig(
+                top_n=get_bee_bite_top_n(profile_id),
+                score_threshold=get_bee_bite_score_threshold(profile_id).min_score,
+                r_trade=params.bite_r_trade,
+                portfolio_risk_limit=params.bite_portfolio_risk_limit,
+                min_stop_atr_ratio=params.bite_min_stop_atr_ratio,
+                t_max_in_trade=params.bite_t_max_in_trade,
+                cooldown_bars=get_bee_bite_runtime(profile_id).cooldown_hours,
+                max_age_range=params.bite_max_age_range,
+                reclaim_limit=params.bite_reclaim_limit,
+                bee_bite_profile_id=profile_id,
+            ),
+            commission_rate=0.0,
+            slippage=0.0,
+        )
+        trades = engine.run(entry_frames)
+        self._last_generation_diagnostics = {
+            "mode": "portfolio_only",
+            "profile_id": profile_id,
+            "top_n": get_bee_bite_top_n(profile_id),
+            "score_threshold": get_bee_bite_score_threshold(profile_id).min_score,
+            "portfolio_score": engine.consume_last_run_diagnostics(),
+            "trades_generated": len(trades),
+        }
+        return trades
 
     def build_parameter_grid(self) -> list[BeeBiteParams]:
         return build_bee_bite_grid(profile_id=self._profile_id, grid_mode=self._grid_mode)
@@ -63,4 +152,8 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
         return None
 
     def consume_last_generation_diagnostics(self) -> dict[str, object]:
+        if self._last_generation_diagnostics:
+            diagnostics = self._last_generation_diagnostics.copy()
+            self._last_generation_diagnostics = {}
+            return diagnostics
         return self._engine.consume_last_generation_diagnostics()

--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -314,6 +314,8 @@ class BacktestRunner:
             )
             if portfolio_trades is not None:
                 all_trades.extend(portfolio_trades)
+            elif strategy.__class__.__name__ == "BeeBiteStrategy":
+                raise RuntimeError("BeeBiteStrategy должен использовать только portfolio pipeline.")
             else:
                 for symbol, mtf_frames in symbol_frames.items():
                     cfg = self._inject_runtime_fields(


### PR DESCRIPTION
### Motivation
- Избежать расхождения результатов между single-symbol и portfolio-run, выбрав один основной движок для `bee_bite` и упростив дисциплину риска. 
- Обеспечить детерминированный и однозначный pipeline в раннере, чтобы запуск `bee_bite` всегда использовал портфельный путь.

### Description
- Добавлена полноценная реализация `BeeBiteStrategy.generate_events_portfolio(...)`, которая собирает entry-frames по символам, конфигурирует `PortfolioStateEngine` и возвращает портфельные `TradeResult`-ы, с сохранением diagnostics. 
- Помечены legacy-пути `generate_events` и `generate_events_multi_tf` как deprecated через `DeprecationWarning` и сохранена их обратная совместимость через оригинальный движок. 
- В `vectorbt_runner/backtest_runner.py` зафиксирован детерминированный поток: если `strategy.generate_events_portfolio(...)` возвращает `None` и стратегия — `BeeBiteStrategy`, раннер выдаёт `RuntimeError`, чтобы избежать silent fallback на per-symbol pipeline. 
- Добавлены необходимые импорты/типовые уточнения и локальное хранение diagnostics в `BeeBiteStrategy.consume_last_generation_diagnostics()` для корректного сбора диагностик портфельного запуска.

### Testing
- Выполнена компиляция изменённых модулей командой `python -m compileall strategy/bee_bite/bee_bite_strategy.py vectorbt_runner/backtest_runner.py`, которая завершилась успешно. 
- Изменения закоммичены; не добавлялись новые автоматические тесты.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1a64575883208aaba58121a881e8)