### PR TITLE
bee_bite: make bite_max_retest_depth a real stability threshold

### DIFF
--- a/strategy/bee_bite/README.md
+++ b/strategy/bee_bite/README.md
@@ -30,6 +30,7 @@ python main.py run-backtest --strategy bee_bite --bee-bite-profile A --bee-bite-
 ```
 
 - Единицы bee_bite заданы явно:
+  - `bite_max_retest_depth` — порог стабильности range в ATR (`stability_threshold` в `_freeze_range`), диапазон `(0, 2]`;
   - `bite_reclaim_limit_bars` — лимит ожидания reclaim в барах entry-TF (для портфельного режима это бары 15m);
   - `bite_cooldown_hours` и `bite_max_age_range_hours` — runtime-параметры в часах с конвертацией в бары 15m внутри `PortfolioStateEngine`.
 
@@ -48,6 +49,12 @@ BEE_BITE_GRID_MODE=baseline
 3. Для CLI-значения действует runtime-валидация `validate_bee_bite_runtime()` по диапазонам профиля (`top_n_min..top_n_max`) и доп. ограничению для `expanded` (`>= 20`).
 
 Итог: в portfolio mode источник `top_n` — сначала CLI/конфиг запуска, иначе профильный дефолт.
+
+## Приоритет порога стабильности range
+
+- В `_freeze_range` всегда используется `params.bite_max_retest_depth` как главный порог стабильности (`max(p10_last6)-min(p10_last6) <= bite_max_retest_depth * atr_bg`).
+- Профиль A/B/C задаёт только дефолт этого параметра в `BEE_BITE_PROFILE_BASELINES` (`A=0.20`, `B=0.25`, `C=0.30`).
+- Таким образом, `bite_max_retest_depth` — реальный рабочий параметр (не псевдо-поле в выводе).
 
 Основные модули реализации:
 - `strategy/bee_bite/bee_bite_strategy.py`

--- a/strategy/bee_bite/bee_bite_strategy.py
+++ b/strategy/bee_bite/bee_bite_strategy.py
@@ -154,6 +154,7 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
         )
 
     def params_to_row(self, params: BeeBiteParams) -> dict[str, int | float | str | None]:
+        """Параметры, влияющие на поведение алгоритма и отчёт оптимизации."""
         return {
             "bite_profile_id": params.bite_profile_id,
             "bite_grid_mode": params.bite_grid_mode,

--- a/strategy/bee_bite/config.py
+++ b/strategy/bee_bite/config.py
@@ -128,7 +128,7 @@ BEE_BITE_PROFILE_BASELINES: dict[BeeBiteProfileId, BeeBiteParams] = {
         bite_min_rr=3.0,
         bite_tp2_mult=2.0,
         bite_min_move_atr=0.5,
-        bite_max_retest_depth=1.0,
+        bite_max_retest_depth=0.20,
         bite_confirmation_bars=2,
         bite_entry_trigger=EntryTrigger.PRICE_CONFIRMATION,
         bite_min_depth_threshold=BEE_BITE_PROFILE_RUNTIME["A"].min_depth_threshold,
@@ -149,7 +149,7 @@ BEE_BITE_PROFILE_BASELINES: dict[BeeBiteProfileId, BeeBiteParams] = {
         bite_min_rr=3.5,
         bite_tp2_mult=2.5,
         bite_min_move_atr=0.5,
-        bite_max_retest_depth=1.0,
+        bite_max_retest_depth=0.25,
         bite_confirmation_bars=2,
         bite_entry_trigger=EntryTrigger.PRICE_CONFIRMATION,
         bite_min_depth_threshold=BEE_BITE_PROFILE_RUNTIME["B"].min_depth_threshold,
@@ -170,7 +170,7 @@ BEE_BITE_PROFILE_BASELINES: dict[BeeBiteProfileId, BeeBiteParams] = {
         bite_min_rr=2.5,
         bite_tp2_mult=1.5,
         bite_min_move_atr=0.5,
-        bite_max_retest_depth=1.0,
+        bite_max_retest_depth=0.30,
         bite_confirmation_bars=1,
         bite_entry_trigger=EntryTrigger.IMMEDIATE,
         bite_min_depth_threshold=BEE_BITE_PROFILE_RUNTIME["C"].min_depth_threshold,
@@ -382,6 +382,8 @@ def validate_bee_bite_params(params: BeeBiteParams) -> None:
         raise ValueError("параметр bite_min_rr должен быть в диапазоне (1.0, 8.0]")
     if params.bite_tp2_mult <= 1.0 or params.bite_tp2_mult > 4.0:
         raise ValueError("параметр bite_tp2_mult должен быть в диапазоне (1.0, 4.0]")
+    if params.bite_max_retest_depth <= 0.0 or params.bite_max_retest_depth > 2.0:
+        raise ValueError("параметр bite_max_retest_depth должен быть в диапазоне (0, 2]")
     if params.bite_confirmation_bars < 1 or params.bite_confirmation_bars > 6:
         raise ValueError("параметр bite_confirmation_bars должен быть в диапазоне [1, 6]")
     if params.bite_min_depth_threshold <= 0.0 or params.bite_min_depth_threshold > 1.0:

--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -95,11 +95,6 @@ class BeeBiteEngine:
         "C": 32,
     }
     FIXED_RANGE_WINDOW: int | None = None
-    PROFILE_STABILITY_THRESHOLD: dict[str, float] = {
-        "A": 0.20,
-        "B": 0.25,
-        "C": 0.30,
-    }
     PROFILE_TIME_EXIT_HOURS_NO_TP1: dict[str, int] = {
         "A": 12,
         "B": 8,
@@ -863,7 +858,7 @@ class BeeBiteEngine:
             rolling_lows = np.array([float(item.low) for item in rolling_window])
             p10_last6.append(float(np.quantile(rolling_lows, 0.10)))
 
-        stability_threshold = self.PROFILE_STABILITY_THRESHOLD.get(params.bite_profile_id, params.bite_max_retest_depth)
+        stability_threshold = params.bite_max_retest_depth
         if max(p10_last6) - min(p10_last6) > stability_threshold * atr_bg:
             return None
 


### PR DESCRIPTION
### Motivation
- Упорядочить поведение порога стабильности диапазона: параметр `bite_max_retest_depth` должен быть реальным рабочим порогом, а не «псевдо‑полем», заданным только в профилях и проигнорированным движком.
- Добавить явную валидацию диапазона для предотвращения некорректных конфигураций.

### Description
- В `strategy/bee_bite/config.py` добавлена валидация `bite_max_retest_depth` в `validate_bee_bite_params` с диапазоном `(0, 2]`.
- В `BEE_BITE_PROFILE_BASELINES` заданы осмысленные дефолты для `bite_max_retest_depth` (`A=0.20`, `B=0.25`, `C=0.30`) чтобы профиль лишь предлагал стартовое значение.
- В `strategy/bee_bite/engine.py` удалён профильный словарь `PROFILE_STABILITY_THRESHOLD` и в `_freeze_range` заменено поведение на использование `params.bite_max_retest_depth` как единого рабочего порога стабильности.
- Документация `strategy/bee_bite/README.md` синхронизирована: добавлено описание `bite_max_retest_depth`, диапазон и правило приоритета; в `BeeBiteStrategy.params_to_row` добавлен краткий docstring, указывающий что вывод содержит управляющие параметры.

### Testing
- Выполнена проверка компиляции: `python -m compileall strategy/bee_bite/config.py strategy/bee_bite/engine.py strategy/bee_bite/bee_bite_strategy.py`, компиляция прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b0207497c83209a4fd75707fbc263)