### PR TITLE
Adjust profile penalty logic in portfolio candidate scoring

### DIFF
--- a/simulation/portfolio_state_engine.py
+++ b/simulation/portfolio_state_engine.py
@@ -517,12 +517,8 @@ class PortfolioStateEngine:
             score_trace["range_volume_zscore"] = 1.0
         score += score_trace["range_volume_zscore"]
 
-        # 8) Profile penalties (6–8 bars).
-        if profile == "A" and reclaim_bars >= 6:
-            score_trace["profile_penalty"] = -1.0
-        elif profile == "B" and reclaim_bars >= 7:
-            score_trace["profile_penalty"] = -1.0
-        elif profile == "C" and reclaim_bars >= 8:
+        # 8) Profile penalties: only for B/C when reclaim window is 6..8 bars.
+        if profile in {"B", "C"} and 6 <= reclaim_bars <= 8:
             score_trace["profile_penalty"] = -1.0
         score += score_trace["profile_penalty"]
 


### PR DESCRIPTION
### Motivation
- Remove the conservative (`A`) reclaim-bar penalty and make profile penalty behavior consistent across `B` and `C` profiles. 
- Ensure the penalty only applies for a specific reclaim window so it is not applied outside the intended range.

### Description
- Replaced the multi-branch profile checks in `_score_candidate` with a single condition that applies `score_trace["profile_penalty"] = -1.0` only when `profile` is in `{"B", "C"}` and `6 <= reclaim_bars <= 8`.
- Eliminated any penalty path for profile `A`, and constrained the `B`/`C` penalty to the inclusive `6..8` reclaim bars window.

### Testing
- Ran `python -m py_compile simulation/portfolio_state_engine.py` which succeeded.
- Attempted a quick runtime check that calls `_score_candidate` for profiles `A`, `B`, and `C` across reclaim bars but the script could not complete due to a missing dependency (`pandas`) in the environment, so dynamic verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac9e55af08320a3b0fb1b8ac9cc28)