### PR TITLE
Allow optional `risk_manager` in BreakoutStrategy._extra_retest_filter_metrics

### DIFF
--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -279,7 +279,9 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         row: CandleRow,
         breakout: PendingBreakout,
         params: BreakoutParams,
+        risk_manager: RiskManager | None = None,
     ) -> dict[str, float | bool]:
+        _ = risk_manager
         natr = max(float(row.get("natr", 0.0)), STRATEGY_NATR_EPSILON)
         if breakout.side == PositionSide.LONG:
             move = (float(row["close"]) - float(row["low"])) / max(float(row["close"]), STRATEGY_PRICE_EPSILON)


### PR DESCRIPTION
### Motivation
- Fix a `TypeError` raised when `generate_events_multi_tf` passed a `risk_manager` keyword to `BreakoutStrategy._extra_retest_filter_metrics`, which did not accept it.

### Description
- Update the signature of `BreakoutStrategy._extra_retest_filter_metrics` to accept `risk_manager: RiskManager | None = None` and reference it (`_ = risk_manager`) so existing call sites can pass the argument without changing filter logic.

### Testing
- Compiled the module with `python -m compileall strategy/breakout/breakout_strategy.py` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aecc55a2083208f68c2a9c898fc8d)