### PR TITLE
Enforce upstream oi_break_avg contract and add validation/diagnostics for bee_bite portfolio engine

### DIFF
--- a/simulation/portfolio_state_engine.py
+++ b/simulation/portfolio_state_engine.py
@@ -150,6 +150,8 @@ class PortfolioStateEngine:
         "topn_fail",
         "break_emergency",
     )
+    OI_BREAK_AVG_MIN_VALID_COVERAGE: float = 0.90
+    OI_BREAK_AVG_MIN_VALID_SAMPLES: int = 32
 
     def run(self, symbol_frames: dict[str, pd.DataFrame]) -> list[TradeResult]:
         self._last_run_diagnostics = {
@@ -158,7 +160,16 @@ class PortfolioStateEngine:
             "candidates": [],
             "selected_symbols": [],
             "reset_counters": {reason: 0 for reason in self.RESET_REASONS},
+            "oi_break_avg_validation": {
+                "source": "upstream_feature_pipeline",
+                "required": True,
+                "validated_symbols": [],
+                "skipped_symbols": {},
+            },
         }
+        symbol_frames = self._filter_frames_by_oi_break_avg(symbol_frames)
+        if not symbol_frames:
+            return []
         timeline = self._build_timeline(symbol_frames)
         if not timeline:
             return []
@@ -203,6 +214,42 @@ class PortfolioStateEngine:
 
         trades.extend(self._close_open_positions(symbol_frames=symbol_frames, timeline=timeline))
         return sorted(trades, key=lambda trade: (trade.exit_timestamp_ms, trade.entry_timestamp_ms))
+
+    def _filter_frames_by_oi_break_avg(self, symbol_frames: dict[str, pd.DataFrame]) -> dict[str, pd.DataFrame]:
+        validated: dict[str, pd.DataFrame] = {}
+        diagnostics = self._last_run_diagnostics.get("oi_break_avg_validation")
+        validated_symbols: list[str] = []
+        skipped_symbols: dict[str, str] = {}
+
+        for symbol, frame in symbol_frames.items():
+            if "oi_break_avg" not in frame.columns:
+                skipped_symbols[symbol] = "missing_column"
+                continue
+
+            numeric = pd.to_numeric(frame["oi_break_avg"], errors="coerce")
+            finite_positive = numeric.notna() & np.isfinite(numeric) & (numeric > 0.0)
+            valid_count = int(finite_positive.sum())
+            coverage = float(valid_count / max(len(frame.index), 1))
+            if valid_count < self.OI_BREAK_AVG_MIN_VALID_SAMPLES:
+                skipped_symbols[symbol] = (
+                    f"insufficient_valid_samples:{valid_count}<{self.OI_BREAK_AVG_MIN_VALID_SAMPLES}"
+                )
+                continue
+            if coverage < self.OI_BREAK_AVG_MIN_VALID_COVERAGE:
+                skipped_symbols[symbol] = (
+                    f"low_valid_coverage:{coverage:.3f}<{self.OI_BREAK_AVG_MIN_VALID_COVERAGE:.3f}"
+                )
+                continue
+
+            prepared = frame.copy()
+            prepared["oi_break_avg"] = numeric
+            validated[symbol] = prepared
+            validated_symbols.append(symbol)
+
+        if isinstance(diagnostics, dict):
+            diagnostics["validated_symbols"] = validated_symbols
+            diagnostics["skipped_symbols"] = skipped_symbols
+        return validated
 
     def consume_last_run_diagnostics(self) -> dict[str, object]:
         diagnostics = self._last_run_diagnostics.copy()

--- a/strategy/bee_bite/README.md
+++ b/strategy/bee_bite/README.md
@@ -45,3 +45,29 @@ BEE_BITE_GRID_MODE=baseline
 - `strategy/bee_bite/engine.py`
 - `strategy/bee_bite/trade_plan.py`
 - `strategy/bee_bite/config.py`
+
+## Входные признаки (portfolio mode)
+
+Единый источник `oi_break_avg` закреплён как **upstream feature pipeline**:
+- `PortfolioStateEngine` не пересчитывает `oi_break_avg` внутри FSM;
+- поле должно быть заранее подготовлено в входном `entry_frame` для каждого символа.
+
+### Обязательные поля
+
+- Базовые OHLCV: `timestamp`, `open`, `high`, `low`, `close`, `volume`.
+- Для score-компонента OI: `oi_break_avg`.
+
+Для `oi_break_avg` действует строгая валидация качества на уровне `PortfolioStateEngine`:
+- колонка должна присутствовать;
+- не менее `32` валидных значений (`finite && > 0`);
+- покрытие валидными значениями не ниже `0.90` по фрейму.
+
+Если критерии не выполнены, символ пропускается до начала FSM. Причина попадает в diagnostics-флаг
+`portfolio_score.oi_break_avg_validation.skipped_symbols`.
+
+### Опциональные поля и fallback
+
+- `oi_reclaim`, `taker_buy_ratio|taker_ratio`, `avg_volume_range|avg_range_volume|range_volume_avg`,
+  `range_volume_zscore|volume_range_zscore|zscore_range_volume`, `spread|bid_ask_spread|effective_spread`.
+- При отсутствии или плохом качестве этих полей стратегия не падает: соответствующий компонент score даёт `0` баллов,
+  а причина фиксируется в `score_trace.data_quality_notes`.


### PR DESCRIPTION
### Motivation

- Установить единый источник `oi_break_avg` как данные upstream feature-pipeline и исключить смешанный режим, когда движок частично пересчитывает OI локально.
- Жёстко проверять качество входного поля `oi_break_avg` перед запуском FSM, чтобы избежать тихой деградации качества скоринга и обеспечить явную диагностику пропущенных символов.

### Description

- Добавлены параметры качества в `PortfolioStateEngine`: `OI_BREAK_AVG_MIN_VALID_COVERAGE = 0.90` и `OI_BREAK_AVG_MIN_VALID_SAMPLES = 32` для определения минимальной достоверности поля `oi_break_avg`.
- Введён метод `_filter_frames_by_oi_break_avg` который валидирует по-символьно входные фреймы и пропускает символы с отсутствующей колонкой, недостаточным числом валидных сэмплов или низким покрытием; результаты записываются в `_last_run_diagnostics["oi_break_avg_validation"]` как `validated_symbols` и `skipped_symbols`.
- Выполнена ранняя фильтрация `symbol_frames` по `oi_break_avg` перед построением timeline; обновлена документация `strategy/bee_bite/README.md` с требованиями к входным признакам (обязательные поля, опциональные поля и поведение fallback).

### Testing

- Скомпилированы изменённые модули командой `python -m compileall simulation/portfolio_state_engine.py strategy/bee_bite/README.md`, компиляция прошла успешно.
- Не добавлялись новые автоматические тесты (в соответствии с политикой).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699af89357ec8320aeb6009c71d0233c)