### PR TITLE
Валидация bite_t_max_in_trade (>=1) для bee_bite

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -206,6 +206,8 @@ def _build_bee_bite_params_from_row(
 ) -> BeeBiteParams:
     bite_t_max_in_trade_raw = row.get("bite_t_max_in_trade")
     bite_t_max_in_trade = None if pd.isna(bite_t_max_in_trade_raw) else int(bite_t_max_in_trade_raw)
+    if bite_t_max_in_trade is not None and bite_t_max_in_trade < 1:
+        raise ValueError("параметр bite_t_max_in_trade должен быть >= 1 или None")
     bite_reclaim_limit_raw = row.get("bite_reclaim_limit_bars")
     if pd.isna(bite_reclaim_limit_raw):
         bite_reclaim_limit_raw = row.get("bite_reclaim_limit")

--- a/strategy/bee_bite/config.py
+++ b/strategy/bee_bite/config.py
@@ -432,6 +432,8 @@ def validate_bee_bite_params(params: BeeBiteParams) -> None:
         raise ValueError("параметр bite_cooldown_hours должен быть в диапазоне [1, 100]")
     if params.bite_min_stop_atr_ratio <= 0.0 or params.bite_min_stop_atr_ratio > 1.0:
         raise ValueError("параметр bite_min_stop_atr_ratio должен быть в диапазоне (0, 1]")
+    if params.bite_t_max_in_trade is not None and params.bite_t_max_in_trade < 1:
+        raise ValueError("параметр bite_t_max_in_trade должен быть >= 1 или None")
 
     if params.bite_entry_trigger == EntryTrigger.PRICE_CONFIRMATION and params.bite_confirmation_bars < 2:
         raise ValueError("режим reclaim (PRICE_CONFIRMATION) требует bite_confirmation_bars >= 2")

--- a/strategy/bee_bite/engine.py
+++ b/strategy/bee_bite/engine.py
@@ -595,6 +595,8 @@ class BeeBiteEngine:
 
         limit = len(rows) - 1
         if params.bite_t_max_in_trade is not None:
+            # Основной контроль диапазона делается в validate_bee_bite_params;
+            # max(1, ...) оставляем только как safety-net на уровне исполнения.
             limit = min(limit, entry_idx + max(1, params.bite_t_max_in_trade))
 
         result_type = TradeResultType.BE


### PR DESCRIPTION
### Motivation
- Убедиться, что параметр `bite_t_max_in_trade` при передаче из таблиц и в runtime не может принимать некорректные значения (< 1), и чтобы ошибки появлялись на этапе валидации, а не глубже в исполнении.

### Description
- Добавлена явная проверка в `validate_bee_bite_params` (`strategy/bee_bite/config.py`), которая выбрасывает `ValueError` с понятным сообщением, если `bite_t_max_in_trade is not None` и `< 1`.
- В `BeeBiteEngine._try_open_trade` (`strategy/bee_bite/engine.py`) оставлен `max(1, ...)` только как safety-net и добавлен комментарий, что основной отбор некорректных значений происходит на этапе валидации.
- Ужесточен путь сборки параметров из таблицы в `cli/commands.py` в `_build_bee_bite_params_from_row`, при этом поведение для пустых/NaN значений сохранено (`NaN -> None`), а числовые значения `< 1` теперь отсекаются с тем же `ValueError`.

### Testing
- Выполнена компиляция изменённых модулей командой `python -m compileall strategy/bee_bite/config.py strategy/bee_bite/engine.py cli/commands.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b30a553848320b255a347377d2918)