### PR TITLE
Add two-stage reclaim/retest timeout flow for profile A

### DIFF
--- a/simulation/portfolio_state_engine.py
+++ b/simulation/portfolio_state_engine.py
@@ -44,6 +44,7 @@ class PortfolioEngineConfig:
     cooldown_bars: int = 8
     max_age_range_bars: int = 24
     reclaim_limit_bars: int = 0
+    retest_limit_bars: int = 0
     break_fail_threshold: int = 2
     min_pump_pct: float = 0.02
     max_range_width_pct: float = 0.03
@@ -137,10 +138,12 @@ class PortfolioStateEngine:
     FIXED_RANGE_WINDOW: int | None = None
     PROFILE_STABILITY_THRESHOLD: dict[str, float] = field(default_factory=lambda: {"A": 0.20, "B": 0.25, "C": 0.30})
     PROFILE_RECLAIM_TIMEOUT: dict[str, int] = field(default_factory=lambda: {"A": 5, "B": 6, "C": 8})
+    PROFILE_RETEST_TIMEOUT: dict[str, int] = field(default_factory=lambda: {"A": 6, "B": 6, "C": 8})
     PROFILE_MICRO_OFFSETS: dict[str, float] = field(default_factory=lambda: {"A": 0.15, "B": 0.10, "C": 0.05})
     RESET_REASONS: tuple[str, ...] = (
         "max_age_range",
         "reclaim_timeout",
+        "retest_timeout",
         "micro_filter_fail",
         "stop_distance_fail",
         "score_fail",
@@ -387,7 +390,14 @@ class PortfolioStateEngine:
             break_start_idx = state.break_start_timeline_idx if state.break_start_timeline_idx is not None else timeline_idx
             reclaim_anchor_idx = state.reclaim_bar_timeline_idx if state.reclaim_bar_timeline_idx is not None else break_start_idx
             reclaim_bars = max(timeline_idx - reclaim_anchor_idx + 1, 1)
-            if (timeline_idx - break_start_idx) > self._resolve_reclaim_limit_bars():
+
+            profile = (self.config.bee_bite_profile_id or "").upper()
+            primary_reclaim_fixed = profile == "A" and state.reclaim_bar_timeline_idx is not None
+            if primary_reclaim_fixed:
+                if state.retest_deadline_timeline_idx is not None and timeline_idx > state.retest_deadline_timeline_idx:
+                    self._reset_symbol(symbol=symbol, state=state, reason="retest_timeout", timeline_idx=timeline_idx)
+                    return None
+            elif (timeline_idx - break_start_idx) > self._resolve_reclaim_limit_bars():
                 self._reset_symbol(symbol=symbol, state=state, reason="reclaim_timeout", timeline_idx=timeline_idx)
                 return None
 
@@ -409,17 +419,12 @@ class PortfolioStateEngine:
 
             reclaim_confirmed = state.support is not None and close > state.support and depth >= min_depth
 
-            profile = (self.config.bee_bite_profile_id or "").upper()
             if profile == "A" and reclaim_confirmed and state.reclaim_bar_timeline_idx is None:
                 state.reclaim_bar_timeline_idx = timeline_idx
-                state.retest_deadline_timeline_idx = timeline_idx + 6
+                state.retest_deadline_timeline_idx = timeline_idx + self._resolve_retest_limit_bars()
                 state.touched_retest_zone = False
 
             if profile == "A" and state.reclaim_bar_timeline_idx is not None:
-                if state.retest_deadline_timeline_idx is not None and timeline_idx > state.retest_deadline_timeline_idx:
-                    self._reset_symbol(symbol=symbol, state=state, reason="reclaim_timeout", timeline_idx=timeline_idx)
-                    return None
-
                 support = float(state.support if state.support is not None else close)
                 atr_ref = float(state.atr_bg if state.atr_bg is not None else 0.0)
                 zone_upper = support + (0.05 * atr_ref)
@@ -747,6 +752,16 @@ class PortfolioStateEngine:
         if profile in self.PROFILE_RECLAIM_TIMEOUT:
             return int(self.PROFILE_RECLAIM_TIMEOUT[profile])
         return 3
+
+    def _resolve_retest_limit_bars(self) -> int:
+        runtime_limit_bars = int(self.config.retest_limit_bars)
+        if runtime_limit_bars > 0:
+            return runtime_limit_bars
+
+        profile = (self.config.bee_bite_profile_id or "").upper()
+        if profile in self.PROFILE_RETEST_TIMEOUT:
+            return int(self.PROFILE_RETEST_TIMEOUT[profile])
+        return 6
 
     def _resolve_range_window_len(self) -> int:
         if self.FIXED_RANGE_WINDOW is not None:


### PR DESCRIPTION
### Motivation
- Enforce a clear two-stage flow for break handling so profile A first must achieve a primary reclaim and then pass a separate retest window to avoid premature global timeout resets.
- Make retest timing configurable at runtime and per-profile to allow tuning of the second-stage confirmation independently from the initial reclaim timeout.
- Surface a distinct diagnostics reason for timeouts that occur after primary reclaim to help identify where signals are lost.

### Description
- Added a runtime config `retest_limit_bars` to `PortfolioEngineConfig` and the profile-level mapping `PROFILE_RETEST_TIMEOUT` in `simulation/portfolio_state_engine.py` to control retest timing.
- Added `retest_timeout` to `RESET_REASONS` and updated the `BREAK_ACTIVE` logic to implement the two-stage model for profile `A`: before primary reclaim the code enforces `reclaim_limit`, and after primary reclaim it enforces the separate `retest` deadline.
- When primary reclaim is fixed the code now sets `retest_deadline_timeline_idx` using `self._resolve_retest_limit_bars()` instead of a hardcoded value, and triggers a reset with reason `retest_timeout` if that deadline is missed.
- Implemented `_resolve_retest_limit_bars()` with runtime-config priority and profile fallback, and applied changes in `simulation/portfolio_state_engine.py` to wire the new behavior.

### Testing
- Ran `python -m py_compile simulation/portfolio_state_engine.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699af7ebb8b8832099561b0fb80114bf)