### PR TITLE
Apply `bite_volume_mult` pump-volume filter and sync portfolio engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ python main.py run-backtest --strategy bee_bite
 
 `--plot-from-results` автоматически читает нужные колонки под выбранную стратегию:
 - `retest` — поля `lookback`, `volume_mult`, ...
-- `bee_bite` — поля `bite_lookback`, `bite_volume_mult`, ...
+- `bee_bite` — поля `bite_lookback`, `bite_volume_mult`, ... (`bite_volume_mult` реально участвует во входе: фильтр аномального объёма в `SEEK_PUMP`).
 
 Опционально можно выбрать конкретную комбинацию через `--id`:
 - сначала ищется точное совпадение в колонках `id` / `combination_id` / `rank`;

--- a/simulation/portfolio_state_engine.py
+++ b/simulation/portfolio_state_engine.py
@@ -54,6 +54,7 @@ class PortfolioEngineConfig:
     bee_bite_profile_id: str | None = None
     bee_bite_tp1_share: float | None = None
     bee_bite_tp1_stop_buffer_pct: float = 0.001
+    bite_volume_mult: float = 1.0
 
 
 @dataclass(slots=True)
@@ -878,6 +879,21 @@ class PortfolioStateEngine:
         atr_bg_values = [float(item["atr_bg"]) for item in atr_bg_window if item.get("atr_bg") is not None and float(item["atr_bg"] or 0.0) > 0]
         atr_bg = float(np.median(atr_bg_values)) if atr_bg_values else atr_pre
         if atr_bg <= 0:
+            return None
+
+        pump_volumes = [float(item["volume"] or 0.0) for item in recent]
+        baseline_volumes = [
+            float(item["volume"] or 0.0)
+            for item in atr_bg_window
+            if item.get("volume") is not None and float(item["volume"] or 0.0) > 0.0
+        ]
+        if not pump_volumes or not baseline_volumes:
+            return None
+        baseline_volume = float(np.median(baseline_volumes))
+        if baseline_volume <= 0.0:
+            return None
+        pump_volume = float(np.mean(pump_volumes))
+        if pump_volume < (float(self.config.bite_volume_mult) * baseline_volume):
             return None
 
         recent_highs = [float(item["high"] or 0.0) for item in recent]

--- a/strategy/bee_bite/README.md
+++ b/strategy/bee_bite/README.md
@@ -37,6 +37,7 @@ python main.py run-backtest --strategy bee_bite --bee-bite-profile A --bee-bite-
 ## Параметры, которые влияют на вход и TP
 
 - `bite_min_move_atr`: в `SEEK_PUMP` сетап допускается только если импульс `up_impulse/down_impulse >= bite_min_move_atr * atr_bg` (дополнительный фильтр поверх профильного `IMPULSE_THRESHOLDS`).
+- `bite_volume_mult`: в `SEEK_PUMP` используется фильтр аномального объёма: средний объём последних `pump_window=6` свечей должен быть не меньше `bite_volume_mult * median(volume)` по rolling-базе `atr_bg_window_len=96` свечей до пампа.
 - `bite_tp2_mult`: участвует в расчёте TP2-дистанции в trade-plan как `tp2_distance = max(bite_tp2_mult * atr_bg, bite_tp2_mult * stop_distance)`.
   - fixed-TP2 доступен только если экстремум пампа покрывает эту дистанцию;
   - иначе используется fallback на trailing-цель с тем же `tp2_distance`.

--- a/strategy/bee_bite/bee_bite_strategy.py
+++ b/strategy/bee_bite/bee_bite_strategy.py
@@ -143,6 +143,7 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
                 max_age_range_bars=self._hours_to_15m_bars(params.bite_max_age_range_hours),
                 reclaim_limit_bars=params.bite_reclaim_limit_bars,
                 bee_bite_profile_id=profile_id,
+                bite_volume_mult=params.bite_volume_mult,
             ),
             commission_rate=0.0,
             slippage=0.0,

--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -63,6 +63,7 @@ class PriceRow:
     high: float
     low: float
     close: float
+    volume: float
     atr14: float
 
 
@@ -446,6 +447,7 @@ class BeeBiteEngine:
                     high=float(row.high),
                     low=float(row.low),
                     close=float(row.close),
+                    volume=float(row.volume),
                     atr14=float(row.atr14),
                 )
             )
@@ -797,6 +799,17 @@ class BeeBiteEngine:
         atr_bg_values = [float(item.atr14) for item in rows[atr_bg_start_idx:pump_start_idx]]
         atr_bg = float(np.median(atr_bg_values)) if atr_bg_values else 0.0
         if atr_bg <= 0:
+            return None
+
+        pump_volumes = [float(item.volume) for item in recent]
+        baseline_volumes = [float(item.volume) for item in rows[atr_bg_start_idx:pump_start_idx]]
+        if not pump_volumes or not baseline_volumes:
+            return None
+        baseline_volume = float(np.median(baseline_volumes))
+        if baseline_volume <= 0:
+            return None
+        pump_volume = float(np.mean(pump_volumes))
+        if pump_volume < (params.bite_volume_mult * baseline_volume):
             return None
 
         pump_highs = [float(item.high) for item in recent]


### PR DESCRIPTION
### Motivation
- `bite_volume_mult` was present in config/grid/CLI/params but never used in pump admission logic, causing mismatch between documentation and behavior.
- The portfolio-mode engine needed the same volume-based pump filter to keep single-symbol and portfolio behavior consistent.
- Documentation promised a working `bite_volume_mult` parameter, so README files required alignment with actual logic.

### Description
- Added `volume` to `PriceRow` and populated it in `_build_price_rows` to make per-candle volume available to the FSM (`strategy/bee_bite/engine.py`).
- Implemented volume-based pump filter in `BeeBiteEngine._resolve_pump_signal`: compute `pump_volume` (mean of last `pump_window=6` candles) and `baseline_volume` (median over `atr_bg_window_len=96` candles before the pump) and reject the pump if `pump_volume < params.bite_volume_mult * baseline_volume` (`strategy/bee_bite/engine.py`).
- Synchronized equivalent logic in portfolio mode by adding `bite_volume_mult` to `PortfolioEngineConfig` and applying the same pump volume check in `PortfolioStateEngine._resolve_pump_signal` (`simulation/portfolio_state_engine.py`).
- Propagated `bite_volume_mult` from `BeeBiteStrategy` into `PortfolioEngineConfig` so portfolio runs use the strategy parameter, and updated docs in `strategy/bee_bite/README.md` and root `README.md` to reflect real behavior.

### Testing
- Compiled modified modules with `python -m compileall strategy/bee_bite/engine.py simulation/portfolio_state_engine.py strategy/bee_bite/bee_bite_strategy.py` and compilation succeeded with no syntax errors.
- Repository changes were committed successfully (change set includes the engine, portfolio engine, strategy, and README updates).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b074fa7d48320a786eb1e0dcd6826)