### PR TITLE
Add profile-aware micro-offset reclaim filter before signal build

### DIFF
--- a/simulation/portfolio_state_engine.py
+++ b/simulation/portfolio_state_engine.py
@@ -136,6 +136,7 @@ class PortfolioStateEngine:
     FIXED_RANGE_WINDOW: int | None = None
     PROFILE_STABILITY_THRESHOLD: dict[str, float] = field(default_factory=lambda: {"A": 0.20, "B": 0.25, "C": 0.30})
     PROFILE_RECLAIM_TIMEOUT: dict[str, int] = field(default_factory=lambda: {"A": 5, "B": 6, "C": 8})
+    PROFILE_MICRO_OFFSETS: dict[str, float] = field(default_factory=lambda: {"A": 0.15, "B": 0.10, "C": 0.05})
     RESET_REASONS: tuple[str, ...] = (
         "max_age_range",
         "reclaim_timeout",
@@ -407,6 +408,13 @@ class PortfolioStateEngine:
                 reclaim_confirmed = state.touched_retest_zone and close > trigger_close
 
             if reclaim_confirmed:
+                support = float(state.support if state.support is not None else close)
+                atr_ref = float(state.atr_bg if state.atr_bg is not None else 0.0)
+                micro_offset = self._resolve_micro_offset()
+                if close <= (support + micro_offset * atr_ref):
+                    self._reset_symbol(symbol=symbol, state=state, reason="micro_filter_fail", timeline_idx=timeline_idx)
+                    return None
+
                 signal = self._build_signal(symbol=symbol, row=row, side=state.break_side, state=state)
                 if signal is None:
                     self._reset_symbol(symbol=symbol, state=state, reason="micro_filter_fail", timeline_idx=timeline_idx)
@@ -701,6 +709,10 @@ class PortfolioStateEngine:
         profile = (self.config.bee_bite_profile_id or "").upper()
         mapping = {"A": 0.15, "B": 0.12, "C": 0.10}
         return float(mapping.get(profile, 0.12))
+
+    def _resolve_micro_offset(self) -> float:
+        profile = (self.config.bee_bite_profile_id or "").upper()
+        return float(self.PROFILE_MICRO_OFFSETS.get(profile, 0.10))
 
     def _resolve_pump_signal(
         self,


### PR DESCRIPTION
### Motivation
- Ensure reclaim entries are gated by a small profile-dependent micro filter to avoid marginal reclaims being treated as valid entries. 
- Apply the same micro-filter logic uniformly for all symbols and run it before signal construction and candidate scoring. 

### Description
- Added `PROFILE_MICRO_OFFSETS` mapping with values `A=0.15`, `B=0.10`, `C=0.05` to `PortfolioStateEngine` for profile-specific micro offsets. 
- Inserted an explicit micro-filter check in the `PortfolioState.BREAK_ACTIVE` flow that requires `close > support + micro_offset * atr_bg` before calling `_build_signal(...)`. 
- On micro-filter failure the existing reset reason `micro_filter_fail` is used and the symbol is reset via `_reset_symbol(...)`, which moves it into cooldown. 
- Added helper method `_resolve_micro_offset()` to resolve the micro offset for the active profile and preserved the existing profile `A` retest logic; the micro-filter only gates reclaim entry.

### Testing
- Ran `python -m py_compile simulation/portfolio_state_engine.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad20cd6c8832081ab7fd00c793fe8)