### PR TITLE
Use runtime-configurable top_n for bee_bite portfolio mode and align profile defaults

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -1159,6 +1159,7 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
             cooldown_hours=config.strategy.bee_bite_cooldown_hours,
             max_age_range_hours=config.strategy.bee_bite_max_age_range_hours,
         )
+        config.strategy.bee_bite_portfolio_top_n = getattr(args, "top_n", None)
     levels_timeframe = _resolve_timeframe(
         getattr(args, "levels_tf", None),
         fallback=config.strategy.levels_timeframe,

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -179,6 +179,11 @@ def load_config(env_path: str | Path = ".env") -> AppConfig:
         ),
         bee_bite_cooldown_hours=int(os.getenv("BEE_BITE_COOLDOWN_HOURS", os.getenv("BEE_BITE_COOLDOWN_BARS", str(bee_bite_runtime.cooldown_hours)))),
         bee_bite_max_age_range_hours=int(os.getenv("BEE_BITE_MAX_AGE_RANGE_HOURS", os.getenv("BEE_BITE_MAX_AGE_RANGE", str(bee_bite_runtime.max_age_range_hours)))),
+        bee_bite_portfolio_top_n=(
+            int(os.getenv("BEE_BITE_TOP_N"))
+            if os.getenv("BEE_BITE_TOP_N") is not None
+            else None
+        ),
     )
 
     simulation_config = SimulationConfig(

--- a/config/strategy_config.py
+++ b/config/strategy_config.py
@@ -24,3 +24,4 @@ class StrategyConfig:
     bee_bite_retest_mode: BeeBiteRetestMode = "confirmation"
     bee_bite_cooldown_hours: int = 8
     bee_bite_max_age_range_hours: int = 24
+    bee_bite_portfolio_top_n: int | None = None

--- a/strategy/bee_bite/README.md
+++ b/strategy/bee_bite/README.md
@@ -40,6 +40,15 @@ BEE_BITE_PROFILE=A
 BEE_BITE_GRID_MODE=baseline
 ```
 
+
+## Как определяется итоговый `top_n` в portfolio mode
+
+1. Если передан `--top-n` в `run-backtest`, это значение прокидывается в `BeeBiteStrategy` и затем в `PortfolioEngineConfig(top_n=...)`.
+2. Если `--top-n` не передан, используется профильный fallback из `BEE_BITE_PROFILE_TOP_N` (`A=5`, `B=10`, `C=20`).
+3. Для CLI-значения действует runtime-валидация `validate_bee_bite_runtime()` по диапазонам профиля (`top_n_min..top_n_max`) и доп. ограничению для `expanded` (`>= 20`).
+
+Итог: в portfolio mode источник `top_n` — сначала CLI/конфиг запуска, иначе профильный дефолт.
+
 Основные модули реализации:
 - `strategy/bee_bite/bee_bite_strategy.py`
 - `strategy/bee_bite/engine.py`

--- a/strategy/bee_bite/bee_bite_strategy.py
+++ b/strategy/bee_bite/bee_bite_strategy.py
@@ -34,6 +34,7 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
         retest_mode: BeeBiteRetestMode,
         cooldown_hours: int,
         max_age_range_hours: int,
+        portfolio_top_n: int | None = None,
     ) -> None:
         self._profile_id = profile_id
         self._grid_mode = grid_mode
@@ -41,6 +42,7 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
         self._retest_mode = retest_mode
         self._cooldown_hours = cooldown_hours
         self._max_age_range_hours = max_age_range_hours
+        self._portfolio_top_n = portfolio_top_n
         self._engine = BeeBiteEngine()
         self._last_generation_diagnostics: dict[str, object] = {}
 
@@ -109,9 +111,10 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
             return []
 
         profile_id = params.bite_profile_id
+        resolved_top_n = self._portfolio_top_n if self._portfolio_top_n is not None else get_bee_bite_top_n(profile_id)
         engine = PortfolioStateEngine(
             config=PortfolioEngineConfig(
-                top_n=get_bee_bite_top_n(profile_id),
+                top_n=resolved_top_n,
                 score_threshold=get_bee_bite_score_threshold(profile_id).min_score,
                 r_trade=params.bite_r_trade,
                 portfolio_risk_limit=params.bite_portfolio_risk_limit,
@@ -129,7 +132,7 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
         self._last_generation_diagnostics = {
             "mode": "portfolio_only",
             "profile_id": profile_id,
-            "top_n": get_bee_bite_top_n(profile_id),
+            "top_n": resolved_top_n,
             "score_threshold": get_bee_bite_score_threshold(profile_id).min_score,
             "portfolio_score": engine.consume_last_run_diagnostics(),
             "trades_generated": len(trades),

--- a/strategy/bee_bite/config.py
+++ b/strategy/bee_bite/config.py
@@ -32,9 +32,9 @@ BEE_BITE_PROFILE_SCORE_THRESHOLDS: dict[BeeBiteProfileId, ScoreThreshold] = {
 }
 
 BEE_BITE_PROFILE_TOP_N: dict[BeeBiteProfileId, int] = {
-    "A": 1,
-    "B": 2,
-    "C": 3,
+    "A": 5,
+    "B": 10,
+    "C": 20,
 }
 
 

--- a/strategy/breakout/breakout_strategy.py
+++ b/strategy/breakout/breakout_strategy.py
@@ -87,10 +87,12 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
         commission_rate: float,
         slippage: float,
         logger: logging.Logger | None = None,
+        portfolio_top_n: int | None = None,
     ) -> None:
         self._commission_rate = commission_rate
         self._slippage = slippage
         self._logger = logger or logging.getLogger(__name__)
+        self._portfolio_top_n = portfolio_top_n
         self._last_generation_diagnostics: dict[str, object] = {}
         self._level_detector = LevelDetector()
 
@@ -791,7 +793,11 @@ class BreakoutStrategy(BaseStrategy[BreakoutParams]):
             return []
 
         profile_id = getattr(params, "bite_profile_id", None)
-        profile_top_n = get_bee_bite_top_n(profile_id) if profile_id is not None else 1
+        profile_top_n = (
+            self._portfolio_top_n
+            if self._portfolio_top_n is not None
+            else (get_bee_bite_top_n(profile_id) if profile_id is not None else len(entry_frames))
+        )
         score_threshold = get_bee_bite_score_threshold(profile_id).min_score if profile_id is not None else 0.0
 
         engine = PortfolioStateEngine(

--- a/strategy/factory.py
+++ b/strategy/factory.py
@@ -15,6 +15,11 @@ def build_breakout_strategy(config: AppConfig, logger: Logger) -> BreakoutStrate
         commission_rate=config.simulation.commission_rate,
         slippage=config.simulation.slippage,
         logger=logger,
+        portfolio_top_n=(
+            config.strategy.bee_bite_portfolio_top_n
+            if config.strategy.bee_bite_portfolio_top_n is not None
+            else None
+        ),
     )
 
 
@@ -29,5 +34,6 @@ def build_strategy(config: AppConfig, logger: Logger) -> BaseStrategy[object]:
             retest_mode=config.strategy.bee_bite_retest_mode,
             cooldown_hours=config.strategy.bee_bite_cooldown_hours,
             max_age_range_hours=config.strategy.bee_bite_max_age_range_hours,
+            portfolio_top_n=config.strategy.bee_bite_portfolio_top_n,
         )
     raise ValueError(f"Неподдерживаемый strategy_id: {config.strategy.strategy_id}")


### PR DESCRIPTION
### Motivation
- Align `BEE_BITE_PROFILE_TOP_N` defaults with runtime profile limits so profile fallbacks don't violate `validate_bee_bite_runtime()` minima. 
- Allow passing actual `top_n` from CLI/config into portfolio pipelines instead of relying on a fixed hardcoded fallback. 
- Remove legacy hardcoded `1/2/3` fallbacks in portfolio-mode code paths and document the precedence for `top_n`.

### Description
- Updated profile defaults in `strategy/bee_bite/config.py`: `BEE_BITE_PROFILE_TOP_N` changed from `A=1,B=2,C=3` to `A=5,B=10,C=20` to match profile `top_n_min` expectations. 
- Added `bee_bite_portfolio_top_n` to `StrategyConfig` and load from env var `BEE_BITE_TOP_N` in `config/__init__.py`. 
- Propagate runtime `top_n` from CLI into `config.strategy.bee_bite_portfolio_top_n` in `cli/commands.py` when running `run-backtest`. 
- Pass `bee_bite_portfolio_top_n` through the strategy factory (`strategy/factory.py`) into `BeeBiteStrategy` and `BreakoutStrategy`. 
- Update `BeeBiteStrategy.generate_events_portfolio()` to prefer the injected runtime/config `top_n` (`portfolio_top_n`) and fall back to the profile default from `get_bee_bite_top_n(profile_id)` only when not provided; diagnostics now report the resolved `top_n`. 
- Update `BreakoutStrategy.generate_events_portfolio()` to use the injected `portfolio_top_n` (if present), otherwise use the profile `top_n` (if `bite_profile_id` present), otherwise use `len(entry_frames)` instead of falling back to `1`. 
- Documented final `top_n` resolution order in `strategy/bee_bite/README.md` (CLI/config first, then profile fallback) and noted that `validate_bee_bite_runtime()` still applies validation to CLI values.

### Testing
- Ran byte-compile check: `python -m compileall cli/commands.py config/__init__.py config/strategy_config.py strategy/factory.py strategy/bee_bite/config.py strategy/bee_bite/bee_bite_strategy.py strategy/breakout/breakout_strategy.py` which completed successfully. 
- Verified working tree and commit: `git status --short` and commit created with message `Use runtime top_n for bee_bite portfolio mode` (files changed listed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699afa31e7508320a71e28a97131349b)