### PR TITLE
Fix duplicate --strategy option in launcher parser

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -92,7 +92,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--strategy",
         choices=["retest", "breakout", "bee_bite"],
         default=None,
-        help="Идентификатор стратегии. Приоритетнее STRATEGY_ID из env",
+        help="Идентификатор стратегии (breakout = alias для retest). Приоритетнее STRATEGY_ID из env",
     )
     parser.add_argument(
         "--bee-bite-profile",
@@ -135,12 +135,6 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--input", default=None, help="Входной CSV для отчета")
     parser.add_argument("--output", default=None, help="Выходной путь JSON/CSV")
     parser.add_argument("--plot", default=None, help="Строить графики сделок (true/false)")
-    parser.add_argument(
-        "--strategy",
-        choices=("retest", "breakout", "bee_bite"),
-        default=None,
-        help="Идентификатор стратегии (breakout = alias для retest)",
-    )
     parser.add_argument("--id", type=int, default=None, help="ID комбинации для режима plot-from-results")
     parser.add_argument(
         "--plot-from-results",


### PR DESCRIPTION
### Motivation

- Удалить дублирование аргумента `--strategy` в `launcher.py::_build_parser`, чтобы оставить единую каноническую опцию с корректными `choices` и help.

### Description

- Удалён второй вызов `parser.add_argument("--strategy", ...)` и приведён help в оставшейся декларации к `Идентификатор стратегии (breakout = alias для retest). Приоритетнее STRATEGY_ID из env`, при этом логика прокидывания значения через `_task_namespace` осталась без изменений.

### Testing

- Подтверждена единственная декларация `--strategy` через `rg` и просмотр файла; попытка выполнить `python launcher.py --help` не завершилась из-за отсутствующей зависимости `pandas` (возник `ModuleNotFoundError`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699adbc265a48320801c3636e4f8970d)