### PR TITLE
Unify bee_bite TP2 condition, enforce BE ±0.1% and tighten time-exit resolution

### DIFF
--- a/simulation/portfolio_state_engine.py
+++ b/simulation/portfolio_state_engine.py
@@ -670,9 +670,16 @@ class PortfolioStateEngine:
 
     def _resolve_time_exit_bars(self) -> int | None:
         profile = (self.config.bee_bite_profile_id or "").upper()
+        profile_bars: int | None = None
         if profile in self.PROFILE_TIME_EXIT_HOURS_NO_TP1:
-            return self._hours_to_15m_bars(self.PROFILE_TIME_EXIT_HOURS_NO_TP1[profile])
-        return self.config.t_max_in_trade
+            profile_bars = self._hours_to_15m_bars(self.PROFILE_TIME_EXIT_HOURS_NO_TP1[profile])
+        config_bars = self.config.t_max_in_trade
+
+        if profile_bars is None:
+            return config_bars
+        if config_bars is None:
+            return profile_bars
+        return min(profile_bars, config_bars)
 
     def _resolve_reclaim_limit_bars(self) -> int:
         profile = (self.config.bee_bite_profile_id or "").upper()
@@ -815,7 +822,7 @@ class PortfolioStateEngine:
         else:
             lowest_break = float(state.lowest_break if state.lowest_break is not None else resistance)
             stop = lowest_break + buffer
-            low_before_pump = high_pump if high_pump < entry else entry - atr_bg
+            low_before_pump = float(state.low_before_pump if state.low_before_pump is not None else entry - atr_bg)
 
         plan = build_bee_bite_trade_plan(
             side=side,

--- a/strategy/bee_bite/trade_plan.py
+++ b/strategy/bee_bite/trade_plan.py
@@ -12,6 +12,7 @@ PROFILE_TP1_SHARE: dict[str, float] = {
     "B": 0.6,  # Balanced
     "C": 0.5,  # Aggressive
 }
+BE_OFFSET_RATIO = 0.001
 
 
 @dataclass(frozen=True, slots=True)
@@ -50,17 +51,19 @@ def build_bee_bite_trade_plan(
     if stop_distance <= 0:
         return None
 
+    use_fixed_tp2 = high_pump is not None and (high_pump - entry_price) >= atr_bg
+
     mid = (support + resistance) / 2.0
     if side == PositionSide.LONG:
         tp1 = mid if mid > entry_price else resistance
-        fixed_tp2 = high_pump if high_pump is not None and (high_pump - entry_price) >= atr_bg else None
+        fixed_tp2 = high_pump if use_fixed_tp2 else None
         trailing_tp2 = entry_price + atr_bg
-        be_stop = entry_price * 1.001
+        be_stop = entry_price * (1.0 + BE_OFFSET_RATIO)
     else:
         tp1 = mid if mid < entry_price else support
-        fixed_tp2 = low_before_pump if low_before_pump is not None and (entry_price - low_before_pump) >= atr_bg else None
+        fixed_tp2 = low_before_pump if use_fixed_tp2 and low_before_pump is not None else None
         trailing_tp2 = entry_price - atr_bg
-        be_stop = entry_price * 0.999
+        be_stop = entry_price * (1.0 - BE_OFFSET_RATIO)
 
     trailing_mode = fixed_tp2 is None
     tp2 = trailing_tp2 if trailing_mode else fixed_tp2


### PR DESCRIPTION
### Motivation
- Ensure TP2 selection is driven by a single clear condition based on pump extension so fixed TP2 is used only when the pump exceeds ATR.
- Guarantee the stop is moved to a fixed breakeven offset after TP1 (±0.1%) without profile-dependent deviations.
- Make profile time-exit (6/8/12h) and `t_max_in_trade` interact predictably so the stricter limit applies.

### Description
- Added `BE_OFFSET_RATIO = 0.001` and switched BE stop computation in the trade plan to `entry * (1 ± BE_OFFSET_RATIO)` to enforce ±0.1% for long/short.
- Unified TP2 switching with `use_fixed_tp2 = high_pump is not None and (high_pump - entry_price) >= atr_bg` so fixed TP2 is used only when this single condition is met, otherwise trailing TP2 is selected.
- Short-side signal builder now prefers `state.low_before_pump` when present before falling back to the prior heuristic to produce consistent inputs for the trade plan.
- Adjusted `_resolve_time_exit_bars` to compute both profile-based bars and config `t_max_in_trade` and return the more restrictive value when both are set (handling `None` correctly).

### Testing
- Compiled affected modules with `python -m compileall strategy/bee_bite/trade_plan.py simulation/portfolio_state_engine.py simulation/exit_manager.py` and compilation succeeded.
- Changes were committed (`git commit`) and a PR description was generated, with no new unit tests added per repository/user constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad0ad78948320a3519f3a14a42d14)