### PR TITLE
Resolve pump end index correctly in portfolio state engine

### DIFF
--- a/simulation/portfolio_state_engine.py
+++ b/simulation/portfolio_state_engine.py
@@ -792,13 +792,16 @@ class PortfolioStateEngine:
         if atr_bg <= 0:
             return None
 
-        high_pump = max(float(item["high"] or 0.0) for item in recent)
+        recent_highs = [float(item["high"] or 0.0) for item in recent]
+        high_pump = max(recent_highs)
+        local_pump_idx = max(idx for idx, high in enumerate(recent_highs) if high == high_pump)
+        t_pump_end_idx = timeline_idx - (pump_window - 1) + local_pump_idx
         low_before_pump = float(before_pump["low"] or 0.0)
         pump_height = high_pump - low_before_pump
         impulse_threshold = self.IMPULSE_THRESHOLDS.get((self.config.bee_bite_profile_id or "").upper(), 2.2) * atr_pre
         if pump_height < impulse_threshold:
             return None
-        return high_pump, pump_height, atr_pre, atr_bg, low_before_pump, timeline_idx
+        return high_pump, pump_height, atr_pre, atr_bg, low_before_pump, t_pump_end_idx
 
     def _try_freeze_range(self, *, state: SymbolState, timeline_idx: int) -> tuple[float, float, float, int] | None:
         if state.t_pump_end_idx is None or state.pump_height is None or state.atr_bg is None:


### PR DESCRIPTION
### Motivation
- Fix incorrect global index returned for pump end so range-seeking starts after the actual pump candle within the last 6 bars.
- Ensure `SEEK_RANGE` logic uses a strict start after the pump candle (`start_idx = t_pump_end_idx + 1`) and avoid any implicit lookahead.

### Description
- Updated `_resolve_pump_signal(...)` in `simulation/portfolio_state_engine.py` to compute `recent_highs` over the last `pump_window = 6` bars and find the local index of the `high_pump` as `local_pump_idx`.
- Converted the local index to a global timeline index `t_pump_end_idx = timeline_idx - (pump_window - 1) + local_pump_idx` and return it instead of the previous `timeline_idx` value.
- If multiple equal highs exist in the pump window, the code selects the last occurrence as the pump end; all other return values and the tuple shape remain unchanged to preserve compatibility with `state.t_pump_end_idx` and `_try_freeze_range(...)`.

### Testing
- Compiled the module with `python -m compileall simulation/portfolio_state_engine.py` and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad484c66c8320be24e408c252bc5c)