### PR TITLE
Fix bee_bite retest depth validation check

### DIFF
--- a/strategy/bee_bite/config.py
+++ b/strategy/bee_bite/config.py
@@ -416,7 +416,7 @@ def validate_bee_bite_params(params: BeeBiteParams) -> None:
         raise ValueError("параметр bite_min_rr должен быть в диапазоне (1.0, 8.0]")
     if params.bite_tp2_mult <= 1.0 or params.bite_tp2_mult > 4.0:
         raise ValueError("параметр bite_tp2_mult должен быть в диапазоне (1.0, 4.0]")
-    if params.bite_max_retest_depth <= 0.0 or params.bite_max_retest_depth > 2.0:
+    if not 0.0 < params.bite_max_retest_depth <= 2.0:
         raise ValueError("параметр bite_max_retest_depth должен быть в диапазоне (0, 2]")
     if params.bite_confirmation_bars < 1 or params.bite_confirmation_bars > 6:
         raise ValueError("параметр bite_confirmation_bars должен быть в диапазоне [1, 6]")


### PR DESCRIPTION
### Motivation
- Ensure the `bite_max_retest_depth` validation is expressed as a single clear condition and remove potential duplicated/unreachable checks while keeping surrounding validations consistent.

### Description
- Replace the previous conditional with a single range check `not 0.0 < params.bite_max_retest_depth <= 2.0` and keep the single `raise ValueError("параметр bite_max_retest_depth должен быть в диапазоне (0, 2]")`, and review adjacent validation blocks for similar duplicates.

### Testing
- Ran `python -m py_compile strategy/bee_bite/config.py` which succeeded, and used `rg` to verify there are no duplicate `raise` lines for this parameter in `strategy/bee_bite/config.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b37868b408320bfeebdd82e32353d)