### PR TITLE
Lazy-load vectorbt_runner public exports to break circular import

### DIFF
--- a/vectorbt_runner/__init__.py
+++ b/vectorbt_runner/__init__.py
@@ -1,11 +1,17 @@
-"""Модуль проекта."""
+"""Публичный API пакета ``vectorbt_runner`` с ленивыми импортами."""
 
-from vectorbt_runner.backtest_runner import BacktestRunner
-from vectorbt_runner.backtest_summary import BacktestSummary
-from vectorbt_runner.data_preparer import DataPreparer
-from vectorbt_runner.mtf_frames import SymbolMtfFrames
-from vectorbt_runner.vectorbt_inputs import VectorbtInputs
-from vectorbt_runner.strategy_plotter import StrategyPlotter
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from vectorbt_runner.backtest_runner import BacktestRunner
+    from vectorbt_runner.backtest_summary import BacktestSummary
+    from vectorbt_runner.data_preparer import DataPreparer
+    from vectorbt_runner.mtf_frames import SymbolMtfFrames
+    from vectorbt_runner.strategy_plotter import StrategyPlotter
+    from vectorbt_runner.vectorbt_inputs import VectorbtInputs
 
 __all__ = [
     "BacktestRunner",
@@ -15,3 +21,21 @@ __all__ = [
     "VectorbtInputs",
     "StrategyPlotter",
 ]
+
+_MODULE_BY_NAME = {
+    "BacktestRunner": "vectorbt_runner.backtest_runner",
+    "BacktestSummary": "vectorbt_runner.backtest_summary",
+    "DataPreparer": "vectorbt_runner.data_preparer",
+    "SymbolMtfFrames": "vectorbt_runner.mtf_frames",
+    "VectorbtInputs": "vectorbt_runner.vectorbt_inputs",
+    "StrategyPlotter": "vectorbt_runner.strategy_plotter",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _MODULE_BY_NAME.get(name)
+    if module_name is None:
+        raise AttributeError(f"module 'vectorbt_runner' has no attribute {name!r}")
+
+    module = import_module(module_name)
+    return getattr(module, name)


### PR DESCRIPTION
### Motivation
- Importing `strategy.breakout.breakout_strategy` triggered a circular import because `vectorbt_runner/__init__.py` eagerly imported `strategy_plotter` at package import time. 
- The goal is to defer heavy or mutually-dependent module imports until they are actually accessed to prevent the ImportError caused by the initialization cycle.

### Description
- Replaced eager imports in `vectorbt_runner/__init__.py` with a lazy attribute-based loader using `__getattr__` and `import_module` to defer importing submodules.
- Added a `_MODULE_BY_NAME` mapping and `TYPE_CHECKING`-guarded imports to preserve static typing hints while avoiding runtime imports.
- Preserved the package public API via the existing `__all__` list so external callers can access `BacktestRunner`, `DataPreparer`, `StrategyPlotter`, etc., as before.

### Testing
- Ran `python -m py_compile vectorbt_runner/__init__.py` and it succeeded. 
- Attempted `python -c "import cli.commands; print('ok')"` but full import validation could not be completed because the environment is missing the `pandas` dependency, so a full end-to-end import test was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699adf3022c08320886a91ba6ac92b56)