### PR TITLE
Fix BeeBite trade simulation exit priority ordering

### DIFF
--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -598,12 +598,6 @@ class BeeBiteEngine:
             high = float(row.high)
             close = float(row.close)
 
-            if not tp1_hit and (idx - entry_idx) >= time_exit_candles:
-                exit_price = close
-                exit_idx = idx
-                time_exit_triggered = True
-                break
-
             if setup.side == PositionSide.LONG:
                 active_stop = stop_after_tp1 if tp1_hit else stop
                 if low <= active_stop:
@@ -670,6 +664,12 @@ class BeeBiteEngine:
                         result_type = TradeResultType.TP1_BE
                         exit_idx = idx
                         break
+
+            if not tp1_hit and (idx - entry_idx) >= time_exit_candles:
+                exit_price = close
+                exit_idx = idx
+                time_exit_triggered = True
+                break
 
             exit_price = close
 


### PR DESCRIPTION
### Motivation

- Обеспечить, чтобы на каждом баре сначала обрабатывались ценовые события (SL / TP1 / TP2 / BE), и только если на этом баре не произошло более приоритетного выхода — срабатывать `time-exit`.

### Description

- Перенесена проверка `time-exit` в `BeeBiteEngine._simulate_trade` так, чтобы она выполнялась после веток `LONG`/`SHORT` (после всех проверок SL/TP1/TP2/BE) внутри цикла по барам.
- Гарантировано, что `time-exit` помечается и классифицируется (`_classify_time_exit_result`) только когда он действительно сработал (т.е. `time_exit_triggered == True`) и не перекрывается более приоритетным ценовым выходом.
- Порядок приоритетов одинаков для обеих сторон (`PositionSide.LONG` и `PositionSide.SHORT`) за счёт единого места проверки `time-exit` после общих веток обработки цены.

### Testing

- Выполнена проверка компиляции модуля через `python -m compileall strategy/bee_bite/engine.py`, ошибок компиляции не обнаружено.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b2be63b508320a93d5dca20b989c9)