### PR TITLE
Добавлен готовый CSV с checkpoint-кейсами bee_bite и команда запуска analyze-cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,18 @@ CACHE_DIR=./cache
 
 `cache/results/backtest_results.csv`
 
+Пример файла с контрольными точками для `bee_bite` (монета + ТФ + момент времени + ожидаемое решение):
+
+`examples/bee_bite_checkpoints.csv`
+
+Запуск `analyze-cache` по всем монетам из этого файла:
+
+```bash
+python launcher.py --mode analyze-cache --strategy bee_bite --symbols $(python -c "import csv; from pathlib import Path; p=Path('examples/bee_bite_checkpoints.csv'); rows=csv.DictReader(p.open(encoding='utf-8')); print(' '.join(dict.fromkeys(r['symbol'] for r in rows if r.get('symbol'))))")
+```
+
+
+
 ---
 
 ### 3) Как обработать результат

--- a/examples/bee_bite_checkpoints.csv
+++ b/examples/bee_bite_checkpoints.csv
@@ -1,0 +1,4 @@
+case_id,symbol,levels_tf,entry_tf,datetime_utc,timestamp_ms,expected_decision,expected_reason,comment
+BB-001,BTC/USDT,1d,15m,2025-01-14T12:45:00Z,1736858700000,setup,entry_signal,"Позитивный кейс"
+BB-002,ETH/USDT,1d,15m,2025-01-16T09:30:00Z,1737019800000,skip,retest_timeout,"Ретест не подтвердился"
+BB-003,SOL/USDT,1d,15m,2025-01-18T18:15:00Z,1737224100000,skip,volume_filter_fail,"Нет аномального объёма"


### PR DESCRIPTION
## Что сделано
- Добавлен готовый шаблон файла `examples/bee_bite_checkpoints.csv`.
- Формат файла: `case_id,symbol,levels_tf,entry_tf,datetime_utc,timestamp_ms,expected_decision,expected_reason,comment`.
- В `README.md` добавлен раздел с ссылкой на файл и готовой командой запуска `analyze-cache` по монетам из этого CSV.

## Зачем
Пользователь может быстро заносить примеры в удобном табличном формате и запускать анализ по тем же монетам без ручного перечисления `--symbols`.

## Примечание
Команда из README берет из файла список уникальных символов. Поля времени/ожидаемого решения остаются в CSV для последующей ручной/скриптовой сверки результатов.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b405861e883209322bd9b63a56fa4)