### PR TITLE
Refine RANGE_LOCKED → BREAK_ACTIVE validation and add emergency reset

### DIFF
--- a/simulation/portfolio_state_engine.py
+++ b/simulation/portfolio_state_engine.py
@@ -349,11 +349,28 @@ class PortfolioStateEngine:
 
         if state.state == PortfolioState.RANGE_LOCKED:
             assert state.support is not None and state.resistance is not None
-            if float(row["low"] or close) < state.support:
+            low = float(row["low"] or close)
+            support = float(state.support)
+            core_width = float(
+                state.core_width if state.core_width is not None else abs(float((state.resistance or close) - support))
+            )
+            emergency_break_level = support - (0.7 * core_width)
+            if low < emergency_break_level:
+                self._reset_symbol(symbol=symbol, state=state, reason="break_emergency", timeline_idx=timeline_idx)
+                return None
+
+            if low < support:
+                depth = max(support - low, 0.0)
+                atr_bg = float(state.atr_bg or 0.0)
+                min_depth = self._resolve_min_depth_threshold() * atr_bg
+                max_depth = 0.5 * core_width
+                if depth < min_depth or depth > max_depth:
+                    return None
+
                 state.state = PortfolioState.BREAK_ACTIVE
                 state.break_side = PositionSide.LONG
                 state.break_price = close
-                state.lowest_break = float(row["low"] or close)
+                state.lowest_break = low
                 state.break_start_timeline_idx = timeline_idx
                 state.break_start_timestamp_ms = int(row["timestamp"])
                 state.reclaim_bar_timeline_idx = None
@@ -373,8 +390,14 @@ class PortfolioStateEngine:
                 self._reset_symbol(symbol=symbol, state=state, reason="reclaim_timeout", timeline_idx=timeline_idx)
                 return None
 
-            state.lowest_break = min(state.lowest_break or float(row["low"] or close), float(row["low"] or close))
+            low = float(row["low"] or close)
+            state.lowest_break = min(state.lowest_break or low, low)
             core_width = float(state.core_width if state.core_width is not None else abs(float((state.resistance or close) - (state.support or close))))
+            support_ref = float(state.support if state.support is not None else close)
+            if low < support_ref - (0.7 * core_width):
+                self._reset_symbol(symbol=symbol, state=state, reason="break_emergency", timeline_idx=timeline_idx)
+                return None
+
             depth = max((state.support or close) - (state.lowest_break or close), 0.0)
             atr_bg = float(state.atr_bg or 0.0)
             min_depth = self._resolve_min_depth_threshold() * atr_bg


### PR DESCRIPTION
### Motivation
- Уменьшить количество ложных переходов в состояние `BREAK_ACTIVE` за счёт валидации глубины прокола на текущей свече и синхронизировать порог глубины с профилем через `_resolve_min_depth_threshold()`.
- Обработать критические глубокие пробои немедленным ресетом состояния с отдельной причиной `break_emergency`.

### Description
- В переходе `RANGE_LOCKED -> BREAK_ACTIVE` вычисляется `low`, `support` и `core_width`, и добавлен аварийный порог `emergency_break_level = support - 0.7 * core_width`, при пересечении которого вызывается `_reset_symbol(..., reason="break_emergency")`.
- При `low < support` теперь сразу считается `depth` на текущей свече и сравнивается с `min_depth = _resolve_min_depth_threshold() * atr_bg` и `max_depth = 0.5 * core_width`, и при `depth < min_depth` или `depth > max_depth` переход в `BREAK_ACTIVE` не выполняется (остаёмся в `RANGE_LOCKED`).
- В момент старта `BREAK_ACTIVE` записывается `lowest_break = low` (а не значение из предыдущих расчётов), и в `BREAK_ACTIVE` продолжается обновление `lowest_break` на новых свечах без подмены начальной валидации серии прокола.
- Для расчёта минимальной глубины теперь используется профильный резольвер через вызов `_resolve_min_depth_threshold()` (с учётом `atr_bg`).

### Testing
- Проверка синтаксиса: `python -m compileall simulation/portfolio_state_engine.py` выполнилась успешно.
- Тестов не добавлял по запросу (автоматические юнит-тесты не запускались).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad2abbb0c8320ae48aad6cf31eb6f)