### PR TITLE
Make bee_bite min stop ATR filter configurable

### DIFF
--- a/strategy/bee_bite/config.py
+++ b/strategy/bee_bite/config.py
@@ -430,6 +430,8 @@ def validate_bee_bite_params(params: BeeBiteParams) -> None:
         raise ValueError("параметр bite_max_age_range_hours должен быть в диапазоне [1, 100]")
     if params.bite_cooldown_hours < 1 or params.bite_cooldown_hours > 100:
         raise ValueError("параметр bite_cooldown_hours должен быть в диапазоне [1, 100]")
+    if params.bite_min_stop_atr_ratio <= 0.0 or params.bite_min_stop_atr_ratio > 1.0:
+        raise ValueError("параметр bite_min_stop_atr_ratio должен быть в диапазоне (0, 1]")
 
     if params.bite_entry_trigger == EntryTrigger.PRICE_CONFIRMATION and params.bite_confirmation_bars < 2:
         raise ValueError("режим reclaim (PRICE_CONFIRMATION) требует bite_confirmation_bars >= 2")

--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -550,7 +550,8 @@ class BeeBiteEngine:
         )
         if trade_plan is None:
             return None, entry_idx, False
-        if trade_plan.stop_distance < (0.3 * setup.atr_bg):
+        min_stop_ratio = params.bite_min_stop_atr_ratio
+        if trade_plan.stop_distance < (min_stop_ratio * setup.atr_bg):
             return None, entry_idx, True
 
         rr_to_tp2 = self._resolve_reward_risk(


### PR DESCRIPTION
### Motivation
- Replace a hardcoded minimum stop-distance threshold (0.3 * ATR) with a configurable parameter so the strategy can adapt to different risk profiles and align with portfolio-level settings.

### Description
- In `strategy/bee_bite/engine.py` replaced the hardcoded check `trade_plan.stop_distance < (0.3 * setup.atr_bg)` with a named local `min_stop_ratio = params.bite_min_stop_atr_ratio` and used it in the comparison `trade_plan.stop_distance < (min_stop_ratio * setup.atr_bg)` for readability.
- In `strategy/bee_bite/config.py` added validation for `bite_min_stop_atr_ratio` ensuring it is in the range `(0, 1]` to keep the filter within expected operational bounds.
- Reviewed surrounding code and adjusted the check to avoid referencing a fixed `0.3` so the behavior is driven by the parameter.

### Testing
- Compiled the modified modules with `python -m py_compile strategy/bee_bite/engine.py strategy/bee_bite/config.py` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b2fcfc12483209c53a9d3fc98c71f)