### PR TITLE
Increase profile A no-TP1 time exit to 12h

### DIFF
--- a/simulation/portfolio_state_engine.py
+++ b/simulation/portfolio_state_engine.py
@@ -111,7 +111,7 @@ class PortfolioStateEngine:
     )
     PROFILE_TIME_EXIT_HOURS_NO_TP1: dict[str, int] = field(
         default_factory=lambda: {
-            "A": 10,
+            "A": 12,
             "B": 8,
             "C": 6,
         }


### PR DESCRIPTION
### Motivation
- Allow profile `A` trades more time before forced exit when TP1 is not reached by increasing the no-TP1 timeout from 10 to 12 hours.

### Description
- Updated `PROFILE_TIME_EXIT_HOURS_NO_TP1["A"]` from `10` to `12` in `simulation/portfolio_state_engine.py` and left the hours-to-15m-bars conversion logic in `_hours_to_15m_bars` unchanged.

### Testing
- Performed static code inspection confirming `_resolve_time_exit_bars` calls `_hours_to_15m_bars` (so 12h -> 48 bars) and that `StatefulPositionSimulator.process_candle` only finalizes by time when `not self.position.tp1_done`.
- Attempted a small runtime sanity check instantiating `PortfolioStateEngine`, but execution failed due to a missing dependency (`pandas`) in the environment so dynamic verification was not completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aca7dee388320b9e31af63106bacd)