### PR TITLE
Unify bee_bite reclaim-mode semantics across single-symbol and portfolio engines

### DIFF
--- a/simulation/portfolio_state_engine.py
+++ b/simulation/portfolio_state_engine.py
@@ -15,6 +15,7 @@ from domain.models.candle import Candle
 from domain.models.trade_result import TradeResult
 from domain.models.trade_signal import TradeSignal
 from domain.value_objects.price import Price
+from strategy.bee_bite.config import BeeBiteReclaimMode, get_bee_bite_reclaim_settings
 from strategy.bee_bite.trade_plan import build_bee_bite_trade_plan, resolve_profile_tp1_share
 from simulation.exit_manager import ExitManager, ExitManagerConfig
 from simulation.order_processor import OrderProcessor
@@ -52,6 +53,7 @@ class PortfolioEngineConfig:
     min_reclaim_pct: float = 0.001
     rr: float = 2.0
     bee_bite_profile_id: str | None = None
+    bee_bite_reclaim_mode: BeeBiteReclaimMode = "strict"
     bee_bite_tp1_share: float | None = None
     bee_bite_tp1_stop_buffer_pct: float = 0.001
     bite_volume_mult: float = 1.0
@@ -141,8 +143,6 @@ class PortfolioStateEngine:
     FIXED_RANGE_WINDOW: int | None = None
     PROFILE_STABILITY_THRESHOLD: dict[str, float] = field(default_factory=lambda: {"A": 0.20, "B": 0.25, "C": 0.30})
     PROFILE_RECLAIM_TIMEOUT: dict[str, int] = field(default_factory=lambda: {"A": 5, "B": 6, "C": 8})
-    PROFILE_RETEST_TIMEOUT: dict[str, int] = field(default_factory=lambda: {"A": 6, "B": 6, "C": 8})
-    PROFILE_MICRO_OFFSETS: dict[str, float] = field(default_factory=lambda: {"A": 0.15, "B": 0.10, "C": 0.05})
     RESET_REASONS: tuple[str, ...] = (
         "max_age_range",
         "reclaim_timeout",
@@ -426,7 +426,8 @@ class PortfolioStateEngine:
             core_width = float(
                 state.core_width if state.core_width is not None else abs(float((state.resistance or close) - support))
             )
-            emergency_break_level = support - (0.7 * core_width)
+            emergency_ratio = self._resolve_reclaim_settings().emergency_reset_ratio
+            emergency_break_level = support - (emergency_ratio * core_width)
             if low < emergency_break_level:
                 self._reset_symbol(symbol=symbol, state=state, reason="break_emergency", timeline_idx=timeline_idx)
                 return None
@@ -459,9 +460,9 @@ class PortfolioStateEngine:
             reclaim_anchor_idx = state.reclaim_bar_timeline_idx if state.reclaim_bar_timeline_idx is not None else break_start_idx
             reclaim_bars = max(timeline_idx - reclaim_anchor_idx + 1, 1)
 
-            profile = (self.config.bee_bite_profile_id or "").upper()
-            primary_reclaim_fixed = profile == "A" and state.reclaim_bar_timeline_idx is not None
-            if primary_reclaim_fixed:
+            reclaim_settings = self._resolve_reclaim_settings()
+            strict_retest_flow = reclaim_settings.retest_limit_bars > 0 and state.reclaim_bar_timeline_idx is not None
+            if strict_retest_flow:
                 if state.retest_deadline_timeline_idx is not None and timeline_idx > state.retest_deadline_timeline_idx:
                     self._reset_symbol(symbol=symbol, state=state, reason="retest_timeout", timeline_idx=timeline_idx)
                     return None
@@ -473,7 +474,8 @@ class PortfolioStateEngine:
             state.lowest_break = min(state.lowest_break or low, low)
             core_width = float(state.core_width if state.core_width is not None else abs(float((state.resistance or close) - (state.support or close))))
             support_ref = float(state.support if state.support is not None else close)
-            if low < support_ref - (0.7 * core_width):
+            emergency_ratio = self._resolve_reclaim_settings().emergency_reset_ratio
+            if low < support_ref - (emergency_ratio * core_width):
                 self._reset_symbol(symbol=symbol, state=state, reason="break_emergency", timeline_idx=timeline_idx)
                 return None
 
@@ -487,12 +489,12 @@ class PortfolioStateEngine:
 
             reclaim_confirmed = state.support is not None and close > state.support and depth >= min_depth
 
-            if profile == "A" and reclaim_confirmed and state.reclaim_bar_timeline_idx is None:
+            if reclaim_settings.retest_limit_bars > 0 and reclaim_confirmed and state.reclaim_bar_timeline_idx is None:
                 state.reclaim_bar_timeline_idx = timeline_idx
                 state.retest_deadline_timeline_idx = timeline_idx + self._resolve_retest_limit_bars()
                 state.touched_retest_zone = False
 
-            if profile == "A" and state.reclaim_bar_timeline_idx is not None:
+            if reclaim_settings.retest_limit_bars > 0 and state.reclaim_bar_timeline_idx is not None:
                 support = float(state.support if state.support is not None else close)
                 atr_ref = float(state.atr_bg if state.atr_bg is not None else 0.0)
                 zone_upper = support + (0.05 * atr_ref)
@@ -825,11 +827,7 @@ class PortfolioStateEngine:
         runtime_limit_bars = int(self.config.retest_limit_bars)
         if runtime_limit_bars > 0:
             return runtime_limit_bars
-
-        profile = (self.config.bee_bite_profile_id or "").upper()
-        if profile in self.PROFILE_RETEST_TIMEOUT:
-            return int(self.PROFILE_RETEST_TIMEOUT[profile])
-        return 6
+        return int(self._resolve_reclaim_settings().retest_limit_bars)
 
     def _resolve_range_window_len(self) -> int:
         if self.FIXED_RANGE_WINDOW is not None:
@@ -848,7 +846,13 @@ class PortfolioStateEngine:
 
     def _resolve_micro_offset(self) -> float:
         profile = (self.config.bee_bite_profile_id or "").upper()
-        return float(self.PROFILE_MICRO_OFFSETS.get(profile, 0.10))
+        mapping = {"A": 0.15, "B": 0.10, "C": 0.05}
+        profile_offset = float(mapping.get(profile, 0.10))
+        reclaim_settings = self._resolve_reclaim_settings()
+        return profile_offset * reclaim_settings.micro_offset_multiplier
+
+    def _resolve_reclaim_settings(self):
+        return get_bee_bite_reclaim_settings(self.config.bee_bite_reclaim_mode)
 
     def _resolve_pump_signal(
         self,

--- a/strategy/bee_bite/README.md
+++ b/strategy/bee_bite/README.md
@@ -34,6 +34,12 @@ python main.py run-backtest --strategy bee_bite --bee-bite-profile A --bee-bite-
   - `bite_reclaim_limit_bars` — лимит ожидания reclaim в барах entry-TF (для портфельного режима это бары 15m);
   - `bite_cooldown_hours` и `bite_max_age_range_hours` — runtime-параметры в часах с конвертацией в бары 15m внутри `PortfolioStateEngine`.
 
+- `bite_reclaim_mode` теперь детерминированно управляет reclaim-логикой через единый map `BEE_BITE_RECLAIM_SETTINGS`:
+  - `strict`: `micro_offset x1.00`, `reclaim_limit +0`, `retest_limit=6`, `emergency_reset=0.70 * core_width`;
+  - `balanced`: `micro_offset x0.75`, `reclaim_limit +1`, `retest_limit=0`, `emergency_reset=0.65 * core_width`;
+  - `aggressive`: `micro_offset x0.50`, `reclaim_limit +2`, `retest_limit=0`, `emergency_reset=0.60 * core_width`.
+
+
 ## Параметры, которые влияют на вход и TP
 
 - `bite_min_move_atr`: в `SEEK_PUMP` сетап допускается только если импульс `up_impulse/down_impulse >= bite_min_move_atr * atr_bg` (дополнительный фильтр поверх профильного `IMPULSE_THRESHOLDS`).

--- a/strategy/bee_bite/bee_bite_strategy.py
+++ b/strategy/bee_bite/bee_bite_strategy.py
@@ -143,6 +143,7 @@ class BeeBiteStrategy(BaseStrategy[BeeBiteParams]):
                 max_age_range_bars=self._hours_to_15m_bars(params.bite_max_age_range_hours),
                 reclaim_limit_bars=params.bite_reclaim_limit_bars,
                 bee_bite_profile_id=profile_id,
+                bee_bite_reclaim_mode=params.bite_reclaim_mode,
                 bite_volume_mult=params.bite_volume_mult,
             ),
             commission_rate=0.0,

--- a/strategy/bee_bite/config.py
+++ b/strategy/bee_bite/config.py
@@ -25,6 +25,14 @@ class ScoreThreshold:
     min_score: float
 
 
+@dataclass(frozen=True, slots=True)
+class BeeBiteReclaimSettings:
+    micro_offset_multiplier: float
+    reclaim_limit_delta: int
+    retest_limit_bars: int
+    emergency_reset_ratio: float
+
+
 BEE_BITE_PROFILE_SCORE_THRESHOLDS: dict[BeeBiteProfileId, ScoreThreshold] = {
     "A": ScoreThreshold(min_score=4.0),
     "B": ScoreThreshold(min_score=3.0),
@@ -35,6 +43,28 @@ BEE_BITE_PROFILE_TOP_N: dict[BeeBiteProfileId, int] = {
     "A": 5,
     "B": 10,
     "C": 20,
+}
+
+
+BEE_BITE_RECLAIM_SETTINGS: dict[BeeBiteReclaimMode, BeeBiteReclaimSettings] = {
+    "strict": BeeBiteReclaimSettings(
+        micro_offset_multiplier=1.0,
+        reclaim_limit_delta=0,
+        retest_limit_bars=6,
+        emergency_reset_ratio=0.70,
+    ),
+    "balanced": BeeBiteReclaimSettings(
+        micro_offset_multiplier=0.75,
+        reclaim_limit_delta=1,
+        retest_limit_bars=0,
+        emergency_reset_ratio=0.65,
+    ),
+    "aggressive": BeeBiteReclaimSettings(
+        micro_offset_multiplier=0.50,
+        reclaim_limit_delta=2,
+        retest_limit_bars=0,
+        emergency_reset_ratio=0.60,
+    ),
 }
 
 
@@ -371,6 +401,10 @@ def get_bee_bite_runtime(profile_id: BeeBiteProfileId) -> BeeBiteProfileRuntime:
     return BEE_BITE_PROFILE_RUNTIME[profile_id]
 
 
+def get_bee_bite_reclaim_settings(reclaim_mode: BeeBiteReclaimMode) -> BeeBiteReclaimSettings:
+    return BEE_BITE_RECLAIM_SETTINGS[reclaim_mode]
+
+
 def validate_bee_bite_params(params: BeeBiteParams) -> None:
     if params.bite_lookback < 5 or params.bite_lookback > 120:
         raise ValueError("параметр bite_lookback должен быть в диапазоне [5, 120]")
@@ -431,21 +465,11 @@ def _apply_runtime_modes(
     max_age_range_hours: int,
 ) -> BeeBiteParams:
     runtime = get_bee_bite_runtime(params.bite_profile_id)
-
-    reclaim_multiplier: dict[BeeBiteReclaimMode, float] = {
-        "strict": 1.0,
-        "balanced": 0.75,
-        "aggressive": 0.5,
-    }
-    reclaim_limit_boost: dict[BeeBiteReclaimMode, int] = {
-        "strict": 0,
-        "balanced": 1,
-        "aggressive": 2,
-    }
+    reclaim_settings = get_bee_bite_reclaim_settings(reclaim_mode)
 
     entry_trigger = EntryTrigger.IMMEDIATE if retest_mode == "immediate" else EntryTrigger.PRICE_CONFIRMATION
     confirmation_bars = 1 if retest_mode == "immediate" else max(2, params.bite_confirmation_bars)
-    min_depth = runtime.min_depth_threshold * reclaim_multiplier[reclaim_mode]
+    min_depth = runtime.min_depth_threshold * reclaim_settings.micro_offset_multiplier
 
     return replace(
         params,
@@ -456,6 +480,6 @@ def _apply_runtime_modes(
         bite_cooldown_hours=cooldown_hours,
         bite_max_age_range_hours=max_age_range_hours,
         bite_min_depth_threshold=min_depth,
-        bite_micro_offset=runtime.micro_offset * reclaim_multiplier[reclaim_mode],
-        bite_reclaim_limit_bars=runtime.reclaim_limit_bars + reclaim_limit_boost[reclaim_mode],
+        bite_micro_offset=runtime.micro_offset * reclaim_settings.micro_offset_multiplier,
+        bite_reclaim_limit_bars=runtime.reclaim_limit_bars + reclaim_settings.reclaim_limit_delta,
     )

--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -15,7 +15,7 @@ from domain.enums.trade_result_type import TradeResultType
 from domain.models.trade_result import TradeResult
 from domain.value_objects.percentage import Percentage
 from domain.value_objects.price import Price
-from strategy.bee_bite.config import BeeBiteParams, get_bee_bite_score_threshold
+from strategy.bee_bite.config import BeeBiteParams, get_bee_bite_reclaim_settings, get_bee_bite_score_threshold
 from strategy.bee_bite.trade_plan import BeeBiteTradePlan, build_bee_bite_trade_plan, resolve_profile_tp1_share
 from strategy.breakout.indicators.level_detector import LevelDetector
 from vectorbt_runner.mtf_frames import SymbolMtfFrames
@@ -82,7 +82,6 @@ class GenerationDiagnostics(TypedDict):
 
 class BeeBiteEngine:
     REQUIRED_COLUMNS = ["timestamp", "open", "high", "low", "close", "volume"]
-    CONSERVATIVE_RETEST_LIMIT = 6
     CONSERVATIVE_RETEST_TOUCH_OFFSET_ATR_BG = 0.05
     CONSERVATIVE_RETEST_CONFIRM_OFFSET_ATR_BG = 0.10
     IMPULSE_THRESHOLDS: dict[str, float] = {
@@ -316,6 +315,7 @@ class BeeBiteEngine:
                         diagnostics["states"].append(state.value)
 
             if state == BeeBiteState.BREAK_ACTIVE and setup is not None and setup.break_idx is not None:
+                reclaim_settings = get_bee_bite_reclaim_settings(params.bite_reclaim_mode)
                 boundary = setup.range_low if setup.side == PositionSide.LONG else setup.range_high
                 if boundary is None:
                     setup = None
@@ -338,7 +338,7 @@ class BeeBiteEngine:
                     setup.lowest_break = max(setup.lowest_break, break_price)
                 reclaim_limit = params.bite_reclaim_limit_bars
                 elapsed_since_break = i - setup.break_idx
-                emergency_level = 0.7 * setup.core_width
+                emergency_level = reclaim_settings.emergency_reset_ratio * setup.core_width
                 emergency_break = (
                     float(row.low) < (boundary - emergency_level)
                     if setup.side == PositionSide.LONG
@@ -368,17 +368,25 @@ class BeeBiteEngine:
                         continue
                     if setup.reclaim_idx is None and reclaim_ok and micro_ok:
                         setup.reclaim_idx = i
-                        if params.bite_retest_mode == "confirmation" and params.bite_confirmation_bars >= 2:
-                            setup.retest_deadline_idx = i + self.CONSERVATIVE_RETEST_LIMIT
+                        if (
+                            params.bite_retest_mode == "confirmation"
+                            and params.bite_confirmation_bars >= 2
+                            and reclaim_settings.retest_limit_bars > 0
+                        ):
+                            setup.retest_deadline_idx = i + reclaim_settings.retest_limit_bars
                             setup.retest_touch_idx = None
 
                     if setup.reclaim_idx is not None:
-                        if params.bite_retest_mode == "confirmation" and params.bite_confirmation_bars >= 2:
+                        if (
+                            params.bite_retest_mode == "confirmation"
+                            and params.bite_confirmation_bars >= 2
+                            and reclaim_settings.retest_limit_bars > 0
+                        ):
                             retest_touch_offset = self.CONSERVATIVE_RETEST_TOUCH_OFFSET_ATR_BG * setup.atr_bg
                             retest_confirm_offset = self.CONSERVATIVE_RETEST_CONFIRM_OFFSET_ATR_BG * setup.atr_bg
                             retest_deadline = setup.retest_deadline_idx
                             if retest_deadline is None:
-                                retest_deadline = setup.reclaim_idx + self.CONSERVATIVE_RETEST_LIMIT
+                                retest_deadline = setup.reclaim_idx + reclaim_settings.retest_limit_bars
                                 setup.retest_deadline_idx = retest_deadline
                             touch_zone = (
                                 float(row.low) <= (reclaim_reference + retest_touch_offset)


### PR DESCRIPTION
### Motivation
- Сделать поведение reclaim-логики детерминированным и управляемым одним источником коэффициентов (micro-offset, лимиты ожидания reclaim/retest, emergency-reset), чтобы профили и режимы не расходились между single-symbol и portfolio путями.
- Зафиксировать профильные коэффициенты в конфиге, чтобы режимы (strict/balanced/aggressive) однозначно влияли на рабочие параметры стратегии.
- Привести портфельный state-engine к той же семантике reclaim, чтобы выбор режима через параметры стратегии давал идентичное поведение в обоих рантаймах.

### Description
- Добавлен тип `BeeBiteReclaimSettings` и словарь `BEE_BITE_RECLAIM_SETTINGS` в `strategy/bee_bite/config.py` с полями `micro_offset_multiplier`, `reclaim_limit_delta`, `retest_limit_bars` и `emergency_reset_ratio`, и публичный геттер `get_bee_bite_reclaim_settings(...)`.
- В `_apply_runtime_modes` профиля (`strategy/bee_bite/config.py`) режим reclaim теперь детерминированно модифицирует `bite_micro_offset`, `bite_reclaim_limit_bars` и `bite_min_depth_threshold` через значения из `BEE_BITE_RECLAIM_SETTINGS`.
- В `strategy/bee_bite/engine.py` FSM использует `bite_reclaim_mode` для получения `reclaim_settings`, применяет `emergency_reset_ratio` для emergency-reset уровня и использует mode-aware `retest_limit_bars` для дедлайнов retest (ветка confirmation включается только если mode задаёт retest окно).
- В `simulation/portfolio_state_engine.py` добавлено поле `bee_bite_reclaim_mode` в `PortfolioEngineConfig`, реализован доступ к `reclaim_settings` через `_resolve_reclaim_settings()`, и та же логика emergency/retest/micro-offset применена в портфельном пути; `BeeBiteStrategy` прокидывает `params.bite_reclaim_mode` в конфиг engine.
- Обновлена документация `strategy/bee_bite/README.md` с таблицей эффектов `bite_reclaim_mode` для явного описания влияния режимов.

### Testing
- Выполнена компиляция изменённых модулей с помощью `python -m compileall strategy/bee_bite/config.py strategy/bee_bite/engine.py strategy/bee_bite/bee_bite_strategy.py simulation/portfolio_state_engine.py` и все файлы успешно скомпилировались.
- Никаких автоматических unit-тестов не добавлялось (согласно указанию).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b12ee9f048320911ddd89edc44bb5)