### PR TITLE
Align bee_bite oi_break_avg validation and diagnostics

### DIFF
--- a/simulation/portfolio_state_engine.py
+++ b/simulation/portfolio_state_engine.py
@@ -165,8 +165,12 @@ class PortfolioStateEngine:
             "oi_break_avg_validation": {
                 "source": "upstream_feature_pipeline",
                 "required": True,
+                "min_valid_coverage": self.OI_BREAK_AVG_MIN_VALID_COVERAGE,
+                "min_valid_samples": self.OI_BREAK_AVG_MIN_VALID_SAMPLES,
                 "validated_symbols": [],
                 "skipped_symbols": {},
+                "validated_count": 0,
+                "skipped_count": 0,
             },
         }
         symbol_frames = self._filter_frames_by_oi_break_avg(symbol_frames)
@@ -221,26 +225,38 @@ class PortfolioStateEngine:
         validated: dict[str, pd.DataFrame] = {}
         diagnostics = self._last_run_diagnostics.get("oi_break_avg_validation")
         validated_symbols: list[str] = []
-        skipped_symbols: dict[str, str] = {}
+        skipped_symbols: dict[str, dict[str, float | int | str | None]] = {}
 
         for symbol, frame in symbol_frames.items():
             if "oi_break_avg" not in frame.columns:
-                skipped_symbols[symbol] = "missing_column"
+                skipped_symbols[symbol] = {
+                    "reason": "missing_column",
+                    "valid_samples": None,
+                    "sample_count": int(len(frame.index)),
+                    "coverage": None,
+                }
                 continue
 
             numeric = pd.to_numeric(frame["oi_break_avg"], errors="coerce")
             finite_positive = numeric.notna() & np.isfinite(numeric) & (numeric > 0.0)
             valid_count = int(finite_positive.sum())
-            coverage = float(valid_count / max(len(frame.index), 1))
+            sample_count = int(len(frame.index))
+            coverage = float(valid_count / max(sample_count, 1))
             if valid_count < self.OI_BREAK_AVG_MIN_VALID_SAMPLES:
-                skipped_symbols[symbol] = (
-                    f"insufficient_valid_samples:{valid_count}<{self.OI_BREAK_AVG_MIN_VALID_SAMPLES}"
-                )
+                skipped_symbols[symbol] = {
+                    "reason": "insufficient_valid_samples",
+                    "valid_samples": valid_count,
+                    "sample_count": sample_count,
+                    "coverage": coverage,
+                }
                 continue
             if coverage < self.OI_BREAK_AVG_MIN_VALID_COVERAGE:
-                skipped_symbols[symbol] = (
-                    f"low_valid_coverage:{coverage:.3f}<{self.OI_BREAK_AVG_MIN_VALID_COVERAGE:.3f}"
-                )
+                skipped_symbols[symbol] = {
+                    "reason": "low_valid_coverage",
+                    "valid_samples": valid_count,
+                    "sample_count": sample_count,
+                    "coverage": coverage,
+                }
                 continue
 
             prepared = frame.copy()
@@ -251,6 +267,8 @@ class PortfolioStateEngine:
         if isinstance(diagnostics, dict):
             diagnostics["validated_symbols"] = validated_symbols
             diagnostics["skipped_symbols"] = skipped_symbols
+            diagnostics["validated_count"] = len(validated_symbols)
+            diagnostics["skipped_count"] = len(skipped_symbols)
         return validated
 
     def consume_last_run_diagnostics(self) -> dict[str, object]:

--- a/strategy/bee_bite/README.md
+++ b/strategy/bee_bite/README.md
@@ -116,8 +116,20 @@ BEE_BITE_GRID_MODE=baseline
 - не менее `32` валидных значений (`finite && > 0`);
 - покрытие валидными значениями не ниже `0.90` по фрейму.
 
+Контракт на уровне `BeeBiteStrategy.generate_events_portfolio`:
+- если `oi_break_avg` отсутствует у **всех** подготовленных символов, выбрасывается `ValueError` с перечнем символов;
+- если колонка отсутствует только у части символов, формируется предупреждение (`RuntimeWarning`), а символы исключаются на этапе валидации engine.
+
 Если критерии не выполнены, символ пропускается до начала FSM. Причина попадает в diagnostics-флаг
-`portfolio_score.oi_break_avg_validation.skipped_symbols`.
+`portfolio_score.oi_break_avg_validation.skipped_symbols` в структурированном виде:
+- `reason`: `missing_column | insufficient_valid_samples | low_valid_coverage`;
+- `valid_samples`: число валидных значений (для `missing_column` — `null`);
+- `sample_count`: размер entry-frame;
+- `coverage`: доля валидных значений (для `missing_column` — `null`).
+
+Сводка по проверке: `validated_count`, `skipped_count`, а также пороги `min_valid_samples` и `min_valid_coverage`.
+Дополнительно в `portfolio_score.oi_break_avg_validation.precheck` сохраняется покрытие входных символов
+на уровне стратегии (`missing_column_count`, `coverage_ratio`, список символов без колонки).
 
 ### Опциональные поля и fallback
 

--- a/strategy/bee_bite/bee_bite_strategy.py
+++ b/strategy/bee_bite/bee_bite_strategy.py
@@ -78,6 +78,7 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
         params: BeeBiteParams,
     ) -> list[TradeResult]:
         entry_frames: dict[str, pd.DataFrame] = {}
+        missing_oi_symbols: list[str] = []
         for symbol, mtf in sorted(symbol_frames.items(), key=lambda item: item[0]):
             frame = self._engine.prepare_data(mtf.entry_frame)
             if frame.empty:
@@ -106,9 +107,27 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
                 "resistance",
             ]
             columns.extend(column for column in optional_columns if column in frame.columns)
+            if "oi_break_avg" not in frame.columns:
+                missing_oi_symbols.append(symbol)
             entry_frames[symbol] = frame[columns].copy()
         if not entry_frames:
             return []
+
+        if len(missing_oi_symbols) == len(entry_frames):
+            symbols_text = ", ".join(sorted(missing_oi_symbols))
+            raise ValueError(
+                "BeeBite portfolio mode requires 'oi_break_avg' in entry_frame for at least one symbol; "
+                f"missing for all prepared symbols: {symbols_text}."
+            )
+
+        if missing_oi_symbols:
+            warnings.warn(
+                "BeeBite portfolio mode: missing 'oi_break_avg' for symbols: "
+                f"{', '.join(sorted(missing_oi_symbols))}. "
+                "These symbols will be excluded during engine validation.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
         profile_id = params.bite_profile_id
         resolved_top_n = self._portfolio_top_n if self._portfolio_top_n is not None else get_bee_bite_top_n(profile_id)
@@ -129,12 +148,24 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
             slippage=0.0,
         )
         trades = engine.run(entry_frames)
+        portfolio_score_diagnostics = engine.consume_last_run_diagnostics()
+        oi_validation = portfolio_score_diagnostics.get("oi_break_avg_validation")
+        if isinstance(oi_validation, dict):
+            oi_validation.setdefault("precheck", {})
+            precheck = oi_validation["precheck"]
+            if isinstance(precheck, dict):
+                precheck["prepared_symbols"] = sorted(entry_frames.keys())
+                precheck["missing_column_symbols"] = sorted(missing_oi_symbols)
+                precheck["missing_column_count"] = len(missing_oi_symbols)
+                precheck["coverage_ratio"] = float(
+                    1.0 - (len(missing_oi_symbols) / max(len(entry_frames), 1))
+                )
         self._last_generation_diagnostics = {
             "mode": "portfolio_only",
             "profile_id": profile_id,
             "top_n": resolved_top_n,
             "score_threshold": get_bee_bite_score_threshold(profile_id).min_score,
-            "portfolio_score": engine.consume_last_run_diagnostics(),
+            "portfolio_score": portfolio_score_diagnostics,
             "trades_generated": len(trades),
         }
         return trades


### PR DESCRIPTION
### Motivation
- Согласовать поведение валидации `oi_break_avg` между уровнем стратегии и портфельным engine, чтобы пользователю было явно видно, почему символы исключаются и чтобы избежать тихого возврата пустого списка.
- Сделать диагностические данные структурированными и информативными для быстрого разбора причин отсутствия сделок по OI-фильтру.

### Description
- В `BeeBiteStrategy.generate_events_portfolio` добавлена предварительная проверка наличия `oi_break_avg` в подготовленных `entry_frame` для каждого символа, сбор списка `missing_oi_symbols`, выброс `ValueError` если колонка отсутствует у всех подготовленных символов и генерация `RuntimeWarning` если отсутствует только у части символов, а также добавление блока `precheck` в диагностике (`prepared_symbols`, `missing_column_symbols`, `missing_column_count`, `coverage_ratio`).
- В `PortfolioStateEngine` расширена секция `oi_break_avg_validation` в `self._last_run_diagnostics` с порогами `min_valid_coverage` и `min_valid_samples`, и изменена структура `skipped_symbols` на детализированный словарь с полями `reason`, `valid_samples`, `sample_count` и `coverage`, а также добавлены агрегаты `validated_count` и `skipped_count`.
- Обновлена документация `strategy/bee_bite/README.md`, чтобы описывать новый контракт поведения: обязательность/необязательность колонки на уровне стратегии, формат структурированных diagnostics и наличие `precheck` сводки.

### Testing
- Выполнена компиляция изменённых модулей командой `python -m compileall strategy/bee_bite/bee_bite_strategy.py simulation/portfolio_state_engine.py` и она завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b0627e4888320a31eadaf7e3622e1)