### PR TITLE
Refine TP1-hit exit policy in BeeBite engine

### DIFF
--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -626,19 +626,24 @@ class BeeBiteEngine:
                     realized_pnl += (tp1 - entry_price) * tp1_share * position_size
                     trailing_reference = max(trailing_reference, close)
                 if tp1_hit:
+                    # Консервативная политика для одной свечи после TP1:
+                    # если одновременно задеты TP2 и защитный стоп, считаем,
+                    # что сначала отработал защитный стоп.
+                    # Для LONG/SHORT порядок проверок зеркален и одинаков по смыслу.
                     trailing_reference = max(trailing_reference, close)
                     trailing_stop = trailing_reference - setup.atr_bg
-                    active_protective_stop = max(stop_after_tp1, trailing_stop) if trailing_mode else stop_after_tp1
-                    if high >= tp2_target:
-                        exit_price = tp2_target
-                        realized_pnl += (tp2_target - entry_price) * remainder_share * position_size
-                        result_type = TradeResultType.TP2
+                    protective_stop_level = max(stop_after_tp1, trailing_stop) if trailing_mode else stop_after_tp1
+                    take_profit_level = tp2_target
+                    if low <= protective_stop_level:
+                        exit_price = protective_stop_level
+                        realized_pnl += (protective_stop_level - entry_price) * remainder_share * position_size
+                        result_type = TradeResultType.TP1_BE
                         exit_idx = idx
                         break
-                    if low <= active_protective_stop:
-                        exit_price = active_protective_stop
-                        realized_pnl += (active_protective_stop - entry_price) * remainder_share * position_size
-                        result_type = TradeResultType.TP1_BE
+                    if high >= take_profit_level:
+                        exit_price = take_profit_level
+                        realized_pnl += (take_profit_level - entry_price) * remainder_share * position_size
+                        result_type = TradeResultType.TP2
                         exit_idx = idx
                         break
             else:
@@ -658,19 +663,24 @@ class BeeBiteEngine:
                     realized_pnl += (entry_price - tp1) * tp1_share * position_size
                     trailing_reference = min(trailing_reference, close)
                 if tp1_hit:
+                    # Консервативная политика для одной свечи после TP1:
+                    # если одновременно задеты TP2 и защитный стоп, считаем,
+                    # что сначала отработал защитный стоп.
+                    # Для LONG/SHORT порядок проверок зеркален и одинаков по смыслу.
                     trailing_reference = min(trailing_reference, close)
                     trailing_stop = trailing_reference + setup.atr_bg
-                    active_protective_stop = min(stop_after_tp1, trailing_stop) if trailing_mode else stop_after_tp1
-                    if low <= tp2_target:
-                        exit_price = tp2_target
-                        realized_pnl += (entry_price - tp2_target) * remainder_share * position_size
-                        result_type = TradeResultType.TP2
+                    protective_stop_level = min(stop_after_tp1, trailing_stop) if trailing_mode else stop_after_tp1
+                    take_profit_level = tp2_target
+                    if high >= protective_stop_level:
+                        exit_price = protective_stop_level
+                        realized_pnl += (entry_price - protective_stop_level) * remainder_share * position_size
+                        result_type = TradeResultType.TP1_BE
                         exit_idx = idx
                         break
-                    if high >= active_protective_stop:
-                        exit_price = active_protective_stop
-                        realized_pnl += (entry_price - active_protective_stop) * remainder_share * position_size
-                        result_type = TradeResultType.TP1_BE
+                    if low <= take_profit_level:
+                        exit_price = take_profit_level
+                        realized_pnl += (entry_price - take_profit_level) * remainder_share * position_size
+                        result_type = TradeResultType.TP2
                         exit_idx = idx
                         break
 


### PR DESCRIPTION
### Motivation
- Устранить смешение семантик TP2 и защитного стопа внутри ветки `if tp1_hit:` и задать явную политику поведения при касании нескольких уровней в одной свече (консервативная/приоритет защитного стопа). 
- Обеспечить зеркальность условий LONG/SHORT и явное разделение уровней для удобства поддержки и предотвратить регрессии.

### Description
- В `BeeBiteEngine._simulate_trade` введены явные переменные `protective_stop_level` и `take_profit_level` для защиты/TP2 и использованы вместо предыдущих смешанных выражений. 
- Изменён порядок проверок при `tp1_hit`: сначала проверяется `protective_stop_level` (закрытие как `TradeResultType.TP1_BE`), затем `take_profit_level` (закрытие как `TradeResultType.TP2`), что реализует консервативную intrabar-политику. 
- Ветви для LONG и SHORT выровнены по логике и операторам сравнения (`low <= protective_stop_level` ↔ `high >= protective_stop_level`, `high >= take_profit_level` ↔ `low <= take_profit_level`). 
- Добавлены комментарии около блоков `tp1_hit`, фиксирующие политику и предотвращающие возвращение к смешению TP2 и trailing-stop.

### Testing
- Выполнена синтаксическая проверка файла `strategy/bee_bite/engine.py` командой `python -m py_compile strategy/bee_bite/engine.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b2ecd130883209a0d95baa7b14146)