### PR TITLE
Refine _freeze_range stability gate to use rolling P10(low) windows

### DIFF
--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -671,7 +671,6 @@ class BeeBiteEngine:
         window = rows[start_idx : end_idx + 1]
         lows = np.array([float(item.low) for item in window])
         highs = np.array([float(item.high) for item in window])
-        closes = np.array([float(item.close) for item in window])
         atr_bg = float(setup.atr_bg)
         if atr_bg <= 0:
             return None
@@ -687,8 +686,15 @@ class BeeBiteEngine:
         if len(window) < 6:
             return None
 
-        close_last6 = closes[-6:]
-        p10_last6 = [float(np.quantile(close_last6[: idx + 1], 0.10)) for idx in range(len(close_last6))]
+        p10_last6: list[float] = []
+        for idx in range(end_idx - 5, end_idx + 1):
+            rolling_start_idx = idx - window_len + 1
+            if rolling_start_idx < min_start_idx:
+                return None
+            rolling_window = rows[rolling_start_idx : idx + 1]
+            rolling_lows = np.array([float(item.low) for item in rolling_window])
+            p10_last6.append(float(np.quantile(rolling_lows, 0.10)))
+
         stability_threshold = self.PROFILE_STABILITY_THRESHOLD.get(params.bite_profile_id, params.bite_max_retest_depth)
         if max(p10_last6) - min(p10_last6) > stability_threshold * atr_bg:
             return None


### PR DESCRIPTION
### Motivation
- Убрать неточную аппроксимацию стабильности через последние закрытия и перейти к проверке на основе low-цен, чтобы стабильность диапазона отражала поведение минимумов.
- Для надёжной оценки стабильности измерять `P10(low)` для каждой из последних 6 свечей, пересчитанную в собственном скользящем окне длины `L`.
- Не фиксировать `support/resistance/core_width`, пока размах этих `P10` не окажется меньше порога стабильности, масштабированного через `ATR_bg`.

### Description
- Удалён расчёт массива `closes` и логики на основе `close_last6` в `BeeBiteEngine._freeze_range` и заменён на работу исключительно с low-ценами и квантилями.
- Добавлен цикл, который для индексов `end_idx-5`..`end_idx` строит своё скользящее окно длины `window_len`, вычисляет `P10` по `low` и собирает `p10_last6`, при этом проверяется доступность истории (`min_start_idx`).
- Стабильность теперь проверяется как `max(p10_last6) - min(p10_last6) <= stability_threshold * atr_bg`, и при нарушении условие приводит к `return None`, иначе функция возвращает `support, resistance, core_width` как ранее.

### Testing
- Запущена компиляция файла через `python -m compileall strategy/bee_bite/engine.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac8afa1e88320bb708ae8d2914e4c)