### PR TITLE
Separate TP2 and protective stop handling in BeeBiteEngine._simulate_trade

### DIFF
--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -579,7 +579,11 @@ class BeeBiteEngine:
         remainder_share = 1.0 - tp1_share
 
         trailing_mode = trade_plan.trailing_mode
-        tp2_fixed = float(trade_plan.tp2) if (not trailing_mode and trade_plan.tp2 is not None) else None
+        tp2_target = float(trade_plan.tp2)
+        if setup.side == PositionSide.LONG and tp2_target <= entry_price:
+            tp2_target = entry_price + abs(tp2_target - entry_price)
+        if setup.side == PositionSide.SHORT and tp2_target >= entry_price:
+            tp2_target = entry_price - abs(tp2_target - entry_price)
         trailing_reference = entry_price
         tp1_hit = False
         stop_after_tp1 = trade_plan.be_stop
@@ -624,16 +628,16 @@ class BeeBiteEngine:
                 if tp1_hit:
                     trailing_reference = max(trailing_reference, close)
                     trailing_stop = trailing_reference - setup.atr_bg
-                    tp2_target = tp2_fixed if tp2_fixed is not None else trailing_stop
+                    active_protective_stop = max(stop_after_tp1, trailing_stop) if trailing_mode else stop_after_tp1
                     if high >= tp2_target:
                         exit_price = tp2_target
                         realized_pnl += (tp2_target - entry_price) * remainder_share * position_size
                         result_type = TradeResultType.TP2
                         exit_idx = idx
                         break
-                    if low <= stop_after_tp1:
-                        exit_price = stop_after_tp1
-                        realized_pnl += (stop_after_tp1 - entry_price) * remainder_share * position_size
+                    if low <= active_protective_stop:
+                        exit_price = active_protective_stop
+                        realized_pnl += (active_protective_stop - entry_price) * remainder_share * position_size
                         result_type = TradeResultType.TP1_BE
                         exit_idx = idx
                         break
@@ -656,16 +660,16 @@ class BeeBiteEngine:
                 if tp1_hit:
                     trailing_reference = min(trailing_reference, close)
                     trailing_stop = trailing_reference + setup.atr_bg
-                    tp2_target = tp2_fixed if tp2_fixed is not None else trailing_stop
+                    active_protective_stop = min(stop_after_tp1, trailing_stop) if trailing_mode else stop_after_tp1
                     if low <= tp2_target:
                         exit_price = tp2_target
                         realized_pnl += (entry_price - tp2_target) * remainder_share * position_size
                         result_type = TradeResultType.TP2
                         exit_idx = idx
                         break
-                    if high >= stop_after_tp1:
-                        exit_price = stop_after_tp1
-                        realized_pnl += (entry_price - stop_after_tp1) * remainder_share * position_size
+                    if high >= active_protective_stop:
+                        exit_price = active_protective_stop
+                        realized_pnl += (entry_price - active_protective_stop) * remainder_share * position_size
                         result_type = TradeResultType.TP1_BE
                         exit_idx = idx
                         break


### PR DESCRIPTION
### Motivation
- Уточнить семантику TP2 и защитного стопа в симуляции сделки, чтобы `tp2` оставался реальным тейк-уровнем из `BeeBiteTradePlan.tp2`, а не использовался как защитный стоп при trailing-режиме.
- Обеспечить корректную классификацию результатов сделки так, чтобы `TradeResultType.TP2` выставлялся только при достижении настоящего TP2, а не при срабатывании защитного/BE-стопа.
- Свести поведение симулятора в соответствие с контрактом `BeeBiteTradePlan` (поля `tp2` и `trailing_mode`).

### Description
- В `BeeBiteEngine._simulate_trade` `tp2_target` теперь инициализируется из `trade_plan.tp2` и нормализуется по направлению относительно `entry_price`, вместо подмены значением `trailing_stop` после `tp1_hit`.
- Введён `active_protective_stop`, который в trailing-режиме объединяет `trailing_stop` и `be_stop`, а в fixed-режиме равен `be_stop`, чтобы `trailing_stop` использовался только как стоп, а не как TP2.
- Уточнены проверки после `tp1_hit`: для `LONG` проверка TP2 — `high >= tp2_target` и защитный стоп — `low <= active_protective_stop`, для `SHORT` проверка TP2 — `low <= tp2_target` и защитный стоп — `high >= active_protective_stop`.
- Изменения внесены в `strategy/bee_bite/engine.py` и поведение сверено с `strategy/bee_bite/trade_plan.py`; никаких новых тестов или вспомогательных скриптов не добавлялось.
- Skills: не использовался ни один `SKILL` из `AGENTS.md` в рамках этой правки.

### Testing
- Запущена компиляция файла через `python -m compileall strategy/bee_bite/engine.py`, которая завершилась успешно.
- Изменения сохранены и зафиксированы в репозитории (код компилируется без синтаксических ошибок).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b2e4b52e48320b4ece0afc4d7d756)