### PR TITLE
Add broader Bee Bite parameter grid via new research mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ python main.py run-backtest --strategy bee_bite
 
 Для `bee_bite` доступны профиль, сетка и runtime-режимы:
 - `--bee-bite-profile {A,B,C}` — фиксированный baseline-профиль;
-- `--bee-bite-grid {baseline,expanded}` — baseline (узкий) или controlled-grid (широкий) вокруг baseline;
+- `--bee-bite-grid {baseline,expanded,research}` — baseline (узкий), expanded (широкий) или research (максимально широкий) вокруг baseline;
 - `--bee-bite-reclaim-mode {strict,balanced,aggressive}` — меняет reclaim-offset и лимит ожидания reclaim в **барах 15m** внутри движка;
 - `--bee-bite-retest-mode {confirmation,immediate}` — выбирает механику входа (подтверждение или мгновенный вход после reclaim);
 - `--bee-bite-cooldown-hours` и `--bee-bite-max-age-range-hours` задаются в **часах**, затем внутри портфельного движка переводятся в бары 15m; в `backtest_results.csv` сохраняются как `bite_cooldown_hours`/`bite_max_age_range_hours` (старые алиасы CLI сохранены для совместимости).
@@ -363,4 +363,5 @@ python main.py run-backtest --strategy bee_bite --bee-bite-profile A --bee-bite-
 
 ```bash
 python main.py run-backtest --strategy bee_bite --bee-bite-profile A --bee-bite-grid expanded --top-n 100
+python main.py run-backtest --strategy bee_bite --bee-bite-profile C --bee-bite-grid research --top-n 120
 ```

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -95,9 +95,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     run_bt.add_argument(
         "--bee-bite-grid",
-        choices=["baseline", "expanded"],
+        choices=["baseline", "expanded", "research"],
         default=None,
-        help="Режим сетки bee_bite: baseline (узкий) или expanded (широкий).",
+        help="Режим сетки bee_bite: baseline (узкий), expanded (широкий) или research (максимально широкий).",
     )
     run_bt.add_argument(
         "--bee-bite-reclaim-mode",

--- a/strategy/bee_bite/README.md
+++ b/strategy/bee_bite/README.md
@@ -22,13 +22,14 @@ python main.py run-backtest --strategy bee_bite --top-n 50
 ## Профиль и сетка
 
 - `--bee-bite-profile {A,B,C}` — выбор baseline-профиля.
-- `--bee-bite-grid {baseline,expanded}` — узкая или расширенная сетка параметров.
+- `--bee-bite-grid {baseline,expanded,research}` — узкая, расширенная или research-сетка параметров.
 
 Примеры:
 
 ```bash
 python main.py run-backtest --strategy bee_bite --bee-bite-profile A --bee-bite-grid baseline --top-n 50
 python main.py run-backtest --strategy bee_bite --bee-bite-profile A --bee-bite-grid expanded --top-n 100
+python main.py run-backtest --strategy bee_bite --bee-bite-profile C --bee-bite-grid research --top-n 120
 ```
 
 - Единицы bee_bite заданы явно:
@@ -66,7 +67,7 @@ BEE_BITE_GRID_MODE=baseline
 
 1. Если передан `--top-n` в `run-backtest`, это значение прокидывается в `BeeBiteStrategy` и затем в `PortfolioEngineConfig(top_n=...)`.
 2. Если `--top-n` не передан, используется профильный fallback из `BEE_BITE_PROFILE_TOP_N` (`A=5`, `B=10`, `C=20`).
-3. Для CLI-значения действует runtime-валидация `validate_bee_bite_runtime()` по диапазонам профиля (`top_n_min..top_n_max`) и доп. ограничению для `expanded` (`>= 20`).
+3. Для CLI-значения действует runtime-валидация `validate_bee_bite_runtime()` по диапазонам профиля (`top_n_min..top_n_max`) и доп. ограничению для `expanded` (`>= 20`) и `research` (`>= 30`).
 
 Итог: в portfolio mode источник `top_n` — сначала CLI/конфиг запуска, иначе профильный дефолт.
 

--- a/strategy/bee_bite/config.py
+++ b/strategy/bee_bite/config.py
@@ -10,12 +10,12 @@ from domain.enums.entry_trigger import EntryTrigger
 from domain.enums.timeframe import Timeframe
 
 BeeBiteProfileId = Literal["A", "B", "C"]
-BeeBiteGridMode = Literal["baseline", "expanded"]
+BeeBiteGridMode = Literal["baseline", "expanded", "research"]
 BeeBiteReclaimMode = Literal["strict", "balanced", "aggressive"]
 BeeBiteRetestMode = Literal["confirmation", "immediate"]
 
 BEE_BITE_PROFILE_IDS: tuple[BeeBiteProfileId, ...] = ("A", "B", "C")
-BEE_BITE_GRID_MODES: tuple[BeeBiteGridMode, ...] = ("baseline", "expanded")
+BEE_BITE_GRID_MODES: tuple[BeeBiteGridMode, ...] = ("baseline", "expanded", "research")
 BEE_BITE_RECLAIM_MODES: tuple[BeeBiteReclaimMode, ...] = ("strict", "balanced", "aggressive")
 BEE_BITE_RETEST_MODES: tuple[BeeBiteRetestMode, ...] = ("confirmation", "immediate")
 
@@ -226,6 +226,18 @@ BEE_BITE_EXTENDED_GRID_OFFSETS: dict[str, tuple[int | float | EntryTrigger, ...]
     "bite_entry_trigger": (EntryTrigger.IMMEDIATE, EntryTrigger.PRICE_CONFIRMATION),
 }
 
+BEE_BITE_RESEARCH_GRID_OFFSETS: dict[str, tuple[int | float | EntryTrigger, ...]] = {
+    "bite_lookback": (-8, -4, 0, 4, 8),
+    "bite_volume_mult": (-0.5, -0.25, 0.0, 0.25, 0.5),
+    "bite_retest_window_hours": (-18, -9, 0, 9, 18),
+    "bite_min_rr": (-0.75, -0.35, 0.0, 0.35, 0.75),
+    "bite_tp2_mult": (-0.75, -0.35, 0.0, 0.35, 0.75),
+    "bite_min_move_atr": (-0.2, -0.1, 0.0, 0.1, 0.2),
+    "bite_max_retest_depth": (-0.10, -0.05, 0.0, 0.05, 0.10),
+    "bite_confirmation_bars": (-1, 0, 1),
+    "bite_entry_trigger": (EntryTrigger.IMMEDIATE, EntryTrigger.PRICE_CONFIRMATION),
+}
+
 
 def parse_bee_bite_profile_id(raw_value: str | None, *, default: BeeBiteProfileId = "A") -> BeeBiteProfileId:
     profile = (raw_value or default).strip().upper()
@@ -286,27 +298,33 @@ def build_bee_bite_grid(
     if grid_mode == "baseline":
         return [baseline]
 
-    lookbacks = _numeric_candidates(baseline.bite_lookback, BEE_BITE_EXTENDED_GRID_OFFSETS["bite_lookback"])
-    volume_mult = _numeric_candidates(baseline.bite_volume_mult, BEE_BITE_EXTENDED_GRID_OFFSETS["bite_volume_mult"])
+    offsets_map = BEE_BITE_EXTENDED_GRID_OFFSETS if grid_mode == "expanded" else BEE_BITE_RESEARCH_GRID_OFFSETS
+
+    lookbacks = _numeric_candidates(baseline.bite_lookback, offsets_map["bite_lookback"])
+    volume_mult = _numeric_candidates(baseline.bite_volume_mult, offsets_map["bite_volume_mult"])
     retest_windows = _numeric_candidates(
         baseline.bite_retest_window_hours,
-        BEE_BITE_EXTENDED_GRID_OFFSETS["bite_retest_window_hours"],
+        offsets_map["bite_retest_window_hours"],
     )
-    min_rr = _numeric_candidates(baseline.bite_min_rr, BEE_BITE_EXTENDED_GRID_OFFSETS["bite_min_rr"])
-    tp2_mult = _numeric_candidates(baseline.bite_tp2_mult, BEE_BITE_EXTENDED_GRID_OFFSETS["bite_tp2_mult"])
+    min_rr = _numeric_candidates(baseline.bite_min_rr, offsets_map["bite_min_rr"])
+    tp2_mult = _numeric_candidates(baseline.bite_tp2_mult, offsets_map["bite_tp2_mult"])
+    min_move_atr = _numeric_candidates(baseline.bite_min_move_atr, offsets_map["bite_min_move_atr"])
+    max_retest_depth = _numeric_candidates(baseline.bite_max_retest_depth, offsets_map["bite_max_retest_depth"])
     confirmation_bars = _numeric_candidates(
         baseline.bite_confirmation_bars,
-        BEE_BITE_EXTENDED_GRID_OFFSETS["bite_confirmation_bars"],
+        offsets_map["bite_confirmation_bars"],
     )
-    entry_triggers = tuple(BEE_BITE_EXTENDED_GRID_OFFSETS["bite_entry_trigger"])
+    entry_triggers = tuple(offsets_map["bite_entry_trigger"])
 
     combinations: list[BeeBiteParams] = []
-    for lb, vm, rw, rr, tp2, confirm_bars, trigger in product(
+    for lb, vm, rw, rr, tp2, mma, mrd, confirm_bars, trigger in product(
         lookbacks,
         volume_mult,
         retest_windows,
         min_rr,
         tp2_mult,
+        min_move_atr,
+        max_retest_depth,
         confirmation_bars,
         entry_triggers,
     ):
@@ -317,9 +335,11 @@ def build_bee_bite_grid(
             bite_retest_window_hours=int(rw),
             bite_min_rr=float(rr),
             bite_tp2_mult=float(tp2),
+            bite_min_move_atr=float(mma),
+            bite_max_retest_depth=float(mrd),
             bite_confirmation_bars=int(confirm_bars),
             bite_entry_trigger=trigger,
-            bite_grid_mode="expanded",
+            bite_grid_mode=grid_mode,
         )
         try:
             validate_bee_bite_params(params)
@@ -387,6 +407,8 @@ def validate_bee_bite_runtime(
         )
     if grid_mode == "expanded" and top_n < max(20, runtime.top_n_min):
         raise ValueError("для bee_bite в режиме expanded параметр --top-n должен быть >= 20")
+    if grid_mode == "research" and top_n < max(30, runtime.top_n_min):
+        raise ValueError("для bee_bite в режиме research параметр --top-n должен быть >= 30")
 
 
 def get_bee_bite_score_threshold(profile_id: BeeBiteProfileId) -> ScoreThreshold:


### PR DESCRIPTION
## Summary
- added new `bee_bite` grid mode: `research`
- extended Bee Bite grid generation to sweep additional parameters in non-baseline modes:
  - `bite_min_move_atr`
  - `bite_max_retest_depth`
  - plus existing lookback/volume/retest-window/min-rr/tp2/confirmation/entry-trigger
- made `build_bee_bite_grid()` route offsets by mode:
  - `expanded` keeps current controlled offsets
  - `research` uses wider offsets for broader optimization search
- updated runtime validation with stricter guard for broad search:
  - `research` requires `top-n >= 30`

## CLI / docs
- CLI now accepts `--bee-bite-grid research`
- updated root README and `strategy/bee_bite/README.md` to document the new mode and example usage

## Why
User requested a wider Bee Bite parameter grid to run analysis and select stronger parameter combinations from a broader search space.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b386b96088320a7e3d7f9418da8a0)