### PR TITLE
Передать буфер BE в `build_bee_bite_trade_plan`

### DIFF
--- a/simulation/portfolio_state_engine.py
+++ b/simulation/portfolio_state_engine.py
@@ -53,6 +53,7 @@ class PortfolioEngineConfig:
     rr: float = 2.0
     bee_bite_profile_id: str | None = None
     bee_bite_tp1_share: float | None = None
+    bee_bite_tp1_stop_buffer_pct: float = 0.001
 
 
 @dataclass(slots=True)
@@ -964,6 +965,7 @@ class PortfolioStateEngine:
             resistance=resistance,
             high_pump=high_pump,
             low_before_pump=low_before_pump,
+            be_offset_ratio=self.config.bee_bite_tp1_stop_buffer_pct,
         )
         if plan is None or plan.stop_distance < (0.3 * atr_bg):
             return None

--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -460,6 +460,7 @@ class BeeBiteEngine:
             resistance=float(setup.range_high),
             high_pump=setup.high_pump,
             low_before_pump=setup.low_before_pump,
+            be_offset_ratio=params.bite_tp1_stop_buffer_pct,
         )
         if trade_plan is None:
             return None, entry_idx, False

--- a/strategy/bee_bite/trade_plan.py
+++ b/strategy/bee_bite/trade_plan.py
@@ -12,9 +12,6 @@ PROFILE_TP1_SHARE: dict[str, float] = {
     "B": 0.6,  # Balanced
     "C": 0.5,  # Aggressive
 }
-BE_OFFSET_RATIO = 0.001
-
-
 @dataclass(frozen=True, slots=True)
 class BeeBiteTradePlan:
     stop_loss: float
@@ -42,6 +39,7 @@ def build_bee_bite_trade_plan(
     resistance: float,
     high_pump: float | None,
     low_before_pump: float | None,
+    be_offset_ratio: float,
 ) -> BeeBiteTradePlan | None:
     """Собирает план сделки bee_bite c выбором fixed/trailing TP2 по стороне.
 
@@ -53,6 +51,8 @@ def build_bee_bite_trade_plan(
     Если fixed TP2 недоступен, используется fallback на trailing TP2.
     """
     if atr_bg <= 0:
+        return None
+    if be_offset_ratio < 0:
         return None
 
     if side == PositionSide.LONG:
@@ -68,7 +68,7 @@ def build_bee_bite_trade_plan(
         tp1 = mid if mid > entry_price else resistance
         fixed_tp2 = high_pump if use_fixed_tp2 else None
         trailing_tp2 = entry_price + atr_bg
-        be_stop = entry_price * (1.0 + BE_OFFSET_RATIO)
+        be_stop = entry_price * (1.0 + be_offset_ratio)
     else:
         use_fixed_tp2 = (
             low_before_pump is not None and (entry_price - low_before_pump) >= atr_bg
@@ -76,7 +76,7 @@ def build_bee_bite_trade_plan(
         tp1 = mid if mid < entry_price else support
         fixed_tp2 = low_before_pump if use_fixed_tp2 else None
         trailing_tp2 = entry_price - atr_bg
-        be_stop = entry_price * (1.0 - BE_OFFSET_RATIO)
+        be_stop = entry_price * (1.0 - be_offset_ratio)
 
     trailing_mode = fixed_tp2 is None
     tp2 = trailing_tp2 if trailing_mode else fixed_tp2


### PR DESCRIPTION
### Motivation
- Устранить жёстко заданную глобальную константу для смещения BE и дать возможность настраивать буфер BE из конфигурации портфельного движка.
- Избежать двух конкурирующих источников значения `BE_OFFSET_RATIO` и обеспечить единый путь настройки для стратегии и портфеля.

### Description
- Добавлен входной аргумент `be_offset_ratio` в сигнатуру `build_bee_bite_trade_plan(...)` в `strategy/bee_bite/trade_plan.py` и добавлена простая валидация (отрицательное значение — отклонение). 
- Расчёт `be_stop` теперь использует `be_offset_ratio` вместо удалённой глобальной константы `BE_OFFSET_RATIO` и сама константа удалена.
- В `strategy/bee_bite/engine.py` в методе `_simulate_trade` передаётся `params.bite_tp1_stop_buffer_pct` в вызов `build_bee_bite_trade_plan(...)`.
- В `simulation/portfolio_state_engine.py` добавлено поле конфигурации `bee_bite_tp1_stop_buffer_pct: float = 0.001` в `PortfolioEngineConfig`, и в `_build_signal` это значение передаётся как `be_offset_ratio` в `build_bee_bite_trade_plan(...)`.

### Testing
- Выполнена проверка компиляции изменённых модулей командой `python -m compileall strategy/bee_bite/trade_plan.py strategy/bee_bite/engine.py simulation/portfolio_state_engine.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699afde5401883209e00e9bd756df25f)