### PR TITLE
Refine bee_bite time-exit classification and propagate to reporting

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -1454,10 +1454,16 @@ def _make_report_inner(config: AppConfig, args: argparse.Namespace) -> int:
         "max_dd",
         "sl_count",
         "be_count",
+        "time_exit_profit_count",
         "tp1_be_count",
         "tp2_count",
     ]
     missing_columns = [column for column in required_columns if column not in frame.columns]
+    if missing_columns:
+        if missing_columns == ["time_exit_profit_count"]:
+            frame = frame.copy()
+            frame["time_exit_profit_count"] = 0
+            missing_columns = []
     if missing_columns:
         logger.error("подготовка-отчета: отсутствуют обязательные колонки: %s", ", ".join(missing_columns))
         return 1
@@ -1493,6 +1499,7 @@ def _make_report_inner(config: AppConfig, args: argparse.Namespace) -> int:
     distribution = TradeResultsDistribution(
         SL=int(source["sl_count"].sum()),
         BE=int(source["be_count"].sum()),
+        TIME_EXIT_PROFIT=int(source["time_exit_profit_count"].sum()),
         TP1_BE=int(source["tp1_be_count"].sum()),
         TP2=int(source["tp2_count"].sum()),
     )

--- a/domain/enums/trade_result_type.py
+++ b/domain/enums/trade_result_type.py
@@ -6,5 +6,6 @@ from enum import Enum
 class TradeResultType(str, Enum):
     SL = "SL"
     BE = "BE"
+    TIME_EXIT_PROFIT = "TIME_EXIT_PROFIT"
     TP1_BE = "TP1_BE"
     TP2 = "TP2"

--- a/domain/models/reporting/trade_results_distribution.py
+++ b/domain/models/reporting/trade_results_distribution.py
@@ -9,5 +9,6 @@ from dataclasses import dataclass
 class TradeResultsDistribution:
     SL: int
     BE: int
+    TIME_EXIT_PROFIT: int
     TP1_BE: int
     TP2: int

--- a/strategy/bee_bite/README.md
+++ b/strategy/bee_bite/README.md
@@ -55,6 +55,15 @@ BEE_BITE_GRID_MODE=baseline
 - `strategy/bee_bite/trade_plan.py`
 - `strategy/bee_bite/config.py`
 
+## Классификация исходов сделок
+
+- При срабатывании `time-exit` **до достижения TP1** (`PROFILE_TIME_EXIT_HOURS_NO_TP1`) итоговый `result_type`
+  определяется по знаку `pnl`:
+  - отрицательный `pnl` → `SL`;
+  - около нуля → `BE`;
+  - положительный `pnl` → `TIME_EXIT_PROFIT`.
+- Сделки после достижения TP1 продолжают использовать существующие исходы (`TP1_BE` / `TP2`) по правилам trade-plan.
+
 ## Входные признаки (portfolio mode)
 
 Единый источник `oi_break_avg` закреплён как **upstream feature pipeline**:

--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -500,6 +500,7 @@ class BeeBiteEngine:
         exit_price = entry_price
         exit_idx = limit
         realized_pnl = 0.0
+        time_exit_triggered = False
         for idx in range(entry_idx + 1, limit + 1):
             row = rows[idx]
             low = float(row.low)
@@ -508,8 +509,8 @@ class BeeBiteEngine:
 
             if not tp1_hit and (idx - entry_idx) >= time_exit_candles:
                 exit_price = close
-                result_type = TradeResultType.BE
                 exit_idx = idx
+                time_exit_triggered = True
                 break
 
             if setup.side == PositionSide.LONG:
@@ -600,6 +601,8 @@ class BeeBiteEngine:
                 realized_pnl = (exit_price - entry_price) * position_size
             else:
                 realized_pnl = (entry_price - exit_price) * position_size
+            if time_exit_triggered:
+                result_type = self._classify_time_exit_result(realized_pnl)
 
         pnl = realized_pnl
         pnl_percent = 0.0 if entry_price == 0 else (pnl / entry_price) * 100.0
@@ -615,6 +618,15 @@ class BeeBiteEngine:
             retest_timestamp_ms=setup.retest_timestamp,
         )
         return trade, exit_idx, False
+
+    @staticmethod
+    def _classify_time_exit_result(pnl: float) -> TradeResultType:
+        epsilon = 1e-9
+        if pnl < -epsilon:
+            return TradeResultType.SL
+        if pnl > epsilon:
+            return TradeResultType.TIME_EXIT_PROFIT
+        return TradeResultType.BE
 
     @staticmethod
     def _score_trade_plan(*, setup: SetupContext, plan: BeeBiteTradePlan, entry_price: float) -> float:

--- a/vectorbt_runner/backtest_runner.py
+++ b/vectorbt_runner/backtest_runner.py
@@ -88,6 +88,7 @@ class BacktestRunner:
                 "max_dd": BACKTEST_EMPTY_MAX_DD,
                 "sl_count": BACKTEST_ZERO_COUNT,
                 "be_count": BACKTEST_ZERO_COUNT,
+                "time_exit_profit_count": BACKTEST_ZERO_COUNT,
                 "tp1_be_count": BACKTEST_ZERO_COUNT,
                 "tp2_count": BACKTEST_ZERO_COUNT,
             }
@@ -98,6 +99,7 @@ class BacktestRunner:
         pnl_percent = BACKTEST_EMPTY_PNL_PERCENT
         sl_count = BACKTEST_ZERO_COUNT
         be_count = BACKTEST_ZERO_COUNT
+        time_exit_profit_count = BACKTEST_ZERO_COUNT
         tp1_be_count = BACKTEST_ZERO_COUNT
         tp2_count = BACKTEST_ZERO_COUNT
 
@@ -115,6 +117,8 @@ class BacktestRunner:
                 sl_count += 1
             elif trade.result_type == TradeResultType.BE:
                 be_count += 1
+            elif trade.result_type == TradeResultType.TIME_EXIT_PROFIT:
+                time_exit_profit_count += 1
             elif trade.result_type == TradeResultType.TP1_BE:
                 tp1_be_count += 1
             elif trade.result_type == TradeResultType.TP2:
@@ -154,6 +158,7 @@ class BacktestRunner:
             "max_dd": round(float(max_dd), BACKTEST_ROUND_MAX_DD),
             "sl_count": sl_count,
             "be_count": be_count,
+            "time_exit_profit_count": time_exit_profit_count,
             "tp1_be_count": tp1_be_count,
             "tp2_count": tp2_count,
         }


### PR DESCRIPTION
### Motivation
- Time-exit events that occur before TP1 needed deterministic classification based on realized PnL sign so aggregated reports reflect profit/loss correctly.
- Reporting and backtest aggregation required a new bucket to represent positive time-exit profits and remain backward-compatible with existing CSVs.

### Description
- Changed `BeeBiteEngine._simulate_trade` to mark time-exit triggers and classify result by `pnl` sign via a helper `_classify_time_exit_result` (maps negative → `SL`, ~0 → `BE`, positive → `TIME_EXIT_PROFIT`).
- Added `TIME_EXIT_PROFIT` to `domain.enums.trade_result_type.TradeResultType`.
- Extended `domain.models.reporting.TradeResultsDistribution` with `TIME_EXIT_PROFIT` and updated `vectorbt_runner.backtest_runner` to count `TIME_EXIT_PROFIT` in metrics output.
- Made CLI report builder tolerant to older CSVs by faking `time_exit_profit_count = 0` when that single column is missing, and updated `strategy/bee_bite/README.md` with the new classification logic.

### Testing
- Ran `python -m compileall strategy/bee_bite/engine.py cli/commands.py vectorbt_runner/backtest_runner.py domain/enums/trade_result_type.py domain/models/reporting/trade_results_distribution.py` and compilation completed without errors.
- Verified code locations with `rg -n "time_exit_profit_count|TIME_EXIT_PROFIT"` to ensure changes are propagated and found expected occurrences.
- No automated unit tests were added (per instruction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699afe6eaec48320b6fa591246c3a781)