### PR TITLE
Fix invalid type casts in CCXT futures client

### DIFF
--- a/data/exchanges/ccxt_futures_client.py
+++ b/data/exchanges/ccxt_futures_client.py
@@ -82,13 +82,13 @@ class CcxtFuturesClient(ExchangeClient):
                 defaultType=CCXT_MARKET_TYPE_SWAP,
                 fetchCurrencies=False,
             )
-            return cast(CcxtFuturesApi, ccxt.binanceusdm(cast(Any, params)))
+            return cast(CcxtFuturesApi, cast(object, ccxt.binanceusdm(cast(Any, params))))
         if exchange == Exchange.BYBIT:
             params["options"] = CcxtClientOptions(defaultType=CCXT_MARKET_TYPE_SWAP)
-            return cast(CcxtFuturesApi, ccxt.bybit(cast(Any, params)))
+            return cast(CcxtFuturesApi, cast(object, ccxt.bybit(cast(Any, params))))
         if exchange == Exchange.OKX:
             params["options"] = CcxtClientOptions(defaultType=CCXT_MARKET_TYPE_SWAP)
-            return cast(CcxtFuturesApi, ccxt.okx(cast(Any, params)))
+            return cast(CcxtFuturesApi, cast(object, ccxt.okx(cast(Any, params))))
         raise ValueError(f"Unsupported exchange for CCXT futures client: {exchange}")
 
     def _retry_exchange_call(


### PR DESCRIPTION
### Motivation
- Silence IDE `PyInvalidCastInspection` warnings for CCXT exchange constructors by avoiding a direct cast between unrelated types and ensuring the exchange instances are cast through `object` before `CcxtFuturesApi`.

### Description
- Update `CcxtFuturesClient._build_client` to return `cast(CcxtFuturesApi, cast(object, ccxt.<exchange>(cast(Any, params))))` for Binance (`binanceusdm`), Bybit (`bybit`), and OKX (`okx`).

### Testing
- Ran `python -m compileall data/exchanges/ccxt_futures_client.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aebb5e7c08320b4aebc915c938870)