### PR TITLE
Allow bee_bite runtime overrides and normalize CLI naming to hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ python main.py run-backtest --strategy bee_bite
 - `--bee-bite-grid {baseline,expanded}` — baseline (узкий) или controlled-grid (широкий) вокруг baseline;
 - `--bee-bite-reclaim-mode {strict,balanced,aggressive}` — меняет reclaim-offset и лимит ожидания reclaim внутри движка;
 - `--bee-bite-retest-mode {confirmation,immediate}` — выбирает механику входа (подтверждение или мгновенный вход после reclaim);
-- `--bee-bite-cooldown-bars` и `--bee-bite-max-age-range` передаются в runtime-параметры стратегии и видны в `backtest_results.csv`.
+- `--bee-bite-cooldown-hours` и `--bee-bite-max-age-range-hours` передаются в runtime-параметры стратегии и видны в `backtest_results.csv` (`--*-bars`/`--bee-bite-max-age-range` сохранены как совместимые алиасы).
 
 Переменные окружения для `bee_bite`:
 

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -1118,13 +1118,13 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
             default=profile_runtime.retest_mode,
         )
         config.strategy.bee_bite_cooldown_bars = (
-            int(getattr(args, "bee_bite_cooldown_bars", None))
-            if getattr(args, "bee_bite_cooldown_bars", None) is not None
+            int(getattr(args, "bee_bite_cooldown_hours", None))
+            if getattr(args, "bee_bite_cooldown_hours", None) is not None
             else profile_runtime.cooldown_hours
         )
         config.strategy.bee_bite_max_age_range = (
-            int(getattr(args, "bee_bite_max_age_range", None))
-            if getattr(args, "bee_bite_max_age_range", None) is not None
+            int(getattr(args, "bee_bite_max_age_range_hours", None))
+            if getattr(args, "bee_bite_max_age_range_hours", None) is not None
             else profile_runtime.max_age_range_hours
         )
         validate_bee_bite_runtime(
@@ -1133,8 +1133,8 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
             top_n=getattr(args, "top_n", None),
             reclaim_mode=config.strategy.bee_bite_reclaim_mode,
             retest_mode=config.strategy.bee_bite_retest_mode,
-            cooldown_bars=config.strategy.bee_bite_cooldown_bars,
-            max_age_range=config.strategy.bee_bite_max_age_range,
+            cooldown_hours=config.strategy.bee_bite_cooldown_bars,
+            max_age_range_hours=config.strategy.bee_bite_max_age_range,
         )
     levels_timeframe = _resolve_timeframe(
         getattr(args, "levels_tf", None),

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -112,16 +112,20 @@ def build_parser() -> argparse.ArgumentParser:
         help="Режим retest в bee_bite: immediate=мгновенный вход, confirmation=вход после подтверждения (валидируется профилем).",
     )
     run_bt.add_argument(
+        "--bee-bite-cooldown-hours",
         "--bee-bite-cooldown-bars",
-        type=_positive_int_for("--bee-bite-cooldown-bars"),
+        dest="bee_bite_cooldown_hours",
+        type=_positive_int_for("--bee-bite-cooldown-hours"),
         default=None,
-        help="Cooldown (в барах) для bee_bite: применяется в движке после неудачного reclaim/отклонённого входа.",
+        help="Cooldown (в часах) для bee_bite: применяется в движке после неудачного reclaim/отклонённого входа.",
     )
     run_bt.add_argument(
+        "--bee-bite-max-age-range-hours",
         "--bee-bite-max-age-range",
-        type=_positive_int_for("--bee-bite-max-age-range"),
+        dest="bee_bite_max_age_range_hours",
+        type=_positive_int_for("--bee-bite-max-age-range-hours"),
         default=None,
-        help="Максимальный возраст range (в барах) для bee_bite: после этого setup сбрасывается.",
+        help="Максимальный возраст range (в часах) для bee_bite: после этого setup сбрасывается.",
     )
     run_bt.add_argument("--plot", default=False, help="Строить графики сделок (true/false)")
     run_bt.add_argument(

--- a/launcher.py
+++ b/launcher.py
@@ -119,16 +119,20 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Режим retest в bee_bite: immediate=мгновенный вход, confirmation=вход после подтверждения (валидируется профилем).",
     )
     parser.add_argument(
+        "--bee-bite-cooldown-hours",
         "--bee-bite-cooldown-bars",
+        dest="bee_bite_cooldown_hours",
         type=int,
         default=None,
-        help="Cooldown (в барах) для bee_bite: применяется в движке после неудачного reclaim/отклонённого входа.",
+        help="Cooldown (в часах) для bee_bite: применяется в движке после неудачного reclaim/отклонённого входа.",
     )
     parser.add_argument(
+        "--bee-bite-max-age-range-hours",
         "--bee-bite-max-age-range",
+        dest="bee_bite_max_age_range_hours",
         type=int,
         default=None,
-        help="Максимальный возраст range (в барах) для bee_bite: после этого setup сбрасывается.",
+        help="Максимальный возраст range (в часах) для bee_bite: после этого setup сбрасывается.",
     )
     parser.add_argument("--output-dir", default=None, help="Директория сохранения изображений для plot-режимов")
     parser.add_argument("--limit", type=int, default=None, help="Ограничение числа свечей/событий для plot-режимов")
@@ -167,15 +171,23 @@ def _task_namespace(task: dict[str, Any], cli_args: argparse.Namespace) -> argpa
         bee_bite_grid=task.get("bee_bite_grid", cli_args.bee_bite_grid),
         bee_bite_reclaim_mode=task.get("bee_bite_reclaim_mode", cli_args.bee_bite_reclaim_mode),
         bee_bite_retest_mode=task.get("bee_bite_retest_mode", cli_args.bee_bite_retest_mode),
-        bee_bite_cooldown_bars=(
-            int(task["bee_bite_cooldown_bars"])
-            if "bee_bite_cooldown_bars" in task and task.get("bee_bite_cooldown_bars") is not None
-            else cli_args.bee_bite_cooldown_bars
+        bee_bite_cooldown_hours=(
+            int(task["bee_bite_cooldown_hours"])
+            if "bee_bite_cooldown_hours" in task and task.get("bee_bite_cooldown_hours") is not None
+            else (
+                int(task["bee_bite_cooldown_bars"])
+                if "bee_bite_cooldown_bars" in task and task.get("bee_bite_cooldown_bars") is not None
+                else cli_args.bee_bite_cooldown_hours
+            )
         ),
-        bee_bite_max_age_range=(
-            int(task["bee_bite_max_age_range"])
-            if "bee_bite_max_age_range" in task and task.get("bee_bite_max_age_range") is not None
-            else cli_args.bee_bite_max_age_range
+        bee_bite_max_age_range_hours=(
+            int(task["bee_bite_max_age_range_hours"])
+            if "bee_bite_max_age_range_hours" in task and task.get("bee_bite_max_age_range_hours") is not None
+            else (
+                int(task["bee_bite_max_age_range"])
+                if "bee_bite_max_age_range" in task and task.get("bee_bite_max_age_range") is not None
+                else cli_args.bee_bite_max_age_range_hours
+            )
         ),
         output_dir=task.get("output_dir", cli_args.output_dir),
         limit=(

--- a/strategy/bee_bite/bee_bite_strategy.py
+++ b/strategy/bee_bite/bee_bite_strategy.py
@@ -32,15 +32,15 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
         grid_mode: BeeBiteGridMode,
         reclaim_mode: BeeBiteReclaimMode,
         retest_mode: BeeBiteRetestMode,
-        cooldown_bars: int,
-        max_age_range: int,
+        cooldown_hours: int,
+        max_age_range_hours: int,
     ) -> None:
         self._profile_id = profile_id
         self._grid_mode = grid_mode
         self._reclaim_mode = reclaim_mode
         self._retest_mode = retest_mode
-        self._cooldown_bars = cooldown_bars
-        self._max_age_range = max_age_range
+        self._cooldown_hours = cooldown_hours
+        self._max_age_range_hours = max_age_range_hours
         self._engine = BeeBiteEngine()
         self._last_generation_diagnostics: dict[str, object] = {}
 
@@ -146,8 +146,8 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
             grid_mode=self._grid_mode,
             reclaim_mode=self._reclaim_mode,
             retest_mode=self._retest_mode,
-            cooldown_bars=self._cooldown_bars,
-            max_age_range=self._max_age_range,
+            cooldown_hours=self._cooldown_hours,
+            max_age_range_hours=self._max_age_range_hours,
         )
 
     def params_to_row(self, params: BeeBiteParams) -> dict[str, int | float | str | None]:

--- a/strategy/bee_bite/config.py
+++ b/strategy/bee_bite/config.py
@@ -243,15 +243,15 @@ def build_bee_bite_grid(
     grid_mode: BeeBiteGridMode,
     reclaim_mode: BeeBiteReclaimMode,
     retest_mode: BeeBiteRetestMode,
-    cooldown_bars: int,
-    max_age_range: int,
+    cooldown_hours: int,
+    max_age_range_hours: int,
 ) -> list[BeeBiteParams]:
     baseline = _apply_runtime_modes(
         params=BEE_BITE_PROFILE_BASELINES[profile_id],
         reclaim_mode=reclaim_mode,
         retest_mode=retest_mode,
-        cooldown_bars=cooldown_bars,
-        max_age_range=max_age_range,
+        cooldown_hours=cooldown_hours,
+        max_age_range_hours=max_age_range_hours,
     )
     if grid_mode == "baseline":
         return [baseline]
@@ -307,8 +307,8 @@ def validate_bee_bite_runtime(
     top_n: int | None,
     reclaim_mode: BeeBiteReclaimMode,
     retest_mode: BeeBiteRetestMode,
-    cooldown_bars: int,
-    max_age_range: int,
+    cooldown_hours: int,
+    max_age_range_hours: int,
 ) -> None:
     if profile_id not in BEE_BITE_PROFILE_IDS:
         raise ValueError(f"Неподдерживаемый профиль bee_bite: {profile_id}")
@@ -342,10 +342,10 @@ def validate_bee_bite_runtime(
         supported = ", ".join(allowed_retest)
         raise ValueError(f"профиль {profile_id} поддерживает retest_mode только из [{supported}]")
 
-    if cooldown_bars != runtime.cooldown_hours:
-        raise ValueError(f"профиль {profile_id} требует cooldown_bars={runtime.cooldown_hours}")
-    if max_age_range != runtime.max_age_range_hours:
-        raise ValueError(f"профиль {profile_id} требует max_age_range={runtime.max_age_range_hours}")
+    if cooldown_hours < 1 or cooldown_hours > 100:
+        raise ValueError("параметр cooldown_hours должен быть в диапазоне [1, 100]")
+    if max_age_range_hours < 1 or max_age_range_hours > 100:
+        raise ValueError("параметр max_age_range_hours должен быть в диапазоне [1, 100]")
 
     if top_n is None:
         return
@@ -425,8 +425,8 @@ def _apply_runtime_modes(
     params: BeeBiteParams,
     reclaim_mode: BeeBiteReclaimMode,
     retest_mode: BeeBiteRetestMode,
-    cooldown_bars: int,
-    max_age_range: int,
+    cooldown_hours: int,
+    max_age_range_hours: int,
 ) -> BeeBiteParams:
     runtime = get_bee_bite_runtime(params.bite_profile_id)
 
@@ -451,8 +451,8 @@ def _apply_runtime_modes(
         bite_confirmation_bars=confirmation_bars,
         bite_reclaim_mode=reclaim_mode,
         bite_retest_mode=retest_mode,
-        bite_cooldown_bars=cooldown_bars,
-        bite_max_age_range=max_age_range,
+        bite_cooldown_bars=cooldown_hours,
+        bite_max_age_range=max_age_range_hours,
         bite_min_depth_threshold=min_depth,
         bite_micro_offset=runtime.micro_offset * reclaim_multiplier[reclaim_mode],
         bite_reclaim_limit=runtime.reclaim_limit + reclaim_limit_boost[reclaim_mode],

--- a/strategy/factory.py
+++ b/strategy/factory.py
@@ -27,7 +27,7 @@ def build_strategy(config: AppConfig, logger: Logger) -> BaseStrategy[object]:
             grid_mode=config.strategy.bee_bite_grid_mode,
             reclaim_mode=config.strategy.bee_bite_reclaim_mode,
             retest_mode=config.strategy.bee_bite_retest_mode,
-            cooldown_bars=config.strategy.bee_bite_cooldown_bars,
-            max_age_range=config.strategy.bee_bite_max_age_range,
+            cooldown_hours=config.strategy.bee_bite_cooldown_bars,
+            max_age_range_hours=config.strategy.bee_bite_max_age_range,
         )
     raise ValueError(f"Неподдерживаемый strategy_id: {config.strategy.strategy_id}")


### PR DESCRIPTION
### Motivation
- Сделать возможным переопределение runtime-параметров bee_bite вместо принудительного соответствия профильным дефолтам и убрать неоднозначность единиц (bars vs hours).
- Упростить передачу и применение значений cooldown/max-age по всему пайплайну стратегии, сохранив обратную совместимость для существующих вызовов.

### Description
- Ослабил валидацию в `validate_bee_bite_runtime`: проверка `cooldown`/`max_age_range` теперь делает range-валидацию `[1, 100]` по часам вместо строгого равенства с профильными значениями.
- Привёл сигнатуры и переменные к единому формату `*_hours` в ключевых функциях: `build_bee_bite_grid`, `_apply_runtime_modes`, `validate_bee_bite_runtime`, и в `BeeBiteStrategy` (теперь принимает `cooldown_hours`/`max_age_range_hours`).
- Обеспечил корректную передачу переопределённых значений через фабрику стратегии `build_strategy` и в местах построения гридов/движка (передача `*_hours` везде).
- Нормализовал CLI и launcher: добавлены основные флаги `--bee-bite-cooldown-hours` и `--bee-bite-max-age-range-hours` с сохранёнными alias `--bee-bite-cooldown-bars` и `--bee-bite-max-age-range` для совместимости, и обновлён парсинг батч-конфигураций с приоритетом новых ключей.
- Обновил README, указав новые имена флагов и отметив поддержку legacy-алиасов.

### Testing
- Компиляция модулей успешно выполнена командой `python -m compileall cli strategy launcher.py config` и вернула безошибочный результат.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699addd2f6c48320a2d497345192356b)