### PR TITLE
Avoid negative indexing in ATR pre-window TR calculation

### DIFF
--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -763,11 +763,15 @@ class BeeBiteEngine:
         atr_window = rows[atr_start_idx:before_pump_idx]
 
         tr_values: list[float] = []
-        for n, item in enumerate(atr_window):
-            prev_close = float(rows[atr_start_idx + n - 1].close)
+        prev_close: float | None = None
+        # Защита от look-ahead и отрицательных индексов: TR считаем только по данным внутри ATR-окна,
+        # для первой свечи окна берём её же close в качестве prev_close.
+        for item in atr_window:
+            prev_close = float(item.close) if prev_close is None else prev_close
             high = float(item.high)
             low = float(item.low)
             tr_values.append(max(high - low, abs(high - prev_close), abs(low - prev_close)))
+            prev_close = float(item.close)
         atr_pre = float(np.mean(tr_values)) if tr_values else 0.0
         if atr_pre <= 0:
             return None


### PR DESCRIPTION
### Motivation
- Prevent a possible negative index and look-ahead when computing True Range over the ATR pre-pump window in `_resolve_pump_signal`, which could reference `rows[-1]` for the first ATR candle.

### Description
- Rewrote the `tr_values` loop in `strategy/bee_bite/engine.py` `_resolve_pump_signal` to compute `prev_close` only from candles inside the ATR window and use the current candle's `close` for the first candle, removing the `rows[atr_start_idx + n - 1]` access and adding a comment that the block is protected from look-ahead.

### Testing
- Ran `python -m compileall strategy/bee_bite/engine.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b0367273c83209aa35917bcb38b0c)