### PR TITLE
Fix plot-from-results fallback to prefer .output/strategy CSV

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -17,6 +17,8 @@ import pandas as pd
 
 from config import AppConfig
 from constants import (
+    DEFAULT_BACKTEST_OUTPUT_FILE,
+    DEFAULT_RESULTS_DIR,
     DEFAULT_QUALITY_REPORT_OUTPUT_FILE,
     DEFAULT_REPORT_OUTPUT_FILE,
     OI_STALE_MIN_OBSERVATIONS,
@@ -415,9 +417,22 @@ def _load_plot_params_row_from_results(
     logger: Logger,
     strategy_id: str,
 ) -> pd.Series | None:
-    csv_path = Path(getattr(args, "results_input", None) or getattr(args, "input", None) or (
-        config.backtest.results_dir / config.backtest.results_file_name
-    ))
+    explicit_csv_path = getattr(args, "results_input", None) or getattr(args, "input", None)
+    if explicit_csv_path is not None:
+        csv_path = Path(explicit_csv_path)
+    else:
+        configured_results_dir = Path(config.backtest.results_dir)
+        strategy_results_dir = _resolve_results_dir_for_strategy(configured_results_dir, strategy_id)
+        fallback_results_dir = _resolve_results_dir_for_strategy(Path(DEFAULT_RESULTS_DIR), strategy_id)
+        candidate_paths = [
+            strategy_results_dir / config.backtest.results_file_name,
+            strategy_results_dir / "results.csv",
+            configured_results_dir / config.backtest.results_file_name,
+            fallback_results_dir / "results.csv",
+            fallback_results_dir / DEFAULT_BACKTEST_OUTPUT_FILE,
+        ]
+        csv_path = next((candidate for candidate in candidate_paths if candidate.exists()), candidate_paths[0])
+
     if not csv_path.exists():
         logger.error("plot-from-results: файл результатов не найден: %s", csv_path)
         return None


### PR DESCRIPTION
### Motivation
- `--plot-from-results` failed to find results when environment/config pointed to legacy `cache/results/...` while actual CSVs live in `.output/results/strategy/<strategy>/...`.
- Make CSV resolution robust so users can omit explicit `--results-input` and the command will still find strategy-specific files under the current default layout.

### Description
- Updated CSV resolution in `cli/commands.py::_load_plot_params_row_from_results` to prefer explicit `--results-input`/`--input` and otherwise try a list of candidate paths covering configured and default `.output` locations.
- Added imports of `DEFAULT_RESULTS_DIR` and `DEFAULT_BACKTEST_OUTPUT_FILE` from `constants` to drive the fallback logic without hardcoded strings.
- Candidate search now checks strategy-specific configured directory + configured file name, `results.csv` in that directory, the configured base directory, and default `.output/results/strategy/<strategy>/results.csv` / `backtest_results.csv` before failing.
- Modified logic returns the first existing candidate and preserves the original error logging when no file is found.

### Testing
- Ran `python -m py_compile cli/commands.py` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ae579e4ec83208906c1051b810ccf)