### PR TITLE
Unify portfolio state timeout units to 15m bars

### DIFF
--- a/simulation/portfolio_state_engine.py
+++ b/simulation/portfolio_state_engine.py
@@ -40,8 +40,8 @@ class PortfolioEngineConfig:
     min_stop_atr_ratio: float = 0.3
     t_max_in_trade: int | None = None
     cooldown_bars: int = 8
-    max_age_range: int = 24
-    reclaim_limit: int = 3
+    max_age_range_bars: int = 24
+    reclaim_limit_bars: int = 3
     break_fail_threshold: int = 2
     min_pump_pct: float = 0.02
     max_range_width_pct: float = 0.03
@@ -287,7 +287,7 @@ class PortfolioStateEngine:
                 row_atr = row.get("atr_bg")
                 state.atr_bg = float(row_atr) if row_atr is not None and row_atr > 0 else state.range_high - state.range_low
                 state.age = 0
-            elif state.age > self.config.max_age_range:
+            elif state.age > self.config.max_age_range_bars:
                 self._reset_state(state)
             return None
 
@@ -305,7 +305,7 @@ class PortfolioStateEngine:
             if width_pct <= self.config.max_range_width_pct and state.age >= 2:
                 state.state = PortfolioState.RANGE_LOCKED
                 state.age = 0
-            elif state.age > self.config.max_age_range:
+            elif state.age > self.config.max_age_range_bars:
                 self._reset_state(state)
             return None
 
@@ -327,7 +327,7 @@ class PortfolioStateEngine:
                 state.break_start_timeline_idx = timeline_idx
                 state.break_start_timestamp_ms = int(row["timestamp"])
                 state.age = 0
-            elif state.age > self.config.max_age_range:
+            elif state.age > self.config.max_age_range_bars:
                 self._reset_state(state)
             return None
 
@@ -335,7 +335,7 @@ class PortfolioStateEngine:
             assert state.break_side is not None and state.break_price is not None
             break_start_idx = state.break_start_timeline_idx if state.break_start_timeline_idx is not None else timeline_idx
             reclaim_bars = max(timeline_idx - break_start_idx + 1, 1)
-            if (timeline_idx - break_start_idx) > self.config.reclaim_limit:
+            if (timeline_idx - break_start_idx) > self.config.reclaim_limit_bars:
                 self._reset_state(state)
                 return None
 

--- a/strategy/bee_bite/bee_bite_strategy.py
+++ b/strategy/bee_bite/bee_bite_strategy.py
@@ -103,9 +103,9 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
                 portfolio_risk_limit=params.bite_portfolio_risk_limit,
                 min_stop_atr_ratio=params.bite_min_stop_atr_ratio,
                 t_max_in_trade=params.bite_t_max_in_trade,
-                cooldown_bars=get_bee_bite_runtime(profile_id).cooldown_hours,
-                max_age_range=params.bite_max_age_range,
-                reclaim_limit=params.bite_reclaim_limit,
+                cooldown_bars=self._hours_to_15m_bars(get_bee_bite_runtime(profile_id).cooldown_hours),
+                max_age_range_bars=self._hours_to_15m_bars(params.bite_max_age_range),
+                reclaim_limit_bars=self._hours_to_15m_bars(params.bite_reclaim_limit),
                 bee_bite_profile_id=profile_id,
             ),
             commission_rate=0.0,
@@ -121,6 +121,10 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
             "trades_generated": len(trades),
         }
         return trades
+
+    @staticmethod
+    def _hours_to_15m_bars(hours: int) -> int:
+        return max(1, hours * 4)
 
     def build_parameter_grid(self) -> list[BeeBiteParams]:
         return build_bee_bite_grid(profile_id=self._profile_id, grid_mode=self._grid_mode)


### PR DESCRIPTION
### Motivation
- Убрать смешение часов и баров в логике портфельного state-engine и сделать единицы таймаутов однородными (15m-бары).
- Обеспечить корректные сравнения `state.age` (в барах) с конфигурационными таймаутами и исключить ошибки из-за смешанных единиц.

### Description
- Переименованы поля конфигурации в `PortfolioEngineConfig`: `max_age_range` -> `max_age_range_bars` и `reclaim_limit` -> `reclaim_limit_bars` в `simulation/portfolio_state_engine.py` для явного указания единиц (бары). 
- В state-machine заменены все проверki времени/возраста на использование новых баровых полей (`max_age_range_bars`, `reclaim_limit_bars`) для сравнения с `state.age` и reclaim-логикой. 
- В точке инициализации `PortfolioEngineConfig` внутри `strategy/bee_bite/bee_bite_strategy.py` произведена конвертация часовых параметров в 15m-бары (`hours * 4`) для `cooldown`, `max_age_range` и `reclaim_limit` перед передачей в движок. 
- Добавлен локальный хелпер `BeeBiteStrategy._hours_to_15m_bars` для единого способа перевода часов в 15m-бары.

### Testing
- Скомпилированы изменённые файлы командой `python -m compileall simulation/portfolio_state_engine.py strategy/bee_bite/bee_bite_strategy.py`, компиляция прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1c6de1288320bccc67f4598a2887)