### PR TITLE
Rename breakout strategy naming to retest (keep breakout alias)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ CLI-проект для загрузки данных, бектеста и от�
 В проекте используется 3 README-файла:
 
 1. `README.md` (этот файл) — общий запуск, инфраструктура, launcher/CLI.
-2. `strategy/breakout/README.md` — стратегия `breakout` (включая alias `retest`).
+2. `strategy/breakout/README.md` — стратегия `retest` (включая alias `breakout`).
 3. `strategy/bee_bite/README.md` — стратегия `bee_bite`.
 
 Если нужна стратегия-специфика, в первую очередь смотри README внутри соответствующей папки стратегии.
@@ -207,7 +207,7 @@ python launcher.py --mode analyze-cache --top-n 50
 python launcher.py --mode analyze-cache --top-n 50 --plot true
 python launcher.py --mode analyze-cache --symbols BTC/USDT ETH/USDT --plot-from-results --results-input ./cache/results/backtest_results.csv
 python launcher.py --mode analyze-cache --plot-from-results --results-input ./cache/results/strategy/retest/results.csv --id 1156 --strategy retest
-python launcher.py --mode analyze-cache --top-n 50 --strategy breakout
+python launcher.py --mode analyze-cache --top-n 50 --strategy retest
 python launcher.py --mode analyze-cache --top-n 50 --strategy bee_bite
 python launcher.py --mode analyze-cache --symbols BTC/USDT --strategy bee_bite --plot-from-results --results-input ./cache/results/backtest_results.csv
 python launcher.py --mode make-report --input ./results/backtest_results.csv --output ./results/report.json
@@ -259,9 +259,9 @@ python launcher.py --config run_config.json
 
 
 
-### Выбор стратегии (`breakout` / `bee_bite`)
+### Выбор стратегии (`retest` / `bee_bite`)
 
-По умолчанию используется `breakout`. Можно задать через `.env`:
+По умолчанию используется `retest`. Можно задать через `.env`:
 
 ```env
 STRATEGY_ID=bee_bite
@@ -270,19 +270,19 @@ STRATEGY_ID=bee_bite
 Или переопределить на конкретный запуск через CLI (имеет приоритет над `.env`):
 
 ```bash
-python main.py run-backtest --strategy breakout
+python main.py run-backtest --strategy retest
 python main.py run-backtest --strategy bee_bite
 ```
 
 `--plot-from-results` автоматически читает нужные колонки под выбранную стратегию:
-- `breakout` — поля `lookback`, `volume_mult`, ...
+- `retest` — поля `lookback`, `volume_mult`, ...
 - `bee_bite` — поля `bite_lookback`, `bite_volume_mult`, ...
 
 Опционально можно выбрать конкретную комбинацию через `--id`:
 - сначала ищется точное совпадение в колонках `id` / `combination_id` / `rank`;
 - если таких колонок нет — `--id` трактуется как 1-based номер строки в CSV.
 
-`--strategy retest` поддерживается как alias для `breakout`.
+`--strategy breakout` поддерживается как alias для `retest`.
 
 Для `bee_bite` доступны профиль и режим сетки:
 - `--bee-bite-profile {A,B,C}` — фиксированный baseline-профиль;
@@ -340,7 +340,7 @@ python main.py check-quality
 python main.py clear-cache
 ```
 
-## Параметры breakout-стратегии
+## Параметры retest-стратегии
 
 По умолчанию грид `retest_window_hours` для перебора параметров: `12, 24, 36, 48` (в часах).
 

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -139,14 +139,15 @@ def _resolve_strategy_id(config: AppConfig, args: argparse.Namespace) -> str:
     strategy_override = getattr(args, "strategy", None)
     if strategy_override is not None:
         normalized = str(strategy_override).strip().lower()
-        if normalized == "retest":
-            return "breakout"
+        if normalized == "breakout":
+            return "retest"
         return normalized
     return config.strategy.strategy_id
 
 
 def _resolve_results_dir_for_strategy(base_results_dir: Path, strategy_id: str) -> Path:
     strategy_folder_by_id = {
+        "retest": "retest",
         "breakout": "retest",
         "bee_bite": "bee_bite",
     }
@@ -164,7 +165,7 @@ def _build_breakout_params_from_row(
     entry_timeframe: Timeframe,
     strategy_id: str,
 ) -> BreakoutParams:
-    if strategy_id == "breakout":
+    if strategy_id in {"retest", "breakout"}:
         prefix = ""
     elif strategy_id == "bee_bite":
         prefix = "bite_"
@@ -367,7 +368,7 @@ def _plot_for_strategy(
     entry_timeframe: Timeframe,
     log_prefix: str,
 ) -> bool:
-    if strategy_id == "breakout":
+    if strategy_id in {"retest", "breakout"}:
         _plot_trade_setups_for_symbols(
             config=config,
             args=args,
@@ -424,6 +425,22 @@ def _load_plot_params_row_from_results(
         return None
 
     required_columns_by_strategy = {
+        "retest": [
+
+            "lookback",
+            "volume_mult",
+            "retest_window_hours",
+            "retest_zone",
+            "min_rr",
+            "sl_mode",
+            "tp2_mult",
+            "min_body_ratio",
+            "min_move_atr",
+            "max_retest_depth",
+            "confirmation_bars",
+            "entry_trigger",
+            "retest_zone_atr",
+        ],
         "breakout": [
             "lookback",
             "volume_mult",
@@ -437,6 +454,7 @@ def _load_plot_params_row_from_results(
             "max_retest_depth",
             "confirmation_bars",
             "entry_trigger",
+            "retest_zone_atr",
         ],
         "bee_bite": [
             "bite_profile_id",
@@ -1320,13 +1338,13 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
         entry_timeframe=entry_timeframe,
     )
     summary = runner.build_summary(results)
-    if strategy_id == "breakout" and PARAMETER_GRID_SIZE != TARGET_PARAMETER_COMBINATIONS:
+    if strategy_id in {"retest", "breakout"} and PARAMETER_GRID_SIZE != TARGET_PARAMETER_COMBINATIONS:
         logger.warning(
             "запуск-бэктеста: расчетная мощность сетки=%s отличается от целевой=%s (ожидается 5832)",
             PARAMETER_GRID_SIZE,
             TARGET_PARAMETER_COMBINATIONS,
         )
-    if strategy_id == "breakout" and len(results) != TARGET_PARAMETER_COMBINATIONS:
+    if strategy_id in {"retest", "breakout"} and len(results) != TARGET_PARAMETER_COMBINATIONS:
         logger.warning(
             "запуск-бэктеста: фактическое число комбинаций=%s отличается от целевого=%s (ожидается 5832)",
             len(results),
@@ -1771,7 +1789,7 @@ def _plot_daily_levels_inner(config: AppConfig, args: argparse.Namespace) -> int
 
     strategy = build_strategy(config, logger)
     if not isinstance(strategy, BreakoutStrategy):
-        logger.error("plot-daily-levels поддерживает только breakout")
+        logger.error("plot-daily-levels поддерживает только retest")
         return 1
     base_params = strategy.build_parameter_grid()[0]
     plotter = StrategyPlotter(data_preparer=preparer, strategy=strategy)
@@ -1923,7 +1941,7 @@ def _plot_retests_inner(config: AppConfig, args: argparse.Namespace) -> int:
 
     strategy = build_strategy(config, logger)
     if not isinstance(strategy, BreakoutStrategy):
-        logger.error("plot-retests поддерживает только breakout")
+        logger.error("plot-retests поддерживает только retest")
         return 1
     base_params = strategy.build_parameter_grid()[0]
     plotter = StrategyPlotter(data_preparer=preparer, strategy=strategy)

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -83,9 +83,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     run_bt.add_argument(
         "--strategy",
-        choices=["breakout", "bee_bite", "retest"],
+        choices=["retest", "breakout", "bee_bite"],
         default=None,
-        help="Идентификатор стратегии (retest = alias для breakout). Приоритетнее STRATEGY_ID из env",
+        help="Идентификатор стратегии (breakout = alias для retest). Приоритетнее STRATEGY_ID из env",
     )
     run_bt.add_argument(
         "--bee-bite-profile",

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -44,7 +44,7 @@ __all__ = [
     "load_config",
 ]
 
-SUPPORTED_STRATEGY_IDS = {"breakout", "bee_bite"}
+SUPPORTED_STRATEGY_IDS = {"retest", "breakout", "bee_bite"}
 
 
 # region Приватные
@@ -84,8 +84,10 @@ def _parse_bool(value: str | None, *, default: bool = False) -> bool:
     raise ValueError(f"Invalid boolean value: {value}")
 
 
-def _parse_strategy_id(value: str | None, *, default: str = "breakout") -> str:
+def _parse_strategy_id(value: str | None, *, default: str = "retest") -> str:
     strategy_id = (value or default).strip().lower()
+    if strategy_id == "breakout":
+        strategy_id = "retest"
     if strategy_id not in SUPPORTED_STRATEGY_IDS:
         supported = ", ".join(sorted(SUPPORTED_STRATEGY_IDS))
         raise ValueError(f"Invalid STRATEGY_ID: {strategy_id}. Supported values: {supported}")

--- a/config/strategy_config.py
+++ b/config/strategy_config.py
@@ -15,7 +15,7 @@ from strategy.bee_bite.config import (
 
 @dataclass(slots=True)
 class StrategyConfig:
-    strategy_id: str = "breakout"
+    strategy_id: str = "retest"
     levels_timeframe: Timeframe = Timeframe.D1
     entry_timeframe: Timeframe = Timeframe.M15
     bee_bite_profile: BeeBiteProfileId = "A"

--- a/launcher.py
+++ b/launcher.py
@@ -90,7 +90,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--strategy",
-        choices=["breakout", "bee_bite"],
+        choices=["retest", "breakout", "bee_bite"],
         default=None,
         help="Идентификатор стратегии. Приоритетнее STRATEGY_ID из env",
     )
@@ -137,9 +137,9 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--plot", default=None, help="Строить графики сделок (true/false)")
     parser.add_argument(
         "--strategy",
-        choices=("breakout", "bee_bite", "retest"),
+        choices=("retest", "breakout", "bee_bite"),
         default=None,
-        help="Идентификатор стратегии (retest = alias для breakout)",
+        help="Идентификатор стратегии (breakout = alias для retest)",
     )
     parser.add_argument("--id", type=int, default=None, help="ID комбинации для режима plot-from-results")
     parser.add_argument(

--- a/strategy/breakout/README.md
+++ b/strategy/breakout/README.md
@@ -1,25 +1,25 @@
 # Breakout strategy
 
-Документация по стратегии `breakout` (alias: `retest`).
+Документация по стратегии `retest` (alias: `breakout`).
 
 ## Как запустить
 
 Через `launcher.py`:
 
 ```bash
-python launcher.py --mode analyze-cache --top-n 50 --strategy breakout
+python launcher.py --mode analyze-cache --top-n 50 --strategy retest
 python launcher.py --mode analyze-cache --plot-from-results --results-input ./cache/results/strategy/retest/results.csv --id 1156 --strategy retest
 ```
 
 Через `main.py`:
 
 ```bash
-python main.py run-backtest --strategy breakout --top-n 50
+python main.py run-backtest --strategy retest --top-n 50
 ```
 
 ## Поддержка `--plot-from-results`
 
-Для `breakout`/`retest` из CSV читаются breakout-колонки параметров (например, `lookback`, `volume_mult` и связанные с ними поля).
+Для `retest`/`breakout` из CSV читаются breakout-колонки параметров (например, `lookback`, `volume_mult` и связанные с ними поля).
 
 ## Параметры стратегии
 

--- a/strategy/factory.py
+++ b/strategy/factory.py
@@ -19,7 +19,7 @@ def build_breakout_strategy(config: AppConfig, logger: Logger) -> BreakoutStrate
 
 
 def build_strategy(config: AppConfig, logger: Logger) -> BaseStrategy[object]:
-    if config.strategy.strategy_id == "breakout":
+    if config.strategy.strategy_id == "retest":
         return build_breakout_strategy(config, logger)
     if config.strategy.strategy_id == "bee_bite":
         return BeeBiteStrategy(


### PR DESCRIPTION
## Summary
- switched canonical strategy id from `breakout` to `retest`
- kept backward compatibility by accepting `breakout` as an alias and normalizing it to `retest`
- updated CLI/launcher strategy choices and help text to reflect the new naming
- updated strategy selection logic and related error messages to use `retest`
- refreshed README docs to present `retest` as the primary strategy name

## Code changes
- `config/strategy_config.py`: default `strategy_id` changed to `retest`
- `config/__init__.py`: supported ids include `retest`; `breakout` is normalized to `retest`
- `strategy/factory.py`: main strategy branch uses `retest`
- `cli/parser.py` and `launcher.py`: strategy argument choices/help updated
- `cli/commands.py`:
  - normalize `--strategy breakout` -> `retest`
  - handle `retest` as canonical id in plotting/backtest logic
  - keep compatibility for legacy `breakout` rows/paths
  - user-facing messages updated from `breakout` to `retest`
- `README.md` and `strategy/breakout/README.md`: docs updated to reflect new canonical naming

## Validation
- `python -m py_compile cli/commands.py cli/parser.py config/__init__.py config/strategy_config.py launcher.py strategy/factory.py`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ada3a094083208db78bab282794a0)