### PR TITLE
Add combination-id based plot-from-results selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ python launcher.py --mode analyze-cache --symbols BTC/USDT ETH/USDT
 python launcher.py --mode analyze-cache --top-n 50
 python launcher.py --mode analyze-cache --top-n 50 --plot true
 python launcher.py --mode analyze-cache --symbols BTC/USDT ETH/USDT --plot-from-results --results-input ./cache/results/backtest_results.csv
+python launcher.py --mode analyze-cache --plot-from-results --results-input ./cache/results/strategy/retest/results.csv --id 1156 --strategy retest
 python launcher.py --mode analyze-cache --top-n 50 --strategy breakout
 python launcher.py --mode analyze-cache --top-n 50 --strategy bee_bite
 python launcher.py --mode analyze-cache --symbols BTC/USDT --strategy bee_bite --plot-from-results --results-input ./cache/results/backtest_results.csv
@@ -266,6 +267,12 @@ python main.py run-backtest --strategy bee_bite
 `--plot-from-results` автоматически читает нужные колонки под выбранную стратегию:
 - `breakout` — поля `lookback`, `volume_mult`, ...
 - `bee_bite` — поля `bite_lookback`, `bite_volume_mult`, ...
+
+Опционально можно выбрать конкретную комбинацию через `--id`:
+- сначала ищется точное совпадение в колонках `id` / `combination_id` / `rank`;
+- если таких колонок нет — `--id` трактуется как 1-based номер строки в CSV.
+
+`--strategy retest` поддерживается как alias для `breakout`.
 
 Для `bee_bite` доступны профиль и режим сетки:
 - `--bee-bite-profile {A,B,C}` — фиксированный baseline-профиль;

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -136,7 +136,10 @@ def _coerce_trade_plot_span(value: object) -> TradePlotSpan | None:
 def _resolve_strategy_id(config: AppConfig, args: argparse.Namespace) -> str:
     strategy_override = getattr(args, "strategy", None)
     if strategy_override is not None:
-        return str(strategy_override).strip().lower()
+        normalized = str(strategy_override).strip().lower()
+        if normalized == "retest":
+            return "breakout"
+        return normalized
     return config.strategy.strategy_id
 
 
@@ -299,15 +302,56 @@ def _load_plot_params_row_from_results(
         logger.error("plot-from-results: отсутствуют обязательные колонки: %s", ", ".join(missing_columns))
         return None
 
-    sorted_frame = frame.sort_values(["profit_factor", "trades_count"], ascending=[False, False], na_position="last")
-    best_row = sorted_frame.iloc[0]
+    selected_id_raw = getattr(args, "id", None)
+    selected_row: pd.Series
+    if selected_id_raw is not None:
+        selected_id = int(selected_id_raw)
+        id_columns = ("id", "combination_id", "rank")
+        matched_by_column: pd.DataFrame | None = None
+        for column in id_columns:
+            if column not in frame.columns:
+                continue
+            numeric_column = pd.to_numeric(frame[column], errors="coerce")
+            matches = frame[numeric_column == selected_id]
+            if not matches.empty:
+                matched_by_column = matches
+                logger.info(
+                    "plot-from-results: найдена комбинация по колонке %s, id=%s, совпадений=%s",
+                    column,
+                    selected_id,
+                    len(matches),
+                )
+                break
+
+        if matched_by_column is not None:
+            selected_row = matched_by_column.iloc[0]
+        else:
+            row_index = selected_id - 1
+            if row_index < 0 or row_index >= len(frame):
+                logger.error(
+                    "plot-from-results: id=%s не найден (нет колонок id/combination_id/rank и номер строки вне диапазона 1..%s)",
+                    selected_id,
+                    len(frame),
+                )
+                return None
+            selected_row = frame.iloc[row_index]
+            logger.warning(
+                "plot-from-results: id=%s не найден в id/combination_id/rank, использован 1-based номер строки=%s",
+                selected_id,
+                selected_id,
+            )
+    else:
+        sorted_frame = frame.sort_values(["profit_factor", "trades_count"], ascending=[False, False], na_position="last")
+        selected_row = sorted_frame.iloc[0]
+
     logger.info(
-        "plot-from-results: использованы параметры из %s (pf=%s, trades_count=%s)",
+        "plot-from-results: использованы параметры из %s (pf=%s, trades_count=%s, id=%s)",
         csv_path,
-        best_row.get("profit_factor", "n/a"),
-        best_row.get("trades_count", "n/a"),
+        selected_row.get("profit_factor", "n/a"),
+        selected_row.get("trades_count", "n/a"),
+        selected_id_raw if selected_id_raw is not None else "best",
     )
-    return best_row
+    return selected_row
 
 def _run_with_logging(command_name: str, config: AppConfig, body: Callable[[], int]) -> int:
     logger = get_logger(

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -83,9 +83,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     run_bt.add_argument(
         "--strategy",
-        choices=["breakout", "bee_bite"],
+        choices=["breakout", "bee_bite", "retest"],
         default=None,
-        help="Идентификатор стратегии. Приоритетнее STRATEGY_ID из env",
+        help="Идентификатор стратегии (retest = alias для breakout). Приоритетнее STRATEGY_ID из env",
     )
     run_bt.add_argument(
         "--bee-bite-profile",
@@ -133,6 +133,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--results-input",
         default=None,
         help="Путь к CSV с результатами для --plot-from-results",
+    )
+    run_bt.add_argument(
+        "--id",
+        type=_positive_int_for("--id"),
+        default=None,
+        help="ID комбинации в CSV (по колонке id/combination_id/rank или по 1-based номеру строки)",
     )
 
     report = subparsers.add_parser("make-report", help="Сформировать JSON-отчет по результатам бектеста")

--- a/launcher.py
+++ b/launcher.py
@@ -86,6 +86,13 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--output", default=None, help="Выходной путь JSON/CSV")
     parser.add_argument("--plot", default=None, help="Строить графики сделок (true/false) для analyze-cache")
     parser.add_argument(
+        "--strategy",
+        choices=("breakout", "bee_bite", "retest"),
+        default=None,
+        help="Идентификатор стратегии (retest = alias для breakout)",
+    )
+    parser.add_argument("--id", type=int, default=None, help="ID комбинации для режима plot-from-results")
+    parser.add_argument(
         "--plot-from-results",
         action="store_true",
         help="Строить графики по готовому backtest_results.csv без полного analyze-cache",
@@ -125,6 +132,12 @@ def _task_namespace(task: dict[str, Any], cli_args: argparse.Namespace) -> argpa
             _to_bool(task.get("plot_from_results"), fallback=cli_args.plot_from_results)
             if "plot_from_results" in task
             else cli_args.plot_from_results
+        ),
+        strategy=task.get("strategy", cli_args.strategy),
+        id=(
+            int(task["id"])
+            if "id" in task and task.get("id") is not None
+            else cli_args.id
         ),
         ignore_coingecko=(
             _to_bool(task.get("ignore_coingecko"), fallback=cli_args.ignore_coingecko)


### PR DESCRIPTION
## Summary
- added `--id` support for backtest/analyze flow so `--plot-from-results` can target a specific combination instead of always picking the best row
- implemented selection logic in `cli/commands.py`:
  - first tries exact match in `id`, `combination_id`, or `rank` columns
  - falls back to 1-based CSV row index when those columns are absent
  - logs clear info/warning/error messages for the selection path
- added `retest` as a strategy alias mapped to `breakout` in strategy resolution
- wired `--strategy` and `--id` into `launcher.py` task namespace
- documented new usage in `README.md` with an example matching strategy-scoped results files

## Validation
- `python -m py_compile cli/parser.py cli/commands.py launcher.py`

## Example
```bash
python launcher.py --mode analyze-cache --plot-from-results --strategy retest --results-input ./cache/results/strategy/retest/results.csv --id 1156
```

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad705c7188320a404439297712781)