### PR TITLE
Resolve pump end as peak candle in bee_bite engine

### DIFF
--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -616,7 +616,8 @@ class BeeBiteEngine:
         if atr_bg <= 0:
             return None
 
-        high_pump = max(float(item.high) for item in recent)
+        pump_highs = [float(item.high) for item in recent]
+        high_pump = max(pump_highs)
         low_pump = min(float(item.low) for item in recent)
         low_before_pump = float(before_pump.low)
         high_before_pump = float(before_pump.high)
@@ -629,7 +630,8 @@ class BeeBiteEngine:
             return None
 
         t_pump_start = int(recent[0].timestamp)
-        t_pump_end = int(recent[-1].timestamp)
+        pump_peak_offset = int(np.argmax(pump_highs))
+        t_pump_end = int(recent[pump_peak_offset].timestamp)
         if up_impulse >= down_impulse:
             return (
                 PositionSide.LONG,


### PR DESCRIPTION
### Motivation
- Корректно определить конец «памп»-импульса внутри 6-свечного окна как timestamp свечи с максимальным `high`, чтобы дальнейшая логика использовала точную точку пика, а не всегда последнюю свечу окна.

### Description
- В `_resolve_pump_signal` собраны `pump_highs = [float(item.high) for item in recent]` и `high_pump` вычисляется как `max(pump_highs)` вместо генератора на месте.
- Вычислен индекс свечи-пика через `pump_peak_offset = int(np.argmax(pump_highs))` и `t_pump_end` теперь устанавливается как `int(recent[pump_peak_offset].timestamp)` вместо `recent[-1].timestamp`.
- Значение `t_pump_end` по-прежнему возвращается из `_resolve_pump_signal` и сохраняется в `SetupContext`, оставаясь единственным используемым значением дальше по потоку.

### Testing
- Запущена проверка компиляции файла: `python -m compileall strategy/bee_bite/engine.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac97586bc8320bed61a8c6a673d3e)