### PR TITLE
Clarify TradeResult typing in _build_metrics_row

### DIFF
--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -7,7 +7,7 @@ from collections import Counter, defaultdict
 from dataclasses import fields, is_dataclass, replace
 from pathlib import Path
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 import pandas as pd
 
@@ -101,10 +101,11 @@ class BacktestRunner:
         tp1_be_count = BACKTEST_ZERO_COUNT
         tp2_count = BACKTEST_ZERO_COUNT
 
-        normalized_trades: list[TradeResult] = trades
+        normalized_trades: list[TradeResult] = cast(list[TradeResult], trades)
         for trade in normalized_trades:
             pnl_value = trade.pnl
-            pnl_percent += float(trade.pnl_percent.value)
+            trade_pnl_percent: float = float(trade.pnl_percent.value)
+            pnl_percent += trade_pnl_percent
             if pnl_value > 0:
                 profits += pnl_value
                 wins += 1


### PR DESCRIPTION
### Motivation
- Resolve a type-analyzer warning and improve clarity when iterating over trades in `_build_metrics_row` by ensuring the loop variable is treated as `TradeResult` and making percentage conversion explicit.

### Description
- Imported `cast` from `typing`, cast `trades` to `list[TradeResult]` with `normalized_trades = cast(list[TradeResult], trades)`, and introduced `trade_pnl_percent: float = float(trade.pnl_percent.value)` used in the accumulation.

### Testing
- Ran `python -m pyright vectorbt_runner/backtest_runner.py` and confirmed the previous warning at the percent-conversion line is no longer reported while remaining diagnostics are unrelated existing issues (`pandas` import resolution and `replace` argument typing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aea77724c8320be6b1cd5069eb693)