### PR TITLE
Bee Bite: убрать выбор профиля A/B/C и использовать полную сетку

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,8 +298,7 @@ python main.py run-backtest --strategy bee_bite
 
 `--strategy breakout` поддерживается как alias для `retest`.
 
-Для `bee_bite` доступны профиль, сетка и runtime-режимы:
-- `--bee-bite-profile {A,B,C}` — фиксированный baseline-профиль;
+Для `bee_bite` доступны режим сетки и runtime-параметры:
 - `--bee-bite-grid {baseline,expanded,research}` — baseline (узкий), expanded (широкий) или research (максимально широкий) вокруг baseline;
 - `--bee-bite-reclaim-mode {strict,balanced,aggressive}` — меняет reclaim-offset и лимит ожидания reclaim в **барах 15m** внутри движка;
 - `--bee-bite-retest-mode {confirmation,immediate}` — выбирает механику входа (подтверждение или мгновенный вход после reclaim);
@@ -308,7 +307,6 @@ python main.py run-backtest --strategy bee_bite
 Переменные окружения для `bee_bite`:
 
 ```env
-BEE_BITE_PROFILE=A
 BEE_BITE_GRID_MODE=baseline
 BEE_BITE_COOLDOWN_HOURS=8
 BEE_BITE_MAX_AGE_RANGE_HOURS=12
@@ -365,15 +363,15 @@ python main.py clear-cache
 
 ## Сценарии запуска Bee Bite
 
-Узкий baseline (один валидный профиль):
+Узкая baseline-сетка (базовые точки по всем режимам):
 
 ```bash
-python main.py run-backtest --strategy bee_bite --bee-bite-profile A --bee-bite-grid baseline --top-n 50
+python main.py run-backtest --strategy bee_bite --bee-bite-grid baseline --top-n 50
 ```
 
-Широкая controlled-сетка вокруг профиля:
+Широкая controlled-сетка:
 
 ```bash
-python main.py run-backtest --strategy bee_bite --bee-bite-profile A --bee-bite-grid expanded --top-n 100
-python main.py run-backtest --strategy bee_bite --bee-bite-profile C --bee-bite-grid research --top-n 120
+python main.py run-backtest --strategy bee_bite --bee-bite-grid expanded --top-n 100
+python main.py run-backtest --strategy bee_bite --bee-bite-grid research --top-n 120
 ```

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -1132,10 +1132,6 @@ def _run_backtest_inner(config: AppConfig, args: argparse.Namespace) -> int:
     config.backtest.results_dir = _resolve_results_dir_for_strategy(config.backtest.results_dir, strategy_id)
 
     if strategy_id == "bee_bite":
-        config.strategy.bee_bite_profile = parse_bee_bite_profile_id(
-            getattr(args, "bee_bite_profile", None),
-            default=config.strategy.bee_bite_profile,
-        )
         profile_runtime = get_bee_bite_runtime(config.strategy.bee_bite_profile)
         config.strategy.bee_bite_grid_mode = parse_bee_bite_grid_mode(
             getattr(args, "bee_bite_grid", None),

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -88,12 +88,6 @@ def build_parser() -> argparse.ArgumentParser:
         help="Идентификатор стратегии (breakout = alias для retest). Приоритетнее STRATEGY_ID из env",
     )
     run_bt.add_argument(
-        "--bee-bite-profile",
-        choices=["A", "B", "C"],
-        default=None,
-        help="Профиль bee_bite (A/B/C). Используется как baseline.",
-    )
-    run_bt.add_argument(
         "--bee-bite-grid",
         choices=["baseline", "expanded", "research"],
         default=None,
@@ -103,13 +97,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--bee-bite-reclaim-mode",
         choices=["strict", "balanced", "aggressive"],
         default=None,
-        help="Режим reclaim в bee_bite: влияет на глубину reclaim/offset и лимит ожидания reclaim в барах 15m (валидируется профилем).",
+        help="Режим reclaim в bee_bite: влияет на глубину reclaim/offset и лимит ожидания reclaim в барах 15m.",
     )
     run_bt.add_argument(
         "--bee-bite-retest-mode",
         choices=["confirmation", "immediate"],
         default=None,
-        help="Режим retest в bee_bite: immediate=мгновенный вход, confirmation=вход после подтверждения (валидируется профилем).",
+        help="Режим retest в bee_bite: immediate=мгновенный вход, confirmation=вход после подтверждения.",
     )
     run_bt.add_argument(
         "--bee-bite-cooldown-hours",

--- a/strategy/bee_bite/README.md
+++ b/strategy/bee_bite/README.md
@@ -21,15 +21,14 @@ python main.py run-backtest --strategy bee_bite --top-n 50
 
 ## Профиль и сетка
 
-- `--bee-bite-profile {A,B,C}` — выбор baseline-профиля.
 - `--bee-bite-grid {baseline,expanded,research}` — узкая, расширенная или research-сетка параметров.
 
 Примеры:
 
 ```bash
-python main.py run-backtest --strategy bee_bite --bee-bite-profile A --bee-bite-grid baseline --top-n 50
-python main.py run-backtest --strategy bee_bite --bee-bite-profile A --bee-bite-grid expanded --top-n 100
-python main.py run-backtest --strategy bee_bite --bee-bite-profile C --bee-bite-grid research --top-n 120
+python main.py run-backtest --strategy bee_bite --bee-bite-grid baseline --top-n 50
+python main.py run-backtest --strategy bee_bite --bee-bite-grid expanded --top-n 100
+python main.py run-backtest --strategy bee_bite --bee-bite-grid research --top-n 120
 ```
 
 - Единицы bee_bite заданы явно:
@@ -58,7 +57,6 @@ python main.py run-backtest --strategy bee_bite --bee-bite-profile C --bee-bite-
 Переменные окружения:
 
 ```env
-BEE_BITE_PROFILE=A
 BEE_BITE_GRID_MODE=baseline
 ```
 
@@ -66,10 +64,10 @@ BEE_BITE_GRID_MODE=baseline
 ## Как определяется итоговый `top_n` в portfolio mode
 
 1. Если передан `--top-n` в `run-backtest`, это значение прокидывается в `BeeBiteStrategy` и затем в `PortfolioEngineConfig(top_n=...)`.
-2. Если `--top-n` не передан, используется профильный fallback из `BEE_BITE_PROFILE_TOP_N` (`A=5`, `B=10`, `C=20`).
-3. Для CLI-значения действует runtime-валидация `validate_bee_bite_runtime()` по диапазонам профиля (`top_n_min..top_n_max`) и доп. ограничению для `expanded` (`>= 20`) и `research` (`>= 30`).
+2. Если `--top-n` не передан, используется fallback из `BEE_BITE_PROFILE_TOP_N` для текущего runtime-конфига.
+3. Для CLI-значения действует runtime-валидация `validate_bee_bite_runtime()` по общему диапазону и доп. ограничению для `expanded` (`>= 20`) и `research` (`>= 30`).
 
-Итог: в portfolio mode источник `top_n` — сначала CLI/конфиг запуска, иначе профильный дефолт.
+Итог: в portfolio mode источник `top_n` — сначала CLI/конфиг запуска, иначе дефолт runtime-конфига.
 
 ## Приоритет порога стабильности range
 

--- a/strategy/bee_bite/config.py
+++ b/strategy/bee_bite/config.py
@@ -288,64 +288,69 @@ def build_bee_bite_grid(
     cooldown_hours: int,
     max_age_range_hours: int,
 ) -> list[BeeBiteParams]:
-    baseline = _apply_runtime_modes(
-        params=BEE_BITE_PROFILE_BASELINES[profile_id],
-        reclaim_mode=reclaim_mode,
-        retest_mode=retest_mode,
-        cooldown_hours=cooldown_hours,
-        max_age_range_hours=max_age_range_hours,
-    )
+    _ = profile_id
+    baselines = [
+        _apply_runtime_modes(
+            params=BEE_BITE_PROFILE_BASELINES[current_profile_id],
+            reclaim_mode=reclaim_mode,
+            retest_mode=retest_mode,
+            cooldown_hours=cooldown_hours,
+            max_age_range_hours=max_age_range_hours,
+        )
+        for current_profile_id in BEE_BITE_PROFILE_IDS
+    ]
     if grid_mode == "baseline":
-        return [baseline]
+        return baselines
 
     offsets_map = BEE_BITE_EXTENDED_GRID_OFFSETS if grid_mode == "expanded" else BEE_BITE_RESEARCH_GRID_OFFSETS
-
-    lookbacks = _numeric_candidates(baseline.bite_lookback, offsets_map["bite_lookback"])
-    volume_mult = _numeric_candidates(baseline.bite_volume_mult, offsets_map["bite_volume_mult"])
-    retest_windows = _numeric_candidates(
-        baseline.bite_retest_window_hours,
-        offsets_map["bite_retest_window_hours"],
-    )
-    min_rr = _numeric_candidates(baseline.bite_min_rr, offsets_map["bite_min_rr"])
-    tp2_mult = _numeric_candidates(baseline.bite_tp2_mult, offsets_map["bite_tp2_mult"])
-    min_move_atr = _numeric_candidates(baseline.bite_min_move_atr, offsets_map["bite_min_move_atr"])
-    max_retest_depth = _numeric_candidates(baseline.bite_max_retest_depth, offsets_map["bite_max_retest_depth"])
-    confirmation_bars = _numeric_candidates(
-        baseline.bite_confirmation_bars,
-        offsets_map["bite_confirmation_bars"],
-    )
-    entry_triggers = tuple(offsets_map["bite_entry_trigger"])
-
     combinations: list[BeeBiteParams] = []
-    for lb, vm, rw, rr, tp2, mma, mrd, confirm_bars, trigger in product(
-        lookbacks,
-        volume_mult,
-        retest_windows,
-        min_rr,
-        tp2_mult,
-        min_move_atr,
-        max_retest_depth,
-        confirmation_bars,
-        entry_triggers,
-    ):
-        params = replace(
-            baseline,
-            bite_lookback=int(lb),
-            bite_volume_mult=float(vm),
-            bite_retest_window_hours=int(rw),
-            bite_min_rr=float(rr),
-            bite_tp2_mult=float(tp2),
-            bite_min_move_atr=float(mma),
-            bite_max_retest_depth=float(mrd),
-            bite_confirmation_bars=int(confirm_bars),
-            bite_entry_trigger=trigger,
-            bite_grid_mode=grid_mode,
+
+    for baseline in baselines:
+        lookbacks = _numeric_candidates(baseline.bite_lookback, offsets_map["bite_lookback"])
+        volume_mult = _numeric_candidates(baseline.bite_volume_mult, offsets_map["bite_volume_mult"])
+        retest_windows = _numeric_candidates(
+            baseline.bite_retest_window_hours,
+            offsets_map["bite_retest_window_hours"],
         )
-        try:
-            validate_bee_bite_params(params)
-        except ValueError:
-            continue
-        combinations.append(params)
+        min_rr = _numeric_candidates(baseline.bite_min_rr, offsets_map["bite_min_rr"])
+        tp2_mult = _numeric_candidates(baseline.bite_tp2_mult, offsets_map["bite_tp2_mult"])
+        min_move_atr = _numeric_candidates(baseline.bite_min_move_atr, offsets_map["bite_min_move_atr"])
+        max_retest_depth = _numeric_candidates(baseline.bite_max_retest_depth, offsets_map["bite_max_retest_depth"])
+        confirmation_bars = _numeric_candidates(
+            baseline.bite_confirmation_bars,
+            offsets_map["bite_confirmation_bars"],
+        )
+        entry_triggers = tuple(offsets_map["bite_entry_trigger"])
+
+        for lb, vm, rw, rr, tp2, mma, mrd, confirm_bars, trigger in product(
+            lookbacks,
+            volume_mult,
+            retest_windows,
+            min_rr,
+            tp2_mult,
+            min_move_atr,
+            max_retest_depth,
+            confirmation_bars,
+            entry_triggers,
+        ):
+            params = replace(
+                baseline,
+                bite_lookback=int(lb),
+                bite_volume_mult=float(vm),
+                bite_retest_window_hours=int(rw),
+                bite_min_rr=float(rr),
+                bite_tp2_mult=float(tp2),
+                bite_min_move_atr=float(mma),
+                bite_max_retest_depth=float(mrd),
+                bite_confirmation_bars=int(confirm_bars),
+                bite_entry_trigger=trigger,
+                bite_grid_mode=grid_mode,
+            )
+            try:
+                validate_bee_bite_params(params)
+            except ValueError:
+                continue
+            combinations.append(params)
 
     return combinations
 
@@ -365,32 +370,10 @@ def validate_bee_bite_runtime(
     if grid_mode not in BEE_BITE_GRID_MODES:
         raise ValueError(f"Неподдерживаемый режим сетки bee_bite: {grid_mode}")
 
-    runtime = BEE_BITE_PROFILE_RUNTIME[profile_id]
-
     if reclaim_mode not in BEE_BITE_RECLAIM_MODES:
         raise ValueError(f"Неподдерживаемый reclaim-режим bee_bite: {reclaim_mode}")
     if retest_mode not in BEE_BITE_RETEST_MODES:
         raise ValueError(f"Неподдерживаемый retest-режим bee_bite: {retest_mode}")
-    allowed_reclaim_by_profile: dict[BeeBiteProfileId, tuple[BeeBiteReclaimMode, ...]] = {
-        "A": ("strict",),
-        "B": ("strict", "balanced"),
-        "C": ("balanced", "aggressive"),
-    }
-    allowed_retest_by_profile: dict[BeeBiteProfileId, tuple[BeeBiteRetestMode, ...]] = {
-        "A": ("confirmation",),
-        "B": ("confirmation",),
-        "C": ("confirmation", "immediate"),
-    }
-
-    allowed_reclaim = allowed_reclaim_by_profile[profile_id]
-    if reclaim_mode not in allowed_reclaim:
-        supported = ", ".join(allowed_reclaim)
-        raise ValueError(f"профиль {profile_id} поддерживает reclaim_mode только из [{supported}]")
-
-    allowed_retest = allowed_retest_by_profile[profile_id]
-    if retest_mode not in allowed_retest:
-        supported = ", ".join(allowed_retest)
-        raise ValueError(f"профиль {profile_id} поддерживает retest_mode только из [{supported}]")
 
     if cooldown_hours < 1 or cooldown_hours > 100:
         raise ValueError("параметр cooldown_hours должен быть в диапазоне [1, 100]")
@@ -400,14 +383,16 @@ def validate_bee_bite_runtime(
     if top_n is None:
         return
 
-    if top_n < runtime.top_n_min or top_n > runtime.top_n_max:
+    min_top_n = min(item.top_n_min for item in BEE_BITE_PROFILE_RUNTIME.values())
+    max_top_n = max(item.top_n_max for item in BEE_BITE_PROFILE_RUNTIME.values())
+    if top_n < min_top_n or top_n > max_top_n:
         raise ValueError(
-            f"для bee_bite профиля {profile_id} параметр --top-n должен быть в диапазоне "
-            f"[{runtime.top_n_min}, {runtime.top_n_max}]"
+            f"для bee_bite параметр --top-n должен быть в диапазоне "
+            f"[{min_top_n}, {max_top_n}]"
         )
-    if grid_mode == "expanded" and top_n < max(20, runtime.top_n_min):
+    if grid_mode == "expanded" and top_n < 20:
         raise ValueError("для bee_bite в режиме expanded параметр --top-n должен быть >= 20")
-    if grid_mode == "research" and top_n < max(30, runtime.top_n_min):
+    if grid_mode == "research" and top_n < 30:
         raise ValueError("для bee_bite в режиме research параметр --top-n должен быть >= 30")
 
 


### PR DESCRIPTION
## Что сделано
- Убрал CLI-аргумент `--bee-bite-profile` из `run-backtest`.
- Обновил Bee Bite grid-builder: теперь сетка строится сразу по всем baseline-профилям (A/B/C) и объединяется в единый набор комбинаций.
- Для режима `baseline` теперь возвращаются baseline-комбинации по всем профилям, а не одна точка выбранного профиля.
- Ослабил runtime-валидацию `reclaim/retest` от профильных ограничений и перевёл проверку `top_n` на общий диапазон по стратегии.
- Обновил пользовательскую документацию (`README.md`, `strategy/bee_bite/README.md`) под новую модель без явного выбора профиля.

## Зачем
По запросу пользователя в Bee Bite больше не должно быть ручного выбора профилей A/B/C — должна использоваться полноценная сетка параметров.

## Влияние
- Команды с `--bee-bite-profile` больше не поддерживаются.
- Количество комбинаций в Bee Bite возрастёт, так как сетка теперь охватывает весь baseline-набор.
- Существующие env-параметры `BEE_BITE_PROFILE` остаются совместимыми для runtime-дефолтов, но больше не используются как пользовательский переключатель в CLI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b417a38b083209ecd7c80847c7417)