### PR TITLE
Integrate HTF levels into bee_bite FSM entry flow

### DIFF
--- a/strategy/bee_bite/README.md
+++ b/strategy/bee_bite/README.md
@@ -55,6 +55,26 @@ BEE_BITE_GRID_MODE=baseline
 - `strategy/bee_bite/trade_plan.py`
 - `strategy/bee_bite/config.py`
 
+
+## Влияние HTF-уровней на входы
+
+В `BeeBiteEngine._run_fsm` HTF-уровни (`level_high/level_low`) теперь участвуют в FSM явно:
+
+- **SEEK_PUMP**: направление сетапа фильтруется текущим HTF-контекстом.
+  - `LONG` допускается только если цена пробоя `<= current level_low`.
+  - `SHORT` допускается только если цена пробоя `>= current level_high`.
+  - Если HTF-уровней нет (режим `generate_events()`), фильтр отключается.
+- **SEEK_RANGE**: после фиксации диапазона проверяется привязка к HTF-якорю.
+  - Для `LONG` внутри диапазона должен находиться `level_low`.
+  - Для `SHORT` внутри диапазона должен находиться `level_high`.
+  - При несоответствии диапазон отбрасывается, FSM возвращается в `IDLE`.
+- **RANGE_LOCKED / BREAK_ACTIVE**: прокол и reclaim считаются относительно объединённой границы `reclaim_reference`:
+  - `LONG`: `max(range_low, level_low)` (или `range_low`, если HTF отсутствует).
+  - `SHORT`: `min(range_high, level_high)` (или `range_high`, если HTF отсутствует).
+  - Для входа требуется прокол за диапазон и за `reclaim_reference`, затем закрытие/reclaim обратно через `reclaim_reference` с микро-офсетом.
+
+Это делает логику мультитаймфрейма строгой, а single-TF режим (без `higher_levels`) оставляет в прежнем рабочем виде без обязательных HTF-фильтров.
+
 ## Классификация исходов сделок
 
 - При срабатывании `time-exit` **до достижения TP1** (`PROFILE_TIME_EXIT_HOURS_NO_TP1`) итоговый `result_type`

--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -182,6 +182,8 @@ class BeeBiteEngine:
         trades: list[TradeResult] = []
         level_idx = 0
         cooldown_until_idx = -1
+        current_level_high: float | None = None
+        current_level_low: float | None = None
 
         rows = self._build_price_rows(annotated)
         levels = self._build_level_rows(higher_levels) if not higher_levels.empty else []
@@ -191,11 +193,9 @@ class BeeBiteEngine:
             row = rows[i]
             timestamp = int(row.timestamp)
             price_close = float(row.close)
-            level_high: float | None = None
-            level_low: float | None = None
             while level_idx < len(levels) and int(levels[level_idx].timestamp) <= timestamp:
-                level_high = float(levels[level_idx].level_high)
-                level_low = float(levels[level_idx].level_low)
+                current_level_high = float(levels[level_idx].level_high)
+                current_level_low = float(levels[level_idx].level_low)
                 level_idx += 1
 
             if state == BeeBiteState.IDLE:
@@ -219,6 +219,14 @@ class BeeBiteEngine:
                         high_pump,
                         low_before_pump,
                     ) = pump_signal
+                    if not self._is_direction_allowed_by_htf(
+                        side=side,
+                        level_price=level_price,
+                        level_high=current_level_high,
+                        level_low=current_level_low,
+                    ):
+                        i += 1
+                        continue
                     setup = SetupContext(
                         side=side,
                         level_price=level_price,
@@ -246,15 +254,29 @@ class BeeBiteEngine:
                 elif elapsed >= window_len:
                     range_setup = self._freeze_range(rows=rows, end_idx=i, setup=setup, params=params, window_len=window_len)
                     if range_setup is not None:
-                        setup.range_low, setup.range_high, setup.core_width = range_setup
-                        setup.retest_idx = i
-                        setup.retest_timestamp = timestamp
-                        setup.break_idx = None
-                        setup.reclaim_idx = None
-                        setup.lowest_break = None
-                        setup.retest_touch_idx = None
-                        state = BeeBiteState.RANGE_LOCKED
-                        diagnostics["states"].append(state.value)
+                        range_low, range_high, core_width = range_setup
+                        if self._is_range_aligned_with_htf(
+                            side=setup.side,
+                            range_low=range_low,
+                            range_high=range_high,
+                            level_high=current_level_high,
+                            level_low=current_level_low,
+                        ):
+                            setup.range_low = range_low
+                            setup.range_high = range_high
+                            setup.core_width = core_width
+                            setup.retest_idx = i
+                            setup.retest_timestamp = timestamp
+                            setup.break_idx = None
+                            setup.reclaim_idx = None
+                            setup.lowest_break = None
+                            setup.retest_touch_idx = None
+                            state = BeeBiteState.RANGE_LOCKED
+                            diagnostics["states"].append(state.value)
+                        else:
+                            setup = None
+                            state = BeeBiteState.IDLE
+                            diagnostics["states"].append(state.value)
 
             if state == BeeBiteState.RANGE_LOCKED and setup is not None:
                 range_started_idx = setup.retest_idx if setup.retest_idx is not None else i
@@ -273,8 +295,18 @@ class BeeBiteEngine:
                     diagnostics["states"].append(state.value)
                     i += 1
                     continue
+                htf_boundary = current_level_low if setup.side == PositionSide.LONG else current_level_high
+                reclaim_reference = self._resolve_reclaim_reference(
+                    side=setup.side,
+                    boundary=boundary,
+                    htf_boundary=htf_boundary,
+                )
                 puncture_price = float(row.low) if setup.side == PositionSide.LONG else float(row.high)
-                puncture_detected = puncture_price < boundary if setup.side == PositionSide.LONG else puncture_price > boundary
+                puncture_detected = (
+                    puncture_price < boundary and puncture_price < reclaim_reference
+                    if setup.side == PositionSide.LONG
+                    else puncture_price > boundary and puncture_price > reclaim_reference
+                )
                 if puncture_detected and setup.atr_bg > 0 and setup.core_width > 0:
                     depth = abs(puncture_price - boundary)
                     min_depth = params.bite_min_depth_threshold * setup.atr_bg
@@ -295,6 +327,12 @@ class BeeBiteEngine:
                     diagnostics["states"].append(state.value)
                     i += 1
                     continue
+                htf_boundary = current_level_low if setup.side == PositionSide.LONG else current_level_high
+                reclaim_reference = self._resolve_reclaim_reference(
+                    side=setup.side,
+                    boundary=boundary,
+                    htf_boundary=htf_boundary,
+                )
                 break_price = float(row.low) if setup.side == PositionSide.LONG else float(row.high)
                 if setup.lowest_break is None:
                     setup.lowest_break = break_price
@@ -316,11 +354,13 @@ class BeeBiteEngine:
                     diagnostics["states"].append(state.value)
                 else:
                     reclaim_offset_threshold = params.bite_micro_offset * setup.atr_bg
-                    reclaim_ok = price_close > boundary if setup.side == PositionSide.LONG else price_close < boundary
+                    reclaim_ok = (
+                        price_close > reclaim_reference if setup.side == PositionSide.LONG else price_close < reclaim_reference
+                    )
                     micro_ok = (
-                        price_close > (boundary + reclaim_offset_threshold)
+                        price_close > (reclaim_reference + reclaim_offset_threshold)
                         if setup.side == PositionSide.LONG
-                        else price_close < (boundary - reclaim_offset_threshold)
+                        else price_close < (reclaim_reference - reclaim_offset_threshold)
                     )
                     if reclaim_ok and not micro_ok:
                         cooldown_bars = self._hours_to_candles(params.bite_cooldown_hours, params.entry_timeframe)
@@ -345,16 +385,16 @@ class BeeBiteEngine:
                                 retest_deadline = setup.reclaim_idx + self.CONSERVATIVE_RETEST_LIMIT
                                 setup.retest_deadline_idx = retest_deadline
                             touch_zone = (
-                                float(row.low) <= (boundary + retest_touch_offset)
+                                float(row.low) <= (reclaim_reference + retest_touch_offset)
                                 if setup.side == PositionSide.LONG
-                                else float(row.high) >= (boundary - retest_touch_offset)
+                                else float(row.high) >= (reclaim_reference - retest_touch_offset)
                             )
                             if setup.retest_touch_idx is None and touch_zone:
                                 setup.retest_touch_idx = i
                             confirm_close = (
-                                price_close > (boundary + retest_confirm_offset)
+                                price_close > (reclaim_reference + retest_confirm_offset)
                                 if setup.side == PositionSide.LONG
-                                else price_close < (boundary - retest_confirm_offset)
+                                else price_close < (reclaim_reference - retest_confirm_offset)
                             )
                             if setup.retest_touch_idx is not None and i > setup.retest_touch_idx and confirm_close:
                                 state = BeeBiteState.ENTRY_SIGNAL
@@ -370,9 +410,9 @@ class BeeBiteEngine:
                             confirm_idx = setup.reclaim_idx + params.bite_confirmation_bars
                             if i >= confirm_idx:
                                 confirm_close = (
-                                    price_close > (boundary + reclaim_offset_threshold)
+                                    price_close > (reclaim_reference + reclaim_offset_threshold)
                                     if setup.side == PositionSide.LONG
-                                    else price_close < (boundary - reclaim_offset_threshold)
+                                    else price_close < (reclaim_reference - reclaim_offset_threshold)
                                 )
                                 if confirm_close:
                                     state = BeeBiteState.ENTRY_SIGNAL
@@ -428,6 +468,42 @@ class BeeBiteEngine:
                 )
             )
         return rows
+
+    @staticmethod
+    def _resolve_reclaim_reference(*, side: PositionSide, boundary: float, htf_boundary: float | None) -> float:
+        if htf_boundary is None:
+            return boundary
+        if side == PositionSide.LONG:
+            return max(boundary, htf_boundary)
+        return min(boundary, htf_boundary)
+
+    @staticmethod
+    def _is_direction_allowed_by_htf(
+        *,
+        side: PositionSide,
+        level_price: float,
+        level_high: float | None,
+        level_low: float | None,
+    ) -> bool:
+        if level_high is None or level_low is None:
+            return True
+        if side == PositionSide.LONG:
+            return level_price <= level_low
+        return level_price >= level_high
+
+    @staticmethod
+    def _is_range_aligned_with_htf(
+        *,
+        side: PositionSide,
+        range_low: float,
+        range_high: float,
+        level_high: float | None,
+        level_low: float | None,
+    ) -> bool:
+        if level_high is None or level_low is None:
+            return True
+        anchor = level_low if side == PositionSide.LONG else level_high
+        return range_low <= anchor <= range_high
 
     def _simulate_trade(
         self,


### PR DESCRIPTION
### Motivation
- Make multi-timeframe (HTF) levels (`level_high/level_low`) actively influence entry decisions in the FSM so entries are evaluated against current HTF context instead of only on the level-update candle. 
- Keep single-TF behavior (via `generate_events()` without `higher_levels`) unchanged by using HTF checks as fallbacks when levels are absent.

### Description
- Persist `current_level_high/current_level_low` in `_run_fsm` and update them as the price loop advances instead of using ephemeral locals. 
- Add HTF-aware direction gating in `SEEK_PUMP` via ` _is_direction_allowed_by_htf` so pump signals are filtered by current HTF anchors. 
- Verify HTF anchor alignment after freezing a range in `SEEK_RANGE` via `_is_range_aligned_with_htf`, and discard the range if it is not aligned. 
- Replace puncture/reclaim checks in `RANGE_LOCKED`/`BREAK_ACTIVE` to use a unified `reclaim_reference` (combination of range boundary and HTF boundary) computed by `_resolve_reclaim_reference`. 
- Add helper static methods `_resolve_reclaim_reference`, `_is_direction_allowed_by_htf`, `_is_range_aligned_with_htf` and remove now-unused local level variables; update `strategy/bee_bite/README.md` to document how HTF levels affect inputs and fallback behavior when HTF is absent.

### Testing
- Ran `python -m py_compile strategy/bee_bite/engine.py` to verify syntax, which succeeded. 
- Performed a smoke run using `BeeBiteEngine().generate_events(...)` in a pyenv Python session with no `higher_levels` (single-TF path) and it completed successfully returning a list (no exceptions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b00729e64832088261399efc68074)