### PR TITLE
Unify TP1-share resolution across bee_bite engines

### DIFF
--- a/simulation/portfolio_state_engine.py
+++ b/simulation/portfolio_state_engine.py
@@ -52,6 +52,7 @@ class PortfolioEngineConfig:
     min_reclaim_pct: float = 0.001
     rr: float = 2.0
     bee_bite_profile_id: str | None = None
+    bee_bite_tp1_share: float | None = None
 
 
 @dataclass(slots=True)
@@ -983,7 +984,7 @@ class PortfolioStateEngine:
             retest_timestamp_ms=int(row["timestamp"]),
             atr_bg=atr_bg,
             high_pump=high_pump,
-            tp1_close_ratio=resolve_profile_tp1_share(self.config.bee_bite_profile_id),
+            tp1_close_ratio=resolve_profile_tp1_share(self.config.bee_bite_profile_id, self.config.bee_bite_tp1_share),
         )
         return signal
 

--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -479,7 +479,7 @@ class BeeBiteEngine:
             return None, entry_idx, False
 
         position_size = params.bite_r_trade / risk
-        tp1_share = resolve_profile_tp1_share(params.bite_profile_id)
+        tp1_share = resolve_profile_tp1_share(params.bite_profile_id, params.bite_tp1_share)
         remainder_share = 1.0 - tp1_share
 
         trailing_mode = trade_plan.trailing_mode

--- a/strategy/bee_bite/trade_plan.py
+++ b/strategy/bee_bite/trade_plan.py
@@ -25,8 +25,10 @@ class BeeBiteTradePlan:
     be_stop: float
 
 
-def resolve_profile_tp1_share(profile_id: str | None) -> float:
-    raw = PROFILE_TP1_SHARE.get((profile_id or "").upper(), PROFILE_TP1_SHARE["C"])
+def resolve_profile_tp1_share(profile_id: str | None, tp1_share_override: float | None = None) -> float:
+    raw = tp1_share_override
+    if raw is None:
+        raw = PROFILE_TP1_SHARE.get((profile_id or "").upper(), PROFILE_TP1_SHARE["C"])
     return min(max(raw, 0.05), 0.95)
 
 


### PR DESCRIPTION
### Motivation
- Remove a source of desynchronization between single-symbol and portfolio modes by centralising TP1-share resolution into a single resolver that can accept an explicit override. 
- Allow explicit per-run overrides (from params/config) while preserving profile defaults and existing clamping behavior.

### Description
- Extended `resolve_profile_tp1_share` in `strategy/bee_bite/trade_plan.py` to accept an optional `tp1_share_override` and use it when provided, otherwise falling back to profile baselines with the same `[0.05, 0.95]` clamp. 
- Updated `BeeBiteEngine._simulate_trade` in `strategy/bee_bite/engine.py` to call `resolve_profile_tp1_share(params.bite_profile_id, params.bite_tp1_share)` so single-symbol simulation respects the strategy parameter override. 
- Added optional `bee_bite_tp1_share` to `PortfolioEngineConfig` and changed portfolio signal construction in `simulation/portfolio_state_engine.py` to call `resolve_profile_tp1_share(self.config.bee_bite_profile_id, self.config.bee_bite_tp1_share)` so portfolio mode uses the same resolution rule. 
- Left `bite_tp1_share` field and its validation intact (chose the profile+override approach rather than removing the parameter), and verified codebase references to avoid remaining mismatches; changed files: `strategy/bee_bite/trade_plan.py`, `strategy/bee_bite/engine.py`, `simulation/portfolio_state_engine.py`.

### Testing
- Ran `python -m compileall strategy/bee_bite/trade_plan.py strategy/bee_bite/engine.py simulation/portfolio_state_engine.py` and compilation completed successfully. 
- Searched the codebase for `resolve_profile_tp1_share(`, `bite_tp1_share`, `bee_bite_tp1_share`, and `tp1_close_ratio` to confirm callsites were updated and there are no remaining obvious mismatches. 
- Basic local sanity checks (module import/compilation and quick text searches) passed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699afd553dac832086f1ed3deda368a9)